### PR TITLE
Fix screenshot editor interactions and Homebrew layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,6 @@ and cleans up menu bar and Settings visuals on macOS 26 (Tahoe).
   down arrow has no item directly below.
 
 ### Fixed
-- Command-Z now undoes screenshot annotations even when AppKit routes the
-  shortcut through the application menu without a window on the key event.
-- Clicking an existing screenshot annotation selects it for editing no matter
-  which annotation tool is active.
-- Homebrew Settings now adapts its toolbar at the minimum window width instead
-  of squeezing controls into a broken single row.
 - Brightness keys now really follow the pointer on external monitors that
   macOS drives natively, such as LG UltraFine and Apple displays, including
   with the lid closed. Presses used to land only on the built-in display.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ and cleans up menu bar and Settings visuals on macOS 26 (Tahoe).
   down arrow has no item directly below.
 
 ### Fixed
+- Command-Z now undoes screenshot annotations even when AppKit routes the
+  shortcut through the application menu without a window on the key event.
+- Clicking an existing screenshot annotation selects it for editing no matter
+  which annotation tool is active.
+- Homebrew Settings now adapts its toolbar at the minimum window width instead
+  of squeezing controls into a broken single row.
 - Brightness keys now really follow the pointer on external monitors that
   macOS drives natively, such as LG UltraFine and Apple displays, including
   with the lid closed. Presses used to land only on the built-in display.

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift
@@ -598,6 +598,7 @@ final class ScreenshotEditorModel: ObservableObject {
         switch tool {
         case .text:
             guard isTap else { return }
+            if selectExistingAnnotation(at: point) { return }
             registerUndo()
             var annotation = ScreenshotSupport.Annotation(
                 tool: .text, color: color, stroke: stroke)
@@ -608,6 +609,7 @@ final class ScreenshotEditorModel: ObservableObject {
             editingTextID = annotation.id
         case .sticker:
             guard isTap else { return }
+            if selectExistingAnnotation(at: point) { return }
             registerUndo()
             let bounds = CGRect(origin: .zero, size: imageSize)
             let side = ScreenshotSupport.stickerSide(for: imageSize, scale: scale)
@@ -623,6 +625,7 @@ final class ScreenshotEditorModel: ObservableObject {
             selectedID = annotation.id
         case .counter:
             guard isTap else { return }
+            if selectExistingAnnotation(at: point) { return }
             registerUndo()
             let annotation = ScreenshotSupport.Annotation(
                 tool: .counter,
@@ -639,8 +642,7 @@ final class ScreenshotEditorModel: ObservableObject {
                 if !undoStack.isEmpty { undoStack.removeLast() }
                 refreshUndoFlags()
                 refreshDirtyState()
-                selectedID = hitTest(point)
-                if selectedID != nil { tool = .select }
+                _ = selectExistingAnnotation(at: point)
             } else if let draftID {
                 selectedID = draftID
             }
@@ -661,6 +663,29 @@ final class ScreenshotEditorModel: ObservableObject {
         case .crop:
             break
         }
+    }
+
+    /// A click on an existing mark always means "edit this", even while a
+    /// creation tool is active. Real drags still create with the active tool.
+    /// Sticker selection updates the style picker without mutating the mark;
+    /// text enters its inline editor immediately.
+    @discardableResult
+    private func selectExistingAnnotation(at point: CGPoint) -> Bool {
+        guard let hitID = hitTest(point),
+              let hit = annotations.first(where: { $0.id == hitID })
+        else {
+            selectedID = nil
+            return false
+        }
+        if hit.tool == .sticker {
+            selectedID = nil
+            sticker = ScreenshotSupport.StickerID.sanitized(hit.text)
+        }
+        selectedID = hitID
+        editingTextID = hit.tool == .text ? hitID : nil
+        clearTextSelection()
+        tool = .select
+        return true
     }
 
     private func updateDraft(_ mutate: (inout ScreenshotSupport.Annotation) -> Void) {
@@ -889,7 +914,12 @@ final class ScreenshotEditorController: NSObject, NSWindowDelegate {
 
     private func installKeyMonitor() {
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            guard let self, let window = self.window, event.window === window else { return event }
+            guard let self, let window = self.window,
+                  ScreenshotSupport.editorOwnsKeyEvent(
+                    eventWindowNumber: event.windowNumber,
+                    editorWindowNumber: window.windowNumber,
+                    editorIsKey: window.isKeyWindow)
+            else { return event }
             // While a text field edits, every key belongs to it.
             if window.firstResponder is NSText || self.model.editingTextID != nil {
                 return event
@@ -898,7 +928,11 @@ final class ScreenshotEditorController: NSObject, NSWindowDelegate {
         }
         // Control-scroll adjusts canvas zoom.
         scrollMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
-            guard let self, let window = self.window, event.window === window,
+            guard let self, let window = self.window,
+                  ScreenshotSupport.editorOwnsKeyEvent(
+                    eventWindowNumber: event.windowNumber,
+                    editorWindowNumber: window.windowNumber,
+                    editorIsKey: window.isKeyWindow),
                   event.modifierFlags.contains(.control)
             else { return event }
             let delta = event.scrollingDeltaY

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
@@ -184,6 +184,18 @@ enum ScreenshotSupport {
                       height: min(maximum.height, max(minimum.height, preferred.height)))
     }
 
+    /// Local key monitors normally receive the editor's window number, but
+    /// AppKit can clear it while resolving a main-menu key equivalent such as
+    /// Command-Z. In that case the key window still owns the event. Never use
+    /// the fallback for an event that explicitly belongs to another window.
+    static func editorOwnsKeyEvent(eventWindowNumber: Int,
+                                   editorWindowNumber: Int,
+                                   editorIsKey: Bool) -> Bool {
+        guard editorWindowNumber != 0 else { return false }
+        if eventWindowNumber == editorWindowNumber { return true }
+        return eventWindowNumber == 0 && editorIsKey
+    }
+
     // MARK: - Window picking
 
     struct PickableWindow: Equatable {

--- a/Sources/Vorssaint/UI/Settings/HomebrewSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/HomebrewSettings.swift
@@ -91,35 +91,26 @@ struct HomebrewSettings: View {
 
     private var toolbar: some View {
         VStack(alignment: .leading, spacing: 9) {
-            HStack(spacing: 8) {
-                TextField(l10n.s.homebrewSearchPlaceholder, text: $query)
-                    .textFieldStyle(.roundedBorder)
-                    .onSubmit { search() }
-                Picker("", selection: $searchKind) {
-                    Text(l10n.s.homebrewCasks).tag(HomebrewPackageKind.cask)
-                    Text(l10n.s.homebrewFormulas).tag(HomebrewPackageKind.formula)
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 8) {
+                    searchField
+                    packageKindPicker
+                    searchButton
+                    refreshButton
+                    updateHomebrewButton
                 }
-                .labelsHidden()
-                .frame(width: 116)
-                Button {
-                    search()
-                } label: {
-                    Label(l10n.s.homebrewSearchButton, systemImage: "magnifyingglass")
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 8) {
+                        searchField
+                        packageKindPicker
+                    }
+                    HStack(spacing: 8) {
+                        searchButton
+                        refreshButton
+                        updateHomebrewButton
+                        Spacer(minLength: 0)
+                    }
                 }
-                .disabled(query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || homebrew.isBusy)
-                Button {
-                    homebrew.refreshInstalled()
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                }
-                .help(l10n.s.homebrewRefresh)
-                .disabled(homebrew.isBusy)
-                Button {
-                    pendingAction = HomebrewPendingAction(action: .updateHomebrew)
-                } label: {
-                    Label(l10n.s.homebrewUpdateHomebrew, systemImage: "arrow.triangle.2.circlepath")
-                }
-                .disabled(homebrew.isBusy)
             }
 
             HStack(spacing: 8) {
@@ -133,6 +124,53 @@ struct HomebrewSettings: View {
                 outdatedSummary
             }
         }
+    }
+
+    private var searchField: some View {
+        TextField(l10n.s.homebrewSearchPlaceholder, text: $query)
+            .textFieldStyle(.roundedBorder)
+            .frame(minWidth: 150)
+            .onSubmit { search() }
+    }
+
+    private var packageKindPicker: some View {
+        Picker("", selection: $searchKind) {
+            Text(l10n.s.homebrewCasks).tag(HomebrewPackageKind.cask)
+            Text(l10n.s.homebrewFormulas).tag(HomebrewPackageKind.formula)
+        }
+        .labelsHidden()
+        .frame(width: 116)
+    }
+
+    private var searchButton: some View {
+        Button {
+            search()
+        } label: {
+            Label(l10n.s.homebrewSearchButton, systemImage: "magnifyingglass")
+        }
+        .fixedSize()
+        .disabled(query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || homebrew.isBusy)
+    }
+
+    private var refreshButton: some View {
+        Button {
+            homebrew.refreshInstalled()
+        } label: {
+            Image(systemName: "arrow.clockwise")
+        }
+        .fixedSize()
+        .help(l10n.s.homebrewRefresh)
+        .disabled(homebrew.isBusy)
+    }
+
+    private var updateHomebrewButton: some View {
+        Button {
+            pendingAction = HomebrewPendingAction(action: .updateHomebrew)
+        } label: {
+            Label(l10n.s.homebrewUpdateHomebrew, systemImage: "arrow.triangle.2.circlepath")
+        }
+        .fixedSize()
+        .disabled(homebrew.isBusy)
     }
 
     @ViewBuilder

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -5535,6 +5535,22 @@ struct MetricsTests {
         expect(largeCaptureWindow.width <= 1470 * 0.90
                 && largeCaptureWindow.height <= 956 * 0.88,
                "a large screenshot editor stays inside the visible display")
+        expect(ScreenshotSupport.editorOwnsKeyEvent(eventWindowNumber: 42,
+                                                    editorWindowNumber: 42,
+                                                    editorIsKey: true),
+               "screenshot editor owns key events carrying its window number")
+        expect(ScreenshotSupport.editorOwnsKeyEvent(eventWindowNumber: 0,
+                                                    editorWindowNumber: 42,
+                                                    editorIsKey: true),
+               "screenshot editor owns windowless menu key equivalents while key")
+        expect(!ScreenshotSupport.editorOwnsKeyEvent(eventWindowNumber: 0,
+                                                     editorWindowNumber: 42,
+                                                     editorIsKey: false),
+               "inactive screenshot editor ignores windowless key events")
+        expect(!ScreenshotSupport.editorOwnsKeyEvent(eventWindowNumber: 7,
+                                                     editorWindowNumber: 42,
+                                                     editorIsKey: true),
+               "screenshot editor ignores events explicitly owned by another window")
         let previewFrame = ScreenshotSupport.quickPreviewFrame(
             size: CGSize(width: 286, height: 210),
             anchor: CGRect(x: 1100, y: 100, width: 300, height: 300),


### PR DESCRIPTION
## Summary

- make the Homebrew Settings toolbar adapt to compact window widths
- let the screenshot editor handle Command-Z events that AppKit sends without a window number
- select existing screenshot annotations from any non-modal annotation tool, including text, stickers and counters

## Why

Issue #288 reports a broken Homebrew Settings layout and two inconsistent screenshot editor interactions. The Homebrew toolbar forced all controls into one row at the minimum Settings width. The editor's local key monitor rejected menu key equivalents whose event had no window, and click-only annotation tools always created a new mark before considering an existing one under the pointer.

## Impact

Homebrew controls now fall back to two balanced rows when the detail column is narrow. Screenshot undo keeps text-field editing isolated while accepting windowless Command-Z events only when the editor is key. A click on an existing annotation now switches to Select and opens text inline when applicable; real drags continue creating with the active tool.

Part of #288.

## Checks

- `./build.sh --test` — 2,840 checks passed
- `./build.sh` — release build and bundle signing passed
- `git diff --check`
