### PR TITLE
feat: raise per-app volume boost limit from 200% to 500%

### DIFF
--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -27,7 +27,7 @@ enum DefaultsKey {
     static let previewSize = "previewSize"                // app switcher + dock preview thumbnail size
     static let autoCheckUpdates = "autoCheckUpdates"
     static let releaseNotesOnUpdate = "releaseNotesOnUpdate" // show What's New after an update
-    static let appVolumes = "appVolumes"                  // [bundle id: 0...2]
+    static let appVolumes = "appVolumes"                  // [bundle id: 0...5]
     static let appOutputDevices = "appOutputDevices"      // [bundle id: audio device UID]
     static let preferredInputDevice = "preferredInputDevice" // audio input device UID
     static let finderCutPasteEnabled = "finderCutPasteEnabled"
@@ -279,7 +279,9 @@ enum Defaults {
 
     static func sanitizedAppVolume(_ volume: Double) -> Double {
         guard volume.isFinite else { return 1 }
-        return min(max(volume, 0), 2)
+        // Keep in sync with AppVolumeMixer.maxVolume (not importable in the
+        // standalone test build, so the boost ceiling is duplicated here).
+        return min(max(volume, 0), 5)
     }
 
     static func sanitizedAppOutputDeviceUID(_ value: Any?) -> String? {

--- a/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
+++ b/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
@@ -47,9 +47,9 @@ final class AppVolumeMixer: ObservableObject {
         return false
     }
 
-    /// Volumes run 0...2: 1.0 is 100% (untouched passthrough), up to 2.0 is a
-    /// 200% boost for sources that play too quietly.
-    static let maxVolume: Double = 2.0
+    /// Volumes run 0...5: 1.0 is 100% (untouched passthrough), up to 5.0 is a
+    /// 500% boost for sources that play too quietly.
+    static let maxVolume: Double = 5.0
 
     @Published private(set) var apps: [MixerApp] = []
     @Published private(set) var outputDevices: [MixerOutputDevice] = []

--- a/Sources/Vorssaint/UI/MenuPanel/MixerSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/MixerSection.swift
@@ -6,7 +6,7 @@ import SwiftUI
 
 /// Per-app volume sliders, the mixer macOS never shipped. Shows every app
 /// holding an audio connection (a green dot marks the ones playing right now).
-/// 100% is untouched passthrough; below it attenuates and above it (up to 200%)
+/// 100% is untouched passthrough; below it attenuates and above it (up to 500%)
 /// boosts, with the slider and percentage turning amber in the boost range.
 struct MixerSection: View {
     @ObservedObject private var l10n = L10n.shared

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -174,7 +174,8 @@ struct MetricsTests {
                == ["uninstaller", "homebrew", "cleanURL", "cleaning"],
                "panel item order keeps saved valid items first and appends defaults")
         expectClose(Defaults.sanitizedAppVolume(1.5), 1.5, "valid app volume is preserved")
-        expectClose(Defaults.sanitizedAppVolume(3), 2, "high app volume clamps to boost maximum")
+        expectClose(Defaults.sanitizedAppVolume(3), 3, "in-range boost volume is preserved")
+        expectClose(Defaults.sanitizedAppVolume(6), 5, "high app volume clamps to boost maximum")
         expectClose(Defaults.sanitizedAppVolume(-1), 0, "negative app volume clamps to mute")
         expectClose(Defaults.sanitizedAppVolume(.infinity), 1, "non-finite app volume falls back to unity")
         expect(Defaults.sanitizedAppOutputDeviceUID(" BuiltInSpeakerDevice ") == "BuiltInSpeakerDevice",


### PR DESCRIPTION
Raise the per-app volume mixer's boost ceiling from 200% to 500%.

**Before:** per-app volume sliders capped at 200%.
**After:** cap raised to 500%, giving quiet sources more headroom.

- Centralized on `AppVolumeMixer.maxVolume` (2.0 → 5.0), which drives the slider range, gain clamping, custom-slider math, and the accessibility increment.
- `Defaults.sanitizedAppVolume` keeps its own literal `5` (the constant isn't importable in the standalone test build) with a sync comment.
- The realtime gain path already hard-clips to `[-1, 1]` when boosting, so no distortion/overflow changes were needed.

## Testing

- `./build.sh` builds clean, no warnings.
- `./build.sh --test` passes (438 checks), including updated clamp assertions (`6 → 5`, plus an in-range `3 → 3` case).
- Verified live: boosting and attenuating are audible end-to-end.

## Notes

- No new user-facing strings, so no translation changes are required.