### PR TITLE
Fix repeated Shift+Tab back navigation in the switcher

### DIFF
--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -5,6 +5,7 @@ import AppKit
 import ApplicationServices
 import Combine
 import CoreGraphics
+import QuartzCore
 import SwiftUI
 
 private struct SwitcherSourceContext {
@@ -64,6 +65,11 @@ final class AppSwitcher: ObservableObject {
     private var sessionSourceContext: SwitcherSourceContext?
     private var sessionShortcut: GlobalShortcut?
     private var shiftBackNavigationHeld = false
+    /// A Shift press already navigated backward via flagsChanged; the Tab of
+    /// that same shift+tab gesture is swallowed once so the gesture moves one
+    /// step, not two. A deadline, not a flag, so later Tabs keep navigating.
+    private var shiftNavigationTabSwallowDeadline: TimeInterval = 0
+    private static let shiftNavigationTabSwallowWindow: TimeInterval = 0.3
 
     // Virtual key codes handled during a session.
     private enum KeyCode {
@@ -196,7 +202,9 @@ final class AppSwitcher: ObservableObject {
                                                   fallback: .switcherWindowDefault)
         switch keyCode {
         case _ where keyCode == shortcut.keyCode && shortcut.matches(event: event, allowingExtraShift: true):
-            if shortcut.shiftIsNavigationModifier, flags.contains(.maskShift), shiftBackNavigationHeld {
+            if shortcut.shiftIsNavigationModifier, flags.contains(.maskShift),
+               CACurrentMediaTime() < shiftNavigationTabSwallowDeadline {
+                shiftNavigationTabSwallowDeadline = 0
                 break
             }
             let delta = shortcut.shiftIsNavigationModifier && flags.contains(.maskShift) ? -1 : 1
@@ -277,6 +285,7 @@ final class AppSwitcher: ObservableObject {
                                                                   isShiftHeld: shiftHeld)
         else { return false }
         advanceSelection(by: -1)
+        shiftNavigationTabSwallowDeadline = CACurrentMediaTime() + Self.shiftNavigationTabSwallowWindow
         return true
     }
 
@@ -618,6 +627,7 @@ final class AppSwitcher: ObservableObject {
         sessionSourceContext = nil
         sessionShortcut = nil
         shiftBackNavigationHeld = false
+        shiftNavigationTabSwallowDeadline = 0
     }
 
     // MARK: - Panel


### PR DESCRIPTION
## Behavior before

With the switcher open, holding the shortcut modifier plus Shift and pressing Tab repeatedly only moved the selection backward once. Every Tab after the first was ignored until Shift was released and pressed again, so walking backward through several windows required re-pressing Shift for each step. Starting a session directly with e.g. ⌘⇧Tab had the same problem.

## Behavior after

Holding the modifiers and pressing Tab repeatedly moves the selection backward one step per press, matching the system switcher. Pressing Shift alone still navigates backward immediately, and a combined shift+tab gesture still moves a single step.

## Cause and fix

`handleKeyDown` swallowed Tab whenever `shiftBackNavigationHeld` was set, i.e. for as long as Shift stayed down. That guard exists so the Tab belonging to the same shift+tab gesture does not double-step after the Shift press already navigated via `flagsChanged`, but it also discarded every subsequent Tab.

The permanent flag is replaced with a short one-shot window (`shiftNavigationTabSwallowDeadline`, 300 ms) armed when a Shift press navigates backward: only the Tab of that gesture is swallowed, and later Tabs with Shift held navigate normally.

## Checks

- `./build.sh` finishes without warnings
- `./build/Vorssaint --selftest` passes (SELFTEST OK)
- Verified manually: forward cycling, repeated backward cycling with Shift held, shift-only back navigation, and sessions started reversed

Made with [Cursor](https://cursor.com)