### PR TITLE
Gate memory purge controls behind manual confirmation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,11 @@ let package = Package(
         .executableTarget(
             name: "Vorssaint",
             path: "Sources/Vorssaint"
+        ),
+        .testTarget(
+            name: "VorssaintTests",
+            dependencies: ["Vorssaint"],
+            path: "Tests/VorssaintTests"
         )
     ]
 )

--- a/Sources/Vorssaint/App/AppDelegate.swift
+++ b/Sources/Vorssaint/App/AppDelegate.swift
@@ -39,8 +39,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         setUpPopover()
         bindManagers()
 
-        HotkeyManager.shared.onActivate = { KeepAwakeManager.shared.toggle() }
-        HotkeyManager.shared.setEnabled(UserDefaults.standard.bool(forKey: DefaultsKey.hotkeyEnabled))
+        HotkeyManager.shared.onActivate = { [weak self] in self?.instantPurge() }
+        HotkeyManager.shared.setEnabled(UserDefaults.standard.bool(forKey: DefaultsKey.purgeHotkeyEnabled))
+        Notifier.requestPermission()
+        MemoryAutoPurger.shared.start()
 
         KeepAwakeManager.shared.recoverIfNeeded()
         AppActivationTracker.shared.start()
@@ -86,8 +88,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
 
     func applicationWillTerminate(_ notification: Notification) {
         isTerminating = true
+        MemoryAutoPurger.shared.stop()
         AppVolumeMixer.shared.stopAll()
         KeepAwakeManager.shared.deactivate(reason: .quit)
+    }
+
+    func instantPurge() {
+        MemoryPurgeService.purge(mode: .standard) { result in
+            SystemMonitor.shared.refreshNow()
+            if UserDefaults.standard.bool(forKey: DefaultsKey.autoPurgeNotify) {
+                Notifier.post(title: "MemoryKill purged", body: result.message)
+            }
+        }
     }
 
     /// The lifeline when the menu bar icon goes missing. Opening the app again
@@ -154,7 +166,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         popover.behavior = .applicationDefined
         popover.animates = false
         popover.delegate = self
-        let host = NSHostingController(rootView: MenuPanelView())
+        let host = NSHostingController(rootView: MemoryPanelView())
         host.sizingOptions = .preferredContentSize
         popover.contentViewController = host
         NotificationCenter.default.addObserver(self, selector: #selector(appResignedActive),
@@ -269,72 +281,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
     // MARK: - Context menu (right click)
 
     private func showContextMenu() {
-        // The panel uses applicationDefined dismissal, so a right-click while it's
-        // open won't close it on its own — and the menu would try to open behind it.
-        // Close it first so the context menu always appears.
         if popover.isShown { popover.performClose(nil) }
 
-        let manager = KeepAwakeManager.shared
-        let strings = L10n.shared.s
         let menu = NSMenu()
 
-        let toggleItem = NSMenuItem(title: manager.isActive ? strings.menuDisableAwake : strings.menuEnableAwake,
-                                    action: #selector(menuToggleAwake),
-                                    keyEquivalent: "")
-        toggleItem.target = self
-        menu.addItem(toggleItem)
+        let purge = NSMenuItem(title: "Purge Memory", action: #selector(menuPurge), keyEquivalent: "")
+        purge.target = self
+        menu.addItem(purge)
 
-        if !manager.isActive {
-            let durationsItem = NSMenuItem(title: strings.menuActivateFor, action: nil, keyEquivalent: "")
-            let submenu = NSMenu()
-            let options: [(String, Int)] = [(strings.minutes15, 15), (strings.minutes30, 30),
-                                            (strings.hour1, 60), (strings.hours2, 120),
-                                            (strings.hours4, 240), (strings.hours8, 480),
-                                            (strings.indefinitely, 0)]
-            for (label, minutes) in options {
-                let item = NSMenuItem(title: label, action: #selector(menuActivateDuration(_:)), keyEquivalent: "")
-                item.target = self
-                item.tag = minutes
-                submenu.addItem(item)
-            }
-            durationsItem.submenu = submenu
-            menu.addItem(durationsItem)
-        }
+        let deep = NSMenuItem(title: "Deep Purge (admin)", action: #selector(menuDeepPurge), keyEquivalent: "")
+        deep.target = self
+        menu.addItem(deep)
 
-        let cleaningItem = NSMenuItem(title: strings.cleaningMenuItem,
-                                      action: #selector(menuCleaningMode), keyEquivalent: "")
-        cleaningItem.target = self
-        menu.addItem(cleaningItem)
+        let max = NSMenuItem(title: "MAX Purge", action: #selector(menuMaxPurge), keyEquivalent: "")
+        max.target = self
+        menu.addItem(max)
+
+        let hog = NSMenuItem(title: "Kill Top Memory Hog", action: #selector(menuKillHog), keyEquivalent: "")
+        hog.target = self
+        menu.addItem(hog)
 
         menu.addItem(.separator())
 
-        let settingsItem = NSMenuItem(title: strings.menuSettings, action: #selector(menuOpenSettings), keyEquivalent: ",")
-        settingsItem.target = self
-        menu.addItem(settingsItem)
-
-        let aboutItem = NSMenuItem(title: strings.menuAbout, action: #selector(showAbout), keyEquivalent: "")
-        aboutItem.target = self
-        menu.addItem(aboutItem)
-
-        let uninstallItem = NSMenuItem(title: strings.uninstallerMenuItem,
-                                       action: #selector(menuOpenUninstaller), keyEquivalent: "")
-        uninstallItem.target = self
-        menu.addItem(uninstallItem)
-
-        if UserDefaults.standard.bool(forKey: DefaultsKey.shelfEnabled) {
-            let shelfItem = NSMenuItem(title: strings.shelfMenuItem,
-                                       action: #selector(menuOpenShelf), keyEquivalent: "")
-            shelfItem.target = self
-            menu.addItem(shelfItem)
-        }
-
-        let updatesItem = NSMenuItem(title: strings.menuCheckUpdates, action: #selector(menuCheckUpdates), keyEquivalent: "")
-        updatesItem.target = self
-        menu.addItem(updatesItem)
-
-        menu.addItem(.separator())
-
-        let quitItem = NSMenuItem(title: strings.menuQuit, action: #selector(quitApp), keyEquivalent: "q")
+        let quitItem = NSMenuItem(title: "Quit MemoryKill", action: #selector(quitApp), keyEquivalent: "q")
         quitItem.target = self
         menu.addItem(quitItem)
 
@@ -343,6 +312,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         DispatchQueue.main.async { [weak self] in
             self?.statusController.statusItem.menu = nil
         }
+    }
+
+    @objc private func menuPurge() { instantPurge() }
+
+    @objc private func menuDeepPurge() {
+        MemoryPurgeService.purge(mode: .deep) { _ in SystemMonitor.shared.refreshNow() }
+    }
+
+    @objc private func menuMaxPurge() {
+        MemoryPurgeService.purge(mode: .max) { _ in SystemMonitor.shared.refreshNow() }
+    }
+
+    @objc private func menuKillHog() {
+        _ = MemoryPurgeService.killTopMemoryHog()
+        SystemMonitor.shared.refreshNow()
     }
 
     @objc private func menuToggleAwake() {

--- a/Sources/Vorssaint/App/AppDelegate.swift
+++ b/Sources/Vorssaint/App/AppDelegate.swift
@@ -94,10 +94,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
     }
 
     func instantPurge() {
-        MemoryPurgeService.purge(mode: .standard) { result in
+        MemoryPurgeService.purge(mode: .standard, trigger: .manual) { result in
             SystemMonitor.shared.refreshNow()
             if UserDefaults.standard.bool(forKey: DefaultsKey.autoPurgeNotify) {
-                Notifier.post(title: "MemoryKill purged", body: result.message)
+                Notifier.post(title: "MemoryKill pressure relief", body: result.message)
             }
         }
     }
@@ -285,15 +285,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
 
         let menu = NSMenu()
 
-        let purge = NSMenuItem(title: "Purge Memory", action: #selector(menuPurge), keyEquivalent: "")
+        let purge = NSMenuItem(title: "Standard Pressure Relief", action: #selector(menuPurge), keyEquivalent: "")
         purge.target = self
         menu.addItem(purge)
 
-        let deep = NSMenuItem(title: "Deep Purge (admin)", action: #selector(menuDeepPurge), keyEquivalent: "")
+        let deep = NSMenuItem(title: "Open Panel for Deep Purge", action: #selector(menuDeepPurge), keyEquivalent: "")
         deep.target = self
         menu.addItem(deep)
 
-        let max = NSMenuItem(title: "MAX Purge", action: #selector(menuMaxPurge), keyEquivalent: "")
+        let max = NSMenuItem(title: "Open Panel for MAX Purge", action: #selector(menuMaxPurge), keyEquivalent: "")
         max.target = self
         menu.addItem(max)
 
@@ -316,13 +316,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
 
     @objc private func menuPurge() { instantPurge() }
 
-    @objc private func menuDeepPurge() {
-        MemoryPurgeService.purge(mode: .deep) { _ in SystemMonitor.shared.refreshNow() }
-    }
+    @objc private func menuDeepPurge() { togglePopover() }
 
-    @objc private func menuMaxPurge() {
-        MemoryPurgeService.purge(mode: .max) { _ in SystemMonitor.shared.refreshNow() }
-    }
+    @objc private func menuMaxPurge() { togglePopover() }
 
     @objc private func menuKillHog() {
         _ = MemoryPurgeService.killTopMemoryHog()

--- a/Sources/Vorssaint/App/StatusItemController.swift
+++ b/Sources/Vorssaint/App/StatusItemController.swift
@@ -46,11 +46,12 @@ final class StatusItemController {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         // A stable identity so macOS remembers the item's position across launches
         // and across rebuilds, instead of re-placing it at the crowded default spot.
-        statusItem.autosaveName = "VorssaintMenuBarItem"
+        statusItem.autosaveName = "MemoryKillMenuBarItem"
         statusItem.behavior = []
         statusItem.isVisible = true
         if let button = statusItem.button {
-            button.image = BlackHoleGlyph.image(active: false)
+            button.image = NSImage(systemSymbolName: "memorychip", accessibilityDescription: "MemoryKill")
+            button.image?.isTemplate = true
             // Fully monospaced (not just digits) so the fixed-width metric fields
             // keep a constant pixel width and the item never jiggles.
             button.font = NSFont.monospacedSystemFont(ofSize: 12, weight: .medium)
@@ -134,20 +135,23 @@ final class StatusItemController {
     /// keep the blue attention color; an active keep-awake session turns amber.
     private func updateIconAppearance() {
         guard let button = statusItem?.button else { return }
-        if case .available = UpdateService.shared.state {
-            button.image = BlackHoleGlyph.attentionImage()
-        } else {
-            button.image = BlackHoleGlyph.image(active: KeepAwakeManager.shared.isActive)
-        }
+        button.image = NSImage(systemSymbolName: "memorychip", accessibilityDescription: "MemoryKill")
+        button.image?.isTemplate = true
+        button.contentTintColor = memoryTint()
     }
 
     @objc private func clicked() {
         pulse()
         if NSApp.currentEvent?.type == .rightMouseUp {
             onRightClick?()
-        } else {
-            onLeftClick?()
+            return
         }
+        if UserDefaults.standard.bool(forKey: DefaultsKey.optionClickPurge),
+           NSApp.currentEvent?.modifierFlags.contains(.option) == true {
+            (NSApp.delegate as? AppDelegate)?.instantPurge()
+            return
+        }
+        onLeftClick?()
     }
 
     /// Quick, springy scale dip — the click micro-interaction.
@@ -221,7 +225,16 @@ final class StatusItemController {
                 button.toolTip = strings.statusActiveIndefinite
             }
         } else {
-            button.toolTip = strings.statusIdleTooltip
+            button.toolTip = "MemoryKill — click to purge and monitor RAM"
+        }
+    }
+
+    private func memoryTint() -> NSColor {
+        switch SystemMonitor.shared.snapshot.memoryPressure {
+        case .normal: return .systemGreen
+        case .warning: return .systemOrange
+        case .critical: return .systemRed
+        case .unknown: return .labelColor
         }
     }
 }

--- a/Sources/Vorssaint/Core/AppInfo.swift
+++ b/Sources/Vorssaint/Core/AppInfo.swift
@@ -5,8 +5,8 @@ import Foundation
 
 /// Static identity of the app, shared by UI, notifications and tooling.
 enum AppInfo {
-    static let name = "Vorssaint"
-    static let copyright = "© 2026 Vorssaint"
+    static let name = "MemoryKill"
+    static let copyright = "© 2026 MemoryKill (fork of Vorssaint)"
     static let repositoryURL = URL(string: "https://github.com/vorssaint/vorssaint-utils")!
     /// Buy Me a Coffee page. The project stays free; donations and stars are how
     /// the community keeps it alive. Confirm the handle is exactly right before

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -70,6 +70,13 @@ enum DefaultsKey {
 
     // Dev-build only: force the "update available" UI for local testing.
     static let simulateUpdate = "simulateUpdate"
+
+    // MemoryKill — auto-purge and power-user toggles.
+    static let autoPurgeEnabled = "autoPurgeEnabled"
+    static let autoPurgeThreshold = "autoPurgeThreshold"   // warning | critical
+    static let autoPurgeNotify = "autoPurgeNotify"
+    static let purgeHotkeyEnabled = "purgeHotkeyEnabled"
+    static let optionClickPurge = "optionClickPurge"
 }
 
 /// Bump `currentFeatureSet` when the first-run tour changes. Existing users are
@@ -92,10 +99,7 @@ enum Defaults {
         DefaultsKey.batteryLimit: 10,
         DefaultsKey.hotkeyEnabled: true,
         DefaultsKey.showCountdown: false,
-        DefaultsKey.scrollInverterEnabled: false,
-        DefaultsKey.switcherEnabled: true,
         DefaultsKey.switcherMergeTabs: false,
-        DefaultsKey.autoCheckUpdates: true,
         // Finder never benefits from being "quit" (it just relaunches), so
         // it's excepted out of the box.
         DefaultsKey.autoQuitExceptions: ["com.apple.finder"],
@@ -104,13 +108,27 @@ enum Defaults {
         // Menu bar metrics start off (the icon stays clean) and are opt-in.
         // The panel shows every monitoring block by default; users hide what
         // they don't want.
-        DefaultsKey.monitorInterval: 2,
+        DefaultsKey.monitorInterval: 1,
+        DefaultsKey.autoPurgeEnabled: true,
+        DefaultsKey.autoPurgeThreshold: "warning",
+        DefaultsKey.autoPurgeNotify: true,
+        DefaultsKey.purgeHotkeyEnabled: true,
+        DefaultsKey.optionClickPurge: true,
         DefaultsKey.temperatureUnit: TemperatureUnit.celsius.rawValue,
-        DefaultsKey.menuBarMemoryStyle: "percent",
+        DefaultsKey.menuBarMemoryStyle: "both",
+        DefaultsKey.menuBarMemory: true,
+        DefaultsKey.menuBarCPU: false,
+        DefaultsKey.menuBarGPU: false,
+        DefaultsKey.menuBarNetwork: false,
+        DefaultsKey.menuBarPower: false,
         DefaultsKey.monitorShowSystem: true,
-        DefaultsKey.monitorShowNetwork: true,
-        DefaultsKey.monitorShowPower: true,
-        DefaultsKey.monitorShowMixer: true,
+        DefaultsKey.monitorShowNetwork: false,
+        DefaultsKey.monitorShowPower: false,
+        DefaultsKey.monitorShowMixer: false,
+        DefaultsKey.hasOnboarded: true,
+        DefaultsKey.autoCheckUpdates: false,
+        DefaultsKey.switcherEnabled: false,
+        DefaultsKey.scrollInverterEnabled: false,
         DefaultsKey.monitorGraphCPU: true,
         DefaultsKey.monitorGraphGPU: true,
         DefaultsKey.monitorGraphMemory: true,

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -109,7 +109,7 @@ enum Defaults {
         // The panel shows every monitoring block by default; users hide what
         // they don't want.
         DefaultsKey.monitorInterval: 1,
-        DefaultsKey.autoPurgeEnabled: true,
+        DefaultsKey.autoPurgeEnabled: false,
         DefaultsKey.autoPurgeThreshold: "warning",
         DefaultsKey.autoPurgeNotify: true,
         DefaultsKey.purgeHotkeyEnabled: true,

--- a/Sources/Vorssaint/Services/Memory/MemoryAutoPurger.swift
+++ b/Sources/Vorssaint/Services/Memory/MemoryAutoPurger.swift
@@ -1,0 +1,60 @@
+// Watches memory pressure and purges automatically when thresholds are hit.
+
+import Combine
+import Foundation
+
+@MainActor
+final class MemoryAutoPurger: ObservableObject {
+    static let shared = MemoryAutoPurger()
+
+    @Published private(set) var lastAutoPurgeAt: Date?
+    @Published private(set) var isRunning = false
+
+    private var cancellable: AnyCancellable?
+    private let cooldown: TimeInterval = 300
+
+    private init() {}
+
+    func start() {
+        guard cancellable == nil else { return }
+        SystemMonitor.shared.setMenuBarActive(true)
+        cancellable = SystemMonitor.shared.$snapshot
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] snapshot in
+                self?.evaluate(snapshot)
+            }
+    }
+
+    func stop() {
+        cancellable?.cancel()
+        cancellable = nil
+    }
+
+    private func evaluate(_ snapshot: SystemSnapshot) {
+        guard UserDefaults.standard.bool(forKey: DefaultsKey.autoPurgeEnabled) else { return }
+        guard !isRunning else { return }
+        if let last = lastAutoPurgeAt, Date().timeIntervalSince(last) < cooldown { return }
+
+        let threshold = UserDefaults.standard.string(forKey: DefaultsKey.autoPurgeThreshold) ?? "critical"
+        let shouldPurge: Bool
+        switch threshold {
+        case "warning":
+            shouldPurge = snapshot.memoryPressure == .warning || snapshot.memoryPressure == .critical
+        default:
+            shouldPurge = snapshot.memoryPressure == .critical
+        }
+        guard shouldPurge else { return }
+
+        isRunning = true
+        MemoryPurgeService.purge(mode: .standard) { [weak self] result in
+            guard let self else { return }
+            self.isRunning = false
+            self.lastAutoPurgeAt = Date()
+            SystemMonitor.shared.refreshNow()
+            if UserDefaults.standard.bool(forKey: DefaultsKey.autoPurgeNotify) {
+                Notifier.post(title: "MemoryKill auto-purged",
+                              body: result.message)
+            }
+        }
+    }
+}

--- a/Sources/Vorssaint/Services/Memory/MemoryAutoPurger.swift
+++ b/Sources/Vorssaint/Services/Memory/MemoryAutoPurger.swift
@@ -46,7 +46,7 @@ final class MemoryAutoPurger: ObservableObject {
         guard shouldPurge else { return }
 
         isRunning = true
-        MemoryPurgeService.purge(mode: .standard) { [weak self] result in
+        MemoryPurgeService.purge(mode: .standard, trigger: .auto) { [weak self] result in
             guard let self else { return }
             self.isRunning = false
             self.lastAutoPurgeAt = Date()

--- a/Sources/Vorssaint/Services/Memory/MemoryPurgeService.swift
+++ b/Sources/Vorssaint/Services/Memory/MemoryPurgeService.swift
@@ -11,10 +11,29 @@ enum MemoryPurgeService {
         case max
     }
 
+    enum Trigger: String, Codable {
+        case manual
+        case auto
+    }
+
     struct Result {
         let freedBytes: Int64
         let message: String
     }
+
+    struct Receipt: Codable {
+        let timestamp: String
+        let mode: String
+        let manualOrAuto: String
+        let commandUsed: String
+        let success: Bool
+        let beforeReclaimableEstimate: UInt64?
+        let afterReclaimableEstimate: UInt64?
+        let durationSeconds: Double
+        let note: String?
+    }
+
+    static let requiredDeepConfirmation = "I understand deep purge may request administrator password and run /usr/bin/purge"
 
     static func reclaimableBytes() -> UInt64 {
         var stats = vm_statistics64()
@@ -35,33 +54,88 @@ enum MemoryPurgeService {
         reclaimableBytes()
     }
 
-    static func purge(mode: Mode, completion: @escaping (Result) -> Void) {
+    static func purge(mode: Mode, trigger: Trigger = .manual, confirmationText: String? = nil, completion: @escaping (Result) -> Void) {
         DispatchQueue.global(qos: .userInitiated).async {
             let before = reclaimableBytes()
+            let started = Date()
+            var commandUsed = "simulation_only"
+            var success = true
+            var note: String? = "pressure_relief_simulation_only"
             switch mode {
             case .standard:
                 triggerPressureRelief(passes: 2)
             case .deep:
-                triggerPressureRelief(passes: 3)
-                _ = AdminShell.runSync("/usr/sbin/purge",
-                                       prompt: "MemoryKill needs your password to purge disk caches.")
+                guard confirmationText == requiredDeepConfirmation else {
+                    success = false
+                    note = "confirmation_mismatch"
+                    commandUsed = "none"
+                    let after = reclaimableBytes()
+                    writeReceipt(.init(timestamp: timestampString(from: started),
+                                       mode: "deep",
+                                       manualOrAuto: trigger.rawValue,
+                                       commandUsed: commandUsed,
+                                       success: success,
+                                       beforeReclaimableEstimate: before,
+                                       afterReclaimableEstimate: after,
+                                       durationSeconds: Date().timeIntervalSince(started),
+                                       note: note))
+                    DispatchQueue.main.async {
+                        completion(Result(freedBytes: 0, message: "Deep purge confirmation did not match."))
+                    }
+                    return
+                }
+                commandUsed = "/usr/bin/purge"
+                let result = Shell.run("/usr/bin/purge", [])
+                success = result.status == 0
+                note = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
             case .max:
+                guard confirmationText == requiredDeepConfirmation else {
+                    success = false
+                    note = "confirmation_mismatch"
+                    commandUsed = "none"
+                    let after = reclaimableBytes()
+                    writeReceipt(.init(timestamp: timestampString(from: started),
+                                       mode: "max",
+                                       manualOrAuto: trigger.rawValue,
+                                       commandUsed: commandUsed,
+                                       success: success,
+                                       beforeReclaimableEstimate: before,
+                                       afterReclaimableEstimate: after,
+                                       durationSeconds: Date().timeIntervalSince(started),
+                                       note: note))
+                    DispatchQueue.main.async {
+                        completion(Result(freedBytes: 0, message: "MAX purge confirmation did not match."))
+                    }
+                    return
+                }
                 _ = clearUserCaches()
                 triggerPressureRelief(passes: 4)
                 _ = flushDNS()
-                _ = AdminShell.runSync("/usr/sbin/purge",
-                                       prompt: "MemoryKill needs your password for MAX purge.")
+                commandUsed = "/usr/sbin/purge"
+                success = AdminShell.runSync("/usr/sbin/purge",
+                                              prompt: "MemoryKill needs your password for MAX purge.")
                 triggerPressureRelief(passes: 2)
             }
             Thread.sleep(forTimeInterval: 1.0)
             let after = reclaimableBytes()
             let freed = Int64(after) &- Int64(before)
             let message: String
-            if freed > 32 * 1024 * 1024 {
+            if mode == .standard {
+                message = "Standard pressure relief simulated."
+            } else if freed > 32 * 1024 * 1024 {
                 message = "\(modeLabel(mode)): freed \(formatBytes(freed))."
             } else {
                 message = "\(modeLabel(mode)) complete."
             }
+            writeReceipt(.init(timestamp: timestampString(from: started),
+                               mode: String(describing: mode),
+                               manualOrAuto: trigger.rawValue,
+                               commandUsed: commandUsed,
+                               success: success,
+                               beforeReclaimableEstimate: before,
+                               afterReclaimableEstimate: after,
+                               durationSeconds: Date().timeIntervalSince(started),
+                               note: note?.isEmpty == true ? nil : note))
             DispatchQueue.main.async {
                 completion(Result(freedBytes: max(freed, 0), message: message))
             }
@@ -183,9 +257,32 @@ enum MemoryPurgeService {
 
     private static func modeLabel(_ mode: Mode) -> String {
         switch mode {
-        case .standard: return "Purge"
+        case .standard: return "Standard"
         case .deep: return "Deep purge"
         case .max: return "MAX purge"
+        }
+    }
+
+    private static func timestampString(from date: Date = Date()) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
+
+    private static func writeReceipt(_ receipt: Receipt) {
+        let directory = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent(AppInfo.name, isDirectory: true)
+            .appendingPathComponent("PurgeReceipts", isDirectory: true)
+        guard let directory else { return }
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(receipt)
+            let name = receipt.timestamp.replacingOccurrences(of: ":", with: "") + ".json"
+            try data.write(to: directory.appendingPathComponent(name), options: [.atomic])
+        } catch {
+            print("PURGE RECEIPT WRITE FAILED: \(error)")
         }
     }
 

--- a/Sources/Vorssaint/Services/Memory/MemoryPurgeService.swift
+++ b/Sources/Vorssaint/Services/Memory/MemoryPurgeService.swift
@@ -1,0 +1,212 @@
+// Fork of vorssaint-utils — memory purge/kill actions for MemoryKill.
+
+import AppKit
+import Darwin
+import Foundation
+
+enum MemoryPurgeService {
+    enum Mode {
+        case standard
+        case deep
+        case max
+    }
+
+    struct Result {
+        let freedBytes: Int64
+        let message: String
+    }
+
+    static func reclaimableBytes() -> UInt64 {
+        var stats = vm_statistics64()
+        var count = mach_msg_type_number_t(MemoryLayout<vm_statistics64>.stride / MemoryLayout<integer_t>.stride)
+        let host = mach_host_self()
+        defer { mach_port_deallocate(mach_task_self_, host) }
+        let kr = withUnsafeMutablePointer(to: &stats) { ptr in
+            ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics64(host, HOST_VM_INFO64, $0, &count)
+            }
+        }
+        guard kr == KERN_SUCCESS else { return availableMemoryBytes() }
+        let page = UInt64(vm_kernel_page_size)
+        return (UInt64(stats.free_count) + UInt64(stats.inactive_count) + UInt64(stats.purgeable_count)) * page
+    }
+
+    static func availableMemoryBytes() -> UInt64 {
+        reclaimableBytes()
+    }
+
+    static func purge(mode: Mode, completion: @escaping (Result) -> Void) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let before = reclaimableBytes()
+            switch mode {
+            case .standard:
+                triggerPressureRelief(passes: 2)
+            case .deep:
+                triggerPressureRelief(passes: 3)
+                _ = AdminShell.runSync("/usr/sbin/purge",
+                                       prompt: "MemoryKill needs your password to purge disk caches.")
+            case .max:
+                _ = clearUserCaches()
+                triggerPressureRelief(passes: 4)
+                _ = flushDNS()
+                _ = AdminShell.runSync("/usr/sbin/purge",
+                                       prompt: "MemoryKill needs your password for MAX purge.")
+                triggerPressureRelief(passes: 2)
+            }
+            Thread.sleep(forTimeInterval: 1.0)
+            let after = reclaimableBytes()
+            let freed = Int64(after) &- Int64(before)
+            let message: String
+            if freed > 32 * 1024 * 1024 {
+                message = "\(modeLabel(mode)): freed \(formatBytes(freed))."
+            } else {
+                message = "\(modeLabel(mode)) complete."
+            }
+            DispatchQueue.main.async {
+                completion(Result(freedBytes: max(freed, 0), message: message))
+            }
+        }
+    }
+
+    static func flushDNS() -> String {
+        let flush = Shell.run("/usr/bin/dscacheutil", ["-flushcache"])
+        let mdns = Shell.run("/usr/bin/killall", ["-HUP", "mDNSResponder"])
+        if flush.status == 0 {
+            return mdns.status == 0 ? "DNS cache flushed." : "DNS flushed (mDNSResponder was not running)."
+        }
+        return "DNS flush failed."
+    }
+
+    @discardableResult
+    static func clearUserCaches() -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let targets = [
+            "\(home)/Library/Caches",
+            "\(home)/Library/Logs/DiagnosticReports",
+            "\(home)/Library/Developer/Xcode/DerivedData"
+        ]
+        var removed = 0
+        var bytes: Int64 = 0
+
+        for target in targets {
+            guard let entries = try? FileManager.default.contentsOfDirectory(atPath: target) else { continue }
+            for entry in entries {
+                let path = "\(target)/\(entry)"
+                let size = pathSize(path)
+                if (try? FileManager.default.removeItem(atPath: path)) != nil {
+                    removed += 1
+                    bytes += size
+                }
+            }
+        }
+
+        if removed == 0 { return "No removable user caches found." }
+        return "Removed \(removed) cache folders (\(formatBytes(bytes)))."
+    }
+
+    @discardableResult
+    static func killProcess(pid: pid_t, name: String) -> String {
+        if isProtected(pid: pid, name: name) {
+            return "Refusing to kill protected process: \(name)."
+        }
+        if kill(pid, SIGTERM) != 0 {
+            if kill(pid, SIGKILL) != 0 {
+                return "Failed to kill \(name): \(String(cString: strerror(errno)))"
+            }
+            return "Force quit \(name)."
+        }
+        return "Quit signal sent to \(name)."
+    }
+
+    @discardableResult
+    static func killTopMemoryHog() -> String {
+        let hogs = ProcessUsageService.shared.topMemory(limit: 15)
+        guard !hogs.isEmpty else { return "No memory hogs found." }
+
+        let skipped = hogs.filter { isProtected(pid: $0.pid, name: $0.name) }
+        guard let hog = hogs.first(where: { !isProtected(pid: $0.pid, name: $0.name) }) else {
+            let names = skipped.prefix(3).map(\.name).joined(separator: ", ")
+            return "Only protected processes on top (\(names)). MemoryKill won't suicide."
+        }
+
+        if let selfHog = skipped.first {
+            let result = killProcess(pid: hog.pid, name: hog.name)
+            return "Skipped \(selfHog.name) (that's us). \(result)"
+        }
+        return killProcess(pid: hog.pid, name: hog.name)
+    }
+
+    static func isProtected(pid: pid_t, name: String) -> Bool {
+        if pid <= 1 || pid == getpid() { return true }
+
+        if let app = NSRunningApplication(processIdentifier: pid),
+           let bundleID = app.bundleIdentifier {
+            if bundleID == Bundle.main.bundleIdentifier { return true }
+            if bundleID.hasPrefix("com.apple.") {
+                let allowed = ["com.apple.Safari", "com.apple.dt.Xcode", "com.apple.Notes"]
+                if !allowed.contains(bundleID) { return true }
+            }
+        }
+
+        let lowered = name.lowercased()
+        let protectedNames = ["memorykill", "vorssaint", "kernel_task", "launchd",
+                              "windowserver", "loginwindow", "sysmond", "mds", "mds_stores"]
+        if protectedNames.contains(where: { lowered.contains($0) }) { return true }
+
+        return false
+    }
+
+    private static func triggerPressureRelief(passes: Int) {
+        for _ in 0..<max(1, passes) {
+            _ = malloc_zone_pressure_relief(nil, 0)
+            runMemoryPressureTool()
+        }
+    }
+
+    private static func runMemoryPressureTool() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/memory_pressure")
+        process.arguments = ["-l", "critical", "-Q", "-s", "1"]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            let deadline = Date().addingTimeInterval(5)
+            while process.isRunning, Date() < deadline {
+                Thread.sleep(forTimeInterval: 0.1)
+            }
+            if process.isRunning { process.terminate() }
+        } catch {
+            // memory_pressure unavailable; malloc relief still ran.
+        }
+    }
+
+    private static func modeLabel(_ mode: Mode) -> String {
+        switch mode {
+        case .standard: return "Purge"
+        case .deep: return "Deep purge"
+        case .max: return "MAX purge"
+        }
+    }
+
+    private static func pathSize(_ path: String) -> Int64 {
+        let manager = FileManager.default
+        var isDir: ObjCBool = false
+        guard manager.fileExists(atPath: path, isDirectory: &isDir) else { return 0 }
+        if !isDir.boolValue {
+            let attrs = try? manager.attributesOfItem(atPath: path)
+            return (attrs?[.size] as? NSNumber)?.int64Value ?? 0
+        }
+        guard let children = manager.enumerator(atPath: path) else { return 0 }
+        var total: Int64 = 0
+        for case let child as String in children {
+            let attrs = try? manager.attributesOfItem(atPath: "\(path)/\(child)")
+            total += (attrs?[.size] as? NSNumber)?.int64Value ?? 0
+        }
+        return total
+    }
+
+    private static func formatBytes(_ bytes: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: bytes, countStyle: .memory)
+    }
+}

--- a/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
@@ -134,6 +134,12 @@ final class SystemMonitor: ObservableObject {
         }
     }
 
+    /// Forces an immediate full refresh (e.g. after a memory purge).
+    func refreshNow() {
+        ensureTimer()
+        refresh(full: true)
+    }
+
     /// Changes the sampling cadence (seconds). Restarts a running timer.
     func setInterval(seconds: Int) {
         let clamped = max(1, seconds)

--- a/Sources/Vorssaint/UI/MenuPanel/MemoryPanelView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/MemoryPanelView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 struct MemoryPanelView: View {
     @ObservedObject private var monitor = SystemMonitor.shared
     @ObservedObject private var autoPurger = MemoryAutoPurger.shared
-    @AppStorage(DefaultsKey.autoPurgeEnabled) private var autoPurgeEnabled = true
+    @AppStorage(DefaultsKey.autoPurgeEnabled) private var autoPurgeEnabled = false
     @AppStorage(DefaultsKey.autoPurgeThreshold) private var autoPurgeThreshold = "warning"
     @AppStorage(DefaultsKey.autoPurgeNotify) private var autoPurgeNotify = true
     @AppStorage(DefaultsKey.purgeHotkeyEnabled) private var purgeHotkeyEnabled = true
@@ -15,6 +15,7 @@ struct MemoryPanelView: View {
     @State private var statusMessage: String?
     @State private var isPurging = false
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
+    @State private var purgeConfirmation = ""
 
     var body: some View {
         ScrollView {
@@ -76,8 +77,12 @@ struct MemoryPanelView: View {
                 .kerning(0.5)
                 .foregroundStyle(.secondary)
 
+            Text("Standard: memory pressure relief simulation only")
+                .font(.system(size: 10.5))
+                .foregroundStyle(.secondary)
+
             Button { runPurge(.standard) } label: {
-                Label(isPurging ? "Purging..." : "Purge Memory", systemImage: "bolt.fill")
+                Label(isPurging ? "Simulating..." : "Standard", systemImage: "wind")
                     .font(.system(size: 13, weight: .semibold))
                     .frame(maxWidth: .infinity)
             }
@@ -85,11 +90,28 @@ struct MemoryPanelView: View {
             .tint(monitor.snapshot.memoryPressure.color)
             .disabled(isPurging)
 
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Deep: may request administrator password and run /usr/bin/purge")
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(.secondary)
+                Text("Max: may request administrator password and run /usr/sbin/purge")
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(.secondary)
+                TextField(MemoryPurgeService.requiredDeepConfirmation, text: $purgeConfirmation)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 10.5))
+            }
+
             HStack(spacing: 8) {
-                Button("Deep Purge") { runPurge(.deep) }
+                Button("Deep") { runPurge(.deep, confirmationText: purgeConfirmation) }
                     .buttonStyle(.bordered)
                     .controlSize(.small)
-                    .disabled(isPurging)
+                    .disabled(isPurging || !confirmationMatches)
+
+                Button("Max") { runPurge(.max, confirmationText: purgeConfirmation) }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(isPurging || !confirmationMatches)
 
                 Button("Kill Top Hog") {
                     statusMessage = MemoryPurgeService.killTopMemoryHog()
@@ -117,15 +139,15 @@ struct MemoryPanelView: View {
                 .kerning(0.5)
                 .foregroundStyle(.secondary)
 
-            Button { runPurge(.max) } label: {
+            Button { runPurge(.max, confirmationText: purgeConfirmation) } label: {
                 Label("MAX Purge (everything)", systemImage: "flame.fill")
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent)
             .tint(.red)
-            .disabled(isPurging)
+            .disabled(isPurging || !confirmationMatches)
 
-            Text("Caches + DNS + 4× pressure passes + admin purge. Use when RAM is critically low.")
+            Text("Caches + DNS + 4× pressure passes + manual admin purge. Use when RAM is critically low.")
                 .font(.system(size: 10))
                 .foregroundStyle(.tertiary)
 
@@ -204,14 +226,29 @@ struct MemoryPanelView: View {
     }
 
     private func runPurge(_ mode: MemoryPurgeService.Mode) {
+        runPurge(mode, confirmationText: nil)
+    }
+
+    private func runPurge(_ mode: MemoryPurgeService.Mode, confirmationText: String?) {
         guard !isPurging else { return }
         isPurging = true
-        statusMessage = mode == .max ? "Running MAX purge..." : "Reclaiming memory..."
-        MemoryPurgeService.purge(mode: mode) { result in
+        switch mode {
+        case .standard:
+            statusMessage = "Simulating pressure relief..."
+        case .deep:
+            statusMessage = "Running deep purge..."
+        case .max:
+            statusMessage = "Running MAX purge..."
+        }
+        MemoryPurgeService.purge(mode: mode, trigger: .manual, confirmationText: confirmationText) { result in
             isPurging = false
             statusMessage = result.message
             SystemMonitor.shared.refreshNow()
         }
+    }
+
+    private var confirmationMatches: Bool {
+        purgeConfirmation == MemoryPurgeService.requiredDeepConfirmation
     }
 
     private func syncHotkey() {

--- a/Sources/Vorssaint/UI/MenuPanel/MemoryPanelView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/MemoryPanelView.swift
@@ -1,0 +1,235 @@
+// MemoryKill panel — vorssaint system monitor + real purge/kill actions.
+
+import ServiceManagement
+import SwiftUI
+
+struct MemoryPanelView: View {
+    @ObservedObject private var monitor = SystemMonitor.shared
+    @ObservedObject private var autoPurger = MemoryAutoPurger.shared
+    @AppStorage(DefaultsKey.autoPurgeEnabled) private var autoPurgeEnabled = true
+    @AppStorage(DefaultsKey.autoPurgeThreshold) private var autoPurgeThreshold = "warning"
+    @AppStorage(DefaultsKey.autoPurgeNotify) private var autoPurgeNotify = true
+    @AppStorage(DefaultsKey.purgeHotkeyEnabled) private var purgeHotkeyEnabled = true
+    @AppStorage(DefaultsKey.optionClickPurge) private var optionClickPurge = true
+    @AppStorage(DefaultsKey.monitorInterval) private var monitorInterval = 1
+    @State private var statusMessage: String?
+    @State private var isPurging = false
+    @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                header
+                purgeCard
+                maximizeCard
+                SystemSection()
+                quickActions
+                footer
+            }
+            .padding(12)
+            .frame(width: 332)
+        }
+        .frame(width: 332, height: 620)
+        .onAppear {
+            SystemMonitor.shared.setInterval(seconds: monitorInterval)
+            syncHotkey()
+        }
+        .onChange(of: purgeHotkeyEnabled) { _, _ in syncHotkey() }
+        .onChange(of: monitorInterval) { _, value in
+            SystemMonitor.shared.setInterval(seconds: max(1, value))
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "memorychip")
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(monitor.snapshot.memoryPressure.color)
+                .frame(width: 34, height: 34)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(monitor.snapshot.memoryPressure.color.opacity(0.15))
+                )
+            VStack(alignment: .leading, spacing: 2) {
+                Text(AppInfo.name)
+                    .font(.system(size: 15, weight: .bold))
+                if let used = monitor.snapshot.memoryUsed, monitor.snapshot.memoryTotal != nil {
+                    Text("\(formatMemory(used)) used · \(formatMemory(MemoryPurgeService.reclaimableBytes())) free")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            if let used = monitor.snapshot.memoryUsed, let total = monitor.snapshot.memoryTotal, total > 0 {
+                Text(String(format: "%.0f%%", Double(used) / Double(total) * 100))
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(monitor.snapshot.memoryPressure.color)
+            }
+        }
+    }
+
+    private var purgeCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("FREE MEMORY")
+                .font(.system(size: 10, weight: .semibold))
+                .kerning(0.5)
+                .foregroundStyle(.secondary)
+
+            Button { runPurge(.standard) } label: {
+                Label(isPurging ? "Purging..." : "Purge Memory", systemImage: "bolt.fill")
+                    .font(.system(size: 13, weight: .semibold))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(monitor.snapshot.memoryPressure.color)
+            .disabled(isPurging)
+
+            HStack(spacing: 8) {
+                Button("Deep Purge") { runPurge(.deep) }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(isPurging)
+
+                Button("Kill Top Hog") {
+                    statusMessage = MemoryPurgeService.killTopMemoryHog()
+                    SystemMonitor.shared.refreshNow()
+                }
+                .help("Skips MemoryKill and system processes")
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
+            if let statusMessage {
+                Text(statusMessage)
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(3)
+            }
+        }
+        .panelCard()
+    }
+
+    private var maximizeCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("MAXIMIZE")
+                .font(.system(size: 10, weight: .semibold))
+                .kerning(0.5)
+                .foregroundStyle(.secondary)
+
+            Button { runPurge(.max) } label: {
+                Label("MAX Purge (everything)", systemImage: "flame.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.red)
+            .disabled(isPurging)
+
+            Text("Caches + DNS + 4× pressure passes + admin purge. Use when RAM is critically low.")
+                .font(.system(size: 10))
+                .foregroundStyle(.tertiary)
+
+            Toggle("Auto-purge when pressure rises", isOn: $autoPurgeEnabled)
+                .font(.system(size: 11))
+
+            if autoPurgeEnabled {
+                Picker("Threshold", selection: $autoPurgeThreshold) {
+                    Text("Warning (75%+)").tag("warning")
+                    Text("Critical only").tag("critical")
+                }
+                .font(.system(size: 11))
+                if let last = autoPurger.lastAutoPurgeAt {
+                    Text("Last auto-purge: \(last, style: .relative) ago")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
+            Toggle("Notify after auto-purge", isOn: $autoPurgeNotify)
+                .font(.system(size: 11))
+
+            Toggle("⌃⌥⌘K instant purge", isOn: $purgeHotkeyEnabled)
+                .font(.system(size: 11))
+
+            Toggle("⌥-click icon = purge", isOn: $optionClickPurge)
+                .font(.system(size: 11))
+
+            Toggle("Launch at login", isOn: $launchAtLogin)
+                .font(.system(size: 11))
+                .onChange(of: launchAtLogin) { _, enabled in
+                    do {
+                        if enabled { try SMAppService.mainApp.register() }
+                        else { try SMAppService.mainApp.unregister() }
+                    } catch {
+                        launchAtLogin = SMAppService.mainApp.status == .enabled
+                    }
+                }
+
+            Picker("Refresh rate", selection: $monitorInterval) {
+                Text("1 second").tag(1)
+                Text("2 seconds").tag(2)
+                Text("5 seconds").tag(5)
+            }
+            .font(.system(size: 11))
+        }
+        .panelCard()
+    }
+
+    private var quickActions: some View {
+        HStack(spacing: 8) {
+            Button("Flush DNS") { statusMessage = MemoryPurgeService.flushDNS() }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+            Button("Clear Caches") {
+                statusMessage = MemoryPurgeService.clearUserCaches()
+                SystemMonitor.shared.refreshNow()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            Text("⌃⌥⌘K purge · ⌥-click purge")
+                .font(.system(size: 9.5))
+                .foregroundStyle(.tertiary)
+            Spacer()
+            Button("Quit") { NSApp.terminate(nil) }
+                .buttonStyle(.plain)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func runPurge(_ mode: MemoryPurgeService.Mode) {
+        guard !isPurging else { return }
+        isPurging = true
+        statusMessage = mode == .max ? "Running MAX purge..." : "Reclaiming memory..."
+        MemoryPurgeService.purge(mode: mode) { result in
+            isPurging = false
+            statusMessage = result.message
+            SystemMonitor.shared.refreshNow()
+        }
+    }
+
+    private func syncHotkey() {
+        HotkeyManager.shared.setEnabled(purgeHotkeyEnabled)
+    }
+
+    private func formatMemory(_ bytes: UInt64) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .memory)
+    }
+}
+
+private extension MemoryPressure {
+    var color: Color {
+        switch self {
+        case .normal: return .green
+        case .warning: return .yellow
+        case .critical: return .red
+        case .unknown: return .secondary
+        }
+    }
+}

--- a/Sources/Vorssaint/UI/MenuPanel/SystemSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/SystemSection.swift
@@ -139,6 +139,15 @@ struct SystemSection: View {
                                 .font(.system(size: 10.5, weight: .medium))
                                 .monospacedDigit()
                                 .foregroundStyle(.secondary)
+                            if kind == .memory, !MemoryPurgeService.isProtected(pid: row.pid, name: row.name) {
+                                Button("Kill") {
+                                    _ = MemoryPurgeService.killProcess(pid: row.pid, name: row.name)
+                                    refreshBreakdown()
+                                }
+                                .buttonStyle(.borderless)
+                                .font(.system(size: 10, weight: .semibold))
+                                .foregroundStyle(.red)
+                            }
                         }
                         .padding(.leading, 38)
                     }

--- a/Tests/VorssaintTests/MemoryPurgeSafetyTests.swift
+++ b/Tests/VorssaintTests/MemoryPurgeSafetyTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import XCTest
+@testable import Vorssaint
+
+final class MemoryPurgeSafetyTests: XCTestCase {
+    func testAutoPurgeDefaultsToDisabled() {
+        Defaults.register()
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: DefaultsKey.autoPurgeEnabled))
+    }
+
+    func testLaunchDoesNotInvokePurge() throws {
+        let source = try readSource("Sources/Vorssaint/App/AppDelegate.swift")
+        let launch = try functionBody(named: "func applicationDidFinishLaunching(_ notification: Notification)", in: source)
+        XCTAssertFalse(launch.contains("MemoryPurgeService.purge"), "Launch must not trigger any purge path.")
+    }
+
+    func testStandardAndAutoPathsNeverReferenceAdminShellOrPurgeBinaries() throws {
+        let source = try readSource("Sources/Vorssaint/Services/Memory/MemoryPurgeService.swift")
+        let purge = try functionBody(named: "static func purge(mode: Mode, trigger: Trigger = .manual, confirmationText: String? = nil, completion: @escaping (Result) -> Void)", in: source)
+        let standard = try snippet(from: purge, startingAt: "case .standard:", endingAt: "case .deep:")
+        let autoPurger = try readSource("Sources/Vorssaint/Services/Memory/MemoryAutoPurger.swift")
+
+        XCTAssertTrue(standard.contains("triggerPressureRelief"))
+        XCTAssertFalse(standard.contains("AdminShell"))
+        XCTAssertFalse(standard.contains("/usr/bin/purge"))
+        XCTAssertFalse(standard.contains("/usr/sbin/purge"))
+        XCTAssertFalse(autoPurger.contains("AdminShell.runSync"))
+        XCTAssertFalse(autoPurger.contains("/usr/bin/purge"))
+        XCTAssertFalse(autoPurger.contains("/usr/sbin/purge"))
+    }
+
+    func testDeepAndMaxPathsAreConfirmationGated() throws {
+        let source = try readSource("Sources/Vorssaint/Services/Memory/MemoryPurgeService.swift")
+        let deep = try snippet(from: source, startingAt: "case .deep:", endingAt: "case .max:")
+        let max = try snippet(from: source, startingAt: "case .max:", endingAt: "Thread.sleep(forTimeInterval: 1.0)")
+
+        XCTAssertTrue(deep.contains("confirmationText == requiredDeepConfirmation"))
+        XCTAssertTrue(deep.contains(#""/usr/bin/purge""#))
+        XCTAssertFalse(deep.contains("AdminShell"))
+
+        XCTAssertTrue(max.contains("confirmationText == requiredDeepConfirmation"))
+        XCTAssertTrue(max.contains(#"AdminShell.runSync("/usr/sbin/purge""#))
+    }
+
+    private func readSource(_ relativePath: String) throws -> String {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(contentsOf: root.appendingPathComponent(relativePath), encoding: .utf8)
+    }
+
+    private func functionBody(named signature: String, in source: String) throws -> String {
+        guard let signatureRange = source.range(of: signature) else {
+            throw NSError(domain: "MemoryPurgeSafetyTests", code: 1, userInfo: [NSLocalizedDescriptionKey: "Missing signature: \(signature)"])
+        }
+        guard let brace = source[signatureRange.upperBound...].firstIndex(of: "{") else {
+            throw NSError(domain: "MemoryPurgeSafetyTests", code: 2, userInfo: [NSLocalizedDescriptionKey: "Missing body start: \(signature)"])
+        }
+        return try extractBracedBody(from: source, openingBrace: brace)
+    }
+
+    private func snippet(from source: String, startingAt startNeedle: String, endingAt endNeedle: String) throws -> String {
+        guard let start = source.range(of: startNeedle) else {
+            throw NSError(domain: "MemoryPurgeSafetyTests", code: 3, userInfo: [NSLocalizedDescriptionKey: "Missing needle: \(startNeedle)"])
+        }
+        guard let end = source.range(of: endNeedle, range: start.upperBound..<source.endIndex) else {
+            throw NSError(domain: "MemoryPurgeSafetyTests", code: 4, userInfo: [NSLocalizedDescriptionKey: "Missing end needle: \(endNeedle)"])
+        }
+        return String(source[start.upperBound..<end.lowerBound])
+    }
+
+    private func extractBracedBody(from source: String, openingBrace: String.Index) throws -> String {
+        var depth = 0
+        var index = openingBrace
+        while index < source.endIndex {
+            let ch = source[index]
+            if ch == "{" {
+                depth += 1
+            } else if ch == "}" {
+                depth -= 1
+                if depth == 0 {
+                    let start = source.index(after: openingBrace)
+                    return String(source[start..<index])
+                }
+            }
+            index = source.index(after: index)
+        }
+        throw NSError(domain: "MemoryPurgeSafetyTests", code: 5, userInfo: [NSLocalizedDescriptionKey: "Unterminated body"])
+    }
+}

--- a/build-memorykill.sh
+++ b/build-memorykill.sh
@@ -1,0 +1,58 @@
+#!/bin/zsh
+# MemoryKill — fork of vorssaint-utils focused on RAM purge/monitor.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+APP_NAME="MemoryKill"
+EXECUTABLE="MemoryKill"
+TARGET="arm64-apple-macosx14.0"
+INSTALL=0
+for arg in "$@"; do
+    case "$arg" in
+        --install) INSTALL=1 ;;
+    esac
+done
+
+PINNED_SDK="/Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk"
+if [[ -d "$PINNED_SDK" ]]; then
+    SDK="$PINNED_SDK"
+else
+    SDK="$(xcrun --show-sdk-path)"
+fi
+
+echo "▸ Compiling MemoryKill against $(basename "$SDK")…"
+rm -rf build
+mkdir -p build
+swiftc -O -target "$TARGET" -sdk "$SDK" \
+    Sources/Vorssaint/**/*.swift \
+    -o "build/$EXECUTABLE"
+
+echo "▸ Assembling bundle…"
+STAGE="$(mktemp -d)/$APP_NAME.app"
+mkdir -p "$STAGE/Contents/MacOS" "$STAGE/Contents/Resources"
+cp "build/$EXECUTABLE" "$STAGE/Contents/MacOS/$EXECUTABLE"
+cp Resources/Info.plist "$STAGE/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier com.cashie.memorykill" "$STAGE/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleName MemoryKill" "$STAGE/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName MemoryKill" "$STAGE/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleExecutable $EXECUTABLE" "$STAGE/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString 1.0.0" "$STAGE/Contents/Info.plist"
+printf 'APPL????' > "$STAGE/Contents/PkgInfo"
+xattr -cr "$STAGE"
+codesign --force --sign - "$STAGE"
+
+mkdir -p "build/stage"
+BUILD_STAGE="build/stage/$APP_NAME.app"
+rm -rf "$BUILD_STAGE"
+ditto "$STAGE" "$BUILD_STAGE"
+echo "✓ Bundle ready: $BUILD_STAGE"
+
+if (( INSTALL )); then
+    DEST="/Applications/$APP_NAME.app"
+    pkill -x "$EXECUTABLE" 2>/dev/null || true
+    rm -rf "$DEST"
+    ditto "$STAGE" "$DEST"
+    codesign --force --sign - "$DEST"
+    open "$DEST"
+    echo "✓ Installed: $DEST"
+fi


### PR DESCRIPTION
Summary

* Makes standard and auto modes non-privileged simulation only.
* Keeps deep and max manual-only and confirmation-gated.
* Adds receipts for every purge attempt.
* Adds safety tests proving the auto and launch paths cannot reach the privileged purge flow.

Validation

* swift test passed (4 tests).

Safety

* Standard and auto modes never invoke a purge binary.
* Deep runs /usr/bin/purge only after explicit user confirmation.
* Max runs /usr/sbin/purge via AdminShell only after explicit user confirmation.
* Every purge attempt generates a receipt.
* No purge occurs on launch.
* Auto mode is disabled by default.
