### PR TITLE
Release the mach host port in memoryUsage()

### DIFF
--- a/Sources/Vorssaint/Services/SystemInfo.swift
+++ b/Sources/Vorssaint/Services/SystemInfo.swift
@@ -35,11 +35,13 @@ enum SystemInfo {
     static func memoryUsage() -> (used: UInt64, total: UInt64)? {
         var stats = vm_statistics64()
         var count = mach_msg_type_number_t(MemoryLayout<vm_statistics64>.stride / MemoryLayout<integer_t>.stride)
+        let host = mach_host_self()
         let kr = withUnsafeMutablePointer(to: &stats) { ptr in
             ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
-                host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &count)
+                host_statistics64(host, HOST_VM_INFO64, $0, &count)
             }
         }
+        mach_port_deallocate(mach_task_self_, host)
         guard kr == KERN_SUCCESS else { return nil }
         let page = UInt64(vm_kernel_page_size)
         let used = (UInt64(stats.active_count) + UInt64(stats.wire_count) + UInt64(stats.compressor_page_count)) * page


### PR DESCRIPTION
`SystemInfo.memoryUsage()` calls `mach_host_self()` inline but never releases the returned send right. `mach_host_self()` hands the caller a port reference it must deallocate with `mach_port_deallocate`, so every call leaks one mach port.
`memoryUsage()` runs every ~2s while the menu panel is open (via `SystemMonitor.refresh()`), plus in `--selftest`, so the leak accumulates during normal use.
Capture the host port, use it, and `mach_port_deallocate` it after `host_statistics64` — the same pattern already applied to the twin leak in `SystemMonitor.readCPUUsage()`. This was the only remaining unpatched `mach_host_self()` call site.
- `swift build` (debug + release): clean, no new warnings.
🧙 Built with [WOZCODE](https://wozcode.com)