### PR TITLE
feat(settings): open installed features at their settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
 [Semantic Versioning](https://semver.org/).
 
+## [3.3.2]
+
+### Summary
+Vorssaint 3.3.2 makes installed features easier to configure.
+
+### Changed
+- Installed Features rows open their Settings page and highlight the relevant
+  controls. Thanks to @dorlugasigal.
+
 ## [3.3.1] - 2026-08-09
 
 ### Summary

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -37,7 +37,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.1</string>
+	<string>3.3.2</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>
 		<string>MacOSX</string>

--- a/Sources/Vorssaint/UI/Cleaner/CleanerView.swift
+++ b/Sources/Vorssaint/UI/Cleaner/CleanerView.swift
@@ -319,7 +319,7 @@ struct CleanerView: View {
                     }
                     Button(whatsAppStrings.manageButton) {
                         SettingsRouter.shared.cleanerTool = "whatsApp"
-                        SettingsRouter.shared.page = .cleaner
+                        SettingsRouter.shared.request(FeatureSettingsDestination(.cleaner))
                         appDelegate()?.openSettingsWindow()
                     }
                     .controlSize(.small)

--- a/Sources/Vorssaint/UI/Settings/ClipboardSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/ClipboardSettings.swift
@@ -42,6 +42,7 @@ struct ClipboardSettings: View {
                             .foregroundStyle(.green)
                     }
                 }
+                .settingsSectionAnchor(.clipboardHistory)
 
                 clipboardShortcutSection
 
@@ -107,6 +108,7 @@ struct ClipboardSettings: View {
                 } header: {
                     Text(l10n.s.pastePlainName)
                 }
+                .settingsSectionAnchor(.pastePlain)
             }
 
             if AppFeature.clipboardHistory.isAvailable {

--- a/Sources/Vorssaint/UI/Settings/CutPasteSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/CutPasteSettings.swift
@@ -44,6 +44,7 @@ struct CutPasteSettings: View {
                             .foregroundStyle(.green)
                     }
                 }
+                .settingsSectionAnchor(.finderCutPaste)
 
                 Section(l10n.s.cutPasteHowTitle) {
                     howRow(keys: ["⌘", "X"], text: l10n.s.cutPasteStep1)
@@ -99,6 +100,7 @@ struct CutPasteSettings: View {
                 } header: {
                     Text(renameText.hubTitle)
                 }
+                .settingsSectionAnchor(.finderRename)
             }
 
             if needsAccessibility, !permissions.accessibility {

--- a/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
@@ -243,6 +243,42 @@ private struct FeatureHubRow: View {
 
     var body: some View {
         HStack(spacing: 10) {
+            if installed, feature.hasNavigableSettingsDestination {
+                Button {
+                    SettingsRouter.shared.request(feature.settingsDestination)
+                } label: {
+                    rowContent(showsChevron: true)
+                }
+                .buttonStyle(.plain)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("\(accessibilityTitle). \(feature.hubDescription(hub))")
+                .accessibilityAddTraits(.isLink)
+                .accessibilityRemoveTraits(.isButton)
+            } else {
+                rowContent(showsChevron: false)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("\(accessibilityTitle). \(feature.hubDescription(hub))")
+            }
+            if working {
+                ProgressView()
+                    .controlSize(.small)
+            } else if installed {
+                Button(hub.uninstallButton) { flip(to: false) }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .accessibilityLabel("\(hub.uninstallButton) \(accessibilityTitle)")
+            } else {
+                Button(hub.installButton) { flip(to: true) }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .accessibilityLabel("\(hub.installButton) \(accessibilityTitle)")
+            }
+        }
+        .padding(.vertical, 1)
+    }
+
+    private func rowContent(showsChevron: Bool) -> some View {
+        HStack(spacing: 10) {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill(installed
                         ? AnyShapeStyle(Theme.spaceGradient)
@@ -287,23 +323,15 @@ private struct FeatureHubRow: View {
                     .foregroundStyle(installed ? Color.secondary : Color.secondary.opacity(0.6))
             }
             Spacer(minLength: 8)
-            if working {
-                ProgressView()
-                    .controlSize(.small)
-            } else if installed {
-                Button(hub.uninstallButton) { flip(to: false) }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-            } else {
-                Button(hub.installButton) { flip(to: true) }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.small)
+            if showsChevron {
+                Image(systemName: "chevron.forward")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
             }
         }
-        .padding(.vertical, 1)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityTitle)
-        .accessibilityValue(installed ? "1" : "0")
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
     }
 
     /// A quick, honest beat of feedback: the spinner shows the action landed,

--- a/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
@@ -1,14 +1,211 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Vorssaint
 
+import Combine
 import Foundation
 
-/// The Settings pages. Lives here (Foundation-only) so the visibility rules
-/// below and the unit tests can reason about pages without pulling SwiftUI in.
+/// The Settings pages. Lives here (without SwiftUI) so the visibility rules
+/// below and the unit tests can reason about pages without pulling UI in.
 enum SettingsPage: Hashable {
     case general, features, energy, monitor
     case mouse, switcher, keyDebounce, superKey, cutPaste, autoQuit, cleaner, uninstaller, urlCleaner, homebrew, appUpdates, media, clipboard, windowLayout, shelf, quickTools, textSnippets, screenshot, screenRecorder, radialMenu, commandBar
     case shortcuts, advanced, about, releaseNotes, support
+}
+
+/// Stable, non-localized identities for destinations inside shared Settings
+/// pages. Raw values may be persisted or used by UI identifiers, so cases can
+/// be added but should not be renamed.
+enum SettingsSectionAnchor: String, CaseIterable, Hashable {
+    case panelConfiguration
+    case musicBlocking
+    case keepAwake
+    case brightness
+    case extraBrightness
+    case scrollDirection
+    case smoothScroll
+    case mouseNavigation
+    case mouseButtonShortcuts
+    case middleClick
+    case switcher
+    case dock
+    case finderCutPaste
+    case finderRename
+    case clipboardHistory
+    case pastePlain
+    case quickLauncher
+    case quickToggles
+    case colorPicker
+    case screenOCR
+    case micMute
+    case cameraPreview
+    case scratchpad
+    case soundOutputSwitcher
+    case fanControl
+
+    var page: SettingsPage {
+        switch self {
+        case .panelConfiguration, .musicBlocking: return .general
+        case .keepAwake, .brightness, .extraBrightness: return .energy
+        case .scrollDirection, .smoothScroll, .mouseNavigation, .mouseButtonShortcuts,
+             .middleClick:
+            return .mouse
+        case .switcher, .dock: return .switcher
+        case .finderCutPaste, .finderRename: return .cutPaste
+        case .clipboardHistory, .pastePlain: return .clipboard
+        case .quickLauncher, .quickToggles, .colorPicker, .screenOCR, .micMute, .cameraPreview,
+             .scratchpad:
+            return .quickTools
+        case .soundOutputSwitcher: return .shortcuts
+        case .fanControl: return .monitor
+        }
+    }
+}
+
+/// A feature's nearest configuration surface. The optional anchor distinguishes
+/// a feature section on a shared page; nil means the page itself is the target.
+struct FeatureSettingsDestination: Hashable {
+    let page: SettingsPage
+    let sectionAnchor: SettingsSectionAnchor?
+
+    init(_ page: SettingsPage, sectionAnchor: SettingsSectionAnchor? = nil) {
+        self.page = page
+        self.sectionAnchor = sectionAnchor
+    }
+
+    var hasValidSectionAnchor: Bool {
+        sectionAnchor == nil || sectionAnchor?.page == page
+    }
+}
+
+struct SettingsDestinationRequest: Equatable {
+    let id: UUID
+    let destination: FeatureSettingsDestination
+}
+
+/// Selects a Settings destination and publishes a fresh request identity even
+/// when callers ask for the same page and anchor repeatedly.
+final class SettingsRouter: ObservableObject {
+    static let shared = SettingsRouter()
+
+    @Published var page: SettingsPage = .general
+    @Published private(set) var destination = FeatureSettingsDestination(.general)
+    @Published private(set) var requestID = UUID()
+    @Published private(set) var pendingDestinationRequest: SettingsDestinationRequest?
+    /// One-shot hint for the Cleaner page's tool switcher, so a panel surface
+    /// can land directly on a specific tool. Consumed and cleared on arrival.
+    @Published var cleanerTool: String?
+
+    private init() {}
+
+    func request(_ destination: FeatureSettingsDestination) {
+        let requestID = UUID()
+        self.destination = destination
+        page = destination.page
+        pendingDestinationRequest = SettingsDestinationRequest(id: requestID,
+                                                               destination: destination)
+        self.requestID = requestID
+    }
+
+    /// Clears only the request a view actually handled. A newer request that
+    /// arrived while the destination page was being installed must survive.
+    func consumeDestinationRequest(id: UUID) {
+        guard pendingDestinationRequest?.id == id else { return }
+        pendingDestinationRequest = nil
+    }
+}
+
+extension AppFeature {
+    /// The hub itself is the honest fallback for features without a separate
+    /// configuration surface, but linking a row back to its current page would
+    /// present a chevron that appears to do nothing.
+    var hasNavigableSettingsDestination: Bool {
+        settingsDestination.page != .features
+    }
+
+    /// Exhaustive by design: adding an AppFeature requires choosing its
+    /// Settings destination before the project compiles.
+    var settingsDestination: FeatureSettingsDestination {
+        switch self {
+        case .switcher: return FeatureSettingsDestination(.switcher, sectionAnchor: .switcher)
+        case .dockPreview, .dockClick:
+            return FeatureSettingsDestination(.switcher, sectionAnchor: .dock)
+        case .windowMaximizer:
+            return FeatureSettingsDestination(.general, sectionAnchor: .panelConfiguration)
+        case .windowLayout: return FeatureSettingsDestination(.windowLayout)
+        case .autoQuit: return FeatureSettingsDestination(.autoQuit)
+
+        case .scrollInverter:
+            return FeatureSettingsDestination(.mouse, sectionAnchor: .scrollDirection)
+        case .smoothScroll:
+            return FeatureSettingsDestination(.mouse, sectionAnchor: .smoothScroll)
+        case .mouseNavigation:
+            return FeatureSettingsDestination(.mouse, sectionAnchor: .mouseNavigation)
+        case .mouseButtonShortcuts:
+            return FeatureSettingsDestination(.mouse, sectionAnchor: .mouseButtonShortcuts)
+        case .middleClick:
+            return FeatureSettingsDestination(.mouse, sectionAnchor: .middleClick)
+        case .keyboardDebounce: return FeatureSettingsDestination(.keyDebounce)
+        case .textSnippets: return FeatureSettingsDestination(.textSnippets)
+        case .superKey: return FeatureSettingsDestination(.superKey)
+
+        case .clipboardHistory:
+            return FeatureSettingsDestination(.clipboard, sectionAnchor: .clipboardHistory)
+        case .pastePlain:
+            return FeatureSettingsDestination(.clipboard, sectionAnchor: .pastePlain)
+        case .finderCutPaste:
+            return FeatureSettingsDestination(.cutPaste, sectionAnchor: .finderCutPaste)
+        case .finderRename:
+            return FeatureSettingsDestination(.cutPaste, sectionAnchor: .finderRename)
+        case .shelf: return FeatureSettingsDestination(.shelf)
+        case .urlCleaner: return FeatureSettingsDestination(.urlCleaner)
+        case .diskImageInstaller: return FeatureSettingsDestination(.features)
+
+        case .mixer:
+            return FeatureSettingsDestination(.general, sectionAnchor: .panelConfiguration)
+        case .soundOutputSwitcher:
+            return FeatureSettingsDestination(.shortcuts, sectionAnchor: .soundOutputSwitcher)
+        case .micMute:
+            return FeatureSettingsDestination(.quickTools, sectionAnchor: .micMute)
+        case .musicBlock:
+            return FeatureSettingsDestination(.general, sectionAnchor: .musicBlocking)
+
+        case .keepAwake:
+            return FeatureSettingsDestination(.energy, sectionAnchor: .keepAwake)
+        case .brightness:
+            return FeatureSettingsDestination(.energy, sectionAnchor: .brightness)
+        case .extraBrightness:
+            return FeatureSettingsDestination(.energy, sectionAnchor: .extraBrightness)
+
+        case .quickLauncher:
+            return FeatureSettingsDestination(.quickTools, sectionAnchor: .quickLauncher)
+        case .quickToggles:
+            return FeatureSettingsDestination(.quickTools, sectionAnchor: .quickToggles)
+        case .colorPicker:
+            return FeatureSettingsDestination(.quickTools, sectionAnchor: .colorPicker)
+        case .screenOCR:
+            return FeatureSettingsDestination(.quickTools, sectionAnchor: .screenOCR)
+        case .cleaningMode:
+            return FeatureSettingsDestination(.general, sectionAnchor: .panelConfiguration)
+        case .mediaTools: return FeatureSettingsDestination(.media)
+        case .cleaner: return FeatureSettingsDestination(.cleaner)
+        case .uninstaller: return FeatureSettingsDestination(.uninstaller)
+        case .homebrew: return FeatureSettingsDestination(.homebrew)
+        case .appUpdates: return FeatureSettingsDestination(.appUpdates)
+        case .screenshot: return FeatureSettingsDestination(.screenshot)
+        case .cameraPreview:
+            return FeatureSettingsDestination(.quickTools, sectionAnchor: .cameraPreview)
+        case .radialMenu: return FeatureSettingsDestination(.radialMenu)
+        case .scratchpad:
+            return FeatureSettingsDestination(.quickTools, sectionAnchor: .scratchpad)
+        case .commandBar: return FeatureSettingsDestination(.commandBar)
+        case .screenRecorder: return FeatureSettingsDestination(.screenRecorder)
+
+        case .monitorCPU, .monitorGPU, .monitorMemory, .monitorNetwork, .monitorDisk, .monitorPower:
+            return FeatureSettingsDestination(.monitor)
+        case .fanControl:
+            return FeatureSettingsDestination(.monitor, sectionAnchor: .fanControl)
+        }
+    }
 }
 
 /// Which hub features keep each Settings page alive. A page with several

--- a/Sources/Vorssaint/UI/Settings/MonitorSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/MonitorSettings.swift
@@ -123,6 +123,7 @@ struct MonitorSettings: View {
                             .background(Capsule().fill(Color.accentColor))
                     }
                 }
+                .settingsSectionAnchor(.fanControl)
             }
             Section(l10n.s.monitorGraphsSection) {
                 if AppFeature.monitorCPU.isAvailable {

--- a/Sources/Vorssaint/UI/Settings/MouseButtonSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/MouseButtonSettings.swift
@@ -57,6 +57,7 @@ struct MouseButtonShortcutsSection: View {
                 MouseExceptionsList(scope: .buttonShortcuts)
             }
         }
+        .settingsSectionAnchor(.mouseButtonShortcuts)
         .onDisappear {
             stopCapture()
         }

--- a/Sources/Vorssaint/UI/Settings/QuickToolsSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/QuickToolsSettings.swift
@@ -60,6 +60,7 @@ struct QuickToolsSettings: View {
                 } header: {
                     Text(l10n.s.launcherName)
                 }
+                .settingsSectionAnchor(.quickLauncher)
             }
 
             if AppFeature.quickToggles.isAvailable {
@@ -87,6 +88,7 @@ struct QuickToolsSettings: View {
                 } header: {
                     Text(FeatureStrings.quickToggles(l10n.language).pageTitle)
                 }
+                .settingsSectionAnchor(.quickToggles)
                 .onAppear { brightness.refreshKeyboardLight() }
             }
 
@@ -123,6 +125,7 @@ struct QuickToolsSettings: View {
                 } header: {
                     Text(l10n.s.ocrName)
                 }
+                .settingsSectionAnchor(.screenOCR)
             }
 
             if AppFeature.colorPicker.isAvailable {
@@ -160,6 +163,7 @@ struct QuickToolsSettings: View {
                 } header: {
                     Text(l10n.s.colorPickerName)
                 }
+                .settingsSectionAnchor(.colorPicker)
             }
 
             if AppFeature.micMute.isAvailable {
@@ -198,6 +202,7 @@ struct QuickToolsSettings: View {
                 } header: {
                     Text(l10n.s.micMuteName)
                 }
+                .settingsSectionAnchor(.micMute)
             }
 
             if AppFeature.cameraPreview.isAvailable {
@@ -230,6 +235,7 @@ struct QuickToolsSettings: View {
                 } header: {
                     Text(FeatureStrings.cameraPreview(l10n.language).pageTitle)
                 }
+                .settingsSectionAnchor(.cameraPreview)
             }
 
             if AppFeature.scratchpad.isAvailable {
@@ -291,6 +297,7 @@ struct QuickToolsSettings: View {
                 } header: {
                     Text(FeatureStrings.scratchpad(l10n.language).pageTitle)
                 }
+                .settingsSectionAnchor(.scratchpad)
             }
         }
         .formStyle(.grouped)

--- a/Sources/Vorssaint/UI/Settings/SettingsSectionFocus.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsSectionFocus.swift
@@ -21,12 +21,9 @@ private struct SettingsSectionAnchorModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .id(anchor)
-            .overlay {
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(Color.accentColor, lineWidth: 2)
-                    .opacity(focusedAnchor == anchor ? 0.75 : 0)
-                    .allowsHitTesting(false)
-            }
+            .listRowBackground(
+                Color.accentColor.opacity(focusedAnchor == anchor ? 0.14 : 0)
+            )
     }
 }
 

--- a/Sources/Vorssaint/UI/Settings/SettingsSectionFocus.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsSectionFocus.swift
@@ -21,9 +21,11 @@ private struct SettingsSectionAnchorModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .id(anchor)
-            .listRowBackground(
-                Color.accentColor.opacity(focusedAnchor == anchor ? 0.14 : 0)
-            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .fill(Color.accentColor.opacity(focusedAnchor == anchor ? 0.10 : 0))
+                    .allowsHitTesting(false)
+            }
     }
 }
 

--- a/Sources/Vorssaint/UI/Settings/SettingsSectionFocus.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsSectionFocus.swift
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import SwiftUI
+
+private struct FocusedSettingsSectionAnchorKey: EnvironmentKey {
+    static let defaultValue: SettingsSectionAnchor? = nil
+}
+
+private extension EnvironmentValues {
+    var focusedSettingsSectionAnchor: SettingsSectionAnchor? {
+        get { self[FocusedSettingsSectionAnchorKey.self] }
+        set { self[FocusedSettingsSectionAnchorKey.self] = newValue }
+    }
+}
+
+private struct SettingsSectionAnchorModifier: ViewModifier {
+    let anchor: SettingsSectionAnchor
+    @Environment(\.focusedSettingsSectionAnchor) private var focusedAnchor
+
+    func body(content: Content) -> some View {
+        content
+            .id(anchor)
+            .overlay {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color.accentColor, lineWidth: 2)
+                    .opacity(focusedAnchor == anchor ? 0.75 : 0)
+                    .allowsHitTesting(false)
+            }
+    }
+}
+
+private struct SettingsSectionFocusModifier: ViewModifier {
+    let page: SettingsPage
+
+    @ObservedObject private var router = SettingsRouter.shared
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var focusedAnchor: SettingsSectionAnchor?
+    @State private var highlightID = UUID()
+
+    func body(content: Content) -> some View {
+        ScrollViewReader { proxy in
+            content
+                .environment(\.focusedSettingsSectionAnchor, focusedAnchor)
+                .onAppear {
+                    consumePendingRequest(using: proxy)
+                }
+                .onChange(of: router.requestID) { _, _ in
+                    consumePendingRequest(using: proxy)
+                }
+        }
+    }
+
+    private func consumePendingRequest(using proxy: ScrollViewProxy) {
+        guard let request = router.pendingDestinationRequest,
+              request.destination.page == page else { return }
+
+        router.consumeDestinationRequest(id: request.id)
+        highlightID = request.id
+        guard let anchor = request.destination.sectionAnchor else {
+            focusedAnchor = nil
+            return
+        }
+
+        // A page-changing request publishes before the replacement Form has
+        // completed layout. Retry once after the first run-loop turn because
+        // grouped Forms can register their section IDs on the following pass.
+        DispatchQueue.main.async {
+            guard self.highlightID == request.id else { return }
+            focus(anchor, using: proxy)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+                guard self.highlightID == request.id else { return }
+                focus(anchor, using: proxy)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                    guard self.highlightID == request.id else { return }
+                    if reduceMotion {
+                        focusedAnchor = nil
+                    } else {
+                        withAnimation(.easeOut(duration: 0.25)) {
+                            focusedAnchor = nil
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func focus(_ anchor: SettingsSectionAnchor, using proxy: ScrollViewProxy) {
+        if reduceMotion {
+            proxy.scrollTo(anchor, anchor: .center)
+            focusedAnchor = anchor
+        } else {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                proxy.scrollTo(anchor, anchor: .center)
+                focusedAnchor = anchor
+            }
+        }
+    }
+}
+
+extension View {
+    /// Marks a stable destination inside a Settings page.
+    func settingsSectionAnchor(_ anchor: SettingsSectionAnchor) -> some View {
+        modifier(SettingsSectionAnchorModifier(anchor: anchor))
+    }
+
+    /// Handles one-shot destination requests for one Settings page.
+    func settingsSectionFocus(for page: SettingsPage) -> some View {
+        modifier(SettingsSectionFocusModifier(page: page))
+    }
+}

--- a/Sources/Vorssaint/UI/Settings/SettingsView.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsView.swift
@@ -4,19 +4,6 @@
 import AppKit
 import SwiftUI
 
-/// One entry in the Settings sidebar. New features add a case here and a row in
-/// the Features section, so every feature gets its own page.
-/// Selects the visible Settings page; the menu bar uses it to open Settings
-/// directly on a specific page.
-final class SettingsRouter: ObservableObject {
-    static let shared = SettingsRouter()
-    @Published var page: SettingsPage = .general
-    /// One-shot hint for the Cleaner page's tool switcher, so a panel surface
-    /// can land directly on a specific tool. Consumed and cleared on arrival.
-    @Published var cleanerTool: String?
-    private init() {}
-}
-
 /// System-Settings-style window: a sidebar of pages on the left, the selected
 /// page on the right. Scales cleanly as features are added, and gives each
 /// feature a page of its own with room for examples and advanced options.
@@ -37,6 +24,7 @@ struct SettingsView: View {
                 .navigationSplitViewColumnWidth(min: 198, ideal: 210, max: 240)
         } detail: {
             detail
+                .settingsSectionFocus(for: router.page)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         }
         .navigationSplitViewStyle(.balanced)
@@ -203,6 +191,7 @@ struct GeneralSettings: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            .settingsSectionAnchor(.panelConfiguration)
             if AppFeature.keepAwake.isAvailable {
                 Section(l10n.s.globalHotkeySection) {
                     Toggle(l10n.s.hotkeyToggle, isOn: $hotkeyEnabled)
@@ -248,6 +237,7 @@ struct GeneralSettings: View {
                     }
                     SettingsCaptionText(l10n.s.musicBlockCaption)
                 }
+                .settingsSectionAnchor(.musicBlocking)
             }
             Section(feedbackStrings.sectionTitle) {
                 Button {
@@ -421,6 +411,7 @@ struct EnergySettings: View {
                                               caption: displaySleepStrings.allowDisplaySleepCaption,
                                               isOn: $keepAwakeAllowDisplaySleep)
                 }
+                .settingsSectionAnchor(.keepAwake)
                 Section(automationStrings.automationSection) {
                     SettingsCaptionText(automationStrings.automationCaption)
                     KeepAwakeAutomationEditor()
@@ -513,6 +504,7 @@ struct EnergySettings: View {
                         SettingsCaptionText(strings.externalCaption)
                     }
                 }
+                .settingsSectionAnchor(.brightness)
             }
             if AppFeature.extraBrightness.isAvailable {
                 Section(l10n.s.extraBrightnessName) {
@@ -536,6 +528,7 @@ struct EnergySettings: View {
                         SettingsCaptionText(l10n.s.extraBrightnessUnsupported)
                     }
                 }
+                .settingsSectionAnchor(.extraBrightness)
             }
         }
         .formStyle(.grouped)
@@ -649,6 +642,7 @@ struct MouseSettings: View {
                         MouseExceptionsList(scope: .scrollDirection)
                     }
                 }
+                .settingsSectionAnchor(.scrollDirection)
             }
             if AppFeature.smoothScroll.isAvailable {
                 Section(l10n.s.smoothScrollName) {
@@ -674,6 +668,7 @@ struct MouseSettings: View {
                         MouseExceptionsList(scope: .smoothScroll)
                     }
                 }
+                .settingsSectionAnchor(.smoothScroll)
             }
             if AppFeature.mouseNavigation.isAvailable {
                 Section(l10n.s.mouseNavigationSection) {
@@ -693,6 +688,7 @@ struct MouseSettings: View {
                         MouseExceptionsList(scope: .navigation)
                     }
                 }
+                .settingsSectionAnchor(.mouseNavigation)
             }
             if AppFeature.mouseButtonShortcuts.isAvailable {
                 MouseButtonShortcutsSection()
@@ -728,6 +724,7 @@ struct MouseSettings: View {
                         MouseExceptionsList(scope: .middleClick)
                     }
                 }
+                .settingsSectionAnchor(.middleClick)
             }
             if accessibilityNoteVisible {
                 Section(l10n.s.permissionRequired) {
@@ -874,6 +871,7 @@ struct SwitcherSettings: View {
                         .foregroundStyle(.secondary)
                     SwitcherAppRulesList()
                 }
+                .settingsSectionAnchor(.switcher)
             }
             if AppFeature.dockPreview.isAvailable || AppFeature.dockClick.isAvailable {
                 Section {
@@ -927,6 +925,7 @@ struct SwitcherSettings: View {
                 } header: {
                     Text(l10n.s.dockPreviewName)
                 }
+                .settingsSectionAnchor(.dock)
             }
             if AppFeature.switcher.isAvailable || AppFeature.dockPreview.isAvailable {
                 Section {

--- a/Sources/Vorssaint/UI/Settings/ShortcutsSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/ShortcutsSettings.swift
@@ -37,7 +37,12 @@ struct ShortcutsSettings: View {
             ForEach(visibleGroups, id: \.self) { group in
                 Section(groupTitle(group)) {
                     ForEach(featuresWithShortcuts(in: group), id: \.self) { feature in
-                        featureRows(feature)
+                        if feature == .soundOutputSwitcher {
+                            featureRows(feature)
+                                .settingsSectionAnchor(.soundOutputSwitcher)
+                        } else {
+                            featureRows(feature)
+                        }
                     }
                 }
             }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -4,6 +4,7 @@
 import CoreAudio
 import CoreGraphics
 import Carbon.HIToolbox
+import Combine
 import Darwin
 import Foundation
 
@@ -8223,6 +8224,75 @@ struct MetricsTests {
                "the quick toggles alone keep the quick tools page")
         expect(pageVisible(.clipboard, available: [.finderCutPaste]),
                "the image paste option keeps the Clipboard page available")
+        expect(AppFeature.allCases.allSatisfy { feature in
+            let destination = feature.settingsDestination
+            let gate = FeatureVisibilitySupport.features(for: destination.page)
+            return gate.isEmpty || gate.contains(feature)
+        }, "every feature destination is either always visible or gated by that feature")
+        expect(AppFeature.allCases.allSatisfy { $0.settingsDestination.hasValidSectionAnchor },
+               "every feature anchor belongs to its destination page")
+        expect(Set(AppFeature.allCases.compactMap(\.settingsDestination.sectionAnchor))
+                == Set(SettingsSectionAnchor.allCases),
+               "every declared Settings section anchor is used by a feature destination")
+        expect(AppFeature.windowMaximizer.settingsDestination
+                == FeatureSettingsDestination(.general, sectionAnchor: .panelConfiguration)
+                && AppFeature.mixer.settingsDestination
+                == FeatureSettingsDestination(.general, sectionAnchor: .panelConfiguration)
+                && AppFeature.cleaningMode.settingsDestination
+                == FeatureSettingsDestination(.general, sectionAnchor: .panelConfiguration),
+               "panel-oriented features land on General panel configuration")
+        expect(AppFeature.musicBlock.settingsDestination
+                == FeatureSettingsDestination(.general, sectionAnchor: .musicBlocking)
+                && AppFeature.soundOutputSwitcher.settingsDestination
+                == FeatureSettingsDestination(.shortcuts, sectionAnchor: .soundOutputSwitcher)
+                && AppFeature.diskImageInstaller.settingsDestination
+                == FeatureSettingsDestination(.features),
+               "features without dedicated pages use explicit nearest Settings destinations")
+        expect(!AppFeature.diskImageInstaller.hasNavigableSettingsDestination
+                && AppFeature.allCases.filter { $0 != .diskImageInstaller }
+                    .allSatisfy(\.hasNavigableSettingsDestination),
+               "a feature without a separate configuration surface does not show a dead-end link")
+        expect(AppFeature.monitorCPU.settingsDestination == FeatureSettingsDestination(.monitor)
+                && AppFeature.fanControl.settingsDestination
+                == FeatureSettingsDestination(.monitor, sectionAnchor: .fanControl),
+               "shared monitor destinations distinguish the dedicated fan controls")
+        let settingsRouter = SettingsRouter.shared
+        var settingsRequestCount = 0
+        var settingsRequestsPublishedReady = true
+        let settingsRequestObservation = settingsRouter.$requestID
+            .dropFirst()
+            .sink { requestID in
+                settingsRequestCount += 1
+                settingsRequestsPublishedReady =
+                    settingsRequestsPublishedReady
+                    && settingsRouter.pendingDestinationRequest?.id == requestID
+            }
+        let repeatedDestination = FeatureSettingsDestination(.mouse, sectionAnchor: .middleClick)
+        settingsRouter.request(repeatedDestination)
+        let firstSettingsRequestID = settingsRouter.requestID
+        settingsRouter.request(repeatedDestination)
+        expect(settingsRouter.destination == repeatedDestination
+                && settingsRouter.page == repeatedDestination.page,
+               "a Settings destination request selects its page and preserves its anchor")
+        expect(settingsRequestCount == 2 && settingsRouter.requestID != firstSettingsRequestID,
+               "repeated requests for the same Settings destination remain observable")
+        expect(settingsRequestsPublishedReady,
+               "a Settings request is ready to consume when its request identity is published")
+        let repeatedSettingsRequestID = settingsRouter.requestID
+        settingsRouter.consumeDestinationRequest(id: firstSettingsRequestID)
+        expect(settingsRouter.pendingDestinationRequest?.id == repeatedSettingsRequestID,
+               "consuming an older Settings request cannot clear a newer request")
+        settingsRouter.consumeDestinationRequest(id: repeatedSettingsRequestID)
+        expect(settingsRouter.pendingDestinationRequest == nil,
+               "a handled Settings destination request is cleared")
+        settingsRouter.cleanerTool = "whatsApp"
+        settingsRouter.request(FeatureSettingsDestination(.cleaner))
+        expect(settingsRouter.page == .cleaner && settingsRouter.cleanerTool == "whatsApp",
+               "requesting Cleaner Settings preserves its one-shot tool hint")
+        settingsRouter.consumeDestinationRequest(id: settingsRouter.requestID)
+        settingsRouter.cleanerTool = nil
+        settingsRouter.page = .general
+        withExtendedLifetime(settingsRequestObservation) {}
 
         // MARK: Display brightness (DDC/CI helpers)
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1822,7 +1822,7 @@ struct MetricsTests {
         // per-release decision: this check fails on every version bump so the
         // decision above is made consciously, never by omission.
         let plistVersion = (NSDictionary(contentsOfFile: "Resources/Info.plist")?["CFBundleShortVersionString"] as? String) ?? ""
-        expect(plistVersion == "3.3.1",
+        expect(plistVersion == "3.3.2",
                "bumping the app version requires re-deciding the support prompt pin above")
         expect(SupportUpdateIntroInfo.releaseVersion == "3.3.0",
                "3.3.0 shows the deliberately curated community and support intro")
@@ -1835,7 +1835,8 @@ struct MetricsTests {
                "highlights tour shows once after updating to its pinned release")
         expect(!UpdateHighlightsInfo.shouldShow(appVersion: "3.3.1", lastSeenVersion: "3.3.1"),
                "highlights tour stays hidden after it is seen")
-        expect(!UpdateHighlightsInfo.shouldShow(appVersion: "3.3.0", lastSeenVersion: nil),
+        expect(!UpdateHighlightsInfo.shouldShow(appVersion: "3.3.0", lastSeenVersion: nil)
+               && !UpdateHighlightsInfo.shouldShow(appVersion: "3.3.2", lastSeenVersion: nil),
                "highlights tour never leaks into another release")
         expect(registeredDefaults[DefaultsKey.mixerLowerVolumeOnHeadphonesDisconnect] as? Bool == false,
                "headphone disconnect volume lowering is opt-in")
@@ -8285,9 +8286,9 @@ struct MetricsTests {
         settingsRouter.consumeDestinationRequest(id: repeatedSettingsRequestID)
         expect(settingsRouter.pendingDestinationRequest == nil,
                "a handled Settings destination request is cleared")
-        settingsRouter.cleanerTool = "whatsApp"
+        settingsRouter.cleanerTool = "tool-id"
         settingsRouter.request(FeatureSettingsDestination(.cleaner))
-        expect(settingsRouter.page == .cleaner && settingsRouter.cleanerTool == "whatsApp",
+        expect(settingsRouter.page == .cleaner && settingsRouter.cleanerTool == "tool-id",
                "requesting Cleaner Settings preserves its one-shot tool hint")
         settingsRouter.consumeDestinationRequest(id: settingsRouter.requestID)
         settingsRouter.cleanerTool = nil


### PR DESCRIPTION
Installed Features hub rows now open the Settings page where each feature is
configured. Features that share a page land on their exact section, which is
scrolled into view and briefly highlighted.

## **Demo**:

https://github.com/user-attachments/assets/bebf3d69-ba54-4e89-8ece-09dc4e2048ec

## Changes

- Added an exhaustive, typed **feature-to-Settings destination map** with stable
  section anchors for shared pages.
- Made installed hub rows navigable with a trailing chevron while preserving
  independent Install and Uninstall controls and accessible labels.
- Added one-shot Settings routing that handles repeated requests and prevents
  stale request consumption.
- Added reusable section focusing with a guarded layout retry, transient
  highlighting, and Reduce Motion support.
- Anchored feature controls across General, Energy, Mouse, Switcher, Clipboard,
  Cut/Paste, Quick Tools, Shortcuts, and Monitor settings.
- Kept features without a separate configuration surface free of dead-end
  navigation affordances.
- Added coverage for destination visibility, anchor validity, repeated requests,
  fallback behavior, and Cleaner tool-hint preservation.

## Related Issues

Closes #599

## Notes

- `./build.sh --test` passed with 7006 checks.
- `./build.sh` completed successfully.
- `./build/Vorssaint --selftest` reported `SELFTEST OK`.