### PR TITLE
Add scrolling screenshot capture

### DIFF
--- a/Sources/Vorssaint/Core/ScreenshotStrings.swift
+++ b/Sources/Vorssaint/Core/ScreenshotStrings.swift
@@ -90,6 +90,11 @@ struct ScreenshotFeatureStrings {
     let openEditorCaption: String
     let autoCopyToggle: String
     let autoCopyCaption: String
+    let scrollingCaptureButton: String
+    let scrollingCaptureTitle: String
+    let scrollingCaptureProgressHUD: String
+    let scrollingCaptureHintOff: String
+    let scrollingCaptureHintOn: String
     let hintLoupe: String
     let lastRegionToggle: String
     let backdropBlurLabel: String
@@ -202,6 +207,11 @@ extension ScreenshotFeatureStrings {
         openEditorCaption: "The capture skips the floating preview and opens ready to annotate.",
         autoCopyToggle: "Copy to the clipboard automatically",
         autoCopyCaption: "Every capture goes to the clipboard as soon as it is taken, ready to paste. Saving a file stays a separate choice.",
+        scrollingCaptureButton: "Scrolling capture",
+        scrollingCaptureTitle: "Scrolling screenshot",
+        scrollingCaptureProgressHUD: "Capturing scroll...",
+        scrollingCaptureHintOff: "S toggles scrolling",
+        scrollingCaptureHintOn: "Scrolling on",
         hintLoupe: "Z toggles the loupe",
         lastRegionToggle: "Show the last capture outline",
         backdropBlurLabel: "Blur"
@@ -293,6 +303,11 @@ extension ScreenshotFeatureStrings {
         openEditorCaption: "A captura pula a pré-visualização flutuante e já abre pronta para anotar.",
         autoCopyToggle: "Copiar para a área de transferência automaticamente",
         autoCopyCaption: "Toda captura vai para a área de transferência assim que é feita, pronta para colar. Salvar um arquivo continua sendo uma escolha à parte.",
+        scrollingCaptureButton: "Captura com rolagem",
+        scrollingCaptureTitle: "Captura com rolagem",
+        scrollingCaptureProgressHUD: "Capturando rolagem...",
+        scrollingCaptureHintOff: "S alterna rolagem",
+        scrollingCaptureHintOn: "Rolagem ligada",
         hintLoupe: "Z alterna a lupa",
         lastRegionToggle: "Mostrar o contorno da última captura",
         backdropBlurLabel: "Desfoque"
@@ -384,6 +399,11 @@ extension ScreenshotFeatureStrings {
         openEditorCaption: "Yakalama, yüzen önizlemeyi atlar ve işaretlemeye hazır şekilde açılır.",
         autoCopyToggle: "Otomatik olarak panoya kopyala",
         autoCopyCaption: "Her yakalama alınır alınmaz panoya gider ve yapıştırmaya hazır olur. Dosya olarak kaydetmek ayrı bir seçim olarak kalır.",
+        scrollingCaptureButton: "Kaydırmalı yakalama",
+        scrollingCaptureTitle: "Kaydırmalı ekran görüntüsü",
+        scrollingCaptureProgressHUD: "Kaydırma yakalanıyor...",
+        scrollingCaptureHintOff: "S kaydırmayı açar",
+        scrollingCaptureHintOn: "Kaydırma açık",
         hintLoupe: "Z büyüteci açar/kapatır",
         lastRegionToggle: "Son yakalamanın çerçevesini göster",
         backdropBlurLabel: "Bulanıklık"
@@ -475,6 +495,11 @@ extension ScreenshotFeatureStrings {
         openEditorCaption: "Снимок пропускает плавающее окно предпросмотра и сразу открывается готовым к пометкам.",
         autoCopyToggle: "Автоматически копировать в буфер обмена",
         autoCopyCaption: "Каждый снимок попадает в буфер обмена сразу после съёмки и готов к вставке. Сохранение файла остаётся отдельным выбором.",
+        scrollingCaptureButton: "Снимок с прокруткой",
+        scrollingCaptureTitle: "Снимок с прокруткой",
+        scrollingCaptureProgressHUD: "Снимаем прокрутку...",
+        scrollingCaptureHintOff: "S включает прокрутку",
+        scrollingCaptureHintOn: "Прокрутка включена",
         hintLoupe: "Z включает лупу",
         lastRegionToggle: "Показывать контур последней области",
         backdropBlurLabel: "Размытие"
@@ -566,6 +591,11 @@ extension ScreenshotFeatureStrings {
         openEditorCaption: "La captura omite la previsualización flotante y se abre lista para anotar.",
         autoCopyToggle: "Copiar al portapapeles automáticamente",
         autoCopyCaption: "Cada captura va al portapapeles en cuanto se toma, lista para pegar. Guardar un archivo sigue siendo una elección aparte.",
+        scrollingCaptureButton: "Captura con desplazamiento",
+        scrollingCaptureTitle: "Captura con desplazamiento",
+        scrollingCaptureProgressHUD: "Capturando desplazamiento...",
+        scrollingCaptureHintOff: "S activa desplazamiento",
+        scrollingCaptureHintOn: "Desplazamiento activo",
         hintLoupe: "Z activa la lupa",
         lastRegionToggle: "Mostrar sombra de la última captura",
         backdropBlurLabel: "Desenfoque"
@@ -657,6 +687,11 @@ extension ScreenshotFeatureStrings {
         openEditorCaption: "Die Aufnahme überspringt die schwebende Vorschau und öffnet sich bereit für Anmerkungen.",
         autoCopyToggle: "Automatisch in die Zwischenablage kopieren",
         autoCopyCaption: "Jede Aufnahme landet sofort in der Zwischenablage, bereit zum Einfügen. Das Speichern als Datei bleibt eine eigene Entscheidung.",
+        scrollingCaptureButton: "Scroll-Aufnahme",
+        scrollingCaptureTitle: "Scroll-Screenshot",
+        scrollingCaptureProgressHUD: "Scroll wird aufgenommen...",
+        scrollingCaptureHintOff: "S schaltet Scrollen um",
+        scrollingCaptureHintOn: "Scrollen aktiv",
         hintLoupe: "Z schaltet die Lupe um",
         lastRegionToggle: "Umriss der letzten Aufnahme anzeigen",
         backdropBlurLabel: "Unschärfe"
@@ -748,6 +783,11 @@ extension ScreenshotFeatureStrings {
         openEditorCaption: "La capture ignore l'aperçu flottant et s'ouvre prête à être annotée.",
         autoCopyToggle: "Copier automatiquement dans le presse-papiers",
         autoCopyCaption: "Chaque capture va dans le presse-papiers dès qu'elle est prise, prête à être collée. Enregistrer un fichier reste un choix distinct.",
+        scrollingCaptureButton: "Capture avec défilement",
+        scrollingCaptureTitle: "Capture avec défilement",
+        scrollingCaptureProgressHUD: "Capture du défilement...",
+        scrollingCaptureHintOff: "S active le défilement",
+        scrollingCaptureHintOn: "Défilement activé",
         hintLoupe: "Z active la loupe",
         lastRegionToggle: "Afficher le contour de la dernière capture",
         backdropBlurLabel: "Flou"
@@ -839,6 +879,11 @@ extension ScreenshotFeatureStrings {
         openEditorCaption: "La cattura salta l'anteprima flottante e si apre pronta per le annotazioni.",
         autoCopyToggle: "Copia automaticamente negli appunti",
         autoCopyCaption: "Ogni cattura va negli appunti appena viene fatta, pronta da incollare. Salvare un file resta una scelta a parte.",
+        scrollingCaptureButton: "Cattura con scorrimento",
+        scrollingCaptureTitle: "Screenshot con scorrimento",
+        scrollingCaptureProgressHUD: "Cattura scorrimento...",
+        scrollingCaptureHintOff: "S attiva scorrimento",
+        scrollingCaptureHintOn: "Scorrimento attivo",
         hintLoupe: "Z attiva la lente",
         lastRegionToggle: "Mostra il contorno dell'ultima cattura",
         backdropBlurLabel: "Sfocatura"
@@ -930,6 +975,11 @@ extension ScreenshotFeatureStrings {
         openEditorCaption: "撮影はフローティングプレビューを飛ばして、すぐに注釈を付けられる状態で開きます。",
         autoCopyToggle: "自動的にクリップボードへコピー",
         autoCopyCaption: "撮影した瞬間にクリップボードへ入り、すぐに貼り付けられます。ファイルとして保存するかどうかは別の選択のままです。",
+        scrollingCaptureButton: "スクロール撮影",
+        scrollingCaptureTitle: "スクロールスクリーンショット",
+        scrollingCaptureProgressHUD: "スクロールを撮影中...",
+        scrollingCaptureHintOff: "Sでスクロール切替",
+        scrollingCaptureHintOn: "スクロール有効",
         hintLoupe: "Zでルーペを切り替え",
         lastRegionToggle: "最後のキャプチャ範囲を表示",
         backdropBlurLabel: "ぼかし"
@@ -1021,6 +1071,11 @@ extension ScreenshotFeatureStrings {
         openEditorCaption: "캡처가 떠 있는 미리보기를 건너뛰고 바로 주석을 남길 수 있는 상태로 열립니다.",
         autoCopyToggle: "자동으로 클립보드에 복사",
         autoCopyCaption: "캡처하는 즉시 클립보드에 담겨 바로 붙여넣을 수 있습니다. 파일로 저장하는 것은 여전히 별도의 선택입니다.",
+        scrollingCaptureButton: "스크롤 캡처",
+        scrollingCaptureTitle: "스크롤 스크린샷",
+        scrollingCaptureProgressHUD: "스크롤 캡처 중...",
+        scrollingCaptureHintOff: "S로 스크롤 전환",
+        scrollingCaptureHintOn: "스크롤 켜짐",
         hintLoupe: "Z 키로 확대경 전환",
         lastRegionToggle: "마지막 캡처 영역 표시",
         backdropBlurLabel: "흐림"
@@ -1112,6 +1167,11 @@ extension ScreenshotFeatureStrings {
         openEditorCaption: "截屏会跳过浮动预览，直接打开即可开始标注。",
         autoCopyToggle: "自动复制到剪贴板",
         autoCopyCaption: "每次截屏后会立即进入剪贴板，随时可以粘贴。是否保存为文件仍是单独的选择。",
+        scrollingCaptureButton: "滚动截图",
+        scrollingCaptureTitle: "滚动截图",
+        scrollingCaptureProgressHUD: "正在捕捉滚动...",
+        scrollingCaptureHintOff: "按 S 切换滚动",
+        scrollingCaptureHintOn: "滚动已开启",
         hintLoupe: "按 Z 切换放大镜",
         lastRegionToggle: "显示上次截图区域轮廓",
         backdropBlurLabel: "模糊"
@@ -1203,6 +1263,11 @@ extension ScreenshotFeatureStrings {
         openEditorCaption: "截圖會略過浮動預覽，直接開啟即可開始標註。",
         autoCopyToggle: "自動拷貝到剪貼板",
         autoCopyCaption: "每次截圖後會立即進入剪貼板，隨時可以貼上。是否儲存為檔案仍是獨立的選擇。",
+        scrollingCaptureButton: "捲動截圖",
+        scrollingCaptureTitle: "捲動截圖",
+        scrollingCaptureProgressHUD: "正在擷取捲動...",
+        scrollingCaptureHintOff: "按 S 切換捲動",
+        scrollingCaptureHintOn: "捲動已開啟",
         hintLoupe: "按 Z 切換放大鏡",
         lastRegionToggle: "顯示上次截圖區域輪廓",
         backdropBlurLabel: "模糊"
@@ -1294,6 +1359,11 @@ extension ScreenshotFeatureStrings {
         openEditorCaption: "截圖會略過浮動預覽，直接開啟即可開始標註。",
         autoCopyToggle: "自動拷貝到剪貼板",
         autoCopyCaption: "每次截圖後會立即進入剪貼板，隨時可以貼上。是否儲存為檔案仍是獨立的選擇。",
+        scrollingCaptureButton: "捲動截圖",
+        scrollingCaptureTitle: "捲動截圖",
+        scrollingCaptureProgressHUD: "正在擷取捲動...",
+        scrollingCaptureHintOff: "按 S 切換捲動",
+        scrollingCaptureHintOn: "捲動已開啟",
         hintLoupe: "按 Z 切換放大鏡",
         lastRegionToggle: "顯示上次截圖區域輪廓",
         backdropBlurLabel: "模糊"

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarCatalog.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarCatalog.swift
@@ -149,7 +149,7 @@ struct CommandBarEntry: Identifiable {
 enum CommandBarCatalog {
     /// Ids worth discovering before any habit forms; suggestion fill-ins.
     static let curatedSuggestionIDs = [
-        "action.screenshot", "action.keepAwake", "action.screenOCR",
+        "action.screenshot", "action.scrollingScreenshot", "action.keepAwake", "action.screenOCR",
         "action.clipboardWindow", "action.colorPicker", "action.darkMode",
         "action.snippetLibrary",
     ]
@@ -252,14 +252,23 @@ enum CommandBarCatalog {
 
         // Screen tools first: the beat lets the bar leave before capture.
         if AppFeature.screenshot.isAvailable {
+            let screenshot = FeatureStrings.screenshot(language)
             entries.append(CommandBarEntry(
                 id: "action.screenshot",
-                title: FeatureStrings.screenshot(language).pageTitle,
-                subtitle: area(.screenshot, under: FeatureStrings.screenshot(language).pageTitle),
+                title: screenshot.pageTitle,
+                subtitle: area(.screenshot, under: screenshot.pageTitle),
                 icon: .symbol("camera.viewfinder"),
                 shortcut: roleShortcut(.screenshot),
                 trouble: Permissions.shared.screenRecording ? nil : .needsPermission,
                 run: { _ in afterBeat { ScreenshotService.shared.capture() } }))
+            entries.append(CommandBarEntry(
+                id: "action.scrollingScreenshot",
+                title: screenshot.scrollingCaptureTitle,
+                subtitle: area(.screenshot, under: screenshot.pageTitle),
+                icon: .symbol("rectangle.stack"),
+                trouble: Permissions.shared.screenRecording && Permissions.shared.accessibility
+                    ? nil : .needsPermission,
+                run: { _ in afterBeat { ScreenshotService.shared.captureScrolling() } }))
         }
         if AppFeature.screenRecorder.isAvailable {
             let recorder = FeatureStrings.recorder(language)

--- a/Sources/Vorssaint/Services/QuickTools/ScreenTextService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenTextService.swift
@@ -75,6 +75,8 @@ final class ScreenTextService: ObservableObject {
             case .region:
                 // Only the recorder asks for geometry; this session never does.
                 break
+            case .scrollingRegion:
+                break
             case .cancelled:
                 break
             case .failed:

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotCaptureEngine.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotCaptureEngine.swift
@@ -29,6 +29,22 @@ enum ScreenshotCaptureEngine {
                                     includePointer: includePointer)
     }
 
+    static func captureDisplayRegion(displayID: CGDirectDisplayID,
+                                     pixelRect: CGRect,
+                                     includePointer: Bool) async -> CGImage? {
+        guard var image = await captureDisplay(displayID, includePointer: includePointer)
+        else { return nil }
+        let clamped = ScreenshotSupport.clamp(
+            pixelRect,
+            to: CGRect(x: 0, y: 0, width: image.width, height: image.height))
+        guard !clamped.isEmpty else { return nil }
+        if clamped.width < CGFloat(image.width) || clamped.height < CGFloat(image.height) {
+            guard let cropped = image.cropping(to: clamped) else { return nil }
+            image = cropped
+        }
+        return image
+    }
+
     /// Captures every given screen, keyed by display id. Screens that fail
     /// are simply absent; the caller decides how to degrade.
     static func captureAllDisplays(includePointer: Bool) async -> [CGDirectDisplayID: CGImage] {

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotScrollingCapture.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotScrollingCapture.swift
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import CoreGraphics
+
+/// Captures a selected region repeatedly while scrolling the focused app, then
+/// stitches the slices into one tall screenshot. This stays app-agnostic:
+/// browsers, documents and chat panes all receive the same real scroll event.
+enum ScreenshotScrollingCapture {
+    static func capture(region: RecorderSupport.Region,
+                        includePointer: Bool) async -> ScreenshotSelectionController.Capture? {
+        try? await Task.sleep(nanoseconds: 140_000_000)
+
+        let overlap = ScreenshotSupport.scrollingCaptureOverlapPixels(
+            regionHeight: region.anchorRect.height,
+            scale: region.scale)
+        let step = ScreenshotSupport.scrollingCaptureStepPoints(
+            regionHeight: region.anchorRect.height)
+
+        var slices: [CGImage] = []
+        for index in 0..<ScreenshotSupport.scrollingCaptureMaxFrames {
+            guard let image = await ScreenshotCaptureEngine.captureDisplayRegion(
+                displayID: region.displayID,
+                pixelRect: region.pixelRect,
+                includePointer: includePointer)
+            else { break }
+
+            if let previous = slices.last, areVisuallySame(previous, image) {
+                break
+            }
+            slices.append(image)
+
+            if index < ScreenshotSupport.scrollingCaptureMaxFrames - 1 {
+                postScrollDown(points: step)
+                try? await Task.sleep(nanoseconds: 260_000_000)
+            }
+        }
+
+        guard let image = stitch(slices, fallbackOverlapPixels: overlap) else { return nil }
+        return ScreenshotSelectionController.Capture(image: image,
+                                                     scale: region.scale,
+                                                     anchorRect: region.anchorRect)
+    }
+
+    private static func postScrollDown(points: CGFloat) {
+        let lines = max(1, Int32((points / 18).rounded()))
+        guard let event = CGEvent(scrollWheelEvent2Source: nil,
+                                  units: .line,
+                                  wheelCount: 1,
+                                  wheel1: -lines,
+                                  wheel2: 0,
+                                  wheel3: 0)
+        else { return }
+        event.post(tap: .cghidEventTap)
+    }
+
+    private struct StitchSlice {
+        let image: CGImage
+        let topCrop: Int
+    }
+
+    private struct SampledImage {
+        let width: Int
+        let height: Int
+        let bytes: [UInt8]
+    }
+
+    private static func stitch(_ slices: [CGImage],
+                               fallbackOverlapPixels: Int) -> CGImage? {
+        guard let first = slices.first else { return nil }
+        guard slices.count > 1 else { return first }
+
+        let width = slices.map(\.width).min() ?? first.width
+        var stitchSlices = [StitchSlice(image: first, topCrop: 0)]
+        for index in 1..<slices.count {
+            let image = slices[index]
+            let measuredOverlap = overlapPixels(previous: slices[index - 1],
+                                                current: image,
+                                                fallback: fallbackOverlapPixels)
+            stitchSlices.append(StitchSlice(image: image,
+                                            topCrop: min(measuredOverlap, image.height - 1)))
+        }
+
+        let pieceHeights = stitchSlices.map { slice in
+            max(1, slice.image.height - slice.topCrop)
+        }
+        let height = pieceHeights.reduce(0, +)
+
+        guard let context = CGContext(data: nil,
+                                      width: width,
+                                      height: height,
+                                      bitsPerComponent: 8,
+                                      bytesPerRow: 0,
+                                      space: CGColorSpaceCreateDeviceRGB(),
+                                      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else { return nil }
+        context.interpolationQuality = .none
+
+        var y = height
+        for slice in stitchSlices {
+            guard let piece = slice.image.cropping(to: CGRect(x: 0,
+                                                              y: slice.topCrop,
+                                                              width: width,
+                                                              height: slice.image.height - slice.topCrop))
+            else { continue }
+            y -= piece.height
+            context.draw(piece, in: CGRect(x: 0,
+                                           y: y,
+                                           width: piece.width,
+                                           height: piece.height))
+        }
+        return context.makeImage()
+    }
+
+    private static func overlapPixels(previous: CGImage,
+                                      current: CGImage,
+                                      fallback: Int) -> Int {
+        guard let previousSample = verticalSampleBytes(previous),
+              let currentSample = verticalSampleBytes(current),
+              previousSample.width == currentSample.width
+        else { return fallback }
+
+        let maxOverlap = max(1, min(previousSample.height, currentSample.height) - 1)
+        let fallbackOverlap = min(max(1, fallback), maxOverlap)
+        let coarseStep = max(1, maxOverlap / 160)
+        var candidates = Set<Int>([fallbackOverlap, maxOverlap])
+        for overlap in stride(from: 1, through: maxOverlap, by: coarseStep) {
+            candidates.insert(overlap)
+        }
+
+        var bestOverlap = fallbackOverlap
+        var bestRawScore = Double.greatestFiniteMagnitude
+        var bestScore = Double.greatestFiniteMagnitude
+        for overlap in candidates {
+            guard let rawScore = overlapScore(previous: previousSample,
+                                             current: currentSample,
+                                             overlap: overlap)
+            else { continue }
+            let prior = Double(abs(overlap - fallbackOverlap)) * 0.01
+            let score = rawScore + prior
+            if score < bestScore {
+                bestOverlap = overlap
+                bestRawScore = rawScore
+                bestScore = score
+            }
+        }
+
+        if coarseStep > 1 {
+            let lowerBound = max(1, bestOverlap - coarseStep)
+            let upperBound = min(maxOverlap, bestOverlap + coarseStep)
+            for overlap in lowerBound...upperBound {
+                guard let rawScore = overlapScore(previous: previousSample,
+                                                 current: currentSample,
+                                                 overlap: overlap)
+                else { continue }
+                let prior = Double(abs(overlap - fallbackOverlap)) * 0.01
+                let score = rawScore + prior
+                if score < bestScore {
+                    bestOverlap = overlap
+                    bestRawScore = rawScore
+                    bestScore = score
+                }
+            }
+        }
+
+        return bestRawScore <= 28 ? bestOverlap : fallbackOverlap
+    }
+
+    private static func overlapScore(previous: SampledImage,
+                                     current: SampledImage,
+                                     overlap: Int) -> Double? {
+        let bandHeight = min(96, overlap)
+        guard bandHeight > 0, overlap < previous.height, overlap < current.height else {
+            return nil
+        }
+
+        var starts = [0]
+        let middleStart = max(0, overlap / 2 - bandHeight / 2)
+        let bottomStart = max(0, overlap - bandHeight)
+        if !starts.contains(middleStart) { starts.append(middleStart) }
+        if !starts.contains(bottomStart) { starts.append(bottomStart) }
+
+        var totalDifference = 0
+        var count = 0
+        for start in starts {
+            let previousStart = previous.height - overlap + start
+            let currentStart = start
+            guard previousStart >= 0,
+                  previousStart + bandHeight <= previous.height,
+                  currentStart + bandHeight <= current.height
+            else { continue }
+
+            for rowOffset in 0..<bandHeight {
+                let previousRow = (previousStart + rowOffset) * previous.width * 4
+                let currentRow = (currentStart + rowOffset) * current.width * 4
+                for column in 0..<previous.width {
+                    let previousIndex = previousRow + column * 4
+                    let currentIndex = currentRow + column * 4
+                    for channel in 0..<3 {
+                        totalDifference += abs(Int(previous.bytes[previousIndex + channel])
+                            - Int(current.bytes[currentIndex + channel]))
+                        count += 1
+                    }
+                }
+            }
+        }
+
+        guard count > 0 else { return nil }
+        return Double(totalDifference) / Double(count)
+    }
+
+    private static func verticalSampleBytes(_ image: CGImage) -> SampledImage? {
+        let width = 32
+        let height = image.height
+        var data = [UInt8](repeating: 0, count: width * height * 4)
+        guard let context = CGContext(data: &data,
+                                      width: width,
+                                      height: height,
+                                      bitsPerComponent: 8,
+                                      bytesPerRow: width * 4,
+                                      space: CGColorSpaceCreateDeviceRGB(),
+                                      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else { return nil }
+        context.interpolationQuality = .low
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return SampledImage(width: width, height: height, bytes: data)
+    }
+
+    private static func areVisuallySame(_ lhs: CGImage, _ rhs: CGImage) -> Bool {
+        guard let lhsData = thumbnailBytes(lhs),
+              let rhsData = thumbnailBytes(rhs),
+              lhsData.count == rhsData.count
+        else { return false }
+        var totalDifference = 0
+        for index in lhsData.indices {
+            totalDifference += abs(Int(lhsData[index]) - Int(rhsData[index]))
+        }
+        let average = Double(totalDifference) / Double(lhsData.count)
+        return average < 1.5
+    }
+
+    private static func thumbnailBytes(_ image: CGImage) -> [UInt8]? {
+        let width = 24
+        let height = 24
+        var data = [UInt8](repeating: 0, count: width * height * 4)
+        guard let context = CGContext(data: &data,
+                                      width: width,
+                                      height: height,
+                                      bitsPerComponent: 8,
+                                      bytesPerRow: width * 4,
+                                      space: CGColorSpaceCreateDeviceRGB(),
+                                      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else { return nil }
+        context.interpolationQuality = .low
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return data
+    }
+}

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotSelectionController.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotSelectionController.swift
@@ -35,6 +35,7 @@ final class ScreenshotSelectionController {
     enum Outcome {
         case captured(Capture)
         case region(RecorderSupport.Region)
+        case scrollingRegion(RecorderSupport.Region)
         case cancelled
         case failed
     }
@@ -46,10 +47,22 @@ final class ScreenshotSelectionController {
     private let includePointer: Bool
     private let showLastRegion: Bool
     private let mode: Mode
+    private let supportsScrollingCapture: Bool
     private var finished = false
     /// Read by the overlays so a late event finds a session that is over.
     fileprivate var isOver: Bool { finished }
     fileprivate var spaceIsDown = false
+    fileprivate var scrollingCaptureEnabled = false {
+        didSet {
+            panels.forEach {
+                $0.overlayView.refreshCaptureGuide()
+                $0.overlayView.needsDisplay = true
+            }
+        }
+    }
+    fileprivate var offersScrollingCapture: Bool {
+        supportsScrollingCapture && mode == .image
+    }
     fileprivate var loupeEnabled = false {
         didSet { panels.forEach { $0.overlayView.refreshPointerState() } }
     }
@@ -74,12 +87,14 @@ final class ScreenshotSelectionController {
          includePointer: Bool,
          showLastRegion: Bool,
          purpose: String? = nil,
-         mode: Mode = .image) {
+         mode: Mode = .image,
+         supportsScrollingCapture: Bool = false) {
         self.freeze = freeze
         self.includePointer = includePointer
         self.showLastRegion = showLastRegion
         self.purpose = purpose
         self.mode = mode
+        self.supportsScrollingCapture = supportsScrollingCapture
     }
 
     func begin(completion: @escaping (Outcome) -> Void) {
@@ -172,6 +187,8 @@ final class ScreenshotSelectionController {
                 }
             case kVK_ANSI_R:
                 self.repeatLastRegion()
+            case _ where Self.isScrollingCaptureKey(event):
+                self.toggleScrollingCapture()
             case _ where Self.isLoupeKey(event):
                 self.toggleLoupe()
             default:
@@ -191,6 +208,20 @@ final class ScreenshotSelectionController {
             return typed == "z"
         }
         return Int(event.keyCode) == kVK_ANSI_Z
+    }
+
+    private static func isScrollingCaptureKey(_ event: NSEvent) -> Bool {
+        guard event.modifierFlags.intersection([.command, .control, .option]).isEmpty
+        else { return false }
+        if let typed = event.charactersIgnoringModifiers?.lowercased(), !typed.isEmpty {
+            return typed == "s"
+        }
+        return Int(event.keyCode) == kVK_ANSI_S
+    }
+
+    private func toggleScrollingCapture() {
+        guard offersScrollingCapture else { return }
+        scrollingCaptureEnabled.toggle()
     }
 
     private func toggleLoupe() {
@@ -260,6 +291,10 @@ final class ScreenshotSelectionController {
             finish(.region(region(fromView: viewRect, on: panel, windowID: nil)))
             return
         }
+        if scrollingCaptureEnabled {
+            finish(.scrollingRegion(region(fromView: viewRect, on: panel, windowID: nil)))
+            return
+        }
         let pixelRect = ScreenshotSupport.imagePixelRect(
             fromView: viewRect,
             viewSize: panel.screenFrame.size,
@@ -291,6 +326,10 @@ final class ScreenshotSelectionController {
         markCapturePending()
         if mode == .geometry {
             finish(.region(region(fromView: frame, on: panel, windowID: windowID)))
+            return
+        }
+        if scrollingCaptureEnabled {
+            finish(.scrollingRegion(region(fromView: frame, on: panel, windowID: windowID)))
             return
         }
         Task { @MainActor [weak self] in
@@ -489,6 +528,8 @@ private final class ScreenshotOverlayView: NSView {
     /// while the window server still delivers the tail of a gesture here.
     private weak var controller: ScreenshotSelectionController?
     private weak var panel: ScreenshotOverlayPanel?
+    private let strings: ScreenshotFeatureStrings
+    private let purpose: String?
     private let guideHost: PassThroughHostingView<CaptureGuideView>
 
     private var dragOrigin: CGPoint?
@@ -531,9 +572,13 @@ private final class ScreenshotOverlayView: NSView {
         self.windows = windows
         self.controller = controller
         self.panel = panel
+        self.strings = strings
+        self.purpose = purpose
         guideHost = PassThroughHostingView(rootView: CaptureGuideView(
             strings: strings,
-            purpose: purpose))
+            purpose: purpose,
+            offersScrollingCapture: controller.offersScrollingCapture,
+            scrollingCaptureEnabled: controller.scrollingCaptureEnabled))
         super.init(frame: frame)
         let tracking = NSTrackingArea(rect: .zero,
                                       options: [.activeAlways, .mouseMoved, .mouseEnteredAndExited,
@@ -574,6 +619,14 @@ private final class ScreenshotOverlayView: NSView {
     func updateLoupeImage(_ image: CGImage?) {
         loupeImage = image
         needsDisplay = true
+    }
+
+    func refreshCaptureGuide() {
+        guideHost.rootView = CaptureGuideView(
+            strings: strings,
+            purpose: purpose,
+            offersScrollingCapture: controller?.offersScrollingCapture ?? false,
+            scrollingCaptureEnabled: controller?.scrollingCaptureEnabled ?? false)
     }
 
     // MARK: Mouse
@@ -867,6 +920,8 @@ private final class PassThroughHostingView<Content: View>: NSHostingView<Content
 private struct CaptureGuideView: View {
     let strings: ScreenshotFeatureStrings
     let purpose: String?
+    let offersScrollingCapture: Bool
+    let scrollingCaptureEnabled: Bool
 
     var body: some View {
         HStack(spacing: 12) {
@@ -889,6 +944,10 @@ private struct CaptureGuideView: View {
             Spacer(minLength: 8)
             HStack(spacing: 7) {
                 keyHint("↩", icon: "rectangle.inset.filled")
+                if offersScrollingCapture {
+                    keyHint(scrollingCaptureEnabled ? "S on" : "S",
+                            icon: "rectangle.stack")
+                }
                 keyHint("Z", icon: "plus.magnifyingglass")
                 keyHint("esc", icon: "xmark")
             }
@@ -911,8 +970,14 @@ private struct CaptureGuideView: View {
     }
 
     private var subtitle: String {
-        guard purpose?.isEmpty == false else { return strings.hintClick }
-        return strings.hintDrag + "  ·  " + strings.hintClick
+        let base = purpose?.isEmpty == false
+            ? strings.hintDrag + "  ·  " + strings.hintClick
+            : strings.hintClick
+        guard offersScrollingCapture else { return base }
+        let scrolling = scrollingCaptureEnabled
+            ? strings.scrollingCaptureHintOn
+            : strings.scrollingCaptureHintOff
+        return base + "  ·  " + scrolling
     }
 
     private func keyHint(_ key: String, icon: String) -> some View {

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotService.swift
@@ -19,6 +19,12 @@ final class ScreenshotService: ObservableObject {
     private var editors: [ScreenshotEditorController] = []
     private var countdown: DispatchWorkItem?
     private var countdownRemaining = 0
+    private var countdownMode: CaptureMode = .standard
+
+    private enum CaptureMode {
+        case standard
+        case scrolling
+    }
 
     private var strings: ScreenshotFeatureStrings {
         FeatureStrings.screenshot(L10n.shared.language)
@@ -66,6 +72,14 @@ final class ScreenshotService: ObservableObject {
     /// Starts a capture; pressing the shortcut again while a countdown runs
     /// cancels it, and a session in progress is left alone.
     func capture() {
+        startCapture(.standard)
+    }
+
+    func captureScrolling() {
+        startCapture(.scrolling)
+    }
+
+    private func startCapture(_ mode: CaptureMode) {
         // Another feature may already own the capture surface (copying text
         // off the screen picks an area the same way).
         guard session == nil, !ScreenshotSelectionController.isSessionOnScreen else { return }
@@ -78,20 +92,26 @@ final class ScreenshotService: ObservableObject {
             Permissions.shared.requestScreenRecording()
             return
         }
+        if mode == .scrolling, !Permissions.shared.accessibility {
+            Permissions.shared.requestAccessibility()
+            return
+        }
         let delay = ScreenshotSupport.sanitizedDelay(
             UserDefaults.standard.integer(forKey: DefaultsKey.screenshotDelay))
         if delay > 0 {
+            countdownMode = mode
             countdownRemaining = delay
             tickCountdown()
         } else {
-            beginSelection()
+            beginSelection(mode)
         }
     }
 
     private func tickCountdown() {
         guard countdownRemaining > 0 else {
+            let mode = countdownMode
             countdown = nil
-            beginSelection()
+            beginSelection(mode)
             return
         }
         QuickToolHUD.showCountdown(countdownRemaining)
@@ -104,7 +124,7 @@ final class ScreenshotService: ObservableObject {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: work)
     }
 
-    private func beginSelection() {
+    private func beginSelection(_ mode: CaptureMode) {
         guard session == nil, !ScreenshotSelectionController.isSessionOnScreen else { return }
         preview?.close()
         preview = nil
@@ -112,7 +132,10 @@ final class ScreenshotService: ObservableObject {
         let controller = ScreenshotSelectionController(
             freeze: defaults.bool(forKey: DefaultsKey.screenshotFreeze),
             includePointer: defaults.bool(forKey: DefaultsKey.screenshotIncludePointer),
-            showLastRegion: defaults.bool(forKey: DefaultsKey.screenshotShowLastRegion))
+            showLastRegion: defaults.bool(forKey: DefaultsKey.screenshotShowLastRegion),
+            purpose: mode == .scrolling ? strings.scrollingCaptureTitle : nil,
+            mode: mode == .scrolling ? .geometry : .image,
+            supportsScrollingCapture: mode == .standard)
         session = controller
         controller.begin { [weak self] outcome in
             guard let self else { return }
@@ -120,14 +143,35 @@ final class ScreenshotService: ObservableObject {
             switch outcome {
             case .captured(let capture):
                 self.route(capture)
-            case .region:
-                // Only the recorder asks for geometry; this session never does.
-                break
+            case .region(let region):
+                guard mode == .scrolling else { break }
+                self.captureScrolling(region)
+            case .scrollingRegion(let region):
+                self.captureScrolling(region)
             case .cancelled:
                 break
             case .failed:
                 QuickToolHUD.show(icon: "camera.viewfinder", message: self.strings.captureFailed)
             }
+        }
+    }
+
+    private func captureScrolling(_ region: RecorderSupport.Region) {
+        guard Permissions.shared.accessibility else {
+            Permissions.shared.requestAccessibility()
+            return
+        }
+        QuickToolHUD.show(icon: "rectangle.stack", message: strings.scrollingCaptureProgressHUD)
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let capture = await ScreenshotScrollingCapture.capture(
+                region: region,
+                includePointer: false)
+            else {
+                QuickToolHUD.show(icon: "camera.viewfinder", message: self.strings.captureFailed)
+                return
+            }
+            self.route(capture)
         }
     }
 

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
@@ -20,6 +20,23 @@ enum ScreenshotSupport {
         allowedDelays.contains(raw) ? raw : 0
     }
 
+    // MARK: - Scrolling capture
+
+    static let scrollingCaptureMaxFrames = 7
+
+    /// Successive scroll captures intentionally overlap: the overlap hides
+    /// small inertial-scroll differences and gives the stitched image enough
+    /// repeated context to read naturally.
+    static func scrollingCaptureOverlapPixels(regionHeight: CGFloat,
+                                              scale: CGFloat) -> Int {
+        let scaled = max(1, regionHeight * max(scale, 1))
+        return Int(min(max(scaled * 0.18, 72), scaled * 0.42).rounded())
+    }
+
+    static func scrollingCaptureStepPoints(regionHeight: CGFloat) -> CGFloat {
+        min(max(regionHeight * 0.82, 60), 900)
+    }
+
     // MARK: - Selection geometry
 
     /// Rectangle between two drag points. `square` constrains to the largest

--- a/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
+++ b/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
@@ -224,7 +224,7 @@ final class ScreenRecorderService: ObservableObject {
             switch outcome {
             case .region(let region):
                 self.startCountdown(for: region)
-            case .captured, .cancelled:
+            case .captured, .scrollingRegion, .cancelled:
                 break
             case .failed:
                 QuickToolHUD.show(icon: "record.circle", message: self.strings.recordFailed)

--- a/Sources/Vorssaint/UI/Settings/ScreenshotSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/ScreenshotSettings.swift
@@ -37,6 +37,11 @@ struct ScreenshotSettings: View {
                 } label: {
                     Label(strings.captureButton, systemImage: "camera.viewfinder")
                 }
+                Button {
+                    ScreenshotService.shared.captureScrolling()
+                } label: {
+                    Label(strings.scrollingCaptureButton, systemImage: "rectangle.stack")
+                }
                 Text(strings.panelCaption)
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -55,6 +60,9 @@ struct ScreenshotSettings: View {
                 }
                 if !permissions.screenRecording {
                     PermissionRow(kind: .screenRecording)
+                }
+                if !permissions.accessibility {
+                    PermissionRow(kind: .accessibility)
                 }
             } header: {
                 Text(strings.pageTitle)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -7649,6 +7649,17 @@ struct MetricsTests {
                 && ScreenshotSupport.sanitizedDelay(7) == 0
                 && ScreenshotSupport.sanitizedDelay(-3) == 0,
                "capture delay only accepts the offered steps")
+        expect(ScreenshotSupport.scrollingCaptureMaxFrames == 7,
+               "scrolling screenshots stop after a bounded number of slices")
+        expect(ScreenshotSupport.scrollingCaptureOverlapPixels(regionHeight: 600, scale: 2) == 216,
+               "scrolling screenshots keep a proportional overlap between slices")
+        expect(ScreenshotSupport.scrollingCaptureOverlapPixels(regionHeight: 80, scale: 1) == 34,
+               "short scrolling regions clamp overlap below half the capture")
+        expect(ScreenshotSupport.scrollingCaptureStepPoints(regionHeight: 900) == 738
+                && ScreenshotSupport.scrollingCaptureStepPoints(regionHeight: 1200) == 900,
+               "scrolling screenshots cap large scroll steps")
+        expectClose(Double(ScreenshotSupport.scrollingCaptureStepPoints(regionHeight: 120)), 98.4,
+                    "scrolling screenshots keep small scroll steps proportional")
 
         let dragRect = ScreenshotSupport.selectionRect(from: CGPoint(x: 100, y: 80),
                                                        to: CGPoint(x: 40, y: 200))


### PR DESCRIPTION
## Summary

- Adds a scrolling screenshot action for Issue #439 that reuses the existing region selector, scrolls the focused app, and stitches successive captures into one tall image.
- Exposes the action from Screenshot settings and Command Bar.
- Keeps the normal screenshot flow unchanged, routing the stitched result through the existing preview/editor/save/copy pipeline.

## Validation

- `git diff --check`
- `swift build`
- `./build.sh --test` (`TESTS OK (6018 checks)`)

Related to #439.
