### PR TITLE
Show what a main switch turns off in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,18 @@ All notable changes to this project are documented here. The format follows
 
 ### Summary
 Vorssaint 3.3.2 prevents a Switcher shortcut crash and keeps its labels in sync.
-It also removes false App Updates listings, improves feature setup and clarifies Full Disk Access.
+It also removes false App Updates listings, improves feature setup, clarifies Full Disk Access
+and shows which options a main switch turns off.
 
 ### Changed
 - Installed Features rows open their Settings page and highlight the relevant
   controls. Thanks to @dorlugasigal.
 - Cleaning and the Uninstaller now explain how to grant Full Disk Access and
   that the app must reopen. Thanks to @PathGao.
+- Quit on close exceptions are no longer editable while the feature is off, since
+  nothing reads them there. Thanks to @PathGao.
+- Showing Clipboard in the panel now sits on its own in Settings, since it keeps
+  working while history capture is off. Thanks to @PathGao.
 
 ### Fixed
 - App Updates no longer offers store updates that belong to a different app.

--- a/Sources/Vorssaint/UI/Settings/AutoQuitSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/AutoQuitSettings.swift
@@ -35,6 +35,9 @@ struct AutoQuitSettings: View {
                     .foregroundStyle(.secondary)
             }
 
+            // The exception list has one reader, the window check, and that only
+            // runs while the feature does. With the switch off every edit here
+            // is a no-op, so the list follows it.
             Section(l10n.s.autoQuitExceptionsTitle) {
                 if sortedExceptions.isEmpty {
                     Text(l10n.s.autoQuitExceptionsEmpty)
@@ -61,6 +64,7 @@ struct AutoQuitSettings: View {
                             }
                         }
                     }
+                    .disabled(!enabled)
                 }
 
                 Button {
@@ -68,6 +72,7 @@ struct AutoQuitSettings: View {
                 } label: {
                     Label(l10n.s.autoQuitAddApp, systemImage: "plus")
                 }
+                .disabled(!enabled)
 
                 Text(l10n.s.autoQuitExceptionsCaption)
                     .font(.caption)

--- a/Sources/Vorssaint/UI/Settings/ClipboardSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/ClipboardSettings.swift
@@ -65,6 +65,13 @@ struct ClipboardSettings: View {
                         }
                     }
                     .disabled(!enabled)
+                }
+
+                // Its own section because it is the one setting here that keeps
+                // working with capture off: the panel entry stays, saying so,
+                // and still opens the saved items. Sitting among the disabled
+                // rows it read as one that had been missed.
+                Section {
                     Toggle(text.showInPanel, isOn: $showInPanel)
                 }
             }


### PR DESCRIPTION
Follow-up to #493, which tied the Clipboard History settings to their switch. Two panels were left inconsistent with it, in opposite directions.

### Quit on close

With the feature off, the exception list stayed fully editable. Nothing reads it there: `autoQuitExceptions` has exactly one reader, `AutoQuitService.checkWindows`, which only runs while the service does. Adding an app while the feature is off does nothing and gives no sign of it.

The list and the *Add app…* button now follow the switch, the same way the Clipboard rows do.

### Clipboard

The opposite problem. `Show in the panel` sat in the same section as the four rows that #493 disabled, but it deliberately does *not* follow the switch, and shouldn't: with capture off the panel entry stays, says so in its caption (`MenuPanelView`, `clipboardEnabled ? caption : disabled`) and still opens the saved items. One live row in the middle of four greyed ones reads as a row that was missed.

No behavior change here, only grouping: it moves to its own section, so the group that follows the switch is the group that looks like it.

### Not changed

Text Snippets looks like the same defect and is not one. `textSnippetsEnabled` only gates automatic expansion; `SnippetLibraryService` reads `snippetLibraryEnabled` and the shared snippet list independently of it, so the library and the list still work with the main switch off. Disabling them would break something that works — the same reason #493 kept saved items usable. Left alone deliberately.

### Checks

`./build.sh` clean, `./build.sh --test` (TESTS OK, 6993 checks) and `./build/Vorssaint --selftest` (SELFTEST OK). No new strings, so no translations needed.