### PR TITLE
Share one Full Disk Access note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
 [Semantic Versioning](https://semver.org/).
 
+## [3.3.2]
+
+### Changed
+- The Full Disk Access note in Cleaning and the Uninstaller now says what to do once
+  System Settings opens, which only the Uninstaller page used to mention. Thanks to
+  @PathGao.
+
 ## [3.3.1] - 2026-08-09
 
 ### Summary

--- a/Sources/Vorssaint/UI/Cleaner/CleanerView.swift
+++ b/Sources/Vorssaint/UI/Cleaner/CleanerView.swift
@@ -241,7 +241,9 @@ struct CleanerView: View {
             // the panel gets this one-line home so the feature is findable
             // without opening Settings.
             if compact { whatsAppCard }
-            if !permissions.fullDiskAccess { fdaNote }
+            if !permissions.fullDiskAccess {
+                FullDiskAccessNote(compact: compact).frame(maxWidth: 380)
+            }
             if !compact { Spacer() }
         }
         .padding(compact ? 14 : 28)
@@ -627,26 +629,6 @@ struct CleanerView: View {
                 }
             }
         }
-    }
-
-    private var fdaNote: some View {
-        VStack(alignment: .leading, spacing: 7) {
-            HStack(alignment: .top, spacing: 8) {
-                Image(systemName: "info.circle").foregroundStyle(.secondary)
-                Text(l10n.s.uninstallerFDANote)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            HStack(spacing: 8) {
-                Button(l10n.s.uninstallerFDAGrant) { permissions.requestFullDiskAccess() }
-                Button(l10n.s.uninstallerFDARelaunch) { appDelegate()?.relaunchApp() }
-            }
-            .controlSize(.small)
-        }
-        .padding(11)
-        .frame(maxWidth: 380)
-        .background(RoundedRectangle(cornerRadius: 9, style: .continuous).fill(Color.primary.opacity(0.05)))
     }
 
     // MARK: Busy

--- a/Sources/Vorssaint/UI/MenuPanel/PanelUninstallerView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/PanelUninstallerView.swift
@@ -82,7 +82,7 @@ struct PanelUninstallerView: View {
                 .fixedSize(horizontal: false, vertical: true)
 
             if !permissions.fullDiskAccess {
-                fdaNote
+                FullDiskAccessNote(compact: true)
             }
         }
         .panelCard()
@@ -122,34 +122,6 @@ struct PanelUninstallerView: View {
                 .padding(.horizontal, 12)
             )
             .animation(.easeOut(duration: 0.15), value: dropTargeted)
-    }
-
-    private var fdaNote: some View {
-        VStack(alignment: .leading, spacing: 7) {
-            HStack(alignment: .top, spacing: 7) {
-                Image(systemName: "info.circle")
-                    .foregroundStyle(.secondary)
-                Text(l10n.s.uninstallerFDANote)
-                    .font(.system(size: 10))
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            HStack(spacing: 7) {
-                Button(l10n.s.uninstallerFDAGrant) {
-                    permissions.requestFullDiskAccess()
-                }
-                Button(l10n.s.uninstallerFDARelaunch) {
-                    appDelegate()?.relaunchApp()
-                }
-            }
-            .controlSize(.small)
-            .font(.system(size: 10.5))
-        }
-        .padding(9)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.primary.opacity(0.045))
-        )
     }
 
     private func busyState(_ message: String) -> some View {

--- a/Sources/Vorssaint/UI/SharedUI.swift
+++ b/Sources/Vorssaint/UI/SharedUI.swift
@@ -37,15 +37,6 @@ struct ShortcutCaps: View {
     }
 }
 
-/// The note shown wherever a scan is limited without Full Disk Access: the
-/// Cleaner and Uninstaller pages and the Uninstaller in the panel.
-///
-/// The three used to be hand-written copies and had drifted apart. Only one of
-/// them carried the hint that says what to do once System Settings opens, which
-/// is the part that is hard to guess, so the other two sent people to a list
-/// where Vorssaint may not even be listed yet.
-///
-/// `compact` is the panel's type scale, matching the other panel cards.
 struct FullDiskAccessNote: View {
     var compact = false
 
@@ -64,7 +55,7 @@ struct FullDiskAccessNote: View {
             }
             Text(l10n.s.uninstallerFDAHint)
                 .font(compact ? .system(size: 9) : .caption2)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             HStack(spacing: compact ? 7 : 8) {
                 Button(l10n.s.uninstallerFDAGrant) { permissions.requestFullDiskAccess() }

--- a/Sources/Vorssaint/UI/SharedUI.swift
+++ b/Sources/Vorssaint/UI/SharedUI.swift
@@ -37,6 +37,51 @@ struct ShortcutCaps: View {
     }
 }
 
+/// The note shown wherever a scan is limited without Full Disk Access: the
+/// Cleaner and Uninstaller pages and the Uninstaller in the panel.
+///
+/// The three used to be hand-written copies and had drifted apart. Only one of
+/// them carried the hint that says what to do once System Settings opens, which
+/// is the part that is hard to guess, so the other two sent people to a list
+/// where Vorssaint may not even be listed yet.
+///
+/// `compact` is the panel's type scale, matching the other panel cards.
+struct FullDiskAccessNote: View {
+    var compact = false
+
+    @ObservedObject private var l10n = L10n.shared
+    @ObservedObject private var permissions = Permissions.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(alignment: .top, spacing: compact ? 7 : 8) {
+                Image(systemName: "info.circle")
+                    .foregroundStyle(.secondary)
+                Text(l10n.s.uninstallerFDANote)
+                    .font(compact ? .system(size: 10) : .caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Text(l10n.s.uninstallerFDAHint)
+                .font(compact ? .system(size: 9) : .caption2)
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: compact ? 7 : 8) {
+                Button(l10n.s.uninstallerFDAGrant) { permissions.requestFullDiskAccess() }
+                // Shown alongside because access only takes effect on relaunch.
+                Button(l10n.s.uninstallerFDARelaunch) { appDelegate()?.relaunchApp() }
+            }
+            .controlSize(.small)
+            .font(compact ? .system(size: 10.5) : nil)
+        }
+        .padding(compact ? 9 : 11)
+        .background(
+            RoundedRectangle(cornerRadius: compact ? 8 : 9, style: .continuous)
+                .fill(Color.primary.opacity(compact ? 0.045 : 0.05))
+        )
+    }
+}
+
 /// Translucent HUD material behind floating panels (the shelf, the switcher, the
 /// cut-feedback HUD). Mirrors the switcher's backdrop so every floating surface
 /// matches.

--- a/Sources/Vorssaint/UI/Uninstall/UninstallerView.swift
+++ b/Sources/Vorssaint/UI/Uninstall/UninstallerView.swift
@@ -63,7 +63,9 @@ struct UninstallerView: View {
                 .font(.caption)
                 .foregroundStyle(.tertiary)
 
-            if !permissions.fullDiskAccess { fullDiskAccessNote }
+            if !permissions.fullDiskAccess {
+                FullDiskAccessNote().frame(width: 360)
+            }
             Spacer()
         }
         .padding(28)
@@ -80,31 +82,6 @@ struct UninstallerView: View {
             uninstaller.select(appURL: app)
             return true
         } isTargeted: { dropTargeted = $0 }
-    }
-
-    private var fullDiskAccessNote: some View {
-        VStack(alignment: .leading, spacing: 7) {
-            HStack(alignment: .top, spacing: 8) {
-                Image(systemName: "info.circle").foregroundStyle(.secondary)
-                Text(l10n.s.uninstallerFDANote)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            Text(l10n.s.uninstallerFDAHint)
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
-                .fixedSize(horizontal: false, vertical: true)
-            HStack(spacing: 8) {
-                Button(l10n.s.uninstallerFDAGrant) { permissions.requestFullDiskAccess() }
-                // Shown alongside because access only takes effect on relaunch.
-                Button(l10n.s.uninstallerFDARelaunch) { appDelegate()?.relaunchApp() }
-            }
-            .controlSize(.small)
-        }
-        .padding(11)
-        .frame(width: 360)
-        .background(RoundedRectangle(cornerRadius: 9, style: .continuous).fill(Color.primary.opacity(0.05)))
     }
 
     // MARK: Busy


### PR DESCRIPTION
Three hand-written copies of the same note, and they had drifted.

| | `uninstallerFDANote` | `uninstallerFDAHint` | padding / radius / fill |
|---|---|---|---|
| `UninstallerView` | yes | **yes** | 11 / 9 / 0.05 |
| `CleanerView` | yes | no | 11 / 9 / 0.05 |
| `PanelUninstallerView` | yes | no | 9 / 8 / 0.045 |

The hint is the part that is hard to guess: *"Turn on Vorssaint in the list. If it is not there, click + and choose Vorssaint from Applications. Access only takes effect after you reopen the app."* Two of the three sent people to a System Settings list where Vorssaint may not be listed yet, with no word about the relaunch, next to a **Reopen now** button whose reason was therefore invisible.

`FullDiskAccessNote` in `SharedUI.swift` now serves all three. `compact` carries the panel's type scale, the same flag `CleanerView` and `AppPickerView` already take. `CleanerView` passes its own `compact` through, so the cleaner inside the panel picks up panel typography too — it used to draw the settings-sized note in a 308pt panel.

Behavior: Cleaning and the panel now show the hint. Both only draw this note when the permission is missing, which is exactly when it is worth the four lines.

### Checks

`./build.sh` clean, `./build.sh --test` (TESTS OK, 6993 checks) and `./build/Vorssaint --selftest` (SELFTEST OK). Net -24 lines. No new strings — the hint already ships in all eight languages.