### PR TITLE
Add more built-in radial menu tools

### DIFF
--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
@@ -511,7 +511,6 @@ final class RadialMenuService: ObservableObject {
             case .quickLauncher: QuickLauncherService.shared.show()
             case .cameraPreview: CameraPreviewService.shared.show()
             case .scratchpad: ScratchpadService.shared.show()
-            case .keepAwake: KeepAwakeManager.shared.toggle()
             case .shelf: ShelfService.shared.summon()
             case .cleaningMode: CleaningModeManager.shared.activate()
             }

--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
@@ -511,6 +511,9 @@ final class RadialMenuService: ObservableObject {
             case .quickLauncher: QuickLauncherService.shared.show()
             case .cameraPreview: CameraPreviewService.shared.show()
             case .scratchpad: ScratchpadService.shared.show()
+            case .keepAwake: KeepAwakeManager.shared.toggle()
+            case .shelf: ShelfService.shared.summon()
+            case .cleaningMode: CleaningModeManager.shared.activate()
             }
         }
     }

--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
@@ -240,7 +240,7 @@ final class RadialMenuService: ObservableObject {
     private func availableItems(_ items: [RadialMenuItem]) -> [RadialMenuItem] {
         items.compactMap { item in
             var item = item
-            if let tool = item.tool, !tool.feature.isAvailable { return nil }
+            if let tool = item.tool, !tool.isRunnable() { return nil }
             if item.kind == .submenu {
                 item.children = availableItems(item.children)
                 if item.children.isEmpty { return nil }
@@ -498,7 +498,7 @@ final class RadialMenuService: ObservableObject {
     }
 
     private func run(_ tool: RadialMenuTool) {
-        guard tool.feature.isAvailable else { return }
+        guard tool.isRunnable() else { return }
         // The same beat the quick panel gives screen-touching tools, so the
         // wheel is really gone before anything captures or presents.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {

--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuSupport.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuSupport.swift
@@ -106,6 +106,15 @@ enum RadialMenuTool: String, Codable, CaseIterable, Identifiable {
     }
 
     var symbolName: String { feature.symbolName }
+
+    /// Hub availability and a feature's own master switch are separate. A
+    /// saved Shelf slice stays dormant while Shelf is explicitly disabled and
+    /// returns automatically when the user enables it again.
+    func isRunnable(isFeatureAvailable: (AppFeature) -> Bool = { $0.isAvailable },
+                    boolFor: (String) -> Bool = { UserDefaults.standard.bool(forKey: $0) }) -> Bool {
+        guard isFeatureAvailable(feature) else { return false }
+        return self != .shelf || boolFor(DefaultsKey.shelfEnabled)
+    }
 }
 
 /// The optional second summoner: a spare side mouse button. Raw values are

--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuSupport.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuSupport.swift
@@ -85,7 +85,7 @@ private struct FailableRadialMenuItem: Decodable {
 /// blob; never rename them.
 enum RadialMenuTool: String, Codable, CaseIterable, Identifiable {
     case screenshot, colorPicker, screenOCR, micMute, clipboardHistory, quickLauncher, cameraPreview,
-         scratchpad
+         scratchpad, keepAwake, shelf, cleaningMode
 
     var id: String { rawValue }
 
@@ -99,6 +99,9 @@ enum RadialMenuTool: String, Codable, CaseIterable, Identifiable {
         case .quickLauncher: return .quickLauncher
         case .cameraPreview: return .cameraPreview
         case .scratchpad: return .scratchpad
+        case .keepAwake: return .keepAwake
+        case .shelf: return .shelf
+        case .cleaningMode: return .cleaningMode
         }
     }
 

--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuSupport.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuSupport.swift
@@ -85,7 +85,7 @@ private struct FailableRadialMenuItem: Decodable {
 /// blob; never rename them.
 enum RadialMenuTool: String, Codable, CaseIterable, Identifiable {
     case screenshot, colorPicker, screenOCR, micMute, clipboardHistory, quickLauncher, cameraPreview,
-         scratchpad, keepAwake, shelf, cleaningMode
+         scratchpad, shelf, cleaningMode
 
     var id: String { rawValue }
 
@@ -99,7 +99,6 @@ enum RadialMenuTool: String, Codable, CaseIterable, Identifiable {
         case .quickLauncher: return .quickLauncher
         case .cameraPreview: return .cameraPreview
         case .scratchpad: return .scratchpad
-        case .keepAwake: return .keepAwake
         case .shelf: return .shelf
         case .cleaningMode: return .cleaningMode
         }

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -1514,6 +1514,8 @@ final class ShelfService: ObservableObject {
     /// docked option on; the docked shelf just steps aside while this panel is
     /// up and comes back when it closes.
     func summon() {
+        guard AppFeature.shelf.isAvailable,
+              UserDefaults.standard.bool(forKey: DefaultsKey.shelfEnabled) else { return }
         let panel = ensurePanel()
         cancelAutoHide()
         position(panel)

--- a/Sources/Vorssaint/UI/Settings/RadialMenuSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/RadialMenuSettings.swift
@@ -343,7 +343,7 @@ private struct RadialItemEditor: View {
     @Environment(\.dismiss) private var dismiss
 
     private var availableTools: [RadialMenuTool] {
-        RadialMenuTool.allCases.filter { $0.feature.isAvailable }
+        RadialMenuTool.allCases.filter { $0.isRunnable() }
     }
 
     private var urlIsInvalid: Bool {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -5513,6 +5513,15 @@ struct MetricsTests {
                 && RadialMenuTool.shelf.feature == .shelf
                 && RadialMenuTool.cleaningMode.feature == .cleaningMode,
                "every wheel tool maps to a real feature and symbol")
+        expect(!RadialMenuTool.shelf.isRunnable(isFeatureAvailable: { _ in true },
+                                                boolFor: { _ in false })
+                && RadialMenuTool.shelf.isRunnable(isFeatureAvailable: { _ in true },
+                                                   boolFor: { $0 == DefaultsKey.shelfEnabled })
+                && !RadialMenuTool.shelf.isRunnable(isFeatureAvailable: { _ in false },
+                                                    boolFor: { _ in true })
+                && RadialMenuTool.keepAwake.isRunnable(isFeatureAvailable: { _ in true },
+                                                       boolFor: { _ in false }),
+               "Shelf wheel slices follow the Shelf master switch without affecting on-demand tools")
 
         // MARK: Dock click with AX-blind apps (issue #200)
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -5508,7 +5508,10 @@ struct MetricsTests {
         expect(RadialMenuTool.allCases.allSatisfy { !$0.symbolName.isEmpty }
                 && RadialMenuTool.screenshot.feature == .screenshot
                 && RadialMenuTool.clipboardHistory.feature == .clipboardHistory
-                && RadialMenuTool.scratchpad.feature == .scratchpad,
+                && RadialMenuTool.scratchpad.feature == .scratchpad
+                && RadialMenuTool.keepAwake.feature == .keepAwake
+                && RadialMenuTool.shelf.feature == .shelf
+                && RadialMenuTool.cleaningMode.feature == .cleaningMode,
                "every wheel tool maps to a real feature and symbol")
 
         // MARK: Dock click with AX-blind apps (issue #200)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -5509,7 +5509,6 @@ struct MetricsTests {
                 && RadialMenuTool.screenshot.feature == .screenshot
                 && RadialMenuTool.clipboardHistory.feature == .clipboardHistory
                 && RadialMenuTool.scratchpad.feature == .scratchpad
-                && RadialMenuTool.keepAwake.feature == .keepAwake
                 && RadialMenuTool.shelf.feature == .shelf
                 && RadialMenuTool.cleaningMode.feature == .cleaningMode,
                "every wheel tool maps to a real feature and symbol")
@@ -5519,8 +5518,8 @@ struct MetricsTests {
                                                    boolFor: { $0 == DefaultsKey.shelfEnabled })
                 && !RadialMenuTool.shelf.isRunnable(isFeatureAvailable: { _ in false },
                                                     boolFor: { _ in true })
-                && RadialMenuTool.keepAwake.isRunnable(isFeatureAvailable: { _ in true },
-                                                       boolFor: { _ in false }),
+                && RadialMenuTool.cleaningMode.isRunnable(isFeatureAvailable: { _ in true },
+                                                          boolFor: { _ in false }),
                "Shelf wheel slices follow the Shelf master switch without affecting on-demand tools")
 
         // MARK: Dock click with AX-blind apps (issue #200)


### PR DESCRIPTION
## Summary

- add an action that summons Shelf
- add an action that starts Cleaning Mode

Each action reuses the same service entry point already used elsewhere in the app. Names, icons, feature availability, permission handling and Cleaning Mode safeguards therefore stay consistent with the existing UI.

Keep Awake now lives in its own focused PR.

Refs #288

## Testing

- `./build.sh --test` (2950 checks)
- `swift build`
