### PR TITLE
feat(menu-bar): add option to hide app icon

### DIFF
--- a/Sources/Vorssaint/App/AppDelegate.swift
+++ b/Sources/Vorssaint/App/AppDelegate.swift
@@ -45,7 +45,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
 
         statusController = StatusItemController()
         statusController.onLeftClick = { [weak self] in self?.toggleMainPopover() }
-        statusController.onRightClick = { [weak self] in self?.showContextMenu() }
+        statusController.onRightClick = { [weak self] button in self?.showContextMenu(anchor: button) }
         statusController.onMetricClick = { [weak self] metric, button in
             self?.showMetricPanel(for: metric, anchoredTo: button)
         }
@@ -561,19 +561,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
 
     // MARK: - Context menu (right click)
 
-    private func showContextMenu() {
+    private func showContextMenu(anchor button: NSStatusBarButton) {
         // The panel uses applicationDefined dismissal, so a right-click while it's
         // open won't close it on its own — and the menu would try to open behind it.
         // Close it first so the context menu always appears.
         if popover.isShown {
-            closePopover { [weak self] in self?.presentContextMenu() }
+            closePopover { [weak self, button] in
+                self?.presentContextMenu(anchor: button)
+            }
             return
         }
 
-        presentContextMenu()
+        presentContextMenu(anchor: button)
     }
 
-    private func presentContextMenu() {
+    private func presentContextMenu(anchor button: NSStatusBarButton) {
         let manager = KeepAwakeManager.shared
         let strings = L10n.shared.s
         let menu = NSMenu()
@@ -638,10 +640,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         quitItem.target = self
         menu.addItem(quitItem)
 
-        statusController.statusItem.menu = menu
-        statusController.button?.performClick(nil)
-        DispatchQueue.main.async { [weak self] in
-            self?.statusController.statusItem.menu = nil
+        if button === statusController.button {
+            statusController.statusItem.menu = menu
+            button.performClick(nil)
+            DispatchQueue.main.async { [weak self] in
+                self?.statusController.statusItem.menu = nil
+            }
+        } else {
+            menu.popUp(positioning: nil, at: NSPoint(x: button.bounds.midX, y: button.bounds.minY), in: button)
         }
     }
 

--- a/Sources/Vorssaint/App/StatusItemController.swift
+++ b/Sources/Vorssaint/App/StatusItemController.swift
@@ -8,7 +8,7 @@ import Combine
 /// title and the tooltip. Click handling is delegated back to the AppDelegate.
 final class StatusItemController {
     var onLeftClick: (() -> Void)?
-    var onRightClick: (() -> Void)?
+    var onRightClick: ((NSStatusBarButton) -> Void)?
     var onMetricClick: ((MenuBarMetric, NSStatusBarButton) -> Void)?
 
     private(set) var statusItem: NSStatusItem!
@@ -103,7 +103,7 @@ final class StatusItemController {
 
         UpdateService.shared.$state
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in self?.updateIconAppearance() }
+            .sink { [weak self] _ in self?.refresh() }
             .store(in: &cancellables)
 
         KeepAwakeManager.shared.$endDate
@@ -157,16 +157,22 @@ final class StatusItemController {
     /// keep the blue attention color; an active keep-awake session turns amber.
     private func updateIconAppearance() {
         guard let button = statusItem?.button else { return }
+        guard button.image != nil else { return }
+        button.image = currentIconImage()
+    }
+
+    private func currentIconImage() -> NSImage? {
         if case .available = UpdateService.shared.state {
-            button.image = BlackHoleGlyph.attentionImage()
+            return BlackHoleGlyph.attentionImage()
         } else {
-            button.image = BlackHoleGlyph.image(active: KeepAwakeManager.shared.isActive)
+            return BlackHoleGlyph.image(active: KeepAwakeManager.shared.isActive)
         }
     }
 
     @objc private func clicked() {
         if NSApp.currentEvent?.type == .rightMouseUp {
-            onRightClick?()
+            guard let button else { return }
+            onRightClick?(button)
         } else {
             onLeftClick?()
         }
@@ -181,6 +187,7 @@ final class StatusItemController {
         let snapshot = SystemMonitor.shared.snapshot
         let metrics = MenuBarMetric.enabled(in: defaults)
         let separateMetrics = defaults.bool(forKey: DefaultsKey.menuBarSeparateMetrics)
+        let userWantsIcon = defaults.bool(forKey: DefaultsKey.showMenuBarIcon)
 
         // Compose the title from the keep-awake countdown (when shown) followed by
         // the pinned live metrics. Built attributed so the memory pressure dot can
@@ -200,9 +207,11 @@ final class StatusItemController {
             title.append(NSAttributedString(string: countdown))
             includesCountdown = true
         }
+        let renderedSeparateMetricCount: Int
         if separateMetrics {
-            refreshMetricStatusItems(metrics: metrics, snapshot: snapshot, strings: strings)
+            renderedSeparateMetricCount = refreshMetricStatusItems(metrics: metrics, snapshot: snapshot, strings: strings)
         } else {
+            renderedSeparateMetricCount = 0
             removeMetricStatusItems(except: Set<String>())
         }
         if !separateMetrics, !metrics.isEmpty {
@@ -216,11 +225,18 @@ final class StatusItemController {
             }
         }
 
+        let shouldShowIcon = MenuBarIconVisibility.shouldShowIcon(
+            userWantsIcon: userWantsIcon,
+            hasInlineContent: title.length > 0,
+            renderedSeparateMetricCount: renderedSeparateMetricCount
+        )
+        statusItem.isVisible = title.length > 0 || shouldShowIcon
         statusItem.length = NSStatusItem.variableLength
 
         if title.length == 0 {
             button.attributedTitle = NSAttributedString(string: "")
-            button.imagePosition = .imageOnly
+            button.image = shouldShowIcon ? currentIconImage() : nil
+            button.imagePosition = shouldShowIcon ? .imageOnly : .noImage
         } else {
             let full = NSMutableAttributedString(string: " ")
             full.append(title)
@@ -242,7 +258,8 @@ final class StatusItemController {
             }
             button.font = font
             button.attributedTitle = full
-            button.imagePosition = .imageLeading
+            button.image = shouldShowIcon ? currentIconImage() : nil
+            button.imagePosition = shouldShowIcon ? .imageLeading : .noImage
         }
 
         if manager.isActive {
@@ -258,10 +275,11 @@ final class StatusItemController {
 
     private func refreshMetricStatusItems(metrics: [MenuBarMetric],
                                           snapshot: SystemSnapshot,
-                                          strings: Strings) {
+                                          strings: Strings) -> Int {
         let groups = metricStatusGroups(for: metrics, strings: strings)
         let wanted = Set(groups.map(\.id))
         removeMetricStatusItems(except: wanted)
+        var renderedCount = 0
 
         for group in groups {
             let title = MenuBarRenderer.attributed(for: snapshot,
@@ -271,6 +289,7 @@ final class StatusItemController {
                 removeMetricStatusItem(for: group.id)
                 continue
             }
+            renderedCount += 1
 
             metricStatusItemFocus[group.id] = group.focusMetric
             let item = metricStatusItems[group.id] ?? installMetricStatusItem(for: group)
@@ -287,6 +306,7 @@ final class StatusItemController {
             button.imagePosition = .noImage
             button.toolTip = group.title
         }
+        return renderedCount
     }
 
     private func metricStatusGroups(for metrics: [MenuBarMetric], strings: Strings) -> [MetricStatusGroup] {
@@ -368,7 +388,7 @@ final class StatusItemController {
 
     @objc private func metricClicked(_ sender: NSStatusBarButton) {
         if NSApp.currentEvent?.type == .rightMouseUp {
-            onRightClick?()
+            onRightClick?(sender)
             return
         }
         guard let metric = focusMetric(from: sender) else {

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -24,6 +24,7 @@ enum DefaultsKey {
     static let keepAwakeShortcut = "keepAwakeShortcut"    // GlobalShortcut storage value
     static let keepAwakeIconTint = "keepAwakeIconTint"    // KeepAwakeIconTint.rawValue
     static let showCountdown = "showCountdownInMenuBar"
+    static let showMenuBarIcon = "showMenuBarIcon"
     static let hasOnboarded = "hasOnboarded"
     static let sleepDisabledFlag = "vorssDisabledSleep"   // internal guard for pmset disablesleep
     static let scrollInverterEnabled = "scrollInverterEnabled"
@@ -239,6 +240,14 @@ enum KeepAwakeIconTint: String, CaseIterable, Identifiable {
     }
 }
 
+enum MenuBarIconVisibility {
+    static func shouldShowIcon(userWantsIcon: Bool,
+                               hasInlineContent: Bool,
+                               renderedSeparateMetricCount: Int) -> Bool {
+        userWantsIcon || (!hasInlineContent && renderedSeparateMetricCount == 0)
+    }
+}
+
 /// Thumbnail size for the app switcher and Dock preview, scaled from one user
 /// preference so both grow together. Captures scale by the same factor, so
 /// larger previews stay sharp.
@@ -289,6 +298,7 @@ enum Defaults {
         DefaultsKey.keepAwakeShortcut: "control+option+command:40",
         DefaultsKey.keepAwakeIconTint: KeepAwakeIconTint.orange.rawValue,
         DefaultsKey.showCountdown: false,
+        DefaultsKey.showMenuBarIcon: true,
         DefaultsKey.scrollInverterEnabled: false,
         DefaultsKey.switcherEnabled: true,
         DefaultsKey.switcherShortcut: "command:48",

--- a/Sources/Vorssaint/Core/Localization.swift
+++ b/Sources/Vorssaint/Core/Localization.swift
@@ -210,6 +210,8 @@ struct Strings {
     let languageLabel: String
     let menuBarSection: String
     let showCountdown: String
+    let showMenuBarIconToggle: String
+    let showMenuBarIconToggleCaption: String
     let globalHotkeySection: String
     let hotkeyToggle: String
     let hotkeyCaption: String
@@ -914,6 +916,8 @@ extension Strings {
         languageLabel: "Idioma",
         menuBarSection: "Barra de menus",
         showCountdown: "Mostrar tempo restante ao lado do ícone",
+        showMenuBarIconToggle: "Mostrar ícone do Vorssaint",
+        showMenuBarIconToggleCaption: "Desative para mostrar só as métricas escolhidas na barra de menus. Se nenhuma métrica estiver ativa, o ícone continua aparecendo para manter o app acessível.",
         globalHotkeySection: "Atalho global",
         hotkeyToggle: "Ativar atalho para “Manter acordado”",
         hotkeyCaption: "Funciona em qualquer app, sem permissões extras.",
@@ -1592,6 +1596,8 @@ extension Strings {
         languageLabel: "Language",
         menuBarSection: "Menu bar",
         showCountdown: "Show remaining time next to the icon",
+        showMenuBarIconToggle: "Show Vorssaint icon",
+        showMenuBarIconToggleCaption: "Turn this off to show only your selected menu bar metrics. If no metrics are active, the icon stays visible so the app remains accessible.",
         globalHotkeySection: "Global shortcut",
         hotkeyToggle: "Enable shortcut for “Keep awake”",
         hotkeyCaption: "Works in any app, no extra permissions.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
@@ -123,6 +123,8 @@ extension Strings {
         languageLabel: "语言",
         menuBarSection: "菜单栏",
         showCountdown: "在图标旁显示剩余时间",
+        showMenuBarIconToggle: "显示 Vorssaint 图标",
+        showMenuBarIconToggleCaption: "关闭后，菜单栏只显示你选择的指标。如果没有启用任何指标，图标仍会保持可见，确保 App 仍可访问。",
         globalHotkeySection: "全局快捷键",
         hotkeyToggle: "启用“保持唤醒”快捷键",
         hotkeyCaption: "在任何 App 中都有效，无需额外权限。",

--- a/Sources/Vorssaint/Core/Localizations/Strings+French.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+French.swift
@@ -123,6 +123,8 @@ extension Strings {
         languageLabel: "Langue",
         menuBarSection: "Barre des menus",
         showCountdown: "Afficher le temps restant à côté de l’icône",
+        showMenuBarIconToggle: "Afficher l’icône Vorssaint",
+        showMenuBarIconToggleCaption: "Désactivez cette option pour n’afficher que les mesures choisies dans la barre des menus. Si aucune mesure n’est active, l’icône reste visible pour que l’app reste accessible.",
         globalHotkeySection: "Raccourci global",
         hotkeyToggle: "Activer le raccourci pour « Garder éveillé »",
         hotkeyCaption: "Fonctionne dans toutes les apps, sans autorisation supplémentaire.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+German.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+German.swift
@@ -123,6 +123,8 @@ extension Strings {
         languageLabel: "Sprache",
         menuBarSection: "Menüleiste",
         showCountdown: "Verbleibende Zeit neben dem Symbol anzeigen",
+        showMenuBarIconToggle: "Vorssaint-Symbol anzeigen",
+        showMenuBarIconToggleCaption: "Deaktiviere dies, um nur die ausgewählten Menüleistenwerte anzuzeigen. Wenn keine Werte aktiv sind, bleibt das Symbol sichtbar, damit die App erreichbar bleibt.",
         globalHotkeySection: "Globaler Kurzbefehl",
         hotkeyToggle: "Kurzbefehl für „Wachhalten“ aktivieren",
         hotkeyCaption: "Funktioniert in jeder App, ohne zusätzliche Berechtigungen.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
@@ -123,6 +123,8 @@ extension Strings {
         languageLabel: "Lingua",
         menuBarSection: "Barra dei menu",
         showCountdown: "Mostra il tempo rimanente accanto all'icona",
+        showMenuBarIconToggle: "Mostra l'icona di Vorssaint",
+        showMenuBarIconToggleCaption: "Disattivalo per mostrare solo le metriche scelte nella barra dei menu. Se non ci sono metriche attive, l'icona resta visibile così l'app rimane accessibile.",
         globalHotkeySection: "Scorciatoia globale",
         hotkeyToggle: "Abilita scorciatoia per «Mantieni attivo»",
         hotkeyCaption: "Funziona in qualsiasi app, senza autorizzazioni aggiuntive.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
@@ -123,6 +123,8 @@ extension Strings {
         languageLabel: "言語",
         menuBarSection: "メニューバー",
         showCountdown: "アイコンの横に残り時間を表示",
+        showMenuBarIconToggle: "Vorssaint アイコンを表示",
+        showMenuBarIconToggleCaption: "オフにすると、選択したメニューバーの計測値だけを表示します。計測値が有効でない場合は、アプリへアクセスできるようにアイコンを表示したままにします。",
         globalHotkeySection: "グローバルショートカット",
         hotkeyToggle: "「スリープ防止」のショートカットを有効にする",
         hotkeyCaption: "追加のアクセス権なしで、どのアプリでも使えます。",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
@@ -123,6 +123,8 @@ extension Strings {
         languageLabel: "Idioma",
         menuBarSection: "Barra de menús",
         showCountdown: "Mostrar el tiempo restante junto al icono",
+        showMenuBarIconToggle: "Mostrar el icono de Vorssaint",
+        showMenuBarIconToggleCaption: "Desactívalo para mostrar solo las métricas elegidas en la barra de menús. Si no hay métricas activas, el icono seguirá visible para que la app siga siendo accesible.",
         globalHotkeySection: "Atajo global",
         hotkeyToggle: "Activar atajo para «Mantener activo»",
         hotkeyCaption: "Funciona en cualquier app, sin permisos adicionales.",

--- a/Sources/Vorssaint/UI/MenuBarMetricsPreview.swift
+++ b/Sources/Vorssaint/UI/MenuBarMetricsPreview.swift
@@ -23,6 +23,7 @@ struct MenuBarMetricsPreview: View {
     @AppStorage(DefaultsKey.menuBarCombineTemperatures) private var combineTemperatures = true
     @AppStorage(DefaultsKey.menuBarLabelStyle) private var labelStyle = "compact"
     @AppStorage(DefaultsKey.menuBarMemoryStyle) private var memoryStyle = "percent"
+    @AppStorage(DefaultsKey.showMenuBarIcon) private var showMenuBarIcon = true
     @AppStorage(DefaultsKey.temperatureUnit) private var temperatureUnit = TemperatureUnit.celsius.rawValue
 
     var body: some View {
@@ -41,8 +42,10 @@ struct MenuBarMetricsPreview: View {
             Image(systemName: "battery.75")
                 .foregroundStyle(.white.opacity(0.5))
             HStack(spacing: 5) {
-                glyph
-                    .frame(width: 20, height: 14)
+                if shouldShowGlyph(lines: lines) {
+                    glyph
+                        .frame(width: 20, height: 14)
+                }
                 if !lines.isEmpty {
                     VStack(alignment: .leading, spacing: 0) {
                         ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
@@ -80,6 +83,10 @@ struct MenuBarMetricsPreview: View {
         let _ = battery
         let _ = power
         return MenuBarMetric.enabled(in: .standard)
+    }
+
+    private func shouldShowGlyph(lines: [[MenuBarSegment]]) -> Bool {
+        showMenuBarIcon || activeMetrics.isEmpty || lines.isEmpty
     }
 
     @ViewBuilder

--- a/Sources/Vorssaint/UI/Settings/SettingsView.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsView.swift
@@ -109,6 +109,7 @@ struct GeneralSettings: View {
     @State private var loginError: String?
     @AppStorage(DefaultsKey.hotkeyEnabled) private var hotkeyEnabled = true
     @AppStorage(DefaultsKey.showCountdown) private var showCountdown = false
+    @AppStorage(DefaultsKey.showMenuBarIcon) private var showMenuBarIcon = true
 
     var body: some View {
         Form {
@@ -140,6 +141,10 @@ struct GeneralSettings: View {
             }
             Section(l10n.s.menuBarSection) {
                 Toggle(l10n.s.showCountdown, isOn: $showCountdown)
+                Toggle(l10n.s.showMenuBarIconToggle, isOn: $showMenuBarIcon)
+                Text(l10n.s.showMenuBarIconToggleCaption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                 Button(l10n.s.showMenuBarIcon) {
                     appDelegate()?.reshowStatusItem()
                 }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -37,6 +37,23 @@ struct MetricsTests {
 
         // MARK: Byte / rate formatting
 
+        expect(MenuBarIconVisibility.shouldShowIcon(userWantsIcon: true,
+                                                    hasInlineContent: false,
+                                                    renderedSeparateMetricCount: 0),
+               "menu bar icon shows when user preference is enabled")
+        expect(MenuBarIconVisibility.shouldShowIcon(userWantsIcon: false,
+                                                    hasInlineContent: false,
+                                                    renderedSeparateMetricCount: 0),
+               "menu bar icon stays visible when no metrics or text preserve app access")
+        expect(!MenuBarIconVisibility.shouldShowIcon(userWantsIcon: false,
+                                                     hasInlineContent: true,
+                                                     renderedSeparateMetricCount: 0),
+               "menu bar icon hides when inline menu bar text remains clickable")
+        expect(!MenuBarIconVisibility.shouldShowIcon(userWantsIcon: false,
+                                                     hasInlineContent: false,
+                                                     renderedSeparateMetricCount: 1),
+               "menu bar icon hides when separate metric items remain clickable")
+
         expectEqual(MetricFormat.bytes(0), "0 B", "bytes zero")
         expectEqual(MetricFormat.bytes(512), "512 B", "bytes < 1K")
         expectEqual(MetricFormat.bytes(1024), "1.0 KB", "bytes 1K")


### PR DESCRIPTION
## Summary
- Adds a General settings toggle to show or hide the Vorssaint menu bar planet icon.
- Keeps selected menu bar metrics visible when the icon is hidden, including CPU/RAM-only setups.
- Preserves app access with an icon fallback when no metrics/text are visible and anchors right-click menus to the clicked metric item.

## Changes
| File | Change |
|------|--------|
| `Sources/Vorssaint/UI/Settings/SettingsView.swift` | Adds the General settings toggle and explanatory caption. |
| `Sources/Vorssaint/App/StatusItemController.swift` | Applies the icon visibility preference and preserves metric/status item click behavior. |
| `Sources/Vorssaint/App/AppDelegate.swift` | Anchors right-click context menus to the clicked status bar button. |
| `Sources/Vorssaint/Core/Defaults.swift` | Adds the persisted default and pure visibility helper. |
| `Sources/Vorssaint/UI/MenuBarMetricsPreview.swift` | Updates the live preview to reflect hidden-icon mode. |
| `Sources/Vorssaint/Core/Localization.swift`, `Sources/Vorssaint/Core/Localizations/Strings+*.swift` | Adds localized strings for the new setting. |
| `Tests/MetricsTests.swift` | Covers the icon visibility/access fallback matrix. |

## Test Plan
- [x] `./build.sh --test`
- [x] `swift build`
- [x] Installed locally with `./build.sh --install` and verified `/Applications/Vorssaint.app` codesign.
- [x] Fresh review confirmed no blocking findings.

## Notes
No linked issue was found for this direct UX improvement. Manual macOS menu bar QA is still recommended for final visual spacing checks.