### PR TITLE
Screenshot: optional automatic copy to the clipboard

### DIFF
--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -312,6 +312,7 @@ enum DefaultsKey {
     static let screenshotBackdropStyle = "screenshotBackdropStyle"
     static let screenshotBackdropPresets = "screenshotBackdropPresets"
     static let screenshotOpenEditorDirectly = "screenshotOpenEditorDirectly"
+    static let screenshotCopyToClipboard = "screenshotCopyToClipboard"
     static let panelUtilityScreenshot = "panelUtilityScreenshot"
 
     // Window Layout — snapping, global shortcuts and optional pointer gestures.
@@ -787,6 +788,7 @@ enum Defaults {
         DefaultsKey.screenshotBackdropStyle: "",
         DefaultsKey.screenshotBackdropPresets: "[]",
         DefaultsKey.screenshotOpenEditorDirectly: false,
+        DefaultsKey.screenshotCopyToClipboard: false,
         DefaultsKey.panelUtilityScreenshot: true,
         DefaultsKey.windowLayoutShortcutsEnabled: false,
         DefaultsKey.windowGestureEnabled: false,

--- a/Sources/Vorssaint/Core/ScreenshotStrings.swift
+++ b/Sources/Vorssaint/Core/ScreenshotStrings.swift
@@ -76,6 +76,8 @@ struct ScreenshotFeatureStrings {
     let backdropCustomLabel: String
     let openEditorToggle: String
     let openEditorCaption: String
+    let autoCopyToggle: String
+    let autoCopyCaption: String
     let hintLoupe: String
 }
 
@@ -172,6 +174,8 @@ extension ScreenshotFeatureStrings {
         backdropCustomLabel: "Custom",
         openEditorToggle: "Open the editor right after capturing",
         openEditorCaption: "The capture skips the floating preview and opens ready to annotate.",
+        autoCopyToggle: "Copy to the clipboard automatically",
+        autoCopyCaption: "Every capture goes to the clipboard as soon as it is taken, ready to paste. Saving a file stays a separate choice.",
         hintLoupe: "Z toggles the loupe"
     )
 
@@ -247,6 +251,8 @@ extension ScreenshotFeatureStrings {
         backdropCustomLabel: "Personalizado",
         openEditorToggle: "Abrir o editor logo após capturar",
         openEditorCaption: "A captura pula a pré-visualização flutuante e já abre pronta para anotar.",
+        autoCopyToggle: "Copiar para a área de transferência automaticamente",
+        autoCopyCaption: "Toda captura vai para a área de transferência assim que é feita, pronta para colar. Salvar um arquivo continua sendo uma escolha à parte.",
         hintLoupe: "Z alterna a lupa"
     )
 
@@ -322,6 +328,8 @@ extension ScreenshotFeatureStrings {
         backdropCustomLabel: "Özel",
         openEditorToggle: "Yakaladıktan hemen sonra düzenleyiciyi aç",
         openEditorCaption: "Yakalama, yüzen önizlemeyi atlar ve işaretlemeye hazır şekilde açılır.",
+        autoCopyToggle: "Otomatik olarak panoya kopyala",
+        autoCopyCaption: "Her yakalama alınır alınmaz panoya gider ve yapıştırmaya hazır olur. Dosya olarak kaydetmek ayrı bir seçim olarak kalır.",
         hintLoupe: "Z büyüteci açar/kapatır"
     )
 
@@ -397,6 +405,8 @@ extension ScreenshotFeatureStrings {
         backdropCustomLabel: "Свой",
         openEditorToggle: "Открывать редактор сразу после снимка",
         openEditorCaption: "Снимок пропускает плавающее окно предпросмотра и сразу открывается готовым к пометкам.",
+        autoCopyToggle: "Автоматически копировать в буфер обмена",
+        autoCopyCaption: "Каждый снимок попадает в буфер обмена сразу после съёмки и готов к вставке. Сохранение файла остаётся отдельным выбором.",
         hintLoupe: "Z включает лупу"
     )
 
@@ -472,6 +482,8 @@ extension ScreenshotFeatureStrings {
         backdropCustomLabel: "Personalizado",
         openEditorToggle: "Abrir el editor justo después de capturar",
         openEditorCaption: "La captura omite la previsualización flotante y se abre lista para anotar.",
+        autoCopyToggle: "Copiar al portapapeles automáticamente",
+        autoCopyCaption: "Cada captura va al portapapeles en cuanto se toma, lista para pegar. Guardar un archivo sigue siendo una elección aparte.",
         hintLoupe: "Z activa la lupa"
     )
 
@@ -547,6 +559,8 @@ extension ScreenshotFeatureStrings {
         backdropCustomLabel: "Eigene",
         openEditorToggle: "Editor direkt nach der Aufnahme öffnen",
         openEditorCaption: "Die Aufnahme überspringt die schwebende Vorschau und öffnet sich bereit für Anmerkungen.",
+        autoCopyToggle: "Automatisch in die Zwischenablage kopieren",
+        autoCopyCaption: "Jede Aufnahme landet sofort in der Zwischenablage, bereit zum Einfügen. Das Speichern als Datei bleibt eine eigene Entscheidung.",
         hintLoupe: "Z schaltet die Lupe um"
     )
 
@@ -622,6 +636,8 @@ extension ScreenshotFeatureStrings {
         backdropCustomLabel: "Personnalisé",
         openEditorToggle: "Ouvrir l'éditeur juste après la capture",
         openEditorCaption: "La capture ignore l'aperçu flottant et s'ouvre prête à être annotée.",
+        autoCopyToggle: "Copier automatiquement dans le presse-papiers",
+        autoCopyCaption: "Chaque capture va dans le presse-papiers dès qu'elle est prise, prête à être collée. Enregistrer un fichier reste un choix distinct.",
         hintLoupe: "Z active la loupe"
     )
 
@@ -697,6 +713,8 @@ extension ScreenshotFeatureStrings {
         backdropCustomLabel: "Personalizzato",
         openEditorToggle: "Apri l'editor subito dopo la cattura",
         openEditorCaption: "La cattura salta l'anteprima flottante e si apre pronta per le annotazioni.",
+        autoCopyToggle: "Copia automaticamente negli appunti",
+        autoCopyCaption: "Ogni cattura va negli appunti appena viene fatta, pronta da incollare. Salvare un file resta una scelta a parte.",
         hintLoupe: "Z attiva la lente"
     )
 
@@ -772,6 +790,8 @@ extension ScreenshotFeatureStrings {
         backdropCustomLabel: "カスタム",
         openEditorToggle: "撮影後すぐにエディタを開く",
         openEditorCaption: "撮影はフローティングプレビューを飛ばして、すぐに注釈を付けられる状態で開きます。",
+        autoCopyToggle: "自動的にクリップボードへコピー",
+        autoCopyCaption: "撮影した瞬間にクリップボードへ入り、すぐに貼り付けられます。ファイルとして保存するかどうかは別の選択のままです。",
         hintLoupe: "Zでルーペを切り替え"
     )
 
@@ -847,6 +867,8 @@ extension ScreenshotFeatureStrings {
         backdropCustomLabel: "사용자화",
         openEditorToggle: "캡처 후 바로 편집기 열기",
         openEditorCaption: "캡처가 떠 있는 미리보기를 건너뛰고 바로 주석을 남길 수 있는 상태로 열립니다.",
+        autoCopyToggle: "자동으로 클립보드에 복사",
+        autoCopyCaption: "캡처하는 즉시 클립보드에 담겨 바로 붙여넣을 수 있습니다. 파일로 저장하는 것은 여전히 별도의 선택입니다.",
         hintLoupe: "Z 키로 확대경 전환"
     )
 
@@ -922,6 +944,8 @@ extension ScreenshotFeatureStrings {
         backdropCustomLabel: "自定义",
         openEditorToggle: "截取后立即打开编辑器",
         openEditorCaption: "截屏会跳过浮动预览，直接打开即可开始标注。",
+        autoCopyToggle: "自动复制到剪贴板",
+        autoCopyCaption: "每次截屏后会立即进入剪贴板，随时可以粘贴。是否保存为文件仍是单独的选择。",
         hintLoupe: "按 Z 切换放大镜"
     )
 
@@ -997,6 +1021,8 @@ extension ScreenshotFeatureStrings {
         backdropCustomLabel: "自訂",
         openEditorToggle: "擷取後立即開啟編輯器",
         openEditorCaption: "截圖會略過浮動預覽，直接開啟即可開始標註。",
+        autoCopyToggle: "自動拷貝到剪貼板",
+        autoCopyCaption: "每次截圖後會立即進入剪貼板，隨時可以貼上。是否儲存為檔案仍是獨立的選擇。",
         hintLoupe: "按 Z 切換放大鏡"
     )
 
@@ -1072,6 +1098,8 @@ extension ScreenshotFeatureStrings {
         backdropCustomLabel: "自訂",
         openEditorToggle: "擷取後立即開啟編輯器",
         openEditorCaption: "截圖會略過浮動預覽，直接開啟即可開始標註。",
+        autoCopyToggle: "自動拷貝到剪貼板",
+        autoCopyCaption: "每次截圖後會立即進入剪貼板，隨時可以貼上。是否儲存為檔案仍是獨立的選擇。",
         hintLoupe: "按 Z 切換放大鏡"
     )
 }

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotService.swift
@@ -132,8 +132,15 @@ final class ScreenshotService: ObservableObject {
 
     /// A finished capture goes to the floating preview, or straight into the
     /// editor when the direct edit preference is on.
+    ///
+    /// The clipboard copy happens first and independently, so it also reaches
+    /// the captures that open straight in the editor, where no preview button
+    /// exists to reach for.
     private func route(_ capture: ScreenshotSelectionController.Capture) {
         preview?.close()
+        if UserDefaults.standard.bool(forKey: DefaultsKey.screenshotCopyToClipboard) {
+            autoCopy(capture)
+        }
         if UserDefaults.standard.bool(forKey: DefaultsKey.screenshotOpenEditorDirectly) {
             openEditor(with: capture)
             return
@@ -175,6 +182,17 @@ final class ScreenshotService: ObservableObject {
             NSApp.setActivationPolicy(.accessory)
             promotedActivationForEditors = false
         }
+    }
+
+    /// Automatic copy stays quiet on success: the preview or the editor is
+    /// already appearing and says the capture happened, so a HUD on top of it
+    /// would only repeat that. A failure still beeps, since nothing else
+    /// would reveal an empty clipboard before the paste.
+    private func autoCopy(_ capture: ScreenshotSelectionController.Capture) {
+        if let image = flatten(capture), ScreenshotEditorController.copyImage(image) {
+            return
+        }
+        NSSound.beep()
     }
 
     @discardableResult

--- a/Sources/Vorssaint/UI/Settings/ScreenshotSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/ScreenshotSettings.swift
@@ -18,6 +18,7 @@ struct ScreenshotSettings: View {
         ScreenshotSupport.Tool.defaultOrderStorage
     @AppStorage(DefaultsKey.screenshotToolShortcutsEnabled) private var toolShortcutsEnabled = true
     @AppStorage(DefaultsKey.screenshotOpenEditorDirectly) private var openEditorDirectly = false
+    @AppStorage(DefaultsKey.screenshotCopyToClipboard) private var copyToClipboard = false
 
     private var strings: ScreenshotFeatureStrings {
         FeatureStrings.screenshot(l10n.language)
@@ -77,6 +78,10 @@ struct ScreenshotSettings: View {
             }
 
             Section {
+                Toggle(strings.autoCopyToggle, isOn: $copyToClipboard)
+                Text(strings.autoCopyCaption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                 folderRow
                 Toggle(strings.downscaleToggle, isOn: $downscale)
                 Text(strings.downscaleCaption)


### PR DESCRIPTION
## Behavior before

Every capture has to be routed by hand. The floating preview appears and the image only reaches the clipboard once **Copy** is clicked. With `screenshotOpenEditorDirectly` on there is no preview at all, so the fastest path to annotating is also the slowest path to pasting — the two preferences work against each other.

For the common case of "grab this, paste it into a chat", that is one deliberate click on top of every single capture.

## Behavior after

A new **Copy to the clipboard automatically** toggle in Settings → Screenshot, **off by default**, so nothing changes for anyone who does not turn it on.

When it is on, the capture is placed on the pasteboard as soon as the selection finishes, before the preview or the editor is shown. `Cmd`+`V` works immediately. The preview still appears with all of its buttons; the editor still opens when the direct-edit preference is on. The two preferences are fully orthogonal:

| Auto-copy | Open editor directly | Result |
|---|---|---|
| off | off | Unchanged: preview with Copy / Save / Delete / Edit |
| on | off | On the clipboard immediately, preview still appears |
| on | on | On the clipboard immediately, editor opens for annotation |
| off | on | Unchanged: straight to the editor |

Saving to a file is untouched and stays an explicit choice from the preview or the editor.

## Implementation

Four files, 53 added lines, nothing removed:

- `Core/Defaults.swift` — `screenshotCopyToClipboard`, registered `false`.
- `Services/QuickTools/ScreenshotService.swift` — `route(_:)` calls a new private `autoCopy(_:)` before deciding between preview and editor, so the copy also covers the direct-to-editor path. It reuses the existing `flatten(_:)` pipeline, so the 1x downscale preference applies exactly as it does to the preview's Copy button, and the existing `ScreenshotEditorController.copyImage(_:)`, so the pasteboard gets the same PNG + TIFF pair as every other copy in the app.
- `UI/Settings/ScreenshotSettings.swift` — the toggle and its caption, in the output section above the save folder.
- `Core/ScreenshotStrings.swift` — `autoCopyToggle` and `autoCopyCaption` in all 13 languages.

No new dependencies, no new types, no changes to existing call sites.

### Two decisions worth a second opinion

**No HUD on success.** `copyDirect(_:)` shows the "Screenshot copied" HUD because the preview closes right after it, leaving nothing on screen. With auto-copy a surface is always about to appear, so a HUD would land on top of the preview and repeat what it already says. A failure still beeps, since an empty clipboard would otherwise only be discovered at the paste. Happy to add the HUD if you would rather have the confirmation.

**Annotations do not re-copy.** If auto-copy puts the raw capture on the clipboard and the capture is then annotated in the editor, the clipboard still holds the un-annotated version until Copy is pressed in the editor. That is a real trap for anyone who edits, but fixing it means refreshing the pasteboard on editor close, which changes editor behavior and reads as a separate topic. Left out to keep this to one change; glad to open a follow-up if you want it.

## Localization

`autoCopyToggle` and `autoCopyCaption` are filled in for all 13 languages in `ScreenshotFeatureStrings`: en, pt-BR, tr, ru, es, de, fr, it, ja, ko, zh-Hans, zh-TW, zh-HK. Terminology follows what the file and `Core/Localizations/` already use, notably 剪贴板 for zh-Hans and 剪貼板 / 拷貝 for zh-TW and zh-HK rather than 剪貼簿 / 複製, and zh-HK mirrors zh-TW here the same way the neighboring `openEditor` strings do.

These are machine-assisted translations reviewed against the surrounding entries for tone and consistency, not native review. Please correct anything that reads wrong — I would rather the strings be right than mine.

## Testing

- `./build.sh` completes with no warnings, before and after the change.
- `./build/Vorssaint --selftest` prints `SELFTEST OK`.
- Built against the Command Line Tools, Swift 6.3.3, on macOS 26.5.2, Apple M4.

I have not exercised an end-to-end capture on the built bundle: it is ad-hoc signed and would need its own Screen Recording grant alongside the installed copy, which I did not want to do on this machine. The change is small and reuses existing, already-tested copy and flatten paths, but the actual capture → clipboard round trip is unverified by me and worth a manual check before merging.

## Notes

No existing issue covers this — I searched the tracker for screenshot and clipboard first and only found closed clipboard-history bugs. Happy to open a feature request to discuss it there instead if you would rather talk it through before looking at code.

Contributed under GPL-3.0-or-later per `CONTRIBUTING.md`.
