### PR TITLE
Add Keep Awake to the radial menu

### DIFF
--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
@@ -511,6 +511,7 @@ final class RadialMenuService: ObservableObject {
             case .quickLauncher: QuickLauncherService.shared.show()
             case .cameraPreview: CameraPreviewService.shared.show()
             case .scratchpad: ScratchpadService.shared.show()
+            case .keepAwake: KeepAwakeManager.shared.toggle()
             }
         }
     }

--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuSupport.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuSupport.swift
@@ -85,7 +85,7 @@ private struct FailableRadialMenuItem: Decodable {
 /// blob; never rename them.
 enum RadialMenuTool: String, Codable, CaseIterable, Identifiable {
     case screenshot, colorPicker, screenOCR, micMute, clipboardHistory, quickLauncher, cameraPreview,
-         scratchpad
+         scratchpad, keepAwake
 
     var id: String { rawValue }
 
@@ -99,6 +99,7 @@ enum RadialMenuTool: String, Codable, CaseIterable, Identifiable {
         case .quickLauncher: return .quickLauncher
         case .cameraPreview: return .cameraPreview
         case .scratchpad: return .scratchpad
+        case .keepAwake: return .keepAwake
         }
     }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -5508,7 +5508,8 @@ struct MetricsTests {
         expect(RadialMenuTool.allCases.allSatisfy { !$0.symbolName.isEmpty }
                 && RadialMenuTool.screenshot.feature == .screenshot
                 && RadialMenuTool.clipboardHistory.feature == .clipboardHistory
-                && RadialMenuTool.scratchpad.feature == .scratchpad,
+                && RadialMenuTool.scratchpad.feature == .scratchpad
+                && RadialMenuTool.keepAwake.feature == .keepAwake,
                "every wheel tool maps to a real feature and symbol")
 
         // MARK: Dock click with AX-blind apps (issue #200)


### PR DESCRIPTION
## Summary

- add Keep Awake to the radial menu's built-in Vorssaint tools
- toggle the existing Keep Awake state directly when the slice is selected
- reuse the feature's existing localized name and icon

This keeps the radial action aligned with the menu-bar control without introducing another state or persistence path.

## User impact

Users can add “Keep Awake” to any radial wheel or submenu and turn it on or off without opening the main panel.

## Testing

- `./build.sh --test` (2949 checks)
- `./build.sh`
- `./build/Vorssaint --selftest`
