### PR TITLE
Allow larger clipboard history limits

### DIFF
--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -498,7 +498,7 @@ enum Defaults {
     static let allowedMenuBarLabelStyles = ["compact", "classic"]
     static let allowedMenuBarMemoryStyles = ["dot", "percent", "both"]
     static let allowedPreviewSizes = ["normal", "large", "xlarge"]
-    static let allowedClipboardHistoryLimits = [20, 50, 100]
+    static let allowedClipboardHistoryLimits = [20, 50, 100, 250, 500, 1_000]
     static let allowedMonitorAlertCooldowns = [2, 5, 15, 30, 60]
 
     static let registeredDefaults: [String: Any] = [

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1797,6 +1797,10 @@ struct MetricsTests {
         expect(Defaults.sanitizedDefaultDuration(999) == 0, "invalid default duration falls back to indefinite")
         expect(Defaults.sanitizedBatteryLimit(15) == 15, "valid battery limit is preserved")
         expect(Defaults.sanitizedBatteryLimit(100) == 10, "invalid battery limit falls back to default")
+        expect(Defaults.sanitizedClipboardHistoryLimit(1_000) == 1_000,
+               "larger clipboard history limits are preserved")
+        expect(Defaults.sanitizedClipboardHistoryLimit(999) == 50,
+               "unsupported clipboard history limits fall back to default")
         expect(Defaults.sanitizedMonitorInterval(5) == 5, "valid monitor interval is preserved")
         expect(Defaults.sanitizedMonitorInterval(7) == 2, "invalid monitor interval falls back to default")
         expect(Defaults.sanitizedKeyboardDebounceWindow(80) == 80,


### PR DESCRIPTION
## Summary

- add 250, 500, and 1000-item clipboard history options
- keep the Settings and Quick Launcher pickers in sync through the shared allowed-values list
- cover larger and unsupported values in the defaults sanitizer tests

## Why

The clipboard history limit was restricted to 20, 50, or 100 items by `Defaults.allowedClipboardHistoryLimits`. Any other value was sanitized back to 50, so users could not retain a longer history even when setting the preference directly.

This keeps the existing `UserDefaults` storage design and offers bounded larger presets without introducing an unrelated storage migration.

## Impact

Users can now retain up to 1000 recent clipboard entries from either clipboard limit picker. The default remains 50.

## Testing

- `./build.sh --test` (`TESTS OK`, 2832 checks)
- `./build.sh`
- `./build/stage/Vorssaint.app/Contents/MacOS/Vorssaint --selftest` (`SELFTEST OK`)

Closes #270
