### PR TITLE
Fix command bar links when the separator is a full-width space

### DIFF
--- a/Sources/Vorssaint/Services/CommandBar/CommandBarLinks.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarLinks.swift
@@ -110,8 +110,11 @@ enum CommandBarLinks {
         let normalizedQuery = CommandBarSearch.normalized(query)
         guard normalizedQuery.hasPrefix(normalizedName + " ") else { return nil }
         // The remainder comes from the ORIGINAL text: what someone searches for
-        // keeps its capitals and its accents.
-        let words = query.split(separator: " ", omittingEmptySubsequences: true)
+        // keeps its capitals and its accents. Splitting on any whitespace — not
+        // just the ASCII space — keeps a full-width space (U+3000), which some
+        // input methods produce, in step with the width-insensitive prefix check
+        // above.
+        let words = query.split(whereSeparator: \.isWhitespace)
         let nameWords = normalizedName.split(separator: " ").count
         guard words.count > nameWords else { return nil }
         return words.dropFirst(nameWords).joined(separator: " ")

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarSupport.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarSupport.swift
@@ -43,9 +43,10 @@ enum CommandBarSearch {
             .folding(options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
                      locale: nil)
             .lowercased()
-            .replacingOccurrences(of: "\n", with: " ")
-            .replacingOccurrences(of: "\t", with: " ")
-        return folded.split(separator: " ").joined(separator: " ")
+        // Splitting on any whitespace — not just the ASCII space — treats the
+        // full-width space (U+3000) that some input methods produce the same
+        // as the half-width one, so "bd　123" folds like "bd 123".
+        return folded.split(whereSeparator: \.isWhitespace).joined(separator: " ")
     }
 
     /// Drops the characters that take up no space and that nobody can type:

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -10423,6 +10423,8 @@ struct MetricsTests {
         expect(CommandBarLinks.trailingArgument(query: "ghost writer", name: "gh") == nil
                 && CommandBarLinks.trailingArgument(query: "gh", name: "gh") == nil,
                "a longer word is not the name, and the name alone is not an argument")
+        expect(CommandBarLinks.trailingArgument(query: "bd\u{3000}123", name: "bd") == "123",
+               "a full-width space separates the name from its argument")
         expect(CommandBarLink(name: "gh", kind: .link, destination: "https://x/{query}").takesQuery
                 && !CommandBarLink(name: "a", kind: .link, destination: "https://x").takesQuery,
                "a destination that waits for a query is a search")


### PR DESCRIPTION
Fixes #468

## Problem

Saved search links (e.g. name `bd`, destination `https://www.baidu.com/s?wd={query}`) stop appearing in the command bar when the space between the name and the argument is a **full-width space** (U+3000), which some input methods (notably Chinese IMEs) produce instead of the ASCII space (U+0020).

Typing `bd　123` (full-width space) causes the link to vanish from the list, and pressing Return does nothing.

## Root cause

Two functions split on the ASCII space (`" "`) only:

1. **`normalized()`** in `CommandBarSupport.swift` — the final `split(separator: " ")` leaves U+3000 in place, so `hasPrefix("bd ")` fails.
2. **`trailingArgument()`** in `CommandBarLinks.swift` — `split(separator: " ")` cannot separate `bd` from the argument.

When `trailingArgument` returns nil, `rankingTitle` falls back to the bare name, the score for `bd　123` becomes nil, and the link is filtered out.

> Note: `.widthInsensitive` in `String.folding(options:)` does **not** fold U+3000 to U+0020 — it only folds full-width *letters/digits*, not punctuation or spaces.

## Fix

Both `normalized()` and `trailingArgument()` now use `split(whereSeparator: \.isWhitespace)`, which treats U+3000 the same as a regular ASCII space.

## Testing

Added a test case in `MetricsTests.swift` for the full-width-space scenario. All 6244 tests pass.