### PR TITLE
Adjust legacyBlockAttachmentNudge for macOS < 27

### DIFF
--- a/Sources/Vorssaint/App/MenuBarRenderer.swift
+++ b/Sources/Vorssaint/App/MenuBarRenderer.swift
@@ -802,11 +802,11 @@ enum MenuBarRenderer {
     }
 
     /// macOS 26 lays out button titles dominated by tall attachments about
-    /// 1.2pt higher than macOS 27, where every block offset below was
+    /// 0.25pt higher than macOS 27, where every block offset below was
     /// calibrated; older systems get a downward nudge so the blocks center
     /// on the menu bar like the system's own icons.
     private static let legacyBlockAttachmentNudge: CGFloat = {
-        if #unavailable(macOS 27) { return -1.2 }
+        if #unavailable(macOS 27) { return -0.25 }
         return 0
     }()
 


### PR DESCRIPTION
Addresses the over-correction of offset as mentioned in https://github.com/vorssaint/vorssaint-utils/issues/253#issuecomment-5013731850

Now, with the nudge becoming so small I'm not even sure whether or not there's really differences between macOS 27 and below, but I don't have macOS 27 to check, and at least on Tahoe as well as even older version like Sonoma, this change makes the icons perfectly center aligned.