### PR TITLE
Improve three-finger middle-click reliability

### DIFF
--- a/Sources/Vorssaint/Services/MiddleClick/MiddleClickService.swift
+++ b/Sources/Vorssaint/Services/MiddleClick/MiddleClickService.swift
@@ -54,8 +54,6 @@ final class MiddleClickService: ObservableObject {
     private let stateLock = NSLock()
     private var fingerCount = 0
     private var lastFrameUptime: TimeInterval = 0
-    /// When the contact count last became exactly three.
-    private var threeFingersSince: TimeInterval?
 
     // Tap-to-middle-click (issue #161), all under `stateLock`. A candidate
     // starts when the chosen finger count lands, collects movement, and is
@@ -134,7 +132,7 @@ final class MiddleClickService: ObservableObject {
         guard Multitouch.available else { return }
 
         guard let tap = CGEvent.tapCreate(
-            tap: .cgSessionEventTap,
+            tap: .cghidEventTap,
             place: .headInsertEventTap,
             options: .defaultTap,
             eventsOfInterest: CGEventMask(1 << CGEventType.leftMouseDown.rawValue)
@@ -180,7 +178,6 @@ final class MiddleClickService: ObservableObject {
         stateLock.lock()
         fingerCount = 0
         lastFrameUptime = 0
-        threeFingersSince = nil
         resetTapCandidateLocked()
         stateLock.unlock()
         isRunning = false
@@ -284,11 +281,6 @@ final class MiddleClickService: ObservableObject {
         let now = ProcessInfo.processInfo.systemUptime
         var fireTap = false
         stateLock.lock()
-        if count == 3 {
-            if fingerCount != 3 { threeFingersSince = now }
-        } else {
-            threeFingersSince = nil
-        }
         fingerCount = count
         lastFrameUptime = now
         if tapFingers > 0 {
@@ -426,12 +418,10 @@ final class MiddleClickService: ObservableObject {
             stateLock.lock()
             let count = fingerCount
             let age = now - lastFrameUptime
-            let settledFor = threeFingersSince.map { now - $0 } ?? 0
             stateLock.unlock()
             let action = MiddleClickSupport.actionForClick(
                 fingerCount: count,
                 frameAge: age,
-                settledFor: settledFor,
                 sinceLastTransformEnd: lastTransformEnd.map { now - $0 },
                 systemDragGestureEnabled: dragGestureEnabled(now: now)
             )

--- a/Sources/Vorssaint/Services/MiddleClick/MiddleClickSupport.swift
+++ b/Sources/Vorssaint/Services/MiddleClick/MiddleClickSupport.swift
@@ -20,15 +20,9 @@ enum MiddleClickSupport {
     /// trackpad, so anything older means the fingers already lifted.
     static let fingerFreshness: TimeInterval = 0.25
 
-    /// The three fingers must have been resting this long before the press:
-    /// a click that arrives together with the third finger's touchdown is a
-    /// synthesized tap-to-click, not a press (a real press needs the fingers
-    /// on the pad before the force builds up).
-    static let minimumSettle: TimeInterval = 0.04
-
     /// Window after a transformed click in which another qualifying click is
     /// treated as a synthesizer bounce and dropped.
-    static let repeatGuard: TimeInterval = 0.30
+    static let repeatGuard: TimeInterval = 0.09
 
     /// Decides what an incoming press becomes. Only real presses count
     /// (owner decision: taps, swipes and resting fingers must never click),
@@ -38,7 +32,6 @@ enum MiddleClickSupport {
     /// feature stands down entirely rather than firing falsely.
     static func actionForClick(fingerCount: Int,
                                frameAge: TimeInterval,
-                               settledFor: TimeInterval,
                                sinceLastTransformEnd: TimeInterval?,
                                systemDragGestureEnabled: Bool) -> MiddleClickClickAction {
         guard !systemDragGestureEnabled else { return .passThrough }
@@ -47,7 +40,6 @@ enum MiddleClickSupport {
            sinceLastTransformEnd < repeatGuard {
             return .swallow
         }
-        guard settledFor >= minimumSettle else { return .passThrough }
         return .transform
     }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -5712,39 +5712,39 @@ struct MetricsTests {
                                                   visibleFrame: CGRect(x: 0, y: 24, width: 1512, height: 958)),
                "dock strip falls back to an edge band when auto-hide reserves nothing")
 
-        expect(MiddleClickSupport.actionForClick(fingerCount: 3, frameAge: 0.05, settledFor: 0.2,
+        expect(MiddleClickSupport.actionForClick(fingerCount: 3, frameAge: 0.05,
                                                  sinceLastTransformEnd: nil,
                                                  systemDragGestureEnabled: false) == .transform,
-               "middle click transforms a settled three-finger press")
-        expect(MiddleClickSupport.actionForClick(fingerCount: 2, frameAge: 0.05, settledFor: 0.2,
+               "middle click transforms a live three-finger press")
+        expect(MiddleClickSupport.actionForClick(fingerCount: 2, frameAge: 0.05,
                                                  sinceLastTransformEnd: nil,
                                                  systemDragGestureEnabled: false) == .passThrough,
                "middle click leaves two-finger clicks alone")
-        expect(MiddleClickSupport.actionForClick(fingerCount: 4, frameAge: 0.05, settledFor: 0.2,
+        expect(MiddleClickSupport.actionForClick(fingerCount: 4, frameAge: 0.05,
                                                  sinceLastTransformEnd: nil,
                                                  systemDragGestureEnabled: false) == .passThrough,
                "middle click leaves four-finger clicks alone")
-        expect(MiddleClickSupport.actionForClick(fingerCount: 3, frameAge: 1.0, settledFor: 0.2,
+        expect(MiddleClickSupport.actionForClick(fingerCount: 3, frameAge: 1.0,
                                                  sinceLastTransformEnd: nil,
                                                  systemDragGestureEnabled: false) == .passThrough,
                "middle click ignores stale contact frames (fingers already lifted)")
-        expect(MiddleClickSupport.actionForClick(fingerCount: 3, frameAge: 0.05, settledFor: 0.01,
+        expect(MiddleClickSupport.actionForClick(fingerCount: 3, frameAge: 0,
                                                  sinceLastTransformEnd: nil,
-                                                 systemDragGestureEnabled: false) == .passThrough,
-               "middle click rejects a click arriving with the third finger's touchdown")
-        expect(MiddleClickSupport.actionForClick(fingerCount: 3, frameAge: 0.05, settledFor: 0.2,
-                                                 sinceLastTransformEnd: 0.1,
+                                                 systemDragGestureEnabled: false) == .transform,
+               "middle click accepts a quick press as soon as the third finger is live")
+        expect(MiddleClickSupport.actionForClick(fingerCount: 3, frameAge: 0.05,
+                                                 sinceLastTransformEnd: 0.05,
                                                  systemDragGestureEnabled: false) == .swallow,
                "middle click drops the tap-to-click bounce right after a transform")
-        expect(MiddleClickSupport.actionForClick(fingerCount: 3, frameAge: 0.05, settledFor: 0.2,
-                                                 sinceLastTransformEnd: 0.5,
+        expect(MiddleClickSupport.actionForClick(fingerCount: 3, frameAge: 0.05,
+                                                 sinceLastTransformEnd: 0.15,
                                                  systemDragGestureEnabled: false) == .transform,
                "middle click accepts a deliberate second press after the guard window")
-        expect(MiddleClickSupport.actionForClick(fingerCount: 1, frameAge: 0.05, settledFor: 0,
-                                                 sinceLastTransformEnd: 0.1,
+        expect(MiddleClickSupport.actionForClick(fingerCount: 1, frameAge: 0.05,
+                                                 sinceLastTransformEnd: 0.05,
                                                  systemDragGestureEnabled: false) == .passThrough,
                "middle click never swallows ordinary one-finger clicks")
-        expect(MiddleClickSupport.actionForClick(fingerCount: 3, frameAge: 0.05, settledFor: 0.2,
+        expect(MiddleClickSupport.actionForClick(fingerCount: 3, frameAge: 0.05,
                                                  sinceLastTransformEnd: nil,
                                                  systemDragGestureEnabled: true) == .passThrough,
                "middle click stands down while the system three-finger drag owns the gesture")


### PR DESCRIPTION
## What changed

This improves how physical three-finger clicks are detected and handled.

- Listen for mouse events at the HID event tap instead of the session event tap.
- Remove the 40 ms settling requirement before accepting a three-finger click.
- Reduce the duplicate-click guard from 300 ms to 90 ms.
- Update the related tests for the new timing behavior.

## Why

I was running into two separate responsiveness problems.

The 40 ms settling requirement could cause a quick three-finger click to pass through as a normal left or right click. Removing this delay allows the click to be transformed as soon as a fresh three-finger contact is detected.

Fast repeated clicks also felt unresponsive because the 300 ms duplicate guard could suppress a valid second click. This was especially noticeable when opening several links or closing browser tabs. Reducing the guard to 90 ms still filters the immediate duplicate event it was designed for, while allowing deliberate consecutive clicks to register normally.

Using the HID event tap also handles the mouse event closer to where it enters the system, making the transformation more consistent.

The existing safety checks remain in place. Clicks are only transformed when exactly three fingers are detected from a recent touch frame. Two-finger, four-finger, stale, and conflicting system gestures continue to pass through normally.

## Testing

I built and tested the developer version on my Mac. Quick three-finger clicks and repeated clicks now register reliably, and normal left and right clicks continue to work as expected.

I also ran the focused middle-click tests and type-checked the Swift sources.

Related to #441.