### PR TITLE
Fix saved search losing its argument in the command bar

### DIFF
--- a/Sources/Vorssaint/Services/CommandBar/CommandBarLinks.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarLinks.swift
@@ -117,6 +117,13 @@ enum CommandBarLinks {
         return words.dropFirst(nameWords).joined(separator: " ")
     }
 
+    /// What a link's row is scored against. Its own name works until the
+    /// person types something after it — from there the row has to be scored
+    /// against everything typed, or the extra words sink it out of the list.
+    static func rankingTitle(name: String, query: String) -> String {
+        trailingArgument(query: query, name: name) != nil ? query : name
+    }
+
     /// The URL a link opens, or nil when what was saved cannot be opened. A
     /// destination without a scheme is treated as a site, which is what people
     /// mean when they paste one in.

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
@@ -953,9 +953,15 @@ final class CommandBarService: ObservableObject {
             // that is the whole point of giving it.
             let aliasBoost = names[entry.stableKey]
                 .flatMap { CommandBarPreferences.aliasHit($0, query: effectiveQuery)?.rawValue } ?? 0
+            // A saved search is cached under its own name, but once an
+            // argument follows that name the row has to be scored against
+            // the whole query or the argument words sink it from the list.
+            let normalizedTitle = sources[index] == .links
+                ? CommandBarSearch.normalized(
+                    CommandBarLinks.rankingTitle(name: entry.title, query: effectiveQuery))
+                : folded?.title ?? CommandBarSearch.normalized(entry.matchTitle ?? entry.title)
             return CommandBarCandidate(index: index,
-                                normalizedTitle: folded?.title
-                                    ?? CommandBarSearch.normalized(entry.matchTitle ?? entry.title),
+                                normalizedTitle: normalizedTitle,
                                 normalizedKeywords: folded?.keywords
                                     ?? CommandBarSearch.normalized(entry.keywords),
                                 // A running app is likelier to be the one

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9275,6 +9275,13 @@ struct MetricsTests {
             CommandBarLink(name: "", kind: .link, destination: "x"),
             CommandBarLink(name: "ok", kind: .link, destination: "x"),
         ])).count == 1, "a half-written shortcut never survives a round trip")
+        expect(CommandBarLinks.rankingTitle(name: "gh", query: "gh vorssaint utils")
+                == "gh vorssaint utils",
+               "once an argument follows the name, the row is scored against the whole query")
+        expect(CommandBarLinks.rankingTitle(name: "gh", query: "gh") == "gh",
+               "the name alone still scores against its own name")
+        expect(CommandBarLinks.rankingTitle(name: "gh", query: "ghost writer") == "gh",
+               "a word that only starts with the name is not an argument, so scoring is untouched")
 
         expect(CommandBarText.wordCount("uma frase com cinco palavras") == 5
                 && CommandBarText.wordCount("  espaços   demais  ") == 2


### PR DESCRIPTION
## Summary

- add CommandBarLinks.rankingTitle, scoring a saved-search row against the
  whole query once its name is followed by an argument, against its own name
  otherwise
- wire it into CommandBarService.searchRows for rows with source .links only
- add three CommandBarLinks.rankingTitle checks alongside the other link
  tests in Tests/MetricsTests.swift

## Root cause

Every row is scored by matching each typed word against its title
(CommandBarSearch.score). A saved search's row matches on its own name, so
typing anything after that name, like "ddg the titanic" instead of just
"ddg", introduced words the title could not match, and the row fell out of
the results right before the moment it was meant to run. The row's own
subtitle ("Type what to look for after the name") promises the opposite.

## Verification

- ./build.sh --test: TESTS OK, 5637 checks (5634 on main before this change,
  +3 for the new checks)
- ./build.sh: release build, no warnings
- ./build/Vorssaint --selftest: SELFTEST OK
- ./build.sh --dev --install: built and ran a Developer-id build alongside
  the real app, added a saved search (ddg -> https://duckduckgo.com/?q={query}),
  confirmed "ddg the titanic" now stays matched and opens DuckDuckGo with the
  right query in the default browser