### PR TITLE
add x86_64 CPU support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: ./Tools/ci-setup-signing.sh
 
       - name: Build
-        run: ./build.sh
+        run: ./build.sh --universal
 
       - name: Selftest
         run: ./build/Vorssaint --selftest

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ E2E/
 *.xcodeproj
 xcuserdata/
 .swiftpm/
+
+# AI Agent
+.harness/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ cd vorssaint-utils
 ./build.sh --install               # install into /Applications and launch
 ```
 
-You need macOS 14 or newer, Apple Silicon and the Xcode Command Line Tools. The
+You need macOS 14 or newer on Apple Silicon or Intel, and the Xcode Command Line Tools. The
 build is a plain `swiftc` invocation, see `build.sh`, with no Xcode project and
 no external dependencies, reproducible by design. `Package.swift` is there so
 SwiftPM aware editors can index the code.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
   <a href="https://github.com/vorssaint/vorssaint-utils/releases"><img src="https://img.shields.io/github/v/release/vorssaint/vorssaint-utils?label=release" alt="Latest release"></a>
   <a href="https://github.com/vorssaint/vorssaint-utils/actions/workflows/ci.yml"><img src="https://github.com/vorssaint/vorssaint-utils/actions/workflows/ci.yml/badge.svg?branch=main&event=push" alt="CI status"></a>
-  <a href="#what-you-need"><img src="https://img.shields.io/badge/macOS-14%2B%20(Apple%20Silicon)-black" alt="macOS 14 and newer, Apple Silicon"></a>
+  <a href="#what-you-need"><img src="https://img.shields.io/badge/macOS-14%2B%20(Apple%20Silicon%20%26%20Intel)-black" alt="macOS 14 and newer, Apple Silicon and Intel"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPL%203.0%20or%20later-blue" alt="License GPL 3.0 or later"></a>
 </p>
 
@@ -105,7 +105,7 @@ Finder cut and paste, the uninstaller and Homebrew's Terminal handoff can also a
 
 ## What you need
 
-- A Mac with Apple Silicon
+- A Mac with Apple Silicon or Intel
 - macOS 14 Sonoma or newer
 - Xcode Command Line Tools, only if you build it yourself
 

--- a/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
+++ b/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
@@ -10,6 +10,14 @@ enum CPUTemperaturePlatform: Equatable {
     case appleM3Family
     case appleM4Family
     case appleM5Family
+    /// Last-generation Intel Mac (Skylake / Coffee Lake / Comet Lake / Ice Lake and
+    /// Xeon W). Die temperatures are exposed through SMC keys with a `TC` prefix,
+    /// unlike Apple Silicon's `Tp` / `Te` / `Tf` family. Selection is coarser than
+    /// the per-generation Apple Silicon tables because Intel Macs span many models.
+    case intelMac
+    /// Anything we cannot classify: VMs, emulators, future unmapped hardware.
+    /// Falls back to "hottest plausible reading" — same behavior the project has
+    /// always used for unmapped Apple Silicon generations.
     case generic
 }
 
@@ -47,16 +55,35 @@ enum TemperatureSensorSelector {
         "Tp0m", "Tp0p", "Tp0u", "Tp0y",
     ]
 
+    /// Intel CPU die-temperature keys. The first two (TC0P / TC0E) are the package
+    /// proximity and hottest-core sensors on virtually every Intel Mac that runs
+    /// macOS 14 (Mac Pro 2019, iMac Pro, iMac 2020, MacBook Pro 2019-2020,
+    /// MacBook Air 2018-2020). Per-core TCnC / TCnP keys vary across generations;
+    /// we accept a broad range and let `displayedCPUTemperature` take the max of
+    /// the mapped ones, which matches what Activity Monitor shows.
+    private static let intelCPUCoreKeys: Set<String> = [
+        "TC0P", "TC0E", "TC0D",
+        "TC1C", "TC2C", "TC3C", "TC4C",
+        "TC5C", "TC6C", "TC7C", "TC8C",
+        "TC9C", "TCAC", "TCBC",
+    ]
+
     static func platform(brandString: String?) -> CPUTemperaturePlatform {
         let brand = brandString?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        switch appleSiliconGeneration(in: brand) {
-        case 1: return .appleM1Family
-        case 2: return .appleM2Family
-        case 3: return .appleM3Family
-        case 4: return .appleM4Family
-        case 5: return .appleM5Family
-        default: return .generic
+        if let generation = appleSiliconGeneration(in: brand) {
+            switch generation {
+            case 1: return .appleM1Family
+            case 2: return .appleM2Family
+            case 3: return .appleM3Family
+            case 4: return .appleM4Family
+            case 5: return .appleM5Family
+            default: return .generic
+            }
         }
+        if isIntelMac(brand: brand) {
+            return .intelMac
+        }
+        return .generic
     }
 
     static func currentPlatform() -> CPUTemperaturePlatform {
@@ -85,7 +112,7 @@ enum TemperatureSensorSelector {
 
     static func hasCPUCoreSet(platform: CPUTemperaturePlatform) -> Bool {
         switch platform {
-        case .appleM1Family, .appleM2Family, .appleM3Family, .appleM4Family, .appleM5Family:
+        case .appleM1Family, .appleM2Family, .appleM3Family, .appleM4Family, .appleM5Family, .intelMac:
             return true
         case .generic: return false
         }
@@ -103,8 +130,35 @@ enum TemperatureSensorSelector {
             return appleM4CPUCoreKeys.contains(key)
         case .appleM5Family:
             return appleM5CPUCoreKeys.contains(key)
+        case .intelMac:
+            return intelCPUCoreKeys.contains(key)
         case .generic:
             return false
+        }
+    }
+
+    /// SMC key prefix used to collect CPU die-temperature sensors. Apple Silicon
+    /// spreads them across `Tp` (performance), `Te` (efficiency) and `Tf` (M3+).
+    /// Intel Macs use a single `TC` family (TC0P / TC0E / TCnC / …).
+    static func cpuKeyPrefixes(for platform: CPUTemperaturePlatform) -> [String] {
+        switch platform {
+        case .intelMac:
+            return ["TC"]
+        case .appleM1Family, .appleM2Family, .appleM3Family, .appleM4Family, .appleM5Family, .generic:
+            return ["Tp", "Te", "Tf"]
+        }
+    }
+
+    /// SMC key prefix used to collect GPU temperature sensors. Apple Silicon's
+    /// AGXAccelerator exposes `Tg…` (lowercase g); Intel integrated graphics and
+    /// AMD Radeon Pro on Intel Macs use `TG…` (uppercase G). SMC keys are case
+    /// sensitive, so both prefixes must be tried when the platform is unknown.
+    static func gpuKeyPrefix(for platform: CPUTemperaturePlatform) -> String {
+        switch platform {
+        case .intelMac:
+            return "TG"
+        case .appleM1Family, .appleM2Family, .appleM3Family, .appleM4Family, .appleM5Family, .generic:
+            return "Tg"
         }
     }
 
@@ -116,6 +170,13 @@ enum TemperatureSensorSelector {
         let afterGeneration = remainder.dropFirst()
         guard afterGeneration.isEmpty || afterGeneration.first == " " else { return nil }
         return generation
+    }
+
+    /// Intel Mac `machdep.cpu.brand_string` always starts with `Intel(R) Core(TM)`
+    /// or `Intel(R) Xeon(R)` and never with `Apple`. We accept a loose match so the
+    /// detector is robust against minor formatting changes across macOS versions.
+    private static func isIntelMac(brand: String) -> Bool {
+        brand.localizedCaseInsensitiveContains("intel")
     }
 
     private static func isPlausibleTemperature(_ value: Double) -> Bool {

--- a/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
@@ -623,12 +623,15 @@ final class SystemMonitor: ObservableObject {
         tempKeysPrepared = true
         guard let client = smc else { return }
 
+        let cpuPrefixes = TemperatureSensorSelector.cpuKeyPrefixes(for: cpuTemperaturePlatform)
+        let gpuPrefix = TemperatureSensorSelector.gpuKeyPrefix(for: cpuTemperaturePlatform)
         let all = client.keys { name in
-            name.hasPrefix("Tp") || name.hasPrefix("Te") || name.hasPrefix("Tg")
+            cpuPrefixes.contains(where: name.hasPrefix)
+                || name.hasPrefix(gpuPrefix)
                 || name.range(of: "^TB[0-9]T$", options: .regularExpression) != nil
         }
-        cpuKeys = all.filter { $0.name.hasPrefix("Tp") || $0.name.hasPrefix("Te") }
-        gpuKeys = all.filter { $0.name.hasPrefix("Tg") }
+        cpuKeys = all.filter { cpuPrefixes.contains(where: $0.name.hasPrefix) }
+        gpuKeys = all.filter { $0.name.hasPrefix(gpuPrefix) }
         batteryKeys = all.filter { $0.name.hasPrefix("TB") }
     }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -345,6 +345,34 @@ struct MetricsTests {
                "Apple M5 uses the mapped CPU core sensor set")
         expect(TemperatureSensorSelector.platform(brandString: "Apple M10") == .generic,
                "future unmapped Apple Silicon generations keep the generic CPU sensor path")
+        expect(TemperatureSensorSelector.platform(brandString: "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz") == .intelMac,
+               "Intel Core brand maps to intelMac platform")
+        expect(TemperatureSensorSelector.platform(brandString: "Intel(R) Xeon(R) W-2140B CPU @ 3.20GHz") == .intelMac,
+               "Intel Xeon brand maps to intelMac platform")
+        expect(TemperatureSensorSelector.platform(brandString: "Apple M1") != .intelMac,
+               "Apple Silicon brands never resolve to intelMac")
+        let intelCPU = TemperatureSensorSelector.displayedCPUTemperature(
+            readings: [("TC0P", 52.0), ("TC0E", 49.0), ("TW0P", 75.0)],
+            platform: .intelMac
+        )
+        expectClose(intelCPU ?? -1, 52.0, "Intel CPU uses hottest mapped TC core (TC0P/TC0E)")
+        let intelMultiCPU = TemperatureSensorSelector.displayedCPUTemperature(
+            readings: [("TC1C", 60.0), ("TC2C", 70.0), ("TC0P", 55.0), ("TCSA", 80.0)],
+            platform: .intelMac
+        )
+        expectClose(intelMultiCPU ?? -1, 70.0, "Intel CPU picks the hottest of any mapped TC core across generations")
+        expect(TemperatureSensorSelector.isCPUCoreKey("TC0P", platform: .intelMac),
+               "Intel TC keys are recognized as CPU cores on intelMac platform")
+        expect(!TemperatureSensorSelector.isCPUCoreKey("TC0P", platform: .appleM1Family),
+               "Intel TC keys are NOT recognized as CPU cores on Apple Silicon platforms")
+        expect(TemperatureSensorSelector.cpuKeyPrefixes(for: .intelMac) == ["TC"],
+               "Intel platform uses the TC prefix family for SMC key collection")
+        expect(TemperatureSensorSelector.cpuKeyPrefixes(for: .appleM3Family).contains("Tf"),
+               "Apple Silicon platforms also discover the Tf family introduced on M3")
+        expect(TemperatureSensorSelector.gpuKeyPrefix(for: .intelMac) == "TG",
+               "Intel platform uses uppercase TG for GPU keys (case sensitive)")
+        expect(TemperatureSensorSelector.gpuKeyPrefix(for: .appleM3Family) == "Tg",
+               "Apple Silicon uses lowercase Tg for GPU keys (case sensitive)")
         let m1CPU = TemperatureSensorSelector.displayedCPUTemperature(
             readings: [("Tp09", 43.0), ("Tp01", 49.0), ("Tp02", 70.0)],
             platform: .appleM1Family

--- a/build.sh
+++ b/build.sh
@@ -12,16 +12,31 @@ cd "$(dirname "$0")"
 
 # Flags: --dev builds the local-only "Vorssaint (Developer)" variant (its own
 # bundle id, so it coexists with the official app); --install puts it in /Applications.
+# --universal compiles both arm64 and x86_64 and lipos them together; --arm64 and
+# --x86_64 force a single architecture, otherwise the host arch is picked.
 DEV=0
 INSTALL=0
 TEST=0
+UNIVERSAL=0
+ARCH=""
 for arg in "$@"; do
     case "$arg" in
-        --dev)     DEV=1 ;;
-        --install) INSTALL=1 ;;
-        --test)    TEST=1 ;;
+        --dev)       DEV=1 ;;
+        --install)   INSTALL=1 ;;
+        --test)      TEST=1 ;;
+        --universal) UNIVERSAL=1 ;;
+        --arm64)     ARCH="arm64" ;;
+        --x86_64)    ARCH="x86_64" ;;
     esac
 done
+
+if (( UNIVERSAL )) && [[ -n "$ARCH" ]]; then
+    echo "▸ --universal cannot be combined with --arm64 or --x86_64" >&2
+    exit 2
+fi
+if [[ -z "$ARCH" ]]; then
+    ARCH="$(uname -m)"
+fi
 
 if (( DEV )); then
     APP_NAME="Vorssaint (Developer)"
@@ -30,7 +45,11 @@ else
     APP_NAME="Vorssaint"
     EXECUTABLE="Vorssaint"
 fi
-TARGET="arm64-apple-macosx14.0"
+case "$ARCH" in
+    arm64)   TARGET="arm64-apple-macosx14.0" ;;
+    x86_64)  TARGET="x86_64-apple-macosx14.0" ;;
+    *)       echo "▸ Unsupported architecture: $ARCH (use --arm64 or --x86_64)" >&2; exit 2 ;;
+esac
 ENTITLEMENTS="Resources/Vorssaint.entitlements"
 LEGACY_IDENTITY="Vorssaint Utils Signing"
 
@@ -120,9 +139,22 @@ fi
 echo "▸ Compiling (release) against $(basename "$SDK")…"
 rm -rf build
 mkdir -p build
-swiftc -O -target "$TARGET" -sdk "$SDK" \
-    Sources/Vorssaint/**/*.swift \
-    -o "build/$EXECUTABLE"
+if (( UNIVERSAL )); then
+    swiftc -O -target arm64-apple-macosx14.0 -sdk "$SDK" \
+        Sources/Vorssaint/**/*.swift \
+        -o "build/$EXECUTABLE.arm64"
+    swiftc -O -target x86_64-apple-macosx14.0 -sdk "$SDK" \
+        Sources/Vorssaint/**/*.swift \
+        -o "build/$EXECUTABLE.x86_64"
+    lipo -create \
+        "build/$EXECUTABLE.arm64" "build/$EXECUTABLE.x86_64" \
+        -output "build/$EXECUTABLE"
+    rm "build/$EXECUTABLE.arm64" "build/$EXECUTABLE.x86_64"
+else
+    swiftc -O -target "$TARGET" -sdk "$SDK" \
+        Sources/Vorssaint/**/*.swift \
+        -o "build/$EXECUTABLE"
+fi
 
 echo "▸ Generating app icon…"
 swift Tools/MakeIcon.swift build/AppIcon.iconset

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -169,7 +169,7 @@ cd vorssaint-utils
 
 ### Requisitos
 - macOS 14 (Sonoma) ou mais recente
-- Apple Silicon
+- Apple Silicon or Intel
 - Xcode Command Line Tools (para compilar)
 
 ## Permissões


### PR DESCRIPTION
At present, only 19 MacBook Pro Intel Core i7 9750H CPUs have been tested. I don't have an additional MacBook for testing, which is theoretically feasible on other versions of CPUs.
And I don't have a MacBook with Apple chips for testing, so I can't verify the current availability.