### PR TITLE
Add native screenshot utility, snapping, and floating thumbnail

### DIFF
--- a/Sources/Vorssaint/App/FeatureRuntime.swift
+++ b/Sources/Vorssaint/App/FeatureRuntime.swift
@@ -156,6 +156,7 @@ final class FeatureRuntime: ObservableObject {
         .colorPicker: { ColorSamplerService.shared.syncWithPreferences() },
         .screenOCR: { ScreenTextService.shared.syncWithPreferences() },
         .cleaner: { CleanerScheduler.shared.syncWithPreferences() },
+        .screenshot: { ScreenshotService.shared.syncWithPreferences() },
         .monitorCPU: { FeatureRuntime.syncMonitor() },
         .monitorGPU: { FeatureRuntime.syncMonitor() },
         .monitorMemory: { FeatureRuntime.syncMonitor() },

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -25,6 +25,13 @@ enum DefaultsKey {
     static let keepAwakeMouseJiggleInterval = "keepAwakeMouseJiggleIntervalMinutes"
     static let hotkeyEnabled = "hotkeyEnabled"
     static let keepAwakeShortcut = "keepAwakeShortcut"    // GlobalShortcut storage value
+    static let screenshotEnabled = "screenshotEnabled"
+    static let screenshotShortcut = "screenshotShortcut"
+    static let screenshotShowThumbnail = "screenshotShowThumbnail"
+    static let screenshotQuickCaptureMode = "screenshotQuickCaptureMode"
+    static let screenshotHideInstructions = "screenshotHideInstructions"
+    static let screenshotSaveAction = "screenshotSaveAction"
+    static let screenshotSaveDirectory = "screenshotSaveDirectory"
     static let keepAwakeIconTint = "keepAwakeIconTint"    // KeepAwakeIconTint.rawValue
     static let keepAwakeActiveIcon = "keepAwakeActiveIcon" // KeepAwakeActiveIcon.rawValue
     static let showCountdown = "showCountdownInMenuBar"
@@ -513,6 +520,13 @@ enum Defaults {
         DefaultsKey.cleanerLastAutoRun: 0.0,
         DefaultsKey.cleanerLastAutoFreed: 0,
         DefaultsKey.cleanerBadgeSeen: false,
+        DefaultsKey.screenshotEnabled: true,
+        DefaultsKey.screenshotShortcut: "command+shift:23",
+        DefaultsKey.screenshotShowThumbnail: true,
+        DefaultsKey.screenshotQuickCaptureMode: 2,
+        DefaultsKey.screenshotHideInstructions: false,
+        DefaultsKey.screenshotSaveAction: 0,
+        DefaultsKey.screenshotSaveDirectory: defaultScreenshotDirectoryPath,
         DefaultsKey.urlCleanerEnabled: false,
         DefaultsKey.textSnippetsEnabled: false,
         DefaultsKey.windowMaximizeEnabled: false,
@@ -914,5 +928,10 @@ enum Defaults {
 
     static func sanitizedPreferredInputDeviceUID(_ value: Any?) -> String? {
         MixerRoutingSupport.sanitizedDeviceUID(value)
+    }
+
+    static var defaultScreenshotDirectoryPath: String {
+        let picturesURL = FileManager.default.urls(for: .picturesDirectory, in: .userDomainMask)[0]
+        return picturesURL.appendingPathComponent("Vorssaint Screenshots").path
     }
 }

--- a/Sources/Vorssaint/Core/FeatureCatalog.swift
+++ b/Sources/Vorssaint/Core/FeatureCatalog.swift
@@ -25,7 +25,7 @@ enum AppFeature: String, CaseIterable {
     case keepAwake, brightness, extraBrightness
     // Tools
     case quickLauncher, quickToggles, colorPicker, screenOCR, cleaningMode, mediaTools,
-         cleaner, uninstaller, homebrew
+         cleaner, uninstaller, homebrew, screenshot
     // System monitor, one entry per metric family (temperatures live with
     // their parent metric: CPU temp with CPU, battery temp with power).
     case monitorCPU, monitorGPU, monitorMemory, monitorNetwork, monitorDisk, monitorPower
@@ -57,7 +57,7 @@ extension AppFeature {
         case .keepAwake, .brightness, .extraBrightness:
             return .energyDisplay
         case .quickLauncher, .quickToggles, .colorPicker, .screenOCR, .cleaningMode, .mediaTools,
-             .cleaner, .uninstaller, .homebrew:
+             .cleaner, .uninstaller, .homebrew, .screenshot:
             return .tools
         case .monitorCPU, .monitorGPU, .monitorMemory, .monitorNetwork, .monitorDisk, .monitorPower:
             return .monitor
@@ -105,6 +105,7 @@ extension AppFeature {
         case .monitorNetwork: return "network"
         case .monitorDisk: return "internaldrive"
         case .monitorPower: return "bolt.fill"
+        case .screenshot: return "crop"
         }
     }
 
@@ -144,7 +145,7 @@ extension AppFeature {
         case .extraBrightness: return [DefaultsKey.extraBrightnessEnabled]
         case .windowLayout, .mixer, .micMute, .keepAwake,
              .quickLauncher, .quickToggles, .colorPicker, .screenOCR, .cleaningMode, .mediaTools,
-             .cleaner, .uninstaller, .homebrew,
+             .cleaner, .uninstaller, .homebrew, .screenshot,
              .monitorCPU, .monitorGPU, .monitorMemory, .monitorNetwork, .monitorDisk, .monitorPower:
             return []
         }
@@ -176,7 +177,7 @@ extension AppFeature {
         case .monitorCPU, .monitorMemory, .monitorDisk, .monitorPower: return [.notifications]
         case .clipboardHistory, .shelf, .urlCleaner, .soundOutputSwitcher, .musicBlock,
              .extraBrightness, .quickLauncher, .colorPicker, .micMute, .mediaTools,
-             .monitorGPU, .monitorNetwork:
+             .screenshot, .monitorGPU, .monitorNetwork:
             return []
         }
     }

--- a/Sources/Vorssaint/Core/FeaturePresets.swift
+++ b/Sources/Vorssaint/Core/FeaturePresets.swift
@@ -90,7 +90,7 @@ extension AppFeature {
             return .periodic
         case .pastePlain, .mixer, .soundOutputSwitcher, .micMute,
              .musicBlock, .keepAwake, .brightness, .quickLauncher, .quickToggles, .colorPicker,
-             .screenOCR, .cleaningMode, .mediaTools, .cleaner, .uninstaller, .homebrew:
+             .screenOCR, .cleaningMode, .mediaTools, .cleaner, .uninstaller, .homebrew, .screenshot:
             return .idle
         }
     }

--- a/Sources/Vorssaint/Core/GlobalShortcut.swift
+++ b/Sources/Vorssaint/Core/GlobalShortcut.swift
@@ -124,6 +124,8 @@ struct GlobalShortcut: Equatable, Hashable {
                                                  modifiers: [.control, .option, .command])
     static let soundOutputSwitcherDefault = GlobalShortcut(keyCode: Int64(kVK_ANSI_S),
                                                            modifiers: [.control, .option, .command])
+    static let screenshotDefault = GlobalShortcut(keyCode: Int64(kVK_ANSI_X),
+                                                  modifiers: [.command, .shift])
     static let windowLayoutLeftDefault = GlobalShortcut(keyCode: Int64(kVK_LeftArrow),
                                                         modifiers: [.control, .option])
     static let windowLayoutRightDefault = GlobalShortcut(keyCode: Int64(kVK_RightArrow),
@@ -394,6 +396,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
     case screenOCR
     case micMute
     case quickLauncher
+    case screenshot
 
     var id: String { storageKey }
 
@@ -410,6 +413,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .screenOCR: return DefaultsKey.screenOCRShortcut
         case .micMute: return DefaultsKey.micMuteShortcut
         case .quickLauncher: return DefaultsKey.quickLauncherShortcut
+        case .screenshot: return DefaultsKey.screenshotShortcut
         }
     }
 
@@ -426,6 +430,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .screenOCR: return .screenOCRDefault
         case .micMute: return .micMuteDefault
         case .quickLauncher: return .quickLauncherDefault
+        case .screenshot: return .screenshotDefault
         }
     }
 
@@ -446,6 +451,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .screenOCR: return strings.ocrName
         case .micMute: return strings.micMuteName
         case .quickLauncher: return strings.launcherName
+        case .screenshot: return "Screenshots"
         }
     }
 
@@ -472,6 +478,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .screenOCR: return [DefaultsKey.screenOCRShortcutEnabled]
         case .micMute: return [DefaultsKey.micMuteShortcutEnabled]
         case .quickLauncher: return [DefaultsKey.quickLauncherShortcutEnabled]
+        case .screenshot: return [DefaultsKey.screenshotEnabled]
         }
     }
 
@@ -490,6 +497,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .screenOCR: return .screenOCR
         case .micMute: return .micMute
         case .quickLauncher: return .quickLauncher
+        case .screenshot: return .screenshot
         }
     }
 

--- a/Sources/Vorssaint/Services/Screenshot/FloatingThumbnailController.swift
+++ b/Sources/Vorssaint/Services/Screenshot/FloatingThumbnailController.swift
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Cocoa
+
+class FloatingThumbnailController: NSObject, NSDraggingSource {
+    static let shared = FloatingThumbnailController()
+    
+    private var window: NSPanel?
+    private var dismissTimer: Timer?
+    private var image: NSImage?
+    
+    func show(image: NSImage) {
+        dismiss()
+        
+        self.image = image
+        
+        let screen = NSScreen.main ?? NSScreen.screens[0]
+        let screenFrame = screen.visibleFrame
+        let width: CGFloat = 220
+        let height: CGFloat = 140
+        let padding: CGFloat = 16
+        
+        let x = screenFrame.maxX - width - padding
+        let y = screenFrame.minY + padding
+        
+        let panel = NSPanel(
+            contentRect: NSRect(x: x + 200, y: y, width: width, height: height),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .floating
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.isReleasedWhenClosed = false
+        panel.hidesOnDeactivate = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary]
+        panel.acceptsMouseMovedEvents = true
+        
+        let view = FloatingThumbnailView(image: image, controller: self)
+        view.frame = NSRect(origin: .zero, size: NSSize(width: width, height: height))
+        panel.contentView = view
+        
+        self.window = panel
+        panel.orderFrontRegardless()
+        
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.3
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().setFrame(NSRect(x: x, y: y, width: width, height: height), display: true)
+        }, completionHandler: nil)
+        
+        startDismissTimer()
+    }
+    
+    func startDismissTimer() {
+        dismissTimer?.invalidate()
+        dismissTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: false) { [weak self] _ in
+            self?.slideOutAndDismiss()
+        }
+    }
+    
+    func stopDismissTimer() {
+        dismissTimer?.invalidate()
+        dismissTimer = nil
+    }
+    
+    func slideOutAndDismiss() {
+        guard let panel = window else { return }
+        let currentFrame = panel.frame
+        let targetX = currentFrame.origin.x + currentFrame.size.width + 50
+        
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.25
+            context.timingFunction = CAMediaTimingFunction(name: .easeIn)
+            panel.animator().setFrame(NSRect(x: targetX, y: currentFrame.origin.y, width: currentFrame.size.width, height: currentFrame.size.height), display: true)
+        }, completionHandler: { [weak self] in
+            self?.dismiss()
+        })
+    }
+    
+    func dismiss() {
+        dismissTimer?.invalidate()
+        dismissTimer = nil
+        window?.orderOut(nil)
+        window = nil
+        image = nil
+    }
+    
+    static func generateUniqueURL(in directoryURL: URL, date: Date) -> URL {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd 'at' h.mm.ss a"
+        let dateString = formatter.string(from: date)
+        let baseName = "Screenshot \(dateString)"
+        let fileExtension = "png"
+        
+        let fileManager = FileManager.default
+        var candidateURL = directoryURL.appendingPathComponent("\(baseName).\(fileExtension)")
+        var counter = 1
+        while fileManager.fileExists(atPath: candidateURL.path) {
+            candidateURL = directoryURL.appendingPathComponent("\(baseName) (\(counter)).\(fileExtension)")
+            counter += 1
+        }
+        return candidateURL
+    }
+    
+    static func saveImageToPictures(image: NSImage) -> URL? {
+        let fileManager = FileManager.default
+        let picturesURL = fileManager.urls(for: .picturesDirectory, in: .userDomainMask)[0]
+        let folderURL = picturesURL.appendingPathComponent("Vorssaint Screenshots")
+        
+        if !fileManager.fileExists(atPath: folderURL.path) {
+            try? fileManager.createDirectory(at: folderURL, withIntermediateDirectories: true, attributes: nil)
+        }
+        
+        let fileURL = FloatingThumbnailController.generateUniqueURL(in: folderURL, date: Date())
+        
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return nil }
+        let rep = NSBitmapImageRep(cgImage: cgImage)
+        if let data = rep.representation(using: .png, properties: [:]) {
+            try? data.write(to: fileURL)
+            return fileURL
+        }
+        return nil
+    }
+    
+    func saveToPictures() {
+        guard let image = image else { return }
+        let saveAction = UserDefaults.standard.integer(forKey: DefaultsKey.screenshotSaveAction)
+        
+        if saveAction == 1 { // Ask where to save
+            let panel = NSSavePanel()
+            panel.allowedContentTypes = [.png]
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd 'at' h.mm.ss a"
+            panel.nameFieldStringValue = "Screenshot \(formatter.string(from: Date())).png"
+            panel.canCreateDirectories = true
+            panel.isExtensionHidden = false
+            
+            if let customDir = UserDefaults.standard.string(forKey: DefaultsKey.screenshotSaveDirectory) {
+                panel.directoryURL = URL(fileURLWithPath: customDir)
+            }
+            
+            NSApp.activate(ignoringOtherApps: true)
+            if panel.runModal() == .OK, let fileURL = panel.url {
+                guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return }
+                let rep = NSBitmapImageRep(cgImage: cgImage)
+                if let data = rep.representation(using: .png, properties: [:]) {
+                    try? data.write(to: fileURL)
+                    NSWorkspace.shared.selectFile(fileURL.path, inFileViewerRootedAtPath: fileURL.deletingLastPathComponent().path)
+                }
+            }
+        } else { // Save to default folder
+            let folderPath = UserDefaults.standard.string(forKey: DefaultsKey.screenshotSaveDirectory) ?? Defaults.defaultScreenshotDirectoryPath
+            let fileManager = FileManager.default
+            let folderURL = URL(fileURLWithPath: folderPath)
+            
+            if !fileManager.fileExists(atPath: folderURL.path) {
+                try? fileManager.createDirectory(at: folderURL, withIntermediateDirectories: true, attributes: nil)
+            }
+            
+            let fileURL = FloatingThumbnailController.generateUniqueURL(in: folderURL, date: Date())
+            
+            guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return }
+            let rep = NSBitmapImageRep(cgImage: cgImage)
+            if let data = rep.representation(using: .png, properties: [:]) {
+                try? data.write(to: fileURL)
+                NSWorkspace.shared.selectFile(fileURL.path, inFileViewerRootedAtPath: folderURL.path)
+            }
+        }
+        slideOutAndDismiss()
+    }
+    
+    func copyToClipboard() {
+        guard let image = image else { return }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.writeObjects([image])
+        slideOutAndDismiss()
+    }
+    
+    func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
+        return .copy
+    }
+    
+    func draggingSession(_ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation) {
+        dismiss()
+    }
+}
+
+class FloatingThumbnailView: NSView {
+    private let image: NSImage
+    private weak var controller: FloatingThumbnailController?
+    
+    private var isHovered = false
+    private var trackingArea: NSTrackingArea?
+    
+    private var mouseDownPoint: NSPoint = .zero
+    private var isSwipeDismissing = false
+    
+    private var buttons: [NSButton] = []
+    
+    init(image: NSImage, controller: FloatingThumbnailController) {
+        self.image = image
+        self.controller = controller
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.cornerRadius = 12
+        layer?.masksToBounds = true
+        layer?.borderColor = NSColor.white.withAlphaComponent(0.2).cgColor
+        layer?.borderWidth = 1.5
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let existing = trackingArea {
+            removeTrackingArea(existing)
+        }
+        let options: NSTrackingArea.Options = [.mouseEnteredAndExited, .activeAlways, .inVisibleRect]
+        let area = NSTrackingArea(rect: bounds, options: options, owner: self, userInfo: nil)
+        addTrackingArea(area)
+        self.trackingArea = area
+    }
+    
+    override func mouseEntered(with event: NSEvent) {
+        isHovered = true
+        controller?.stopDismissTimer()
+        needsDisplay = true
+    }
+    
+    override func mouseExited(with event: NSEvent) {
+        isHovered = false
+        controller?.startDismissTimer()
+        needsDisplay = true
+    }
+    
+    override func draw(_ dirtyRect: NSRect) {
+        NSColor(white: 0.1, alpha: 0.85).set()
+        let path = NSBezierPath(roundedRect: bounds, xRadius: 12, yRadius: 12)
+        path.fill()
+        
+        let imageSize = image.size
+        let viewSize = bounds.size
+        let targetRect = calculateAspectFitRect(imageSize: imageSize, viewSize: viewSize)
+        image.draw(in: targetRect, from: .zero, operation: .sourceOver, fraction: 1.0)
+        
+        if isHovered {
+            NSColor.black.withAlphaComponent(0.3).set()
+            path.fill()
+            drawOverlayButtons()
+        }
+    }
+    
+    private func calculateAspectFitRect(imageSize: NSSize, viewSize: NSSize) -> NSRect {
+        let imageRatio = imageSize.width / imageSize.height
+        let viewRatio = viewSize.width / viewSize.height
+        
+        var targetWidth = viewSize.width
+        var targetHeight = viewSize.height
+        
+        if imageRatio > viewRatio {
+            targetHeight = viewSize.width / imageRatio
+        } else {
+            targetWidth = viewSize.height * imageRatio
+        }
+        
+        let x = (viewSize.width - targetWidth) / 2
+        let y = (viewSize.height - targetHeight) / 2
+        return NSRect(x: x, y: y, width: targetWidth, height: targetHeight)
+    }
+    
+    private func drawOverlayButtons() {
+        if buttons.isEmpty {
+            setupButtons()
+        }
+        for btn in buttons {
+            btn.isHidden = false
+        }
+    }
+    
+    private func setupButtons() {
+        let buttonSize: CGFloat = 32
+        let spacing: CGFloat = 16
+        
+        let names = ["square.and.arrow.down", "doc.on.clipboard", "xmark"]
+        let actions = [#selector(savePressed), #selector(copyPressed), #selector(closePressed)]
+        
+        let totalWidth = CGFloat(names.count) * buttonSize + CGFloat(names.count - 1) * spacing
+        var startX = (bounds.width - totalWidth) / 2
+        let y = (bounds.height - buttonSize) / 2
+        
+        for i in 0..<names.count {
+            let btn = NSButton(frame: NSRect(x: startX, y: y, width: buttonSize, height: buttonSize))
+            btn.bezelStyle = .shadowlessSquare
+            btn.isBordered = false
+            btn.wantsLayer = true
+            btn.layer?.cornerRadius = buttonSize / 2
+            btn.layer?.backgroundColor = NSColor.black.withAlphaComponent(0.6).cgColor
+            btn.image = NSImage(systemSymbolName: names[i], accessibilityDescription: nil)
+            btn.imagePosition = .imageOnly
+            btn.imageScaling = .scaleProportionallyDown
+            btn.contentTintColor = .white
+            btn.target = self
+            btn.action = actions[i]
+            
+            addSubview(btn)
+            buttons.append(btn)
+            startX += buttonSize + spacing
+        }
+    }
+    
+    override func viewWillDraw() {
+        super.viewWillDraw()
+        for btn in buttons {
+            btn.isHidden = !isHovered
+        }
+    }
+    
+    @objc private func savePressed() {
+        controller?.saveToPictures()
+    }
+    
+    @objc private func copyPressed() {
+        controller?.copyToClipboard()
+    }
+    
+    @objc private func closePressed() {
+        controller?.slideOutAndDismiss()
+    }
+    
+    override func mouseDown(with event: NSEvent) {
+        mouseDownPoint = event.locationInWindow
+        isSwipeDismissing = false
+    }
+    
+    override func mouseDragged(with event: NSEvent) {
+        let currentPoint = event.locationInWindow
+        let deltaX = currentPoint.x - mouseDownPoint.x
+        let deltaY = currentPoint.y - mouseDownPoint.y
+        
+        if abs(deltaX) > 15 && abs(deltaY) < 10 && !isSwipeDismissing {
+            isSwipeDismissing = true
+        }
+        
+        if isSwipeDismissing {
+            guard let window = window else { return }
+            var frame = window.frame
+            if deltaX > 0 {
+                frame.origin.x = window.frame.origin.x + deltaX
+                window.setFrame(frame, display: true)
+            }
+        } else if abs(deltaX) > 5 || abs(deltaY) > 5 {
+            triggerSystemDrag(with: event)
+        }
+    }
+    
+    override func mouseUp(with event: NSEvent) {
+        if isSwipeDismissing {
+            let currentPoint = event.locationInWindow
+            let deltaX = currentPoint.x - mouseDownPoint.x
+            if deltaX > 50 {
+                controller?.slideOutAndDismiss()
+            } else {
+                if let panel = window {
+                    let screen = NSScreen.main ?? NSScreen.screens[0]
+                    let screenFrame = screen.visibleFrame
+                    let x = screenFrame.maxX - bounds.width - 16
+                    panel.animator().setFrame(NSRect(x: x, y: panel.frame.origin.y, width: bounds.width, height: bounds.height), display: true)
+                }
+            }
+            isSwipeDismissing = false
+        }
+    }
+    
+    private func triggerSystemDrag(with event: NSEvent) {
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return }
+        let rep = NSBitmapImageRep(cgImage: cgImage)
+        guard let data = rep.representation(using: .png, properties: [:]) else { return }
+        
+        let tempDir = FileManager.default.temporaryDirectory
+        let tempURL = tempDir.appendingPathComponent("screenshot.png")
+        try? data.write(to: tempURL)
+        
+        let draggingItem = NSDraggingItem(pasteboardWriter: tempURL as NSURL)
+        draggingItem.setDraggingFrame(bounds, contents: image)
+        
+        beginDraggingSession(with: [draggingItem], event: event, source: controller!)
+    }
+}

--- a/Sources/Vorssaint/Services/Screenshot/ScreenshotOverlayController.swift
+++ b/Sources/Vorssaint/Services/Screenshot/ScreenshotOverlayController.swift
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Cocoa
+import ScreenCaptureKit
+
+struct ScreenCapture {
+    let screen: NSScreen
+    let image: CGImage
+}
+
+class ScreenshotOverlayController: NSObject {
+    static let shared = ScreenshotOverlayController()
+    
+    private var windows: [ScreenshotOverlayWindow] = []
+    
+    func startCapture() {
+        dismiss()
+        
+        Task {
+            let screens = NSScreen.screens
+            guard !screens.isEmpty else { return }
+            
+            var captures: [ScreenCapture] = []
+            
+            do {
+                let content = try await SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: true)
+                
+                for screen in screens {
+                    // Match screen by display ID
+                    let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
+                    guard let display = content.displays.first(where: { $0.displayID == screenNumber }) else { continue }
+                    
+                    let filter = SCContentFilter(display: display, excludingWindows: [])
+                    let config = SCStreamConfiguration()
+                    let scale = Int(screen.backingScaleFactor)
+                    config.width = display.width * scale
+                    config.height = display.height * scale
+                    config.showsCursor = true
+                    config.captureResolution = .best
+                    
+                    if let image = try? await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config) {
+                        captures.append(ScreenCapture(screen: screen, image: image))
+                    }
+                }
+            } catch {
+                return
+            }
+            
+            guard captures.count == screens.count else { return }
+            
+            let finalCaptures = captures
+            await MainActor.run {
+                for capture in finalCaptures {
+                    let overlayWindow = ScreenshotOverlayWindow(capture: capture, controller: self)
+                    self.windows.append(overlayWindow)
+                    overlayWindow.orderFrontRegardless()
+                    overlayWindow.makeKey()
+                }
+                NSApp.activate(ignoringOtherApps: true)
+            }
+        }
+    }
+    
+    func dismiss() {
+        for win in windows {
+            win.orderOut(nil)
+        }
+        windows.removeAll()
+    }
+    
+    func confirmCapture(cgImage: CGImage, rect: NSRect, screen: NSScreen) {
+        let croppedCG = cropCGImage(cgImage, to: rect, screen: screen)
+        
+        if let finalCG = croppedCG {
+            let nsImage = NSImage(cgImage: finalCG, size: NSSize(width: rect.width, height: rect.height))
+            
+            let mode = UserDefaults.standard.integer(forKey: DefaultsKey.screenshotQuickCaptureMode)
+            
+            // 1. Copy to Clipboard (mode 1 or 2)
+            if mode == 1 || mode == 2 {
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.writeObjects([nsImage])
+            }
+            
+            // Dismiss overlays BEFORE presenting save dialogs or floating previews
+            dismiss()
+            
+            // 2. Save to file (mode 0 or 2)
+            if mode == 0 || mode == 2 {
+                saveImageDirectly(nsImage)
+            }
+            
+            // 3. Show floating thumbnail
+            if UserDefaults.standard.bool(forKey: DefaultsKey.screenshotShowThumbnail) {
+                FloatingThumbnailController.shared.show(image: nsImage)
+            }
+        } else {
+            dismiss()
+        }
+    }
+    
+    private func saveImageDirectly(_ image: NSImage) {
+        let saveAction = UserDefaults.standard.integer(forKey: DefaultsKey.screenshotSaveAction)
+        
+        if saveAction == 1 { // Ask where to save
+            let panel = NSSavePanel()
+            panel.allowedContentTypes = [.png]
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd 'at' h.mm.ss a"
+            panel.nameFieldStringValue = "Screenshot \(formatter.string(from: Date())).png"
+            panel.canCreateDirectories = true
+            panel.isExtensionHidden = false
+            
+            if let customDir = UserDefaults.standard.string(forKey: DefaultsKey.screenshotSaveDirectory) {
+                panel.directoryURL = URL(fileURLWithPath: customDir)
+            }
+            
+            NSApp.activate(ignoringOtherApps: true)
+            if panel.runModal() == .OK, let fileURL = panel.url {
+                guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return }
+                let rep = NSBitmapImageRep(cgImage: cgImage)
+                if let data = rep.representation(using: .png, properties: [:]) {
+                    try? data.write(to: fileURL)
+                }
+            }
+        } else { // Save to default folder
+            let folderPath = UserDefaults.standard.string(forKey: DefaultsKey.screenshotSaveDirectory) ?? Defaults.defaultScreenshotDirectoryPath
+            let fileManager = FileManager.default
+            let folderURL = URL(fileURLWithPath: folderPath)
+            
+            if !fileManager.fileExists(atPath: folderURL.path) {
+                try? fileManager.createDirectory(at: folderURL, withIntermediateDirectories: true, attributes: nil)
+            }
+            
+            let fileURL = FloatingThumbnailController.generateUniqueURL(in: folderURL, date: Date())
+            
+            guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return }
+            let rep = NSBitmapImageRep(cgImage: cgImage)
+            if let data = rep.representation(using: .png, properties: [:]) {
+                try? data.write(to: fileURL)
+            }
+        }
+    }
+    
+    private func cropCGImage(_ image: CGImage, to viewRect: NSRect, screen: NSScreen) -> CGImage? {
+        let scale = CGFloat(image.width) / screen.frame.width
+        let cropRect = CGRect(
+            x: viewRect.origin.x * scale,
+            y: (screen.frame.height - viewRect.maxY) * scale,
+            width: viewRect.width * scale,
+            height: viewRect.height * scale
+        )
+        return image.cropping(to: cropRect)
+    }
+}
+
+class ScreenshotOverlayWindow: NSPanel {
+    private let controller: ScreenshotOverlayController
+    
+    init(capture: ScreenCapture, controller: ScreenshotOverlayController) {
+        self.controller = controller
+        super.init(
+            contentRect: capture.screen.frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        self.level = NSWindow.Level(257)
+        self.isOpaque = false
+        self.backgroundColor = .clear
+        self.hasShadow = false
+        self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        self.animationBehavior = .none
+        
+        let view = ScreenshotOverlayView(capture: capture, controller: controller)
+        view.frame = NSRect(origin: .zero, size: capture.screen.frame.size)
+        self.contentView = view
+    }
+    
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+}
+
+class ScreenshotOverlayView: NSView {
+    private let capture: ScreenCapture
+    private weak var controller: ScreenshotOverlayController?
+    
+    private var selectionStart: NSPoint = .zero
+    private var selectionRect: NSRect = .zero
+    private var isDragging = false
+    
+    private var hoveredWindowRect: NSRect?
+    
+    init(capture: ScreenCapture, controller: ScreenshotOverlayController) {
+        self.capture = capture
+        self.controller = controller
+        super.init(frame: .zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override var acceptsFirstResponder: Bool { true }
+    
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window != nil {
+            let options: NSTrackingArea.Options = [.mouseMoved, .activeAlways, .inVisibleRect]
+            let area = NSTrackingArea(rect: bounds, options: options, owner: self, userInfo: nil)
+            addTrackingArea(area)
+        }
+    }
+    
+    override func keyDown(with event: NSEvent) {
+        let chars = event.charactersIgnoringModifiers
+        if event.keyCode == 53 || chars == "\u{1B}" {
+            controller?.dismiss()
+        } else if chars == "f" || chars == "F" {
+            controller?.confirmCapture(cgImage: capture.image, rect: bounds, screen: capture.screen)
+        } else {
+            super.keyDown(with: event)
+        }
+    }
+    
+    override func draw(_ dirtyRect: NSRect) {
+        let context = NSGraphicsContext.current?.cgContext
+        context?.draw(capture.image, in: bounds)
+        
+        NSColor.black.withAlphaComponent(0.25).set()
+        bounds.fill()
+        
+        if isDragging && !selectionRect.isEmpty {
+            context?.saveGState()
+            let path = NSBezierPath(rect: selectionRect)
+            path.addClip()
+            context?.draw(capture.image, in: bounds)
+            context?.restoreGState()
+            
+            NSColor.systemBlue.setStroke()
+            let border = NSBezierPath(rect: selectionRect.insetBy(dx: 0.5, dy: 0.5))
+            border.lineWidth = 1.5
+            border.stroke()
+        } else if let snapRect = hoveredWindowRect, !snapRect.isEmpty {
+            context?.saveGState()
+            let path = NSBezierPath(rect: snapRect)
+            path.addClip()
+            context?.draw(capture.image, in: bounds)
+            context?.restoreGState()
+            
+            NSColor.systemBlue.withAlphaComponent(0.08).setFill()
+            NSBezierPath(roundedRect: snapRect, xRadius: 4, yRadius: 4).fill()
+            
+            NSColor.systemBlue.withAlphaComponent(0.85).setStroke()
+            let border = NSBezierPath(roundedRect: snapRect.insetBy(dx: 0.5, dy: 0.5), xRadius: 4, yRadius: 4)
+            border.lineWidth = 2
+            border.stroke()
+        }
+        
+        if !UserDefaults.standard.bool(forKey: DefaultsKey.screenshotHideInstructions), !isDragging {
+            drawInstructions()
+        }
+    }
+    
+    private func drawInstructions() {
+        let text = "Drag to select area • Click to snap window • F for full screen • Esc to cancel"
+        let font = NSFont.systemFont(ofSize: 13, weight: .medium)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.white
+        ]
+        
+        let textSize = text.size(withAttributes: attributes)
+        let paddingX: CGFloat = 16
+        let paddingY: CGFloat = 8
+        let width = textSize.width + paddingX * 2
+        let height = textSize.height + paddingY * 2
+        
+        let x = (bounds.width - width) / 2
+        let y = bounds.height - height - 40
+        
+        let capsuleRect = NSRect(x: x, y: y, width: width, height: height)
+        
+        NSColor.black.withAlphaComponent(0.65).set()
+        let path = NSBezierPath(roundedRect: capsuleRect, xRadius: height / 2, yRadius: height / 2)
+        path.fill()
+        
+        NSColor.white.withAlphaComponent(0.15).setStroke()
+        path.lineWidth = 1
+        path.stroke()
+        
+        let textRect = NSRect(
+            x: x + paddingX,
+            y: y + paddingY,
+            width: textSize.width,
+            height: textSize.height
+        )
+        text.draw(in: textRect, withAttributes: attributes)
+    }
+    
+    override func mouseDown(with event: NSEvent) {
+        let location = convert(event.locationInWindow, from: nil)
+        selectionStart = location
+        selectionRect = .zero
+        isDragging = true
+    }
+    
+    override func mouseDragged(with event: NSEvent) {
+        guard isDragging else { return }
+        let location = convert(event.locationInWindow, from: nil)
+        
+        let minX = min(selectionStart.x, location.x)
+        let maxX = max(selectionStart.x, location.x)
+        let minY = min(selectionStart.y, location.y)
+        let maxY = max(selectionStart.y, location.y)
+        
+        selectionRect = NSRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+        needsDisplay = true
+    }
+    
+    override func mouseUp(with event: NSEvent) {
+        guard isDragging else { return }
+        isDragging = false
+        
+        let location = convert(event.locationInWindow, from: nil)
+        let dragDistance = hypot(location.x - selectionStart.x, location.y - selectionStart.y)
+        
+        if dragDistance < 5, let snapRect = hoveredWindowRect, !snapRect.isEmpty {
+            controller?.confirmCapture(cgImage: capture.image, rect: snapRect, screen: capture.screen)
+        } else if selectionRect.width > 5 && selectionRect.height > 5 {
+            controller?.confirmCapture(cgImage: capture.image, rect: selectionRect, screen: capture.screen)
+        } else {
+            selectionRect = .zero
+            needsDisplay = true
+        }
+    }
+    
+    override func mouseMoved(with event: NSEvent) {
+        guard !isDragging else { return }
+        
+        let screenPoint = window?.convertPoint(toScreen: event.locationInWindow) ?? .zero
+        let mainHeight = NSScreen.screens.first?.frame.height ?? 0
+        let windowOrigin = window?.frame.origin ?? .zero
+        
+        if let result = ScreenshotOverlayView.windowRectOnBackground(
+            screenPoint: screenPoint,
+            overlayWindowNumber: window?.windowNumber ?? 0,
+            windowOrigin: windowOrigin,
+            viewBounds: bounds,
+            screenH: mainHeight
+        ) {
+            hoveredWindowRect = result.rect
+        } else {
+            hoveredWindowRect = nil
+        }
+        needsDisplay = true
+    }
+    
+    private struct WindowSnapCandidate {
+        let rect: NSRect
+        let windowID: CGWindowID
+        let area: CGFloat
+    }
+    
+    private static func windowRectOnBackground(
+        screenPoint: NSPoint,
+        overlayWindowNumber: Int,
+        windowOrigin: NSPoint,
+        viewBounds: NSRect,
+        screenH: CGFloat
+    ) -> WindowSnapResult? {
+        guard
+            let windowList = CGWindowListCopyWindowInfo(
+                [.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]]
+        else { return nil }
+        
+        var frontmost: WindowSnapCandidate?
+        
+        for info in windowList {
+            guard let layer = info[kCGWindowLayer as String] as? Int, layer == 0,
+                  let boundsDict = info[kCGWindowBounds as String] as? [String: CGFloat],
+                  let winNum = info[kCGWindowNumber as String] as? Int,
+                  winNum != overlayWindowNumber
+            else { continue }
+            
+            let cgX = boundsDict["X"] ?? 0
+            let cgY = boundsDict["Y"] ?? 0
+            let cgW = boundsDict["Width"] ?? 0
+            let cgH = boundsDict["Height"] ?? 0
+            guard cgW > 10 && cgH > 10 else { continue }
+            
+            let appKitRect = NSRect(x: cgX, y: screenH - cgY - cgH, width: cgW, height: cgH)
+            if appKitRect.contains(screenPoint) {
+                let viewRect = NSRect(
+                    x: appKitRect.origin.x - windowOrigin.x,
+                    y: appKitRect.origin.y - windowOrigin.y,
+                    width: appKitRect.width,
+                    height: appKitRect.height
+                )
+                let candidate = WindowSnapCandidate(
+                    rect: viewRect.intersection(viewBounds),
+                    windowID: CGWindowID(winNum),
+                    area: cgW * cgH
+                )
+                if frontmost == nil {
+                    frontmost = candidate
+                }
+            }
+        }
+        
+        guard let best = frontmost else { return nil }
+        return WindowSnapResult(rect: best.rect, windowID: best.windowID)
+    }
+}
+
+struct WindowSnapResult {
+    let rect: NSRect
+    let windowID: CGWindowID
+}

--- a/Sources/Vorssaint/Services/Screenshot/ScreenshotService.swift
+++ b/Sources/Vorssaint/Services/Screenshot/ScreenshotService.swift
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Carbon.HIToolbox
+import Combine
+import Foundation
+
+final class ScreenshotService: ObservableObject {
+    static let shared = ScreenshotService()
+    
+    @Published var hotkeyRegistrationFailed = false
+    
+    private var hotKeyRef: EventHotKeyRef?
+    private var hotKeyHandler: EventHandlerRef?
+    private var registeredShortcut: GlobalShortcut?
+    
+    private init() {}
+    
+    func syncWithPreferences() {
+        if UserDefaults.standard.bool(forKey: DefaultsKey.screenshotEnabled) {
+            registerHotkey()
+        } else {
+            unregisterHotkey()
+        }
+    }
+    
+    private func registerHotkey() {
+        let shortcut = GlobalShortcut.saved(for: DefaultsKey.screenshotShortcut,
+                                            fallback: .screenshotDefault)
+        if hotKeyRef != nil, registeredShortcut == shortcut { return }
+        unregisterHotkey()
+        
+        if hotKeyHandler == nil {
+            var spec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
+                                     eventKind: UInt32(kEventHotKeyPressed))
+            InstallEventHandler(GetEventDispatcherTarget(), { _, event, userData -> OSStatus in
+                guard userData != nil else { return OSStatus(eventNotHandledErr) }
+                var id = EventHotKeyID()
+                if let event {
+                    GetEventParameter(event, EventParamName(kEventParamDirectObject),
+                                      EventParamType(typeEventHotKeyID), nil,
+                                      MemoryLayout<EventHotKeyID>.size, nil, &id)
+                }
+                guard id.id == 8 else { return OSStatus(eventNotHandledErr) }
+                DispatchQueue.main.async {
+                    ScreenshotOverlayController.shared.startCapture()
+                }
+                return noErr
+            }, 1, &spec, Unmanaged.passUnretained(self).toOpaque(), &hotKeyHandler)
+        }
+        
+        let id = EventHotKeyID(signature: 0x5655_5353, id: 8) // 'VUSS'
+        var ref: EventHotKeyRef?
+        let status = RegisterEventHotKey(shortcut.carbonKeyCode,
+                                         shortcut.carbonModifiers,
+                                         id, GetEventDispatcherTarget(), 0, &ref)
+        if status == noErr, let ref {
+            hotKeyRef = ref
+            registeredShortcut = shortcut
+            hotkeyRegistrationFailed = false
+        } else {
+            hotKeyRef = nil
+            registeredShortcut = nil
+            hotkeyRegistrationFailed = true
+        }
+    }
+    
+    private func unregisterHotkey() {
+        if let hotKeyRef {
+            UnregisterEventHotKey(hotKeyRef)
+        }
+        hotKeyRef = nil
+        registeredShortcut = nil
+        hotkeyRegistrationFailed = false
+    }
+}

--- a/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
@@ -541,6 +541,7 @@ extension AppFeature {
         case .monitorNetwork: return s.monitorShowNetwork
         case .monitorDisk: return s.diskSection
         case .monitorPower: return s.powerSection
+        case .screenshot: return "Screenshots"
         }
     }
 
@@ -585,6 +586,7 @@ extension AppFeature {
         case .monitorNetwork: return hub.descMonitorNetwork
         case .monitorDisk: return hub.descMonitorDisk
         case .monitorPower: return hub.descMonitorPower
+        case .screenshot: return "Take screenshots, snap window areas, and manage clipboard & output configurations."
         }
     }
 }

--- a/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
@@ -7,7 +7,7 @@ import Foundation
 /// below and the unit tests can reason about pages without pulling SwiftUI in.
 enum SettingsPage: Hashable {
     case general, features, energy, monitor
-    case mouse, switcher, keyDebounce, cutPaste, autoQuit, uninstaller, urlCleaner, homebrew, media, clipboard, windowLayout, shelf, quickTools, textSnippets
+    case mouse, switcher, keyDebounce, cutPaste, autoQuit, uninstaller, urlCleaner, homebrew, media, clipboard, windowLayout, shelf, quickTools, textSnippets, screenshot
     case shortcuts, advanced, about, releaseNotes, support
 }
 
@@ -38,6 +38,7 @@ enum FeatureVisibilitySupport {
         case .uninstaller: return [.uninstaller]
         case .keyDebounce: return [.keyboardDebounce]
         case .textSnippets: return [.textSnippets]
+        case .screenshot: return [.screenshot]
         case .general, .features, .shortcuts, .advanced, .about, .releaseNotes, .support:
             return []
         }

--- a/Sources/Vorssaint/UI/Settings/ScreenshotSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/ScreenshotSettings.swift
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import SwiftUI
+
+struct ScreenshotSettings: View {
+    @ObservedObject private var l10n = L10n.shared
+    @ObservedObject private var service = ScreenshotService.shared
+    @AppStorage(DefaultsKey.screenshotEnabled) private var enabled = true
+    @AppStorage(DefaultsKey.screenshotShowThumbnail) private var showThumbnail = true
+    @AppStorage(DefaultsKey.screenshotQuickCaptureMode) private var quickCaptureMode = 2
+    @AppStorage(DefaultsKey.screenshotHideInstructions) private var hideInstructions = false
+    @AppStorage(DefaultsKey.screenshotSaveAction) private var saveAction = 0
+    @AppStorage(DefaultsKey.screenshotSaveDirectory) private var saveDirectory = Defaults.defaultScreenshotDirectoryPath
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Enable Screenshot Capture", isOn: $enabled)
+                    .onChange(of: enabled) { _, _ in
+                        ScreenshotService.shared.syncWithPreferences()
+                    }
+                Text("Enable a global shortcut to capture a region on your screen and copy it to the clipboard.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if enabled {
+                Section {
+                    ShortcutPreferenceRow(role: .screenshot, isEnabled: true) {
+                        ScreenshotService.shared.syncWithPreferences()
+                    }
+                    if service.hotkeyRegistrationFailed {
+                        Text(l10n.s.shortcutUnavailable)
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+                    
+                    Toggle("Show Floating Thumbnail", isOn: $showThumbnail)
+                    Text("Show a draggable preview in the bottom-right corner of the screen after taking a screenshot.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    
+                    Toggle("Hide capture instructions", isOn: $hideInstructions)
+                    Text("Hide the text instructions displayed at the top of the screen during screen capture.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                
+                Section("Capture Behavior") {
+                    Picker("Enter / Quick Capture:", selection: $quickCaptureMode) {
+                        Text("Save to file").tag(0)
+                        Text("Copy to clipboard").tag(1)
+                        Text("Save + copy to clipboard").tag(2)
+                        Text("Do nothing").tag(3)
+                    }
+                    .pickerStyle(.menu)
+                    Text("Choose what action to perform automatically when you complete a screenshot selection.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                
+                Section("Output Settings") {
+                    Picker("Save action:", selection: $saveAction) {
+                        Text("Save to default folder").tag(0)
+                        Text("Ask where to save").tag(1)
+                    }
+                    .pickerStyle(.menu)
+                    
+                    HStack {
+                        Text("Save folder:")
+                        Spacer()
+                        TextField("", text: $saveDirectory)
+                            .disabled(true)
+                            .labelsHidden()
+                            .textFieldStyle(.roundedBorder)
+                            .frame(minWidth: 150, maxWidth: .infinity)
+                        Button("Browse…") {
+                            browseFolder()
+                        }
+                    }
+                }
+                
+                Section("Instructions") {
+                    bullet("1", "Press the global shortcut to activate the capture crosshair.")
+                    bullet("2", "Hover over any window to highlight its boundaries, then click to capture it instantly.")
+                    bullet("3", "Click and drag to select any custom region on the screen.")
+                    bullet("4", "On mouse release, the screenshot is processed according to your Quick Capture action.")
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private func bullet(_ number: String, _ text: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text(number)
+                .font(.system(size: 11, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+                .frame(width: 18, height: 18)
+                .background(Circle().fill(Color.accentColor))
+            Text(text)
+                .font(.callout)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+    
+    private func browseFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        if panel.runModal() == .OK, let url = panel.url {
+            saveDirectory = url.path
+        }
+    }
+}

--- a/Sources/Vorssaint/UI/Settings/SettingsView.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 
 /// One entry in the Settings sidebar. New features add a case here and a row in
 /// the Features section, so every feature gets its own page.
+
 /// Selects the visible Settings page; the menu bar uses it to open Settings
 /// directly on a specific page.
 final class SettingsRouter: ObservableObject {
@@ -106,6 +107,8 @@ struct SettingsView: View {
                             icon: "text.append",
                             keywords: [FeatureStrings.snippets(l10n.language).triggerLabel,
                                        FeatureStrings.snippets(l10n.language).addButton]),
+                SidebarItem(page: .screenshot, title: "Screenshots", icon: "crop",
+                            keywords: ["screenshot", "capture", "snapping", "thumbnail", "quick capture"]),
             ]),
             (categories.app, [
                 SidebarItem(page: .shortcuts, title: l10n.s.shortcutsPageTitle, icon: "command",
@@ -184,6 +187,7 @@ struct SettingsView: View {
         case .windowLayout: WindowLayoutSettings()
         case .shelf: ShelfSettings()
         case .shortcuts: ShortcutsSettings()
+        case .screenshot: ScreenshotSettings()
         case .advanced: AdvancedSettings()
         case .about: AboutSettings()
         case .releaseNotes: ReleaseNotesSettings()


### PR DESCRIPTION
### Description
This PR implements a native Screenshot & Screen Capture feature inside Vorssaint, bringing features inspired by `sw33tLie/macshot` directly into the app:

- **Region Capture & Window Snapping**: Users can click and drag to select custom regions, or hover over window bounds to snap-select windows on mouse release.
- **On-Screen Instructions Capsule**: A translucent capsule overlay guides the capture workflow, showing key controls: `Drag to select area • Click to snap window • F for full screen • Esc to cancel`.
- **Additional Keyboard Controls**: Built-in support for `Esc` to cancel, and `F`/`f` to capture the entire screen instantly.
- **Advanced Configuration UI Settings**: A new "Screenshots" tab in Settings to:
  - Toggle the screenshot utility and record custom global hotkeys.
  - Choose auto-dismissing floating thumbnail previews.
  - Set default Quick Capture actions (Save, Copy, Save + Copy, or Do Nothing).
  - Hide/show the capture helper text.
  - Select/browse custom folders to save screenshots.

All implementation uses native Swift, SwiftUI settings forms, and relies on `SCScreenshotManager` (ScreenCaptureKit) under the hood for clean, modern captures.