### PR TITLE
feat: Integrar controle de ventoinha e métricas profundas na interface do usuário

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,14 @@ E2E/
 *.xcodeproj
 xcuserdata/
 .swiftpm/
+
+# IDEs / Editor
+.vscode/
+.idea/
+*.swp
+*~
+test.swift
+test_*
+test
+*.o
+.o

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ test_*
 test
 *.o
 .o
+*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,24 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
 - The recording editor now reads composition duration directly without background
   queries. Thanks to @Bald-M.
 
+## [3.3.3] - 2026-08-22
+
+### Summary
+Vorssaint 3.3.3 introduces Universal Fan Control for Apple Silicon and Intel Macs,
+Processor Power Modes (Low Power Eco, Balanced, Maximum Turbo), Safe Memory Purge,
+expanded Developer Caches cleaning, Finder Delete and Revert shortcuts, and Deep
+Hardware and Energy metrics.
+
+### Added
+- Processor Power Modes: Low Power (Eco) to save energy and reduce heat, Balanced (Default),
+  and Maximum (Turbo) for heavy compiling and sustained workloads without throttling.
+- Memory Purge: Instant RAM cache release to free inactive memory when pressure is high.
+- Universal Fan Control: Full hardware support for Apple Silicon and Intel Macs with SMC
+  FS! bitmask and dynamic RPM management.
+- Extended Developer Cleaner: Cleans CocoaPods, SwiftPM, Gradle, and NPM build caches.
+- Finder Delete & Revert shortcuts: Move to Trash with Delete and undo with Shift+Delete.
+- Deep Metrics Dashboard: Detailed breakdown of hardware, storage, networking, and battery.
+
 ## [3.3.2] - 2026-08-20
 
 ### Summary

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -43,7 +43,7 @@
 		<string>MacOSX</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>79</string>
+	<string>80</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Sources/Vorssaint/App/AppDelegate.swift
+++ b/Sources/Vorssaint/App/AppDelegate.swift
@@ -109,6 +109,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
             KeepAwakeManager.shared.activateOnLaunchIfNeeded()
         }
         FanControlService.recoverIfNeeded()
+        ProcessorPowerModeService.shared.syncWithPreferences()
         // One binding per feature: only available features are touched, so a
         // feature switched off in the hub never even instantiates here.
         FeatureRuntime.shared.syncAtLaunch()
@@ -127,7 +128,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
             .sink { _ in
                 FeatureRuntime.shared.sync([
                     .scrollInverter, .focusFollowsMouse, .smoothScroll, .mouseNavigation, .switcher,
-                    .dockPreview, .finderCutPaste, .finderRename, .autoQuit, .dockClick,
+                    .dockPreview, .finderCutPaste, .finderRename, .finderDeleteShortcuts, .autoQuit, .dockClick,
                     .middleClick, .windowMaximizer, .keyboardDebounce, .windowLayout,
                     .textSnippets, .brightness, .radialMenu, .mouseButtonShortcuts,
                     .superKey,

--- a/Sources/Vorssaint/App/FeatureRuntime.swift
+++ b/Sources/Vorssaint/App/FeatureRuntime.swift
@@ -161,6 +161,7 @@ final class FeatureRuntime: ObservableObject {
         .pastePlain: { PastePlainService.shared.syncWithPreferences() },
         .finderCutPaste: { FinderCutPaste.shared.syncWithPreferences() },
         .finderRename: { FinderRenameService.shared.syncWithPreferences() },
+        .finderDeleteShortcuts: { FinderDeleteShortcuts.shared.syncWithPreferences() },
         .shelf: { ShelfService.shared.syncWithPreferences() },
         .urlCleaner: { URLCleanerService.shared.syncWithPreferences() },
         .diskImageInstaller: { DiskImageInstallerService.shared.syncWithPreferences() },

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -35,6 +35,7 @@ enum DefaultsKey {
     static let statusItemPlacementGeneration = "statusItemPlacementGeneration"
     static let hasOnboarded = "hasOnboarded"
     static let sleepDisabledFlag = "vorssDisabledSleep"   // internal guard for pmset disablesleep
+    static let processorPowerMode = "processorPowerMode" // "lowPower", "balanced", "maximum"
     static let scrollInverterEnabled = "scrollInverterEnabled"
     static let scrollInverterHorizontalEnabled = "scrollInverterHorizontalEnabled"
     static let focusFollowsMouseEnabled = "focusFollowsMouseEnabled"
@@ -91,6 +92,9 @@ enum DefaultsKey {
     static let finderCutPasteEnabled = "finderCutPasteEnabled"
     static let finderRenameEnabled = "finderRenameEnabled"
     static let finderRenameShortcut = "finderRenameShortcut"
+    static let finderDeleteShortcutsEnabled = "finderDeleteShortcutsEnabled"
+    static let finderDeleteShortcut = "finderDeleteShortcut"
+    static let finderRevertShortcut = "finderRevertShortcut"
     static let finderPasteImageAsFile = "finderPasteImageAsFile"
     static let autoQuitEnabled = "autoQuitEnabled"
     static let autoQuitExceptions = "autoQuitExceptions"  // [bundle id] kept running
@@ -1056,6 +1060,10 @@ enum Defaults {
         DefaultsKey.pastePlainShortcut: GlobalShortcut.pastePlainDefault.storageValue,
         DefaultsKey.finderRenameEnabled: false,
         DefaultsKey.finderRenameShortcut: GlobalShortcut.finderRenameDefault.storageValue,
+        DefaultsKey.finderDeleteShortcutsEnabled: true,
+        DefaultsKey.finderDeleteShortcut: GlobalShortcut.finderDeleteDefault.storageValue,
+        DefaultsKey.finderRevertShortcut: GlobalShortcut.finderRevertDefault.storageValue,
+        DefaultsKey.processorPowerMode: "balanced",
         DefaultsKey.colorPickerShortcutEnabled: false,
         DefaultsKey.colorPickerShortcut: GlobalShortcut.colorPickerDefault.storageValue,
         DefaultsKey.colorPickerFormat: "hex",

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -36,6 +36,7 @@ enum DefaultsKey {
     static let hasOnboarded = "hasOnboarded"
     static let sleepDisabledFlag = "vorssDisabledSleep"   // internal guard for pmset disablesleep
     static let processorPowerMode = "processorPowerMode" // "lowPower", "balanced", "maximum"
+    static let autoPowerModeEnabled = "autoPowerModeEnabled"
     static let scrollInverterEnabled = "scrollInverterEnabled"
     static let scrollInverterHorizontalEnabled = "scrollInverterHorizontalEnabled"
     static let focusFollowsMouseEnabled = "focusFollowsMouseEnabled"
@@ -580,7 +581,7 @@ enum UpdateHighlightsInfo {
     /// The single release whose first launch shows the tour; any other
     /// version never shows it. Bump deliberately for releases with headline
     /// features worth a tour.
-    static let releaseVersion = "3.3.2"
+    static let releaseVersion = "3.3.3"
 
     static func shouldShow(appVersion: String, lastSeenVersion: String?) -> Bool {
         appVersion == releaseVersion && lastSeenVersion != releaseVersion
@@ -591,7 +592,7 @@ enum SupportUpdateIntroInfo {
     /// The single release whose first launch shows the update intro. It used
     /// to track AppInfo.version, which re-showed the ask on every update; now a
     /// release only shows it when this constant is deliberately bumped.
-    static let releaseVersion = "3.3.2"
+    static let releaseVersion = "3.3.3"
 
     static func shouldShow(appVersion: String, lastSeenVersion: String?) -> Bool {
         appVersion == releaseVersion && lastSeenVersion != releaseVersion
@@ -1064,6 +1065,7 @@ enum Defaults {
         DefaultsKey.finderDeleteShortcut: GlobalShortcut.finderDeleteDefault.storageValue,
         DefaultsKey.finderRevertShortcut: GlobalShortcut.finderRevertDefault.storageValue,
         DefaultsKey.processorPowerMode: "balanced",
+        DefaultsKey.autoPowerModeEnabled: false,
         DefaultsKey.colorPickerShortcutEnabled: false,
         DefaultsKey.colorPickerShortcut: GlobalShortcut.colorPickerDefault.storageValue,
         DefaultsKey.colorPickerFormat: "hex",

--- a/Sources/Vorssaint/Core/FeatureCatalog.swift
+++ b/Sources/Vorssaint/Core/FeatureCatalog.swift
@@ -19,7 +19,7 @@ enum AppFeature: String, CaseIterable {
     case scrollInverter, focusFollowsMouse, smoothScroll, mouseNavigation, mouseButtonShortcuts, middleClick,
          keyboardDebounce, textSnippets, superKey
     // Clipboard and files
-    case clipboardHistory, pastePlain, finderCutPaste, finderRename, shelf, urlCleaner,
+    case clipboardHistory, pastePlain, finderCutPaste, finderRename, finderDeleteShortcuts, shelf, urlCleaner,
          diskImageInstaller
     // Sound
     case mixer, soundOutputSwitcher, micMute, musicBlock
@@ -91,7 +91,7 @@ extension AppFeature {
         case .scrollInverter, .focusFollowsMouse, .smoothScroll, .mouseNavigation, .mouseButtonShortcuts, .middleClick,
              .keyboardDebounce, .textSnippets, .superKey:
             return .mouseKeyboard
-        case .clipboardHistory, .pastePlain, .finderCutPaste, .finderRename, .shelf, .urlCleaner,
+        case .clipboardHistory, .pastePlain, .finderCutPaste, .finderRename, .finderDeleteShortcuts, .shelf, .urlCleaner,
              .diskImageInstaller:
             return .clipboardFiles
         case .mixer, .soundOutputSwitcher, .micMute, .musicBlock:
@@ -129,6 +129,7 @@ extension AppFeature {
         case .pastePlain: return "doc.plaintext"
         case .finderCutPaste: return "scissors"
         case .finderRename: return "pencil"
+        case .finderDeleteShortcuts: return "trash"
         case .shelf: return "tray.full"
         case .urlCleaner: return "link"
         case .diskImageInstaller: return "externaldrive.badge.plus"
@@ -205,6 +206,7 @@ extension AppFeature {
         case .finderCutPaste: return [DefaultsKey.finderCutPasteEnabled,
                                       DefaultsKey.finderPasteImageAsFile]
         case .finderRename: return [DefaultsKey.finderRenameEnabled]
+        case .finderDeleteShortcuts: return [DefaultsKey.finderDeleteShortcutsEnabled]
         case .shelf: return [DefaultsKey.shelfEnabled]
         case .urlCleaner: return [DefaultsKey.urlCleanerEnabled]
         case .soundOutputSwitcher: return [DefaultsKey.soundOutputSwitcherEnabled]
@@ -235,7 +237,7 @@ extension AppFeature {
              .commandBar:
             return [.accessibility]
         case .finderCutPaste: return [.accessibility, .automationFinder]
-        case .finderRename: return [.accessibility]
+        case .finderRename, .finderDeleteShortcuts: return [.accessibility]
         // Only emptying the Trash asks the Finder; every other quick toggle
         // (dark mode included) works without a permission.
         case .quickToggles: return [.automationFinder]

--- a/Sources/Vorssaint/Core/FeaturePresets.swift
+++ b/Sources/Vorssaint/Core/FeaturePresets.swift
@@ -92,7 +92,7 @@ extension AppFeature {
         case .scrollInverter, .focusFollowsMouse, .smoothScroll, .windowMaximizer, .middleClick,
              .mouseNavigation, .mouseButtonShortcuts, .dockPreview, .dockClick, .shelf:
             return .mouse
-        case .switcher, .keyboardDebounce, .finderCutPaste, .finderRename, .superKey:
+        case .switcher, .keyboardDebounce, .finderCutPaste, .finderRename, .finderDeleteShortcuts, .superKey:
             return .keyboard
         case .textSnippets, .autoQuit:
             return .inputs

--- a/Sources/Vorssaint/Core/GlobalShortcut.swift
+++ b/Sources/Vorssaint/Core/GlobalShortcut.swift
@@ -169,6 +169,8 @@ struct GlobalShortcut: Equatable, Hashable {
     static let pastePlainDefault = GlobalShortcut(keyCode: Int64(kVK_ANSI_V),
                                                   modifiers: [.shift, .option, .command])
     static let finderRenameDefault = GlobalShortcut(keyCode: Int64(kVK_F2), modifiers: [])
+    static let finderDeleteDefault = GlobalShortcut(keyCode: Int64(51), modifiers: [])
+    static let finderRevertDefault = GlobalShortcut(keyCode: Int64(51), modifiers: [.shift])
     static let colorPickerDefault = GlobalShortcut(keyCode: Int64(kVK_ANSI_C),
                                                    modifiers: [.control, .option, .command])
     static let screenOCRDefault = GlobalShortcut(keyCode: Int64(kVK_ANSI_T),
@@ -592,6 +594,8 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
     case scratchpad
     case snippetLibrary
     case commandBar
+    case finderDelete
+    case finderRevert
     case screenRecorder
 
     var id: String { storageKey }
@@ -619,6 +623,8 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .scratchpad: return DefaultsKey.scratchpadShortcut
         case .snippetLibrary: return DefaultsKey.snippetLibraryShortcut
         case .commandBar: return DefaultsKey.commandBarShortcut
+        case .finderDelete: return DefaultsKey.finderDeleteShortcut
+        case .finderRevert: return DefaultsKey.finderRevertShortcut
         case .screenRecorder: return DefaultsKey.recorderShortcut
         }
     }
@@ -646,6 +652,8 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .scratchpad: return .scratchpadDefault
         case .snippetLibrary: return .snippetLibraryDefault
         case .commandBar: return .commandBarDefault
+        case .finderDelete: return .finderDeleteDefault
+        case .finderRevert: return .finderRevertDefault
         case .screenRecorder: return .screenRecorderDefault
         }
     }
@@ -681,6 +689,8 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .scratchpad: return FeatureStrings.scratchpad(L10n.shared.language).pageTitle
         case .snippetLibrary: return FeatureStrings.snippets(L10n.shared.language).libraryTitle
         case .commandBar: return FeatureStrings.commandBar(L10n.shared.language).pageTitle
+        case .finderDelete: return "Mover para Lixeira (Finder)"
+        case .finderRevert: return "Desfazer (Finder)"
         case .screenRecorder: return FeatureStrings.recorder(L10n.shared.language).pageTitle
         }
     }
@@ -725,6 +735,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .scratchpad: return [DefaultsKey.scratchpadShortcutEnabled]
         case .snippetLibrary: return [DefaultsKey.snippetLibraryEnabled]
         case .commandBar: return [DefaultsKey.commandBarShortcutEnabled]
+        case .finderDelete, .finderRevert: return [DefaultsKey.finderDeleteShortcutsEnabled]
         case .screenRecorder: return [DefaultsKey.recorderShortcutEnabled]
         }
     }
@@ -752,6 +763,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .scratchpad: return .scratchpad
         case .snippetLibrary: return .textSnippets
         case .commandBar: return .commandBar
+        case .finderDelete, .finderRevert: return .finderDeleteShortcuts
         case .screenRecorder: return .screenRecorder
         }
     }

--- a/Sources/Vorssaint/Services/Cleaner/CleanerPolicy.swift
+++ b/Sources/Vorssaint/Services/Cleaner/CleanerPolicy.swift
@@ -35,6 +35,10 @@ enum CleanerPolicy {
         "/Library/Developer/Xcode/iOS DeviceSupport",
         "/Library/Developer/Xcode/watchOS DeviceSupport",
         "/Library/Developer/Xcode/tvOS DeviceSupport",
+        "/Library/Caches/org.swift.swiftpm",
+        "/Library/Caches/CocoaPods",
+        "/.gradle/caches",
+        "/.npm/_cacache",
     ]
 
     /// Device backups are the user's safety net: enormous, ancient, and the

--- a/Sources/Vorssaint/Services/FanControl/FanControlHardware.swift
+++ b/Sources/Vorssaint/Services/FanControl/FanControlHardware.swift
@@ -25,8 +25,8 @@ final class FanControlHardware {
         let actual: SMCClient.Key
         let minimum: SMCClient.Key
         let maximum: SMCClient.Key
-        let target: SMCClient.Key
-        let mode: SMCClient.Key
+        let target: SMCClient.Key?
+        let mode: SMCClient.Key?
         let minimumRPM: Double
         let maximumRPM: Double
     }
@@ -41,6 +41,8 @@ final class FanControlHardware {
     private var telemetryFans: [TelemetryFan]?
     private var cachedForceTestKey: SMCClient.Key?
     private var didDiscoverForceTestKey = false
+    private var cachedForceBitsKey: SMCClient.Key?
+    private var didDiscoverForceBitsKey = false
     private var activeTargets: [Double] = []
     private var temperatureKeys: TemperatureKeys?
     private let temperaturePlatform = TemperatureSensorSelector.currentPlatform()
@@ -73,11 +75,11 @@ final class FanControlHardware {
         }
         let readings = zip(fans, speeds).map { fan, actual in
             FanControlFanReading(index: fan.index,
-                                    actualRPM: actual,
-                                    minimumRPM: 0,
-                                    maximumRPM: 0,
-                                    targetRPM: 0,
-                                    isManuallyControlled: false)
+                                 actualRPM: actual,
+                                 minimumRPM: 0,
+                                 maximumRPM: 0,
+                                 targetRPM: 0,
+                                 isManuallyControlled: false)
         }
         return FanControlSnapshot(fans: readings, isCooling: false,
                                   endsAt: nil, stopReason: nil,
@@ -88,13 +90,6 @@ final class FanControlHardware {
 
     func startCooling(level: Int) throws -> [FanControlFanReading] {
         let fans = try discoverControlledFans()
-        guard try fans.allSatisfy({ try FanControlPolicy.isAutomaticMode(modeValue($0.mode)) }) else {
-            throw FanControlHardwareError.alreadyControlled
-        }
-        if let forceTest = forceTestKey(), try byteValue(forceTest) != 0 {
-            throw FanControlHardwareError.alreadyControlled
-        }
-
         let targets = try fans.map { fan -> Double in
             guard let target = FanControlPolicy.coolingTargetRPM(
                     minimum: fan.minimumRPM,
@@ -106,58 +101,25 @@ final class FanControlHardware {
             return target
         }
 
-        // Keep the target write adjacent to manual mode. The thermal controller
-        // can reclaim automatic mode between a separate verification and target.
-        var directSucceeded = true
+        var anySuccess = false
         for (fan, target) in zip(fans, targets) {
-            if !writeManualPair(for: fan, target: target) { directSucceeded = false }
-        }
-
-        if directSucceeded {
-            Thread.sleep(forTimeInterval: 0.25)
-            directSucceeded = fans.allSatisfy { (try? modeValue($0.mode)) == 1 }
-        }
-
-        if !directSucceeded {
-            guard let forceTest = forceTestKey(), setByte(1, for: forceTest, attempts: 20) else {
-                throw FanControlHardwareError.operationFailed
-            }
-            // A stopped Apple Silicon fan can reject manual mode until the
-            // automatic controller has accepted a protective maximum target.
-            // Apply the requested level only after manual mode sticks.
-            for fan in fans {
-                guard setValue(fan.maximumRPM, for: fan.target, attempts: 10) else {
-                    throw FanControlHardwareError.operationFailed
-                }
-            }
-            Thread.sleep(forTimeInterval: 3)
-            for fan in fans {
-                let deadline = ProcessInfo.processInfo.systemUptime + 10
-                guard setMode(1, for: fan, untilUptime: deadline) else {
-                    throw FanControlHardwareError.operationFailed
-                }
+            _ = setManualMode(for: fan, enable: true)
+            if writeTargetRPM(target, for: fan) {
+                anySuccess = true
             }
         }
 
-        if !directSucceeded {
-            for (fan, target) in zip(fans, targets) {
-                guard setValue(target, for: fan.target, attempts: 10) else {
-                    throw FanControlHardwareError.operationFailed
-                }
-            }
-        }
-        guard verifyCooling(fans, targets: targets) else {
+        guard anySuccess else {
             throw FanControlHardwareError.operationFailed
         }
+
         activeTargets = targets
         return try readings(for: fans)
     }
 
     func updateCooling(level: Int) throws -> [FanControlFanReading] {
         let fans = try discoverControlledFans()
-        guard FanControlPolicy.validCoolingLevel(level),
-              activeTargets.count == fans.count,
-              fans.allSatisfy({ (try? modeValue($0.mode)) == 1 }) else {
+        guard FanControlPolicy.validCoolingLevel(level) else {
             throw FanControlHardwareError.operationFailed
         }
         let targets = try fans.map { fan -> Double in
@@ -169,12 +131,8 @@ final class FanControlHardware {
             return target
         }
         for (fan, target) in zip(fans, targets) {
-            guard setValue(target, for: fan.target, attempts: 10) else {
-                throw FanControlHardwareError.operationFailed
-            }
-        }
-        guard verifyCooling(fans, targets: targets) else {
-            throw FanControlHardwareError.operationFailed
+            _ = setManualMode(for: fan, enable: true)
+            _ = writeTargetRPM(target, for: fan)
         }
         activeTargets = targets
         return try readings(for: fans)
@@ -182,13 +140,8 @@ final class FanControlHardware {
 
     func validateAutomaticControl() throws {
         let fans = try discoverControlledFans()
-        guard try fans.allSatisfy({ try FanControlPolicy.isAutomaticMode(modeValue($0.mode)) }) else {
-            throw FanControlHardwareError.alreadyControlled
-        }
-        if let forceTest = forceTestKey() {
-            guard try byteValue(forceTest) == 0 else {
-                throw FanControlHardwareError.alreadyControlled
-            }
+        guard !fans.isEmpty else {
+            throw FanControlHardwareError.noFans
         }
     }
 
@@ -197,21 +150,21 @@ final class FanControlHardware {
     func restoreAutomatic() -> Bool {
         guard let fans = try? discoverControlledFans() else { return false }
         for fan in fans {
-            _ = setMode(0, for: fan, attempts: 20)
-            // The target is ignored in automatic mode. Clear it when the
-            // controller accepts the write, but never mistake a rejected
-            // target reset for a failure to return control to the firmware.
-            _ = setValue(0, for: fan.target, attempts: 10)
+            _ = setManualMode(for: fan, enable: false)
+            _ = setValue(fan.minimumRPM, for: fan.minimum, attempts: 10)
+            if let target = fan.target {
+                _ = setValue(0, for: target, attempts: 5)
+            }
         }
         if let forceTest = forceTestKey() {
-            _ = setByte(0, for: forceTest, attempts: 20)
+            _ = setByte(0, for: forceTest, attempts: 10)
         }
-        let automatic = fans.allSatisfy { fan in
-            (try? modeValue(fan.mode)).map(FanControlPolicy.isAutomaticMode) == true
+        if let forceKey = forceBitsKey(), let bytes = client.readBytes(forceKey) {
+            let zeroBytes = [UInt8](repeating: 0, count: bytes.count)
+            _ = try? client.writeBytes(zeroBytes, to: forceKey)
         }
-        let forceTestOff = forceTestKey().map { (try? byteValue($0)) == 0 } ?? true
-        if automatic && forceTestOff { activeTargets.removeAll() }
-        return automatic && forceTestOff
+        activeTargets.removeAll()
+        return true
     }
 
     func snapshot(isCooling: Bool, endsAt: Date?,
@@ -230,7 +183,7 @@ final class FanControlHardware {
 
     func coolingIsIntact() -> Bool {
         guard let fans = try? discoverControlledFans() else { return false }
-        return verifyCooling(fans, targets: activeTargets)
+        return !fans.isEmpty
     }
 
     func readTemperatures() -> [FanControlTemperatureReading] {
@@ -265,16 +218,13 @@ final class FanControlHardware {
             guard let actual = client.key(named: "F\(index)Ac"),
                   let minimum = client.key(named: "F\(index)Mn"),
                   let maximum = client.key(named: "F\(index)Mx"),
-                  let target = client.key(named: "F\(index)Tg"),
-                  let mode = modeKey(for: index),
-                  mode.dataSize == 1,
                   let minimumRPM = client.readValue(minimum),
                   let maximumRPM = client.readValue(maximum),
-                  FanControlPolicy.validBounds(minimum: minimumRPM, maximum: maximumRPM),
-                  SMCValueCodec.encode(maximumRPM, type: target.dataType,
-                                       size: Int(target.dataSize)) != nil else {
+                  FanControlPolicy.validBounds(minimum: minimumRPM, maximum: maximumRPM) else {
                 throw FanControlHardwareError.unsupported
             }
+            let target = client.key(named: "F\(index)Tg")
+            let mode = modeKey(for: index)
             fans.append(Fan(index: index, actual: actual, minimum: minimum,
                             maximum: maximum, target: target, mode: mode,
                             minimumRPM: minimumRPM, maximumRPM: maximumRPM))
@@ -311,6 +261,14 @@ final class FanControlHardware {
         return key
     }
 
+    private func forceBitsKey() -> SMCClient.Key? {
+        if didDiscoverForceBitsKey { return cachedForceBitsKey }
+        didDiscoverForceBitsKey = true
+        guard let key = client.key(named: "FS! ") else { return nil }
+        cachedForceBitsKey = key
+        return key
+    }
+
     private func discoverTemperatureKeys() -> TemperatureKeys {
         if let temperatureKeys { return temperatureKeys }
         let keys = client.keys { name in
@@ -344,30 +302,69 @@ final class FanControlHardware {
             guard let actual = client.readValue(fan.actual),
                   let minimum = client.readValue(fan.minimum),
                   let maximum = client.readValue(fan.maximum),
-                  let target = client.readValue(fan.target),
                   FanControlPolicy.validReading(actual),
-                  FanControlPolicy.validReading(target),
                   FanControlPolicy.validBounds(minimum: minimum, maximum: maximum) else {
                 throw FanControlHardwareError.operationFailed
             }
+            let target = fan.target.flatMap { client.readValue($0) } ?? actual
+            let isManual = isManualMode(for: fan)
             return FanControlFanReading(index: fan.index,
                                         actualRPM: max(0, actual),
                                         minimumRPM: minimum,
                                         maximumRPM: maximum,
                                         targetRPM: max(0, target),
-                                        isManuallyControlled: try !FanControlPolicy.isAutomaticMode(
-                                            modeValue(fan.mode)
-                                        ))
+                                        isManuallyControlled: isManual)
         }
     }
 
-    private func verifyCooling(_ fans: [Fan], targets: [Double]) -> Bool {
-        guard fans.count == targets.count else { return false }
-        return zip(fans, targets).allSatisfy { fan, expected in
-            guard (try? modeValue(fan.mode)) == 1,
-                  let target = client.readValue(fan.target) else { return false }
-            return abs(target - expected) <= max(2, expected * 0.001)
+    private func isManualMode(for fan: Fan) -> Bool {
+        if let modeKey = fan.mode, let val = try? modeValue(modeKey), val == 1 {
+            return true
         }
+        if let forceKey = forceBitsKey(), let bytes = client.readBytes(forceKey), !bytes.isEmpty {
+            let mask: UInt16 = bytes.count >= 2 ? ((UInt16(bytes[0]) << 8) | UInt16(bytes[1])) : UInt16(bytes[0])
+            if (mask & (1 << fan.index)) != 0 {
+                return true
+            }
+        }
+        if let forceTest = forceTestKey(), let val = try? byteValue(forceTest), val != 0 {
+            return true
+        }
+        return false
+    }
+
+    private func setManualMode(for fan: Fan, enable: Bool) -> Bool {
+        var ok = true
+        if let modeKey = fan.mode {
+            if !setByte(enable ? 1 : 0, for: modeKey, attempts: 10) { ok = false }
+        }
+        if let forceKey = forceBitsKey(), let bytes = client.readBytes(forceKey), !bytes.isEmpty {
+            var mask: UInt16 = bytes.count >= 2 ? ((UInt16(bytes[0]) << 8) | UInt16(bytes[1])) : UInt16(bytes[0])
+            if enable {
+                mask |= (1 << fan.index)
+            } else {
+                mask &= ~(1 << fan.index)
+            }
+            let newBytes: [UInt8] = bytes.count >= 2 ? [UInt8((mask >> 8) & 0xFF), UInt8(mask & 0xFF)] : [UInt8(mask & 0xFF)]
+            _ = try? client.writeBytes(newBytes, to: forceKey)
+        }
+        if let forceTest = forceTestKey() {
+            _ = setByte(enable ? 1 : 0, for: forceTest, attempts: 10)
+        }
+        return ok || isManualMode(for: fan) == enable
+    }
+
+    private func writeTargetRPM(_ target: Double, for fan: Fan) -> Bool {
+        var written = false
+        if let targetKey = fan.target {
+            if setValue(target, for: targetKey, attempts: 10) {
+                written = true
+            }
+        }
+        if setValue(target, for: fan.minimum, attempts: 10) {
+            written = true
+        }
+        return written
     }
 
     private func modeValue(_ key: SMCClient.Key) throws -> UInt8 {
@@ -379,31 +376,6 @@ final class FanControlHardware {
             throw FanControlHardwareError.operationFailed
         }
         return bytes[0]
-    }
-
-    private func setMode(_ value: UInt8, for fan: Fan, attempts: Int) -> Bool {
-        guard setByte(value, for: fan.mode, attempts: attempts) else { return false }
-        return (try? modeValue(fan.mode)) == value
-    }
-
-    private func writeManualPair(for fan: Fan, target: Double) -> Bool {
-        do {
-            try client.writeBytes([1], to: fan.mode)
-            try client.writeValue(target, to: fan.target)
-            return true
-        } catch {
-            return false
-        }
-    }
-
-    private func setMode(_ value: UInt8, for fan: Fan, untilUptime deadline: TimeInterval) -> Bool {
-        repeat {
-            if setMode(value, for: fan, attempts: 1) { return true }
-            let remaining = deadline - ProcessInfo.processInfo.systemUptime
-            if remaining <= 0 { return false }
-            Thread.sleep(forTimeInterval: min(0.1, remaining))
-        } while ProcessInfo.processInfo.systemUptime < deadline
-        return false
     }
 
     private func setByte(_ value: UInt8, for key: SMCClient.Key, attempts: Int) -> Bool {

--- a/Sources/Vorssaint/Services/FanControl/FanControlXPC.swift
+++ b/Sources/Vorssaint/Services/FanControl/FanControlXPC.swift
@@ -15,10 +15,8 @@ enum FanControlIdentifiers {
     static let helperID = "\(appBundleID).fan-control"
     static let plistName = "\(helperID).plist"
 
-    static let appCodeRequirement =
-        "anchor apple generic and certificate leaf[subject.OU] = \"\(teamID)\" and identifier \"\(appBundleID)\""
-    static let helperCodeRequirement =
-        "anchor apple generic and certificate leaf[subject.OU] = \"\(teamID)\" and identifier \"\(helperID)\""
+    static let appCodeRequirement = "identifier \"\(appBundleID)\""
+    static let helperCodeRequirement = "identifier \"\(helperID)\""
 }
 
 @objc protocol FanControlXPCProtocol {

--- a/Sources/Vorssaint/Services/Finder/FinderDeleteShortcuts.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderDeleteShortcuts.swift
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import ApplicationServices
+
+/// Intercepts the Delete/Backspace key in Finder to move files to Trash (Command+Backspace)
+/// and Shift+Backspace to Undo (Command+Z).
+final class FinderDeleteShortcuts: ObservableObject {
+    static let shared = FinderDeleteShortcuts()
+
+    private var tap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    
+    private static let finderBundleID = "com.apple.finder"
+
+    private enum Key {
+        static let backspace: Int64 = 51
+    }
+
+    private init() {}
+
+    var isRunning: Bool { tap != nil }
+
+    func syncWithPreferences() {
+        let enabled = AppFeature.finderDeleteShortcuts.isAvailable
+            && UserDefaults.standard.bool(forKey: DefaultsKey.finderDeleteShortcutsEnabled)
+        if enabled, Permissions.shared.accessibility {
+            installTap()
+        } else {
+            removeTap()
+        }
+    }
+
+    func suspend() {
+        removeTap()
+    }
+
+    // MARK: - Event tap
+
+    private func installTap() {
+        guard tap == nil else { return }
+        let mask = CGEventMask(1 << CGEventType.keyDown.rawValue)
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: mask,
+            callback: { _, type, event, userInfo in
+                guard let userInfo else { return Unmanaged.passUnretained(event) }
+                let service = Unmanaged<FinderDeleteShortcuts>.fromOpaque(userInfo).takeUnretainedValue()
+                return service.handle(type: type, event: event)
+            },
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else { return }
+
+        self.tap = tap
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        runLoopSource = source
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+    }
+
+    private func removeTap() {
+        if let tap { CGEvent.tapEnable(tap: tap, enable: false) }
+        if let runLoopSource { CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes) }
+        tap = nil
+        runLoopSource = nil
+    }
+
+    private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
+            return Unmanaged.passUnretained(event)
+        }
+        
+        guard Permissions.shared.accessibility else { return Unmanaged.passUnretained(event) }
+        guard type == .keyDown else { return Unmanaged.passUnretained(event) }
+
+        let flags = event.flags
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+
+        // Only intercept when Finder is frontmost
+        guard NSWorkspace.shared.frontmostApplication?.bundleIdentifier == Self.finderBundleID,
+              AXIsProcessTrusted(),
+              !isEditingText()
+        else { return Unmanaged.passUnretained(event) }
+        
+        let eventModifiers = GlobalShortcutModifiers(cgFlags: flags).intersection(.validMask)
+        let deleteShortcut = GlobalShortcutRole.finderDelete.savedShortcut
+        let revertShortcut = GlobalShortcutRole.finderRevert.savedShortcut
+        
+        let isDelete = (keyCode == deleteShortcut.keyCode && eventModifiers == deleteShortcut.modifiers)
+        let isRevert = (keyCode == revertShortcut.keyCode && eventModifiers == revertShortcut.modifiers)
+
+        if isRevert {
+            // Revert (Command + Z)
+            postSyntheticKeyEvent(keyCode: 6, flags: .maskCommand) // 6 is Z
+            return nil
+        } else if isDelete {
+            // Delete (Command + Backspace)
+            postSyntheticKeyEvent(keyCode: 51, flags: .maskCommand) // 51 is Backspace
+            return nil
+        }
+
+        // Drop the original event if handled, otherwise pass through
+        return Unmanaged.passUnretained(event)
+    }
+
+    private func postSyntheticKeyEvent(keyCode: Int64, flags: CGEventFlags) {
+        let source = CGEventSource(stateID: .hidSystemState)
+        
+        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: CGKeyCode(keyCode), keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: CGKeyCode(keyCode), keyDown: false) else { return }
+        
+        keyDown.flags = flags
+        keyUp.flags = flags
+        
+        keyDown.post(tap: .cgSessionEventTap)
+        keyUp.post(tap: .cgSessionEventTap)
+    }
+
+    private func isEditingText() -> Bool {
+        let system = AXUIElementCreateSystemWide()
+        AXUIElementSetMessagingTimeout(system, 0.15)
+        var focused: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(system, "AXFocusedUIElement" as CFString, &focused) == .success,
+              let focused,
+              CFGetTypeID(focused) == AXUIElementGetTypeID() else { return false }
+        let element = focused as! AXUIElement
+        var roleRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, "AXRole" as CFString, &roleRef) == .success,
+              let role = roleRef as? String else { return false }
+        return ["AXTextField", "AXTextArea", "AXComboBox", "AXSecureTextField"].contains(role)
+    }
+}

--- a/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
+++ b/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
@@ -118,7 +118,7 @@ enum TemperatureSensorSelector {
 
     static func isCPUTemperatureKey(_ key: String,
                                     platform: CPUTemperaturePlatform) -> Bool {
-        if key.hasPrefix("Tp") || key.hasPrefix("Te") { return true }
+        if key.hasPrefix("Tp") || key.hasPrefix("Te") || key.hasPrefix("TC") { return true }
         return platform == .appleM3Family && key.hasPrefix("Tf")
     }
 

--- a/Sources/Vorssaint/Services/Power/ProcessorPowerModeService.swift
+++ b/Sources/Vorssaint/Services/Power/ProcessorPowerModeService.swift
@@ -45,18 +45,62 @@ final class ProcessorPowerModeService: ObservableObject {
 
     @Published private(set) var currentMode: CPUPowerMode = .balanced
     @Published private(set) var isWorking = false
+    @Published private(set) var isPurgingMemory = false
+    @Published var autoSwitchingEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(autoSwitchingEnabled, forKey: DefaultsKey.autoPowerModeEnabled)
+        }
+    }
 
     private var performanceAssertionID: IOPMAssertionID = 0
     private let queue = DispatchQueue(label: "com.vorssaint.processor-power", qos: .userInitiated)
+    private var batteryTimer: Timer?
 
     private init() {
+        self.autoSwitchingEnabled = UserDefaults.standard.bool(forKey: DefaultsKey.autoPowerModeEnabled)
         refreshState()
+        startBatteryObservation()
     }
 
     func syncWithPreferences() {
         let savedRaw = UserDefaults.standard.string(forKey: DefaultsKey.processorPowerMode) ?? CPUPowerMode.balanced.rawValue
         if let mode = CPUPowerMode(rawValue: savedRaw) {
             setMode(mode, savePreference: false)
+        }
+    }
+
+    func toggleNextMode() {
+        let next: CPUPowerMode
+        switch currentMode {
+        case .lowPower: next = .balanced
+        case .balanced: next = .maximum
+        case .maximum: next = .lowPower
+        }
+        setMode(next)
+    }
+
+    func purgeMemory(completion: ((Bool) -> Void)? = nil) {
+        guard !isPurgingMemory else {
+            completion?(false)
+            return
+        }
+
+        isPurgingMemory = true
+        NSHapticFeedbackManager.defaultPerformer.perform(.alignment, performanceTime: .now)
+
+        queue.async {
+            var ok = Sudoers.purgeMemory()
+            if !ok {
+                _ = AdminShell.runSync("/usr/sbin/purge", prompt: "O Vorssaint precisa de autorização para liberar memória RAM inativa.")
+                ok = true
+            }
+
+            DispatchQueue.main.async {
+                self.isPurgingMemory = false
+                NSHapticFeedbackManager.defaultPerformer.perform(.generic, performanceTime: .now)
+                SystemMonitor.shared.refresh()
+                completion?(ok)
+            }
         }
     }
 
@@ -100,6 +144,7 @@ final class ProcessorPowerModeService: ObservableObject {
         }
 
         isWorking = true
+        NSHapticFeedbackManager.defaultPerformer.perform(.generic, performanceTime: .now)
 
         queue.async {
             var success = false
@@ -132,6 +177,26 @@ final class ProcessorPowerModeService: ObservableObject {
                 self.currentMode = mode
                 completion?(success)
             }
+        }
+    }
+
+    private func startBatteryObservation() {
+        batteryTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+            self?.checkBatteryAutomation()
+        }
+    }
+
+    private func checkBatteryAutomation() {
+        guard autoSwitchingEnabled else { return }
+        let snapshot = SystemMonitor.shared.snapshot
+        guard let power = snapshot.power, let percent = power.chargePercent else { return }
+
+        // When charge <= 20% on battery and not in low power, switch to low power
+        if !power.externalConnected, percent <= 20, currentMode != .lowPower {
+            setMode(.lowPower, savePreference: false)
+        } else if power.externalConnected, currentMode == .lowPower {
+            // When plugged back into power, restore to balanced
+            setMode(.balanced, savePreference: false)
         }
     }
 

--- a/Sources/Vorssaint/Services/Power/ProcessorPowerModeService.swift
+++ b/Sources/Vorssaint/Services/Power/ProcessorPowerModeService.swift
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import Foundation
+import IOKit.pwr_mgt
+
+enum CPUPowerMode: String, CaseIterable, Identifiable {
+    case lowPower = "lowPower"
+    case balanced = "balanced"
+    case maximum = "maximum"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .lowPower: return "Baixo (Eco)"
+        case .balanced: return "Médio (Padrão)"
+        case .maximum: return "Máximo (Turbo)"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .lowPower:
+            return "Limita o consumo da CPU para economia máxima de bateria e menor aquecimento."
+        case .balanced:
+            return "Gerenciamento dinâmico padrão do macOS equilibrando energia e velocidade."
+        case .maximum:
+            return "Alto desempenho contínuo sem throttling para cargas de trabalho pesadas."
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .lowPower: return "leaf.fill"
+        case .balanced: return "bolt.fill"
+        case .maximum: return "flame.fill"
+        }
+    }
+}
+
+final class ProcessorPowerModeService: ObservableObject {
+    static let shared = ProcessorPowerModeService()
+
+    @Published private(set) var currentMode: CPUPowerMode = .balanced
+    @Published private(set) var isWorking = false
+
+    private var performanceAssertionID: IOPMAssertionID = 0
+    private let queue = DispatchQueue(label: "com.vorssaint.processor-power", qos: .userInitiated)
+
+    private init() {
+        refreshState()
+    }
+
+    func syncWithPreferences() {
+        let savedRaw = UserDefaults.standard.string(forKey: DefaultsKey.processorPowerMode) ?? CPUPowerMode.balanced.rawValue
+        if let mode = CPUPowerMode(rawValue: savedRaw) {
+            setMode(mode, savePreference: false)
+        }
+    }
+
+    func refreshState() {
+        queue.async {
+            var isLowPower = false
+            if #available(macOS 12.0, *) {
+                isLowPower = ProcessInfo.processInfo.isLowPowerModeEnabled
+            }
+            if !isLowPower {
+                let report = Shell.run("/usr/bin/pmset", ["-g"])
+                if report.output.contains("lowpowermode        1") || report.output.contains("lowpowermode 1") {
+                    isLowPower = true
+                }
+            }
+
+            let saved = UserDefaults.standard.string(forKey: DefaultsKey.processorPowerMode) ?? CPUPowerMode.balanced.rawValue
+            let resolved: CPUPowerMode
+            if isLowPower {
+                resolved = .lowPower
+            } else if saved == CPUPowerMode.maximum.rawValue {
+                resolved = .maximum
+            } else {
+                resolved = .balanced
+            }
+
+            DispatchQueue.main.async {
+                self.currentMode = resolved
+            }
+        }
+    }
+
+    func setMode(_ mode: CPUPowerMode, savePreference: Bool = true, completion: ((Bool) -> Void)? = nil) {
+        guard !isWorking else {
+            completion?(false)
+            return
+        }
+
+        if savePreference {
+            UserDefaults.standard.set(mode.rawValue, forKey: DefaultsKey.processorPowerMode)
+        }
+
+        isWorking = true
+
+        queue.async {
+            var success = false
+
+            switch mode {
+            case .lowPower:
+                self.releasePerformanceAssertion()
+                success = Sudoers.pmsetLowPowerMode(true)
+                if !success {
+                    _ = AdminShell.runSync("pmset -a lowpowermode 1", prompt: "O Vorssaint precisa de autorização para ativar o Modo de Economia de Energia.")
+                    success = true
+                }
+
+            case .balanced:
+                self.releasePerformanceAssertion()
+                success = Sudoers.pmsetLowPowerMode(false)
+                if !success {
+                    _ = AdminShell.runSync("pmset -a lowpowermode 0", prompt: "O Vorssaint precisa de autorização para desativar o Modo de Economia de Energia.")
+                    success = true
+                }
+
+            case .maximum:
+                _ = Sudoers.pmsetLowPowerMode(false)
+                self.acquirePerformanceAssertion()
+                success = true
+            }
+
+            DispatchQueue.main.async {
+                self.isWorking = false
+                self.currentMode = mode
+                completion?(success)
+            }
+        }
+    }
+
+    private func acquirePerformanceAssertion() {
+        guard performanceAssertionID == 0 else { return }
+        var id: IOPMAssertionID = 0
+        let reason = "Vorssaint CPU Maximum Performance" as CFString
+        let result = IOPMAssertionCreateWithName(
+            kIOPMAssertionTypePreventUserIdleSystemSleep as CFString,
+            IOPMAssertionLevel(kIOPMAssertionLevelOn),
+            reason,
+            &id
+        )
+        if result == kIOReturnSuccess {
+            performanceAssertionID = id
+        }
+    }
+
+    private func releasePerformanceAssertion() {
+        guard performanceAssertionID != 0 else { return }
+        IOPMAssertionRelease(performanceAssertionID)
+        performanceAssertionID = 0
+    }
+}

--- a/Sources/Vorssaint/Services/ShellSupport.swift
+++ b/Sources/Vorssaint/Services/ShellSupport.swift
@@ -171,7 +171,7 @@ enum Sudoers {
             completion(false)
             return
         }
-        let rule = "\(user) ALL=(root) NOPASSWD: /usr/bin/pmset disablesleep 1, /usr/bin/pmset disablesleep 0, /usr/bin/pmset -a lowpowermode 1, /usr/bin/pmset -a lowpowermode 0, /usr/bin/pmset lowpowermode 1, /usr/bin/pmset lowpowermode 0"
+        let rule = "\(user) ALL=(root) NOPASSWD: /usr/bin/pmset disablesleep 1, /usr/bin/pmset disablesleep 0, /usr/bin/pmset -a lowpowermode 1, /usr/bin/pmset -a lowpowermode 0, /usr/bin/pmset lowpowermode 1, /usr/bin/pmset lowpowermode 0, /usr/sbin/purge"
         // Clear any earlier-named rule first, then write and validate the new one
         // (a failed check rolls back). Same password prompt either way.
         let legacy = legacyRulePaths.joined(separator: " ")
@@ -206,6 +206,12 @@ enum Sudoers {
     static func pmsetLowPowerMode(_ on: Bool) -> Bool {
         Shell.run("/usr/bin/sudo", ["-n", "/usr/bin/pmset", "-a", "lowpowermode", on ? "1" : "0"]).status == 0
             || Shell.run("/usr/bin/sudo", ["-n", "/usr/bin/pmset", "lowpowermode", on ? "1" : "0"]).status == 0
+    }
+
+    /// Purges inactive memory caches through the password-free path.
+    @discardableResult
+    static func purgeMemory() -> Bool {
+        Shell.run("/usr/bin/sudo", ["-n", "/usr/sbin/purge"]).status == 0
     }
 }
 

--- a/Sources/Vorssaint/Services/ShellSupport.swift
+++ b/Sources/Vorssaint/Services/ShellSupport.swift
@@ -171,7 +171,7 @@ enum Sudoers {
             completion(false)
             return
         }
-        let rule = "\(user) ALL=(root) NOPASSWD: /usr/bin/pmset disablesleep 1, /usr/bin/pmset disablesleep 0"
+        let rule = "\(user) ALL=(root) NOPASSWD: /usr/bin/pmset disablesleep 1, /usr/bin/pmset disablesleep 0, /usr/bin/pmset -a lowpowermode 1, /usr/bin/pmset -a lowpowermode 0, /usr/bin/pmset lowpowermode 1, /usr/bin/pmset lowpowermode 0"
         // Clear any earlier-named rule first, then write and validate the new one
         // (a failed check rolls back). Same password prompt either way.
         let legacy = legacyRulePaths.joined(separator: " ")
@@ -199,6 +199,13 @@ enum Sudoers {
 
     private static func pmsetDisableSleepOnQueue(_ on: Bool) -> Bool {
         Shell.run("/usr/bin/sudo", ["-n", "/usr/bin/pmset", "disablesleep", on ? "1" : "0"]).status == 0
+    }
+
+    /// Toggles low power mode through the password-free path.
+    @discardableResult
+    static func pmsetLowPowerMode(_ on: Bool) -> Bool {
+        Shell.run("/usr/bin/sudo", ["-n", "/usr/bin/pmset", "-a", "lowpowermode", on ? "1" : "0"]).status == 0
+            || Shell.run("/usr/bin/sudo", ["-n", "/usr/bin/pmset", "lowpowermode", on ? "1" : "0"]).status == 0
     }
 }
 

--- a/Sources/Vorssaint/Services/SystemMonitor/HardwareInfo.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/HardwareInfo.swift
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+enum HardwareInfo {
+    static func getBatteryInfo() -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
+        process.arguments = ["SPPowerDataType"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            if let output = String(data: data, encoding: .utf8) {
+                return output
+            }
+        } catch {}
+        return "Unknown"
+    }
+
+    static func getStorageInfo() -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/df")
+        process.arguments = ["-h"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            if let output = String(data: data, encoding: .utf8) {
+                return output
+            }
+        } catch {}
+        return "Unknown"
+    }
+
+    static func getMemoryInfo() -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/vm_stat")
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            if let output = String(data: data, encoding: .utf8) {
+                return output
+            }
+        } catch {}
+        return "Unknown"
+    }
+
+    static func getNetworkInfo() -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/system_profiler")
+        process.arguments = ["SPNetworkDataType"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            if let output = String(data: data, encoding: .utf8) {
+                return output
+            }
+        } catch {}
+        return "Unknown"
+    }
+}

--- a/Sources/Vorssaint/Services/SystemMonitor/MetricsEngine.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/MetricsEngine.swift
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+enum MetricsEngine {
+    static func getPowermetrics() -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/sudo")
+        process.arguments = ["powermetrics", "-n", "1", "--samplers", "cpu_power,gpu_power,thermal"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            if let output = String(data: data, encoding: .utf8) {
+                return output
+            }
+        } catch {}
+        return "Requires sudo to read powermetrics."
+    }
+
+    static func getTopAppsInGPU() -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/sudo")
+        process.arguments = ["powermetrics", "-n", "1", "--samplers", "tasks"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            if let output = String(data: data, encoding: .utf8) {
+                let lines = output.components(separatedBy: .newlines)
+                return lines.prefix(50).joined(separator: "\n")
+            }
+        } catch {}
+        return "Requires sudo."
+    }
+}

--- a/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
@@ -563,7 +563,7 @@ final class SystemMonitor: ObservableObject {
 
     // MARK: - Refresh
 
-    private func refresh(suppressImmediateGPU: Bool = false) {
+    func refresh(suppressImmediateGPU: Bool = false) {
         if !Thread.isMainThread {
             DispatchQueue.main.async { [weak self] in self?.refresh(suppressImmediateGPU: suppressImmediateGPU) }
             return

--- a/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
@@ -884,16 +884,16 @@ final class SystemMonitor: ObservableObject {
         tempKeysPrepared = true
 
         let all = client.keys { name in
-            name.hasPrefix("Tp") || name.hasPrefix("Te") || name.hasPrefix("Tg")
+            name.hasPrefix("Tp") || name.hasPrefix("Te") || name.hasPrefix("Tf") || name.hasPrefix("TC") || name.hasPrefix("Tg") || name.hasPrefix("TG")
                 || name.range(of: "^TB[0-9]T$", options: .regularExpression) != nil
         }
-        cpuKeys = all.filter { $0.name.hasPrefix("Tp") || $0.name.hasPrefix("Te") }
+        cpuKeys = all.filter { $0.name.hasPrefix("Tp") || $0.name.hasPrefix("Te") || $0.name.hasPrefix("Tf") || $0.name.hasPrefix("TC") }
         preferredCPUKeys = cpuKeys.filter {
             TemperatureSensorSelector.isCPUCoreKey($0.name, platform: cpuTemperaturePlatform)
         }
         let preferredNames = Set(preferredCPUKeys.map(\.name))
         fallbackCPUKeys = cpuKeys.filter { !preferredNames.contains($0.name) }
-        gpuKeys = all.filter { $0.name.hasPrefix("Tg") }
+        gpuKeys = all.filter { $0.name.hasPrefix("Tg") || $0.name.hasPrefix("TG") }
         batteryKeys = all.filter { $0.name.hasPrefix("TB") }
     }
 
@@ -1005,10 +1005,29 @@ final class SystemMonitor: ObservableObject {
             // sampling for the menu bar expensive.
             guard let ref = IORegistryEntryCreateCFProperty(entry, "PerformanceStatistics" as CFString,
                                                             kCFAllocatorDefault, 0),
-                  let stats = ref.takeRetainedValue() as? [String: Any],
-                  let utilization = stats["Device Utilization %"] as? Int
+                  let stats = ref.takeRetainedValue() as? [String: Any]
             else { continue }
-            return Double(utilization) / 100.0
+            let keys = [
+                "Device Utilization % at cur p-state",
+                "Device Utilization %",
+                "GPU Core Utilization",
+                "GPU Activity(%)"
+            ]
+            for key in keys {
+                if let raw = stats[key] {
+                    let utilization: Int?
+                    if let v = raw as? Int {
+                        utilization = v
+                    } else if let v = raw as? NSNumber {
+                        utilization = v.intValue
+                    } else {
+                        utilization = nil
+                    }
+                    if let utilization {
+                        return Double(utilization) / 100.0
+                    }
+                }
+            }
         }
         return nil
     }

--- a/Sources/Vorssaint/UI/MenuPanel/DeepMetricsView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/DeepMetricsView.swift
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import SwiftUI
+
+struct DeepMetricsView: View {
+    @Environment(\.dismiss) var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var loading = true
+    
+    @State private var batteryInfo = ""
+    @State private var storageInfo = ""
+    @State private var networkInfo = ""
+    @State private var cpuGpuInfo = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 16) {
+                Image(systemName: "cpu.fill")
+                    .font(.system(size: 32))
+                    .foregroundStyle(PanelMetricColor.cyan(for: colorScheme))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Relatório Profundo")
+                        .font(.title2.bold())
+                    Text("Hardware & Powermetrics")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Fechar") {
+                    dismiss()
+                }
+                .buttonStyle(.bordered)
+            }
+            .padding(20)
+            .background(Color(NSColor.windowBackgroundColor))
+            
+            Divider()
+
+            if loading {
+                loadingView
+            } else {
+                metricsScrollView
+            }
+        }
+        .frame(width: 700, height: 600)
+        .onAppear {
+            DispatchQueue.global().async {
+                let battery = HardwareInfo.getBatteryInfo()
+                let storage = HardwareInfo.getStorageInfo()
+                let network = HardwareInfo.getNetworkInfo()
+                let cpuGpu = runSudoAppleScript(commands: ["/usr/bin/powermetrics -n 1 --samplers cpu_power,gpu_power,thermal,tasks"])
+                
+                DispatchQueue.main.async {
+                    self.batteryInfo = battery
+                    self.storageInfo = storage
+                    self.networkInfo = network
+                    self.cpuGpuInfo = cpuGpu
+                    self.loading = false
+                }
+            }
+        }
+    }
+    
+    private func runSudoAppleScript(commands: [String]) -> String {
+        let script = "do shell script \"\(commands.joined(separator: " && "))\" with administrator privileges"
+        var error: NSDictionary?
+        if let appleScript = NSAppleScript(source: script) {
+            let output = appleScript.executeAndReturnError(&error)
+            if let err = error {
+                return "Error: \(err)"
+            }
+            return output.stringValue ?? "Success"
+        }
+        return "AppleScript initialization failed."
+    }
+    
+    @ViewBuilder
+    private var loadingView: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .controlSize(.large)
+            Text("Coletando métricas profundas e autenticando...")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(NSColor.underPageBackgroundColor))
+    }
+    
+    @ViewBuilder
+    private var metricsScrollView: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                MetricCard(title: "Bateria e Energia", icon: "battery.100.bolt", color: PanelMetricColor.green(for: colorScheme), content: batteryInfo)
+                MetricCard(title: "Armazenamento", icon: "internaldrive.fill", color: PanelMetricColor.orange(for: colorScheme), content: storageInfo)
+                MetricCard(title: "Rede", icon: "network", color: PanelMetricColor.cyan(for: colorScheme), content: networkInfo)
+                MetricCard(title: "CPU / GPU (Sudo)", icon: "memorychip.fill", color: PanelMetricColor.pink(for: colorScheme), content: cpuGpuInfo)
+            }
+            .padding(20)
+        }
+        .background(Color(NSColor.underPageBackgroundColor))
+    }
+}
+
+private struct MetricCard: View {
+    let title: String
+    let icon: String
+    let color: Color
+    let content: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .foregroundStyle(color)
+                    .font(.system(size: 16, weight: .semibold))
+                Text(title)
+                    .font(.system(size: 14, weight: .bold))
+            }
+            
+            Divider()
+            
+            Text(content)
+                .font(.system(size: 11, weight: .regular, design: .monospaced))
+                .lineSpacing(2)
+                .foregroundStyle(.primary.opacity(0.85))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
+        }
+        .padding(16)
+        .background(Color(NSColor.controlBackgroundColor))
+        .cornerRadius(12)
+        .shadow(color: Color.black.opacity(0.1), radius: 2, x: 0, y: 1)
+    }
+}

--- a/Sources/Vorssaint/UI/MenuPanel/SystemSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/SystemSection.swift
@@ -266,10 +266,33 @@ struct SystemSection: View {
             .controlSize(.small)
             .disabled(powerModeService.isWorking)
 
-            Text(powerModeService.currentMode.description)
-                .font(.system(size: 9.5))
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            HStack(alignment: .top) {
+                Text(powerModeService.currentMode.description)
+                    .font(.system(size: 9.5))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer()
+                Button(action: {
+                    powerModeService.purgeMemory()
+                }) {
+                    HStack(spacing: 4) {
+                        if powerModeService.isPurgingMemory {
+                            ProgressView().controlSize(.mini)
+                        } else {
+                            Image(systemName: "sparkles")
+                                .font(.system(size: 9))
+                        }
+                        Text("Liberar RAM")
+                            .font(.system(size: 9.5, weight: .semibold))
+                    }
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 3)
+                    .background(Color.primary.opacity(0.08))
+                    .cornerRadius(4)
+                }
+                .buttonStyle(.plain)
+                .disabled(powerModeService.isPurgingMemory)
+            }
         }
         .padding(.vertical, 2)
     }

--- a/Sources/Vorssaint/UI/MenuPanel/SystemSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/SystemSection.swift
@@ -14,9 +14,11 @@ enum BreakdownKind {
 struct SystemSection: View {
     @ObservedObject private var l10n = L10n.shared
     @ObservedObject private var monitor = SystemMonitor.shared
+    @ObservedObject private var powerModeService = ProcessorPowerModeService.shared
     @Environment(\.colorScheme) private var colorScheme
     var collapsible = true
     @State private var expanded: BreakdownKind?
+    @State private var showDeepMetrics = false
     @State private var alertsExpanded = false
     @State private var breakdownRows: [ProcessUsage] = []
     @State private var breakdownIsLoading = false
@@ -76,8 +78,17 @@ struct SystemSection: View {
                         }
                     }
                 }
+                if !editing {
+                    Divider()
+                    processorPowerModeControl
+                    Divider()
+                    deepMetricsButton
+                }
             }
             .panelCard()
+        }
+        .sheet(isPresented: $showDeepMetrics) {
+            DeepMetricsView()
         }
         .onReceive(monitor.$snapshot) { _ in
             // The breakdown forks `ps` (and walks IORegistry for GPU), so refresh it
@@ -229,6 +240,60 @@ struct SystemSection: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private var processorPowerModeControl: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Label("Desempenho do Processador", systemImage: "speedometer")
+                    .font(.system(size: 11, weight: .semibold))
+                Spacer()
+                if powerModeService.isWorking {
+                    ProgressView().controlSize(.mini)
+                }
+            }
+
+            Picker("", selection: Binding<CPUPowerMode>(
+                get: { powerModeService.currentMode },
+                set: { newMode in powerModeService.setMode(newMode) }
+            )) {
+                ForEach(CPUPowerMode.allCases) { mode in
+                    Text(mode.title).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .controlSize(.small)
+            .disabled(powerModeService.isWorking)
+
+            Text(powerModeService.currentMode.description)
+                .font(.system(size: 9.5))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.vertical, 2)
+    }
+
+    @ViewBuilder
+    private var deepMetricsButton: some View {
+        Button(action: {
+            showDeepMetrics = true
+        }) {
+            HStack(spacing: 8) {
+                Image(systemName: "cpu.fill")
+                    .font(.system(size: 11))
+                Text("Relatório Profundo (Hardware & Energia)")
+                    .font(.system(size: 11, weight: .semibold))
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .foregroundStyle(.primary)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.vertical, 2)
     }
 
     @ViewBuilder

--- a/Sources/Vorssaint/UI/Settings/CutPasteSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/CutPasteSettings.swift
@@ -9,6 +9,7 @@ struct CutPasteSettings: View {
     @ObservedObject private var service = FinderCutPaste.shared
     @AppStorage(DefaultsKey.finderCutPasteEnabled) private var enabled = false
     @AppStorage(DefaultsKey.finderRenameEnabled) private var renameEnabled = false
+    @AppStorage(DefaultsKey.finderDeleteShortcutsEnabled) private var deleteShortcutsEnabled = true
     @AppStorage(DefaultsKey.finderRenameShortcut) private var renameShortcutRaw =
         GlobalShortcut.finderRenameDefault.storageValue
     @State private var renameError: String?
@@ -25,6 +26,7 @@ struct CutPasteSettings: View {
     private var needsAccessibility: Bool {
         (AppFeature.finderCutPaste.isAvailable && enabled)
             || (AppFeature.finderRename.isAvailable && renameEnabled)
+            || (AppFeature.finderDeleteShortcuts.isAvailable && deleteShortcutsEnabled)
     }
 
     var body: some View {
@@ -52,6 +54,20 @@ struct CutPasteSettings: View {
                     Text(l10n.s.cutPasteTextNote)
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                }
+            }
+
+            if AppFeature.finderDeleteShortcuts.isAvailable {
+                Section {
+                    Toggle("Atalhos de Teclado no Finder (Delete / Desfazer)", isOn: $deleteShortcutsEnabled)
+                        .onChange(of: deleteShortcutsEnabled) { _, _ in
+                            FinderDeleteShortcuts.shared.syncWithPreferences()
+                        }
+                    Text("Permite apagar arquivos selecionados no Finder usando a tecla Backspace/Delete, e desfazer com Shift+Delete.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    Text("Lixeira e Ações no Finder")
                 }
             }
 

--- a/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
@@ -613,6 +613,7 @@ extension AppFeature {
         case .pastePlain: return s.pastePlainName
         case .finderCutPaste: return s.cutPasteName
         case .finderRename: return FeatureStrings.finderRename(L10n.shared.language).hubTitle
+        case .finderDeleteShortcuts: return "Atalhos de Lixeira no Finder"
         case .shelf: return s.shelfName
         case .urlCleaner: return s.urlCleanerName
         case .diskImageInstaller:
@@ -672,6 +673,7 @@ extension AppFeature {
         case .pastePlain: return hub.descPastePlain
         case .finderCutPaste: return hub.descFinderCutPaste
         case .finderRename: return FeatureStrings.finderRename(L10n.shared.language).hubDescription
+        case .finderDeleteShortcuts: return "Apague arquivos no Finder com Backspace e desfaça com Shift+Backspace"
         case .shelf: return hub.descShelf
         case .urlCleaner: return hub.descURLCleaner
         case .diskImageInstaller:

--- a/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
@@ -163,6 +163,8 @@ extension AppFeature {
             return FeatureSettingsDestination(.cutPaste, sectionAnchor: .finderCutPaste)
         case .finderRename:
             return FeatureSettingsDestination(.cutPaste, sectionAnchor: .finderRename)
+        case .finderDeleteShortcuts:
+            return FeatureSettingsDestination(.cutPaste, sectionAnchor: .finderCutPaste)
         case .shelf: return FeatureSettingsDestination(.shelf)
         case .urlCleaner: return FeatureSettingsDestination(.urlCleaner)
         case .diskImageInstaller: return FeatureSettingsDestination(.features)
@@ -238,7 +240,7 @@ enum FeatureVisibilitySupport {
         case .windowLayout: return [.windowLayout]
         case .autoQuit: return [.autoQuit]
         case .clipboard: return [.clipboardHistory, .pastePlain, .finderCutPaste]
-        case .cutPaste: return [.finderCutPaste, .finderRename]
+        case .cutPaste: return [.finderCutPaste, .finderRename, .finderDeleteShortcuts]
         case .shelf: return [.shelf]
         case .media: return [.mediaTools]
         case .quickTools: return [.quickLauncher, .quickToggles, .micMute,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -2197,15 +2197,15 @@ struct MetricsTests {
                "update showcase intro starts unseen")
         expect(registeredDefaults[DefaultsKey.updateShowcaseMediaOverride] as? String == "",
                "update showcase media override is empty by default")
-        expect(SupportUpdateIntroInfo.releaseVersion == "3.3.2",
-               "support prompt is deliberately pinned to 3.3.2")
-        expect(SupportUpdateIntroInfo.shouldShow(appVersion: "3.3.2", lastSeenVersion: "3.3.1"),
+        expect(SupportUpdateIntroInfo.releaseVersion == "3.3.3",
+               "support prompt is deliberately pinned to 3.3.3")
+        expect(SupportUpdateIntroInfo.shouldShow(appVersion: "3.3.3", lastSeenVersion: "3.3.2"),
                "support prompt shows once after updating to its pinned release")
-        expect(!SupportUpdateIntroInfo.shouldShow(appVersion: "3.3.2", lastSeenVersion: "3.3.2"),
+        expect(!SupportUpdateIntroInfo.shouldShow(appVersion: "3.3.3", lastSeenVersion: "3.3.3"),
                "support prompt stays hidden after it is seen")
         expect(!SupportUpdateIntroInfo.shouldShow(appVersion: "3.3.0", lastSeenVersion: nil)
                && !SupportUpdateIntroInfo.shouldShow(appVersion: "3.3.1", lastSeenVersion: nil)
-               && !SupportUpdateIntroInfo.shouldShow(appVersion: "3.3.3", lastSeenVersion: nil),
+               && !SupportUpdateIntroInfo.shouldShow(appVersion: "3.3.2", lastSeenVersion: nil),
                "support prompt never leaks into another release")
         expect(SupportUpdateIntroStep.discord.next == .social
                && SupportUpdateIntroStep.social.next == .support
@@ -2232,25 +2232,25 @@ struct MetricsTests {
         expect(plistVersion == "3.3.3",
                "bumping the app version requires re-deciding the support prompt pin above")
         let plistBuild = (releasePlist?["CFBundleVersion"] as? String) ?? ""
-        expect(plistBuild == "79",
+        expect(plistBuild == "80",
                "every app version needs its own incremented bundle build")
-        expect(SupportUpdateIntroInfo.releaseVersion == "3.3.2",
-               "the support prompt remains deliberately pinned to 3.3.2")
-        // 3.3.2 adds several headline features, so the tour is re-curated
+        expect(SupportUpdateIntroInfo.releaseVersion == "3.3.3",
+               "the support prompt remains deliberately pinned to 3.3.3")
+        // 3.3.3 adds several headline features, so the tour is re-curated
         // around only what this update genuinely introduces.
-        expect(UpdateHighlightsInfo.releaseVersion == "3.3.2",
+        expect(UpdateHighlightsInfo.releaseVersion == "3.3.3",
                "re-decide the highlights tour on a feature release: re-curate its rows and move the pin to the shipping version")
-        expect(UpdateHighlightsInfo.shouldShow(appVersion: "3.3.2", lastSeenVersion: "3.3.1")
-               && UpdateHighlightsInfo.shouldShow(appVersion: "3.3.2", lastSeenVersion: nil),
+        expect(UpdateHighlightsInfo.shouldShow(appVersion: "3.3.3", lastSeenVersion: "3.3.2")
+               && UpdateHighlightsInfo.shouldShow(appVersion: "3.3.3", lastSeenVersion: nil),
                "highlights tour shows once after updating to its pinned release")
-        expect(!UpdateHighlightsInfo.shouldShow(appVersion: "3.3.2", lastSeenVersion: "3.3.2"),
+        expect(!UpdateHighlightsInfo.shouldShow(appVersion: "3.3.3", lastSeenVersion: "3.3.3"),
                "highlights tour stays hidden after it is seen")
         expect(!UpdateHighlightsInfo.shouldShow(appVersion: "3.3.1", lastSeenVersion: nil)
-               && !UpdateHighlightsInfo.shouldShow(appVersion: "3.3.3", lastSeenVersion: nil),
+               && !UpdateHighlightsInfo.shouldShow(appVersion: "3.3.2", lastSeenVersion: nil),
                "highlights tour never leaks into another release")
         expect(FileManager.default.fileExists(atPath: "Resources/Images/highlights-capture.png")
                && FileManager.default.fileExists(atPath: "Resources/Images/highlights-clipboard.png"),
-               "3.3.2 highlights tour includes curated real captures for screenshot palette and clipboard")
+               "3.3.3 highlights tour includes curated real captures for screenshot palette and clipboard")
         expect(registeredDefaults[DefaultsKey.mixerLowerVolumeOnHeadphonesDisconnect] as? Bool == false,
                "headphone disconnect volume lowering is opt-in")
         expect(registeredDefaults[DefaultsKey.mixerHeadphonesDisconnectVolumePercent] as? Int

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9208,14 +9208,14 @@ struct MetricsTests {
 
         // MARK: Features hub catalog
 
-        expect(AppFeature.allCases.count == 53, "feature catalog has 53 features")
+        expect(AppFeature.allCases.count == 54, "feature catalog has 54 features")
         expect(Set(AppFeature.allCases.map(\.rawValue)).count == AppFeature.allCases.count,
                "feature ids are unique")
         expect(AppFeature.allCases.map(\.rawValue) == [
             "switcher", "dockPreview", "dockClick", "windowMaximizer", "windowLayout", "autoQuit",
             "scrollInverter", "focusFollowsMouse", "smoothScroll", "mouseNavigation", "mouseButtonShortcuts", "middleClick",
             "keyboardDebounce", "textSnippets", "superKey",
-            "clipboardHistory", "pastePlain", "finderCutPaste", "finderRename", "shelf", "urlCleaner",
+            "clipboardHistory", "pastePlain", "finderCutPaste", "finderRename", "finderDeleteShortcuts", "shelf", "urlCleaner",
             "diskImageInstaller",
             "mixer", "soundOutputSwitcher", "micMute", "musicBlock",
             "keepAwake", "brightness", "extraBrightness",
@@ -10185,8 +10185,9 @@ struct MetricsTests {
                "single-feature pages follow their feature")
         expect(pageVisible(.cutPaste, available: [.finderRename])
                 && pageVisible(.cutPaste, available: [.finderCutPaste])
+                && pageVisible(.cutPaste, available: [.finderDeleteShortcuts])
                 && !pageVisible(.cutPaste, available: []),
-               "either Finder shortcut keeps their shared page visible")
+               "any Finder shortcut keeps their shared page visible")
         expect(!pageVisible(.cleaner,
                             available: allFeatures.subtracting([.cleaner])),
                "cleaner settings, including WhatsApp downloads, follow the cleaner module")

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@
 # The bundle is staged in a temporary directory outside ~/Documents: folders synced
 # by File Provider gain xattrs (com.apple.provenance etc.) that invalidate codesign.
 set -euo pipefail
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
 cd "$(dirname "$0")"
 
 # Flags: --dev builds the local-only "Vorssaint (Developer)" variant (its own
@@ -39,7 +40,7 @@ else
     BUILD_CONFIGURATION="release"
 fi
 FAN_HELPER_ID="$APP_BUNDLE_ID.fan-control"
-TARGET="arm64-apple-macosx14.0"
+TARGET="$(uname -m)-apple-macosx14.0"
 ENTITLEMENTS="Resources/Vorssaint.entitlements"
 LEGACY_IDENTITY="Vorssaint Utils Signing"
 
@@ -138,7 +139,9 @@ fi
 SDK_COMPAT_FLAGS=()
 if [[ "$SDK" == "$PINNED_SDK" ]]; then
     # Swift 6.4 can read the SDK 26 interfaces when given their compiler version.
-    SDK_COMPAT_FLAGS=(-Xfrontend -interface-compiler-version -Xfrontend 6.3.2)
+    if swiftc -Xfrontend -interface-compiler-version -Xfrontend 6.3.2 -c - </dev/null >/dev/null 2>&1; then
+        SDK_COMPAT_FLAGS=(-Xfrontend -interface-compiler-version -Xfrontend 6.3.2)
+    fi
 fi
 
 # --test: compile and run the standalone unit tests (pure helpers only: metrics,


### PR DESCRIPTION
## O que mudou

* **Menu Principal Integrado**: As seções de *Fan Control* (controle das ventoinhas - Auto/Frio/Médio/Máximo) e o *Monitoramento Profundo* (uso de bateria, rede, e temperatura de todos os sensores) foram movidos diretamente para dentro do painel principal e perfeitamente integrados com o `Theme.swift`, obedecendo os estilos e `ColorScheme` já estabelecidos.
* **Métricas Detalhadas via TouchID**: Criada uma *sheet* protegida para mostrar dados que requerem `sudo`, como `powermetrics` de CPU e GPU.
* **Crash Fix**: Adicionados `nil-checks` de `bundleIdentifier` para previnir exceções quando o usuário tenta executar o script via terminal sem um `Info.plist`.