### PR TITLE
Add a Scratchpad background opacity slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,6 @@ pause in chosen apps, and the App Switcher, Scratchpad and radial menu gain clea
   starts on F2, off by default. Thanks to @Mito450.
 - Copied images can become PNG files with ⌘V in Finder, off by default under
   Clipboard. Thanks to @AsphaltDemon.
-- A slider for how solid the Scratchpad background looks. Under Quick Tools,
-  with Scratchpad on. Thanks to @hash00.
 
 ### Changed
 - The Scratchpad now has a pin that keeps the current note open until you close

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ pause in chosen apps, and the App Switcher, Scratchpad and radial menu gain clea
   starts on F2, off by default. Thanks to @Mito450.
 - Copied images can become PNG files with ⌘V in Finder, off by default under
   Clipboard. Thanks to @AsphaltDemon.
+- A slider for how solid the Scratchpad background looks. Under Quick Tools,
+  with Scratchpad on. Thanks to @hash00.
 
 ### Changed
 - The Scratchpad now has a pin that keeps the current note open until you close

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ pause in chosen apps, and the App Switcher, Scratchpad and radial menu gain clea
   starts on F2, off by default. Thanks to @Mito450.
 - Copied images can become PNG files with ⌘V in Finder, off by default under
   Clipboard. Thanks to @AsphaltDemon.
-- A slider for how solid the Scratchpad background looks. Under Quick Tools,
-  with Scratchpad on. Thanks to @hash00.
+- A slider makes the Scratchpad background more solid, up to fully opaque.
+  Under Quick Tools. Thanks to @hash00.
 
 ### Changed
 - The Scratchpad now has a pin that keeps the current note open until you close

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -357,6 +357,7 @@ enum DefaultsKey {
     static let panelUtilityCommandBar = "panelUtilityCommandBar"
     static let scratchpadRetention = "scratchpadRetention"   // never | day | week | month
     static let scratchpadCloseOnClickOutside = "scratchpadCloseOnClickOutside"
+    static let scratchpadBackgroundOpacity = "scratchpadBackgroundOpacity" // how solid the pad's material is drawn (ScratchpadSupport.backgroundOpacityRange)
     static let micMuteActive = "micMuteActive"               // mic muted by the app (survives relaunch)
     static let micMuteSavedVolume = "micMuteSavedVolume"     // input volume to restore on unmute (pre 3.2.0 state)
     static let micMuteSavedVolumes = "micMuteSavedVolumes"   // [device uid: input volume] to restore on unmute
@@ -925,6 +926,7 @@ enum Defaults {
         DefaultsKey.panelUtilityCommandBar: true,
         DefaultsKey.scratchpadRetention: ScratchpadRetention.never.rawValue,
         DefaultsKey.scratchpadCloseOnClickOutside: true,
+        DefaultsKey.scratchpadBackgroundOpacity: 1.0,
         DefaultsKey.micMuteActive: false,
         DefaultsKey.micMuteSavedVolume: 0.75,
         DefaultsKey.micMuteMenuBarIndicator: true,  // owner's call: on by default in 3.1.8 (badge only shows while muted)

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -357,7 +357,7 @@ enum DefaultsKey {
     static let panelUtilityCommandBar = "panelUtilityCommandBar"
     static let scratchpadRetention = "scratchpadRetention"   // never | day | week | month
     static let scratchpadCloseOnClickOutside = "scratchpadCloseOnClickOutside"
-    static let scratchpadBackgroundOpacity = "scratchpadBackgroundOpacity" // how solid the pad's material is drawn (ScratchpadSupport.backgroundOpacityRange)
+    static let scratchpadBackgroundOpacity = "scratchpadBackgroundOpacity" // opaque fill over the pad material (ScratchpadSupport.backgroundOpacityRange)
     static let micMuteActive = "micMuteActive"               // mic muted by the app (survives relaunch)
     static let micMuteSavedVolume = "micMuteSavedVolume"     // input volume to restore on unmute (pre 3.2.0 state)
     static let micMuteSavedVolumes = "micMuteSavedVolumes"   // [device uid: input volume] to restore on unmute
@@ -926,7 +926,7 @@ enum Defaults {
         DefaultsKey.panelUtilityCommandBar: true,
         DefaultsKey.scratchpadRetention: ScratchpadRetention.never.rawValue,
         DefaultsKey.scratchpadCloseOnClickOutside: true,
-        DefaultsKey.scratchpadBackgroundOpacity: 1.0,
+        DefaultsKey.scratchpadBackgroundOpacity: 0.0,
         DefaultsKey.micMuteActive: false,
         DefaultsKey.micMuteSavedVolume: 0.75,
         DefaultsKey.micMuteMenuBarIndicator: true,  // owner's call: on by default in 3.1.8 (badge only shows while muted)

--- a/Sources/Vorssaint/Core/ScratchpadStrings.swift
+++ b/Sources/Vorssaint/Core/ScratchpadStrings.swift
@@ -22,6 +22,8 @@ struct ScratchpadFeatureStrings {
     let retentionCaption: String
     let closeOnClickOutside: String
     let keepOpen: String
+    let backgroundOpacity: String
+    let backgroundOpacityCaption: String
 }
 
 extension FeatureStrings {
@@ -62,7 +64,9 @@ extension ScratchpadFeatureStrings {
         retentionMonth: "After a month unused",
         retentionCaption: "The pad empties itself once the text goes that long without edits.",
         closeOnClickOutside: "Close when I click outside",
-        keepOpen: "Keep open"
+        keepOpen: "Keep open",
+        backgroundOpacity: "Pad background",
+        backgroundOpacityCaption: "Turn it down to see more of what sits behind the pad."
     )
 
     static let ptBR = ScratchpadFeatureStrings(
@@ -82,7 +86,9 @@ extension ScratchpadFeatureStrings {
         retentionMonth: "Após um mês sem uso",
         retentionCaption: "O bloco se esvazia quando o texto passa esse tempo sem edições.",
         closeOnClickOutside: "Fechar ao clicar fora",
-        keepOpen: "Manter aberto"
+        keepOpen: "Manter aberto",
+        backgroundOpacity: "Fundo do bloco",
+        backgroundOpacityCaption: "Diminua para ver mais do que está atrás do bloco."
     )
 
     static let tr = ScratchpadFeatureStrings(
@@ -102,7 +108,9 @@ extension ScratchpadFeatureStrings {
         retentionMonth: "Bir ay kullanılmayınca",
         retentionCaption: "Metin bu süre boyunca düzenlenmezse defter kendini boşaltır.",
         closeOnClickOutside: "Dışarı tıklayınca kapat",
-        keepOpen: "Açık tut"
+        keepOpen: "Açık tut",
+        backgroundOpacity: "Defter arka planı",
+        backgroundOpacityCaption: "Defterin arkasındakileri daha çok görmek için azalt."
     )
 
     static let ru = ScratchpadFeatureStrings(
@@ -122,7 +130,9 @@ extension ScratchpadFeatureStrings {
         retentionMonth: "Через месяц без правок",
         retentionCaption: "Черновик очищается сам, если текст столько времени не редактировался.",
         closeOnClickOutside: "Закрывать при щелчке снаружи",
-        keepOpen: "Оставить открытым"
+        keepOpen: "Оставить открытым",
+        backgroundOpacity: "Фон черновика",
+        backgroundOpacityCaption: "Уменьшите, чтобы видеть больше того, что находится за черновиком."
     )
 
     static let es = ScratchpadFeatureStrings(
@@ -142,7 +152,9 @@ extension ScratchpadFeatureStrings {
         retentionMonth: "Tras un mes sin uso",
         retentionCaption: "El bloc se vacía cuando el texto pasa ese tiempo sin cambios.",
         closeOnClickOutside: "Cerrar al hacer clic fuera",
-        keepOpen: "Mantener abierto"
+        keepOpen: "Mantener abierto",
+        backgroundOpacity: "Fondo del borrador",
+        backgroundOpacityCaption: "Bájalo para ver más de lo que hay detrás del borrador."
     )
 
     static let de = ScratchpadFeatureStrings(
@@ -162,7 +174,9 @@ extension ScratchpadFeatureStrings {
         retentionMonth: "Nach einem Monat ohne Änderung",
         retentionCaption: "Der Zettel leert sich, wenn der Text so lange nicht bearbeitet wurde.",
         closeOnClickOutside: "Beim Klick außerhalb schließen",
-        keepOpen: "Offen halten"
+        keepOpen: "Offen halten",
+        backgroundOpacity: "Hintergrund des Zettels",
+        backgroundOpacityCaption: "Verringere ihn, um mehr von dem zu sehen, was hinter dem Zettel liegt."
     )
 
     static let fr = ScratchpadFeatureStrings(
@@ -182,7 +196,9 @@ extension ScratchpadFeatureStrings {
         retentionMonth: "Après un mois sans modification",
         retentionCaption: "Le bloc se vide quand le texte reste aussi longtemps sans modification.",
         closeOnClickOutside: "Fermer si je clique à l’extérieur",
-        keepOpen: "Garder ouvert"
+        keepOpen: "Garder ouvert",
+        backgroundOpacity: "Fond du brouillon",
+        backgroundOpacityCaption: "Baissez-le pour voir davantage ce qui se trouve derrière le brouillon."
     )
 
     static let it = ScratchpadFeatureStrings(
@@ -202,7 +218,9 @@ extension ScratchpadFeatureStrings {
         retentionMonth: "Dopo un mese senza modifiche",
         retentionCaption: "Il blocco si svuota quando il testo resta così a lungo senza modifiche.",
         closeOnClickOutside: "Chiudi quando clicco fuori",
-        keepOpen: "Mantieni aperto"
+        keepOpen: "Mantieni aperto",
+        backgroundOpacity: "Sfondo della bozza",
+        backgroundOpacityCaption: "Abbassalo per vedere di più di ciò che sta dietro alla bozza."
     )
 
     static let ja = ScratchpadFeatureStrings(
@@ -222,7 +240,9 @@ extension ScratchpadFeatureStrings {
         retentionMonth: "1か月使わなかったら",
         retentionCaption: "その期間編集がないと、メモは自動で空になります。",
         closeOnClickOutside: "外側をクリックしたら閉じる",
-        keepOpen: "開いたままにする"
+        keepOpen: "開いたままにする",
+        backgroundOpacity: "メモの背景",
+        backgroundOpacityCaption: "下げると、メモの後ろにあるものがより見えるようになります。"
     )
 
     static let ko = ScratchpadFeatureStrings(
@@ -242,7 +262,9 @@ extension ScratchpadFeatureStrings {
         retentionMonth: "한 달 동안 사용하지 않으면",
         retentionCaption: "그 기간 동안 편집이 없으면 메모가 자동으로 비워집니다.",
         closeOnClickOutside: "바깥을 클릭하면 닫기",
-        keepOpen: "열어 두기"
+        keepOpen: "열어 두기",
+        backgroundOpacity: "메모 배경",
+        backgroundOpacityCaption: "낮추면 메모 뒤에 있는 것이 더 많이 보입니다."
     )
 
     static let zhHans = ScratchpadFeatureStrings(
@@ -262,7 +284,9 @@ extension ScratchpadFeatureStrings {
         retentionMonth: "一个月未使用后",
         retentionCaption: "文本超过该时间没有编辑时，草稿板会自动清空。",
         closeOnClickOutside: "点击外部时关闭",
-        keepOpen: "保持打开"
+        keepOpen: "保持打开",
+        backgroundOpacity: "草稿板背景",
+        backgroundOpacityCaption: "调低后可以看到更多草稿板后面的内容。"
     )
 
     static let zhTW = ScratchpadFeatureStrings(
@@ -282,7 +306,9 @@ extension ScratchpadFeatureStrings {
         retentionMonth: "一個月未使用後",
         retentionCaption: "文字超過該時間沒有編輯時，草稿板會自動清空。",
         closeOnClickOutside: "點一下外部時關閉",
-        keepOpen: "保持開啟"
+        keepOpen: "保持開啟",
+        backgroundOpacity: "草稿板背景",
+        backgroundOpacityCaption: "調低後可以看到更多草稿板後面的內容。"
     )
 
     static let zhHK = ScratchpadFeatureStrings(
@@ -302,6 +328,8 @@ extension ScratchpadFeatureStrings {
         retentionMonth: "一個月未使用後",
         retentionCaption: "文字超過該時間沒有編輯，草稿板會自動清空。",
         closeOnClickOutside: "點一下外部時關閉",
-        keepOpen: "保持開啟"
+        keepOpen: "保持開啟",
+        backgroundOpacity: "草稿板背景",
+        backgroundOpacityCaption: "調低後可以看到更多草稿板後面的內容。"
     )
 }

--- a/Sources/Vorssaint/Core/ScratchpadStrings.swift
+++ b/Sources/Vorssaint/Core/ScratchpadStrings.swift
@@ -23,7 +23,8 @@ struct ScratchpadFeatureStrings {
     let closeOnClickOutside: String
     let keepOpen: String
     let backgroundOpacity: String
-    let backgroundOpacityCaption: String
+    let backgroundTranslucent: String
+    let backgroundOpaque: String
 }
 
 extension FeatureStrings {
@@ -66,7 +67,8 @@ extension ScratchpadFeatureStrings {
         closeOnClickOutside: "Close when I click outside",
         keepOpen: "Keep open",
         backgroundOpacity: "Pad background",
-        backgroundOpacityCaption: "Turn it down to see more of what sits behind the pad."
+        backgroundTranslucent: "Translucent",
+        backgroundOpaque: "Opaque"
     )
 
     static let ptBR = ScratchpadFeatureStrings(
@@ -88,7 +90,8 @@ extension ScratchpadFeatureStrings {
         closeOnClickOutside: "Fechar ao clicar fora",
         keepOpen: "Manter aberto",
         backgroundOpacity: "Fundo do bloco",
-        backgroundOpacityCaption: "Diminua para ver mais do que está atrás do bloco."
+        backgroundTranslucent: "Translúcido",
+        backgroundOpaque: "Opaco"
     )
 
     static let tr = ScratchpadFeatureStrings(
@@ -110,7 +113,8 @@ extension ScratchpadFeatureStrings {
         closeOnClickOutside: "Dışarı tıklayınca kapat",
         keepOpen: "Açık tut",
         backgroundOpacity: "Defter arka planı",
-        backgroundOpacityCaption: "Defterin arkasındakileri daha çok görmek için azalt."
+        backgroundTranslucent: "Yarı saydam",
+        backgroundOpaque: "Opak"
     )
 
     static let ru = ScratchpadFeatureStrings(
@@ -132,7 +136,8 @@ extension ScratchpadFeatureStrings {
         closeOnClickOutside: "Закрывать при щелчке снаружи",
         keepOpen: "Оставить открытым",
         backgroundOpacity: "Фон черновика",
-        backgroundOpacityCaption: "Уменьшите, чтобы видеть больше того, что находится за черновиком."
+        backgroundTranslucent: "Полупрозрачный",
+        backgroundOpaque: "Непрозрачный"
     )
 
     static let es = ScratchpadFeatureStrings(
@@ -154,7 +159,8 @@ extension ScratchpadFeatureStrings {
         closeOnClickOutside: "Cerrar al hacer clic fuera",
         keepOpen: "Mantener abierto",
         backgroundOpacity: "Fondo del borrador",
-        backgroundOpacityCaption: "Bájalo para ver más de lo que hay detrás del borrador."
+        backgroundTranslucent: "Translúcido",
+        backgroundOpaque: "Opaco"
     )
 
     static let de = ScratchpadFeatureStrings(
@@ -176,7 +182,8 @@ extension ScratchpadFeatureStrings {
         closeOnClickOutside: "Beim Klick außerhalb schließen",
         keepOpen: "Offen halten",
         backgroundOpacity: "Hintergrund des Zettels",
-        backgroundOpacityCaption: "Verringere ihn, um mehr von dem zu sehen, was hinter dem Zettel liegt."
+        backgroundTranslucent: "Durchscheinend",
+        backgroundOpaque: "Deckend"
     )
 
     static let fr = ScratchpadFeatureStrings(
@@ -198,7 +205,8 @@ extension ScratchpadFeatureStrings {
         closeOnClickOutside: "Fermer si je clique à l’extérieur",
         keepOpen: "Garder ouvert",
         backgroundOpacity: "Fond du brouillon",
-        backgroundOpacityCaption: "Baissez-le pour voir davantage ce qui se trouve derrière le brouillon."
+        backgroundTranslucent: "Translucide",
+        backgroundOpaque: "Opaque"
     )
 
     static let it = ScratchpadFeatureStrings(
@@ -220,7 +228,8 @@ extension ScratchpadFeatureStrings {
         closeOnClickOutside: "Chiudi quando clicco fuori",
         keepOpen: "Mantieni aperto",
         backgroundOpacity: "Sfondo della bozza",
-        backgroundOpacityCaption: "Abbassalo per vedere di più di ciò che sta dietro alla bozza."
+        backgroundTranslucent: "Traslucido",
+        backgroundOpaque: "Opaco"
     )
 
     static let ja = ScratchpadFeatureStrings(
@@ -242,7 +251,8 @@ extension ScratchpadFeatureStrings {
         closeOnClickOutside: "外側をクリックしたら閉じる",
         keepOpen: "開いたままにする",
         backgroundOpacity: "メモの背景",
-        backgroundOpacityCaption: "下げると、メモの後ろにあるものがより見えるようになります。"
+        backgroundTranslucent: "半透明",
+        backgroundOpaque: "不透明"
     )
 
     static let ko = ScratchpadFeatureStrings(
@@ -264,7 +274,8 @@ extension ScratchpadFeatureStrings {
         closeOnClickOutside: "바깥을 클릭하면 닫기",
         keepOpen: "열어 두기",
         backgroundOpacity: "메모 배경",
-        backgroundOpacityCaption: "낮추면 메모 뒤에 있는 것이 더 많이 보입니다."
+        backgroundTranslucent: "반투명",
+        backgroundOpaque: "불투명"
     )
 
     static let zhHans = ScratchpadFeatureStrings(
@@ -286,7 +297,8 @@ extension ScratchpadFeatureStrings {
         closeOnClickOutside: "点击外部时关闭",
         keepOpen: "保持打开",
         backgroundOpacity: "草稿板背景",
-        backgroundOpacityCaption: "调低后可以看到更多草稿板后面的内容。"
+        backgroundTranslucent: "半透明",
+        backgroundOpaque: "不透明"
     )
 
     static let zhTW = ScratchpadFeatureStrings(
@@ -308,7 +320,8 @@ extension ScratchpadFeatureStrings {
         closeOnClickOutside: "點一下外部時關閉",
         keepOpen: "保持開啟",
         backgroundOpacity: "草稿板背景",
-        backgroundOpacityCaption: "調低後可以看到更多草稿板後面的內容。"
+        backgroundTranslucent: "半透明",
+        backgroundOpaque: "不透明"
     )
 
     static let zhHK = ScratchpadFeatureStrings(
@@ -330,6 +343,7 @@ extension ScratchpadFeatureStrings {
         closeOnClickOutside: "點一下外部時關閉",
         keepOpen: "保持開啟",
         backgroundOpacity: "草稿板背景",
-        backgroundOpacityCaption: "調低後可以看到更多草稿板後面的內容。"
+        backgroundTranslucent: "半透明",
+        backgroundOpaque: "不透明"
     )
 }

--- a/Sources/Vorssaint/Services/QuickTools/ScratchpadSupport.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScratchpadSupport.swift
@@ -33,12 +33,9 @@ enum ScratchpadRetention: String, CaseIterable {
 }
 
 enum ScratchpadSupport {
-    /// How solid the pad's frosted background is drawn, as a fraction. The
-    /// floor is not zero for the same reason as the Dock preview's: the note
-    /// sits straight on the material, so past a certain point it is reading
-    /// against the desktop and the pad stops looking like a pad. The two share
-    /// a floor so the sliders behave alike.
-    static let backgroundOpacityRange: ClosedRange<Double> = 0.4...1
+    /// The fill sits over the existing material: zero preserves the familiar
+    /// frosted pad, while one fully covers what is behind the window.
+    static let backgroundOpacityRange: ClosedRange<Double> = 0...1
 
     static func sanitizedBackgroundOpacity(_ value: Double) -> Double {
         guard value.isFinite else { return backgroundOpacityRange.upperBound }

--- a/Sources/Vorssaint/Services/QuickTools/ScratchpadSupport.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScratchpadSupport.swift
@@ -33,6 +33,16 @@ enum ScratchpadRetention: String, CaseIterable {
 }
 
 enum ScratchpadSupport {
+    /// The pad still has to carry text, so the material never goes fully clear.
+    /// The floor matches the Dock preview's, which was picked to keep body text
+    /// past the contrast the accessibility guidelines ask for.
+    static let backgroundOpacityRange: ClosedRange<Double> = 0.4...1
+
+    static func sanitizedBackgroundOpacity(_ value: Double) -> Double {
+        guard value.isFinite else { return backgroundOpacityRange.upperBound }
+        return min(max(value, backgroundOpacityRange.lowerBound), backgroundOpacityRange.upperBound)
+    }
+
     static func dismissesOnOutsideClick(isPinned: Bool, exportModalActive: Bool) -> Bool {
         !isPinned && !exportModalActive
     }

--- a/Sources/Vorssaint/Services/QuickTools/ScratchpadSupport.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScratchpadSupport.swift
@@ -33,9 +33,11 @@ enum ScratchpadRetention: String, CaseIterable {
 }
 
 enum ScratchpadSupport {
-    /// The pad still has to carry text, so the material never goes fully clear.
-    /// The floor matches the Dock preview's, which was picked to keep body text
-    /// past the contrast the accessibility guidelines ask for.
+    /// How solid the pad's frosted background is drawn, as a fraction. The
+    /// floor is not zero for the same reason as the Dock preview's: the note
+    /// sits straight on the material, so past a certain point it is reading
+    /// against the desktop and the pad stops looking like a pad. The two share
+    /// a floor so the sliders behave alike.
     static let backgroundOpacityRange: ClosedRange<Double> = 0.4...1
 
     static func sanitizedBackgroundOpacity(_ value: Double) -> Double {

--- a/Sources/Vorssaint/UI/Scratchpad/ScratchpadView.swift
+++ b/Sources/Vorssaint/UI/Scratchpad/ScratchpadView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 struct ScratchpadView: View {
     @ObservedObject private var service = ScratchpadService.shared
     @ObservedObject private var l10n = L10n.shared
-    @AppStorage(DefaultsKey.scratchpadBackgroundOpacity) private var backgroundOpacity = 1.0
+    @AppStorage(DefaultsKey.scratchpadBackgroundOpacity) private var backgroundOpacity = 0.0
     @State private var copied = false
 
     private var text: ScratchpadFeatureStrings { FeatureStrings.scratchpad(l10n.language) }
@@ -21,8 +21,13 @@ struct ScratchpadView: View {
             editor
             footer
         }
-        .background(HUDBackdrop(cornerRadius: 14,
-                                opacity: ScratchpadSupport.sanitizedBackgroundOpacity(backgroundOpacity)))
+        .background {
+            ZStack {
+                HUDBackdrop(cornerRadius: 14)
+                Color(nsColor: .windowBackgroundColor)
+                    .opacity(ScratchpadSupport.sanitizedBackgroundOpacity(backgroundOpacity))
+            }
+        }
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)

--- a/Sources/Vorssaint/UI/Scratchpad/ScratchpadView.swift
+++ b/Sources/Vorssaint/UI/Scratchpad/ScratchpadView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct ScratchpadView: View {
     @ObservedObject private var service = ScratchpadService.shared
     @ObservedObject private var l10n = L10n.shared
+    @AppStorage(DefaultsKey.scratchpadBackgroundOpacity) private var backgroundOpacity = 1.0
     @State private var copied = false
 
     private var text: ScratchpadFeatureStrings { FeatureStrings.scratchpad(l10n.language) }
@@ -20,7 +21,8 @@ struct ScratchpadView: View {
             editor
             footer
         }
-        .background(HUDBackdrop(cornerRadius: 14))
+        .background(HUDBackdrop(cornerRadius: 14,
+                                opacity: ScratchpadSupport.sanitizedBackgroundOpacity(backgroundOpacity)))
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)

--- a/Sources/Vorssaint/UI/Settings/QuickToolsSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/QuickToolsSettings.swift
@@ -23,7 +23,7 @@ struct QuickToolsSettings: View {
     @AppStorage(DefaultsKey.scratchpadShortcutEnabled) private var scratchpadShortcutEnabled = false
     @AppStorage(DefaultsKey.scratchpadRetention) private var scratchpadRetention = ScratchpadRetention.never.rawValue
     @AppStorage(DefaultsKey.scratchpadCloseOnClickOutside) private var scratchpadCloseOnClickOutside = true
-    @AppStorage(DefaultsKey.scratchpadBackgroundOpacity) private var scratchpadBackgroundOpacity = 1.0
+    @AppStorage(DefaultsKey.scratchpadBackgroundOpacity) private var scratchpadBackgroundOpacity = 0.0
     @AppStorage(DefaultsKey.colorPickerFormat) private var colorFormat = "hex"
     @AppStorage(DefaultsKey.colorPickerBareHex) private var colorBareHex = false
     @AppStorage(DefaultsKey.micMuteMenuBarIndicator) private var micMenuBarIndicator = false
@@ -251,19 +251,19 @@ struct QuickToolsSettings: View {
                         .onChange(of: scratchpadCloseOnClickOutside) { _, _ in
                             ScratchpadService.shared.outsideClickPreferenceDidChange()
                         }
-                    HStack {
+                    VStack(alignment: .leading, spacing: 6) {
                         Text(FeatureStrings.scratchpad(l10n.language).backgroundOpacity)
                         Slider(value: scratchpadBackgroundOpacityBinding,
                                in: ScratchpadSupport.backgroundOpacityRange,
                                step: 0.05)
-                        Text("\(scratchpadBackgroundOpacityPercent)%")
-                            .font(.system(.body, design: .monospaced))
-                            .foregroundStyle(.secondary)
-                            .frame(width: 52, alignment: .trailing)
-                    }
-                    Text(FeatureStrings.scratchpad(l10n.language).backgroundOpacityCaption)
+                        HStack {
+                            Text(FeatureStrings.scratchpad(l10n.language).backgroundTranslucent)
+                            Spacer()
+                            Text(FeatureStrings.scratchpad(l10n.language).backgroundOpaque)
+                        }
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                    }
                     Toggle(l10n.s.quickToolShortcutToggle, isOn: $scratchpadShortcutEnabled)
                         .onChange(of: scratchpadShortcutEnabled) { _, _ in
                             ScratchpadService.shared.syncWithPreferences()
@@ -290,10 +290,6 @@ struct QuickToolsSettings: View {
             get: { ScratchpadSupport.sanitizedBackgroundOpacity(scratchpadBackgroundOpacity) },
             set: { scratchpadBackgroundOpacity = ScratchpadSupport.sanitizedBackgroundOpacity($0) }
         )
-    }
-
-    private var scratchpadBackgroundOpacityPercent: Int {
-        Int((ScratchpadSupport.sanitizedBackgroundOpacity(scratchpadBackgroundOpacity) * 100).rounded())
     }
 }
 

--- a/Sources/Vorssaint/UI/Settings/QuickToolsSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/QuickToolsSettings.swift
@@ -23,6 +23,7 @@ struct QuickToolsSettings: View {
     @AppStorage(DefaultsKey.scratchpadShortcutEnabled) private var scratchpadShortcutEnabled = false
     @AppStorage(DefaultsKey.scratchpadRetention) private var scratchpadRetention = ScratchpadRetention.never.rawValue
     @AppStorage(DefaultsKey.scratchpadCloseOnClickOutside) private var scratchpadCloseOnClickOutside = true
+    @AppStorage(DefaultsKey.scratchpadBackgroundOpacity) private var scratchpadBackgroundOpacity = 1.0
     @AppStorage(DefaultsKey.colorPickerFormat) private var colorFormat = "hex"
     @AppStorage(DefaultsKey.colorPickerBareHex) private var colorBareHex = false
     @AppStorage(DefaultsKey.micMuteMenuBarIndicator) private var micMenuBarIndicator = false
@@ -250,6 +251,19 @@ struct QuickToolsSettings: View {
                         .onChange(of: scratchpadCloseOnClickOutside) { _, _ in
                             ScratchpadService.shared.outsideClickPreferenceDidChange()
                         }
+                    HStack {
+                        Text(FeatureStrings.scratchpad(l10n.language).backgroundOpacity)
+                        Slider(value: scratchpadBackgroundOpacityBinding,
+                               in: ScratchpadSupport.backgroundOpacityRange,
+                               step: 0.05)
+                        Text("\(scratchpadBackgroundOpacityPercent)%")
+                            .font(.system(.body, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 52, alignment: .trailing)
+                    }
+                    Text(FeatureStrings.scratchpad(l10n.language).backgroundOpacityCaption)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                     Toggle(l10n.s.quickToolShortcutToggle, isOn: $scratchpadShortcutEnabled)
                         .onChange(of: scratchpadShortcutEnabled) { _, _ in
                             ScratchpadService.shared.syncWithPreferences()
@@ -269,6 +283,17 @@ struct QuickToolsSettings: View {
             }
         }
         .formStyle(.grouped)
+    }
+
+    private var scratchpadBackgroundOpacityBinding: Binding<Double> {
+        Binding(
+            get: { ScratchpadSupport.sanitizedBackgroundOpacity(scratchpadBackgroundOpacity) },
+            set: { scratchpadBackgroundOpacity = ScratchpadSupport.sanitizedBackgroundOpacity($0) }
+        )
+    }
+
+    private var scratchpadBackgroundOpacityPercent: Int {
+        Int((ScratchpadSupport.sanitizedBackgroundOpacity(scratchpadBackgroundOpacity) * 100).rounded())
     }
 }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -6928,7 +6928,7 @@ struct MetricsTests {
                    "no em-dash in visible radial menu strings (\(language.rawValue))")
             let scratchpadValues = Mirror(reflecting: FeatureStrings.scratchpad(language)).children
                 .compactMap { $0.value as? String }
-            expect(scratchpadValues.count == 19 && scratchpadValues.allSatisfy { !$0.isEmpty },
+            expect(scratchpadValues.count == 20 && scratchpadValues.allSatisfy { !$0.isEmpty },
                    "every scratchpad string is set for \(language.rawValue)")
             expect(scratchpadValues.allSatisfy { !$0.contains("—") },
                    "no em-dash in visible scratchpad strings (\(language.rawValue))")
@@ -8237,19 +8237,21 @@ struct MetricsTests {
                 && !ScratchpadSupport.dismissesOnOutsideClick(isPinned: true, exportModalActive: false)
                 && !ScratchpadSupport.dismissesOnOutsideClick(isPinned: false, exportModalActive: true),
                "the scratchpad pin and export dialog both block outside-click dismissal")
-        expect(Defaults.registeredDefaults[DefaultsKey.scratchpadBackgroundOpacity] as? Double == 1.0,
-               "the scratchpad background starts fully solid")
+        expect(Defaults.registeredDefaults[DefaultsKey.scratchpadBackgroundOpacity] as? Double == 0.0,
+               "the scratchpad keeps its familiar translucent background by default")
+        expect(SettingsBackupSupport.exportKeys().contains(DefaultsKey.scratchpadBackgroundOpacity),
+               "the scratchpad background choice travels with the settings backup")
         expect(ScratchpadSupport.sanitizedBackgroundOpacity(0.7) == 0.7,
                "a scratchpad background opacity inside the range is kept")
         expect(ScratchpadSupport.sanitizedBackgroundOpacity(0)
                 == ScratchpadSupport.backgroundOpacityRange.lowerBound
                 && ScratchpadSupport.sanitizedBackgroundOpacity(-3)
                 == ScratchpadSupport.backgroundOpacityRange.lowerBound,
-               "the scratchpad background never goes below the readable floor")
+               "the scratchpad background never goes below the familiar translucent style")
         expect(ScratchpadSupport.sanitizedBackgroundOpacity(4) == 1.0
                 && ScratchpadSupport.sanitizedBackgroundOpacity(.nan) == 1.0
                 && ScratchpadSupport.sanitizedBackgroundOpacity(.infinity) == 1.0,
-               "an out of range or broken scratchpad opacity falls back to solid")
+               "a high or broken scratchpad opacity falls back to fully opaque")
         let scratchpadNow = Date(timeIntervalSince1970: 1_784_000_000)
         expect(!ScratchpadSupport.shouldClear(lastEdited: nil, now: scratchpadNow, retention: .day)
                 && !ScratchpadSupport.shouldClear(lastEdited: scratchpadNow.addingTimeInterval(-90_000),
@@ -8741,6 +8743,7 @@ struct MetricsTests {
         expect(backupKeys.contains(DefaultsKey.scratchpadShortcut)
                 && backupKeys.contains(DefaultsKey.scratchpadShortcutEnabled)
                 && backupKeys.contains(DefaultsKey.scratchpadRetention)
+                && backupKeys.contains(DefaultsKey.scratchpadBackgroundOpacity)
                 && backupKeys.contains(DefaultsKey.panelUtilityScratchpad),
                "scratchpad preferences travel with the settings backup")
         expect(backupKeys.contains(DefaultsKey.radialMenuEnabled)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -6928,7 +6928,7 @@ struct MetricsTests {
                    "no em-dash in visible radial menu strings (\(language.rawValue))")
             let scratchpadValues = Mirror(reflecting: FeatureStrings.scratchpad(language)).children
                 .compactMap { $0.value as? String }
-            expect(scratchpadValues.count == 17 && scratchpadValues.allSatisfy { !$0.isEmpty },
+            expect(scratchpadValues.count == 19 && scratchpadValues.allSatisfy { !$0.isEmpty },
                    "every scratchpad string is set for \(language.rawValue)")
             expect(scratchpadValues.allSatisfy { !$0.contains("—") },
                    "no em-dash in visible scratchpad strings (\(language.rawValue))")
@@ -8237,6 +8237,19 @@ struct MetricsTests {
                 && !ScratchpadSupport.dismissesOnOutsideClick(isPinned: true, exportModalActive: false)
                 && !ScratchpadSupport.dismissesOnOutsideClick(isPinned: false, exportModalActive: true),
                "the scratchpad pin and export dialog both block outside-click dismissal")
+        expect(Defaults.registeredDefaults[DefaultsKey.scratchpadBackgroundOpacity] as? Double == 1.0,
+               "the scratchpad background starts fully solid")
+        expect(ScratchpadSupport.sanitizedBackgroundOpacity(0.7) == 0.7,
+               "a scratchpad background opacity inside the range is kept")
+        expect(ScratchpadSupport.sanitizedBackgroundOpacity(0)
+                == ScratchpadSupport.backgroundOpacityRange.lowerBound
+                && ScratchpadSupport.sanitizedBackgroundOpacity(-3)
+                == ScratchpadSupport.backgroundOpacityRange.lowerBound,
+               "the scratchpad background never goes below the readable floor")
+        expect(ScratchpadSupport.sanitizedBackgroundOpacity(4) == 1.0
+                && ScratchpadSupport.sanitizedBackgroundOpacity(.nan) == 1.0
+                && ScratchpadSupport.sanitizedBackgroundOpacity(.infinity) == 1.0,
+               "an out of range or broken scratchpad opacity falls back to solid")
         let scratchpadNow = Date(timeIntervalSince1970: 1_784_000_000)
         expect(!ScratchpadSupport.shouldClear(lastEdited: nil, now: scratchpadNow, retention: .day)
                 && !ScratchpadSupport.shouldClear(lastEdited: scratchpadNow.addingTimeInterval(-90_000),


### PR DESCRIPTION
## Summary

- add a Scratchpad background control from translucent to fully opaque (#392)
- place clear endpoint labels beside the pad's existing Quick Tools options
- preserve the familiar frosted background by default and adapt the solid fill to light and dark appearances

## Validation

- `./build.sh --test` — TESTS OK (6127 checks)
- `./build.sh --dev --install` — Developer bundle installed and signed
- installed Developer selftest — SELFTEST OK
- real light and dark previews, plus Scratchpad checks at translucent, 50%, and opaque with persistence across relaunch

Related to #392.
