### PR TITLE
Open the app's own store page from the batch update button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and peripheral battery readings, panel behavior and keyboard controls.
   while only the number changes.
 - The Command Bar now finds installed apps kept outside the standard Applications
   folders.
+- Keyboard light is now searchable from Settings and the Command Bar.
+  Thanks to @PathGao.
 - Copy text from screen now prioritizes the interface language, preventing Chinese
   text from being returned as unreadable characters.
 - A disabled built-in display now turns back on when the last external screen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ All notable changes to this project are documented here. The format follows
 
 ### Summary
 Vorssaint 3.3.2 improves app discovery in the Command Bar, recording, Switcher,
-screenshot editing, clipboard history, screen text recognition, Window Layout, Cleaning Mode, Scratchpad, audio and display safety. It also refines app
-management, feedback, feature setup, Fan Control, Quit on close, network monitoring, power
-and peripheral battery readings, panel behavior and keyboard controls.
+screenshot editing, clipboard history, screen text recognition, Window Layout,
+Cleaning Mode, Scratchpad, audio and display safety. It also standardizes app
+lists in Settings and refines feedback, feature setup, Fan Control, Quit on close,
+network monitoring, power, peripheral battery readings, panel behavior and keyboard controls.
 
 ### Added
 - Emoji can open directly from a shortcut assigned to its Command Bar row.
@@ -27,6 +28,8 @@ and peripheral battery readings, panel behavior and keyboard controls.
   nothing reads them there. Thanks to @PathGao.
 - Showing Clipboard in the panel now sits on its own in Settings, since it keeps
   working while history capture is off. Thanks to @PathGao.
+- App lists in Settings now keep names on one line and align their add controls
+  consistently. Thanks to @PathGao.
 - The Command Bar now accepts Control-P and Control-N to move through results.
   Thanks to @theafox.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project are documented here. The format follows
 
 ### Summary
 Vorssaint 3.3.2 improves app discovery in the Command Bar, recording, Switcher,
-screenshots, clipboard history, screen text recognition, Window Layout, Cleaning Mode, Scratchpad, audio and display safety. It also refines app
+screenshot editing, clipboard history, screen text recognition, Window Layout, Cleaning Mode, Scratchpad, audio and display safety. It also refines app
 management, feedback, feature setup, Fan Control, Quit on close, network monitoring, power
 and peripheral battery readings, panel behavior and keyboard controls.
 
@@ -31,6 +31,7 @@ and peripheral battery readings, panel behavior and keyboard controls.
   Thanks to @theafox.
 
 ### Fixed
+- The screenshot editor now lets you draw a new crop directly over the image.
 - Clipboard history now keeps large copied documents instead of silently
   dropping text after 20,000 characters.
 - Window Layout now centers fixed-size windows and stops pending placements from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project are documented here. The format follows
 
 ### Summary
 Vorssaint 3.3.2 improves app discovery in the Command Bar, recording, Switcher,
-screenshots, screen text recognition, Window Layout, Cleaning Mode, Scratchpad, audio and display safety. It also refines app
+screenshots, clipboard history, screen text recognition, Window Layout, Cleaning Mode, Scratchpad, audio and display safety. It also refines app
 management, feedback, feature setup, Fan Control, Quit on close, network monitoring, power
 and peripheral battery readings, panel behavior and keyboard controls.
 
@@ -31,6 +31,8 @@ and peripheral battery readings, panel behavior and keyboard controls.
   Thanks to @theafox.
 
 ### Fixed
+- Clipboard history now keeps large copied documents instead of silently
+  dropping text after 20,000 characters.
 - Window Layout now centers fixed-size windows and stops pending placements from
   undoing Full Screen.
 - The feedback text cursor now lines up with the empty-field hint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and peripheral battery readings, panel behavior and keyboard controls.
   Thanks to @PathGao.
 - The App Switcher now shows its configured shortcut in the large icon mode label.
   Thanks to @liuxxxu.
+- The App Switcher now keeps its shortcut working after your Mac wakes from sleep.
 - The App Switcher now restores minimized windows when selected.
 - The app no longer quits while typing when the Switcher's Windows shortcut uses a
   key whose label comes from the keyboard layout. Thanks to @eioz.

--- a/Sources/Vorssaint/Services/AppUpdates/AppUpdatesService.swift
+++ b/Sources/Vorssaint/Services/AppUpdates/AppUpdatesService.swift
@@ -327,7 +327,10 @@ final class AppUpdatesService: ObservableObject {
         if !tokens.isEmpty {
             startUpgrade(tokens)
         }
-        if AppUpdatesSupport.hasStoreSelection(in: items, selection: selection) {
+        if let page = AppUpdatesSupport.singleStorePage(in: items, selection: selection),
+           let url = URL(string: page) {
+            handOffToStore(url)
+        } else if AppUpdatesSupport.hasStoreSelection(in: items, selection: selection) {
             openAppStoreUpdates()
         }
     }

--- a/Sources/Vorssaint/Services/AppUpdates/AppUpdatesSupport.swift
+++ b/Sources/Vorssaint/Services/AppUpdates/AppUpdatesSupport.swift
@@ -285,6 +285,16 @@ enum AppUpdatesSupport {
         items.contains { selection.contains($0.id) && $0.source == .appStore }
     }
 
+    /// The page a store hand-off can land on. With one store row ticked that is
+    /// its product page, the same place the row's own button goes; the store
+    /// shows one product at a time, so several rows have no such page and the
+    /// hand-off falls back to the updates page.
+    static func singleStorePage(in items: [Item], selection: Set<String>) -> String? {
+        let store = items.filter { selection.contains($0.id) && $0.source == .appStore }
+        guard store.count == 1 else { return nil }
+        return store[0].storePage
+    }
+
     /// Selection kept honest against a list that just changed: rows that are
     /// gone drop out, and rows that appeared arrive already ticked, which is
     /// what "update everything" expects without any extra click.

--- a/Sources/Vorssaint/Services/Clipboard/ClipboardHistorySupport.swift
+++ b/Sources/Vorssaint/Services/Clipboard/ClipboardHistorySupport.swift
@@ -65,11 +65,13 @@ struct ClipboardHistoryEntry: Codable, Equatable, Identifiable {
     var preview: String {
         switch kind {
         case .text:
-            let collapsed = text
+            let prefix = text.prefix(ClipboardHistoryEditing.previewCharacters)
+            let collapsed = prefix
                 .replacingOccurrences(of: "\n", with: " ")
                 .replacingOccurrences(of: "\t", with: " ")
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            return collapsed.isEmpty ? text : collapsed
+            let visible = collapsed.isEmpty ? String(prefix) : collapsed
+            return prefix.endIndex == text.endIndex ? visible : visible + "…"
         case .image:
             return imageDimensionsLabel
         case .files:
@@ -119,7 +121,13 @@ struct ClipboardHistoryEntry: Codable, Equatable, Identifiable {
 }
 
 enum ClipboardHistoryEditing {
-    static let maxCharacters = 20_000
+    /// A copied document should stay available, while a pathological
+    /// pasteboard payload still has a firm in-memory and on-disk bound.
+    static let maxCharacters = 1_000_000
+    /// Rows only need enough text to fill their three visible lines. Keeping
+    /// this bounded prevents a very large saved document from being copied
+    /// again merely to draw its list preview.
+    static let previewCharacters = 2_000
 
     static func storableText(_ text: String) -> String? {
         guard text.count <= maxCharacters,

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift
@@ -118,6 +118,7 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
     private var activeHandle: ScreenshotSupport.Handle?
     private var cropResizeOrigin: CGRect?
     private var cropMoveOrigin: CGRect?
+    private var cropSelectionOrigin: CGRect?
     private var dragRegistered = false
     private var editingSelectedAnnotation = false
     private var newTextID: UUID?
@@ -478,12 +479,17 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
         case .select:
             beginSelectDrag(at: point)
         case .crop:
+            let bounds = CGRect(origin: .zero, size: imageSize)
             if let draft = cropDraft,
                let handle = ScreenshotSupport.handle(at: point, rect: draft,
                                                      tolerance: 14 * scale) {
                 activeHandle = handle
                 cropResizeOrigin = draft
                 cropLoupePoint = handle.position(in: draft)
+            } else if let draft = cropDraft,
+                      ScreenshotSupport.startsNewCropSelection(
+                        at: point, draft: draft, within: bounds) {
+                cropSelectionOrigin = draft
             } else if let draft = cropDraft, draft.contains(point) {
                 cropMoveOrigin = draft
             }
@@ -571,6 +577,10 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
                 let clamped = ScreenshotSupport.clamp(rect, to: bounds)
                 cropDraft = clamped
                 cropLoupePoint = handle.position(in: clamped)
+            } else if cropSelectionOrigin != nil {
+                cropDraft = ScreenshotSupport.clamp(
+                    ScreenshotSupport.selectionRect(from: dragStart, to: point),
+                    to: bounds)
             } else if let origin = cropMoveOrigin {
                 let delta = CGPoint(x: point.x - dragStart.x, y: point.y - dragStart.y)
                 cropDraft = ScreenshotSupport.movedRect(origin, by: delta, within: bounds)
@@ -629,6 +639,7 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
             activeHandle = nil
             cropResizeOrigin = nil
             cropMoveOrigin = nil
+            cropSelectionOrigin = nil
             cropLoupePoint = nil
             dragRegistered = false
             editingSelectedAnnotation = false
@@ -691,7 +702,9 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
         case .select:
             finishSelectDrag(at: point, isTap: isTap)
         case .crop:
-            break
+            if isTap, let origin = cropSelectionOrigin {
+                cropDraft = origin
+            }
         }
     }
 

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
@@ -246,6 +246,15 @@ enum ScreenshotSupport {
                       width: abs(dx), height: abs(dy))
     }
 
+    /// A full-image crop cannot move, so an interior drag must start a new
+    /// selection. Dragging outside an existing crop replaces it as well.
+    static func startsNewCropSelection(at point: CGPoint,
+                                       draft: CGRect,
+                                       within bounds: CGRect) -> Bool {
+        bounds.contains(point)
+            && (draft.standardized == bounds.standardized || !draft.contains(point))
+    }
+
     static func clamp(_ rect: CGRect, to bounds: CGRect) -> CGRect {
         var result = rect.intersection(bounds)
         if result.isNull { result = .zero }

--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -73,6 +73,8 @@ final class AppSwitcher: ObservableObject {
     private var pendingStartAfterStop = false
     /// Alive only while the Switcher's tap needs layout labels off main.
     private var keyboardLayoutObserver: NSObjectProtocol?
+    private var wakeObserver: NSObjectProtocol?
+    private var wakeRetry: DispatchWorkItem?
 
     /// The little state the tap thread needs to route an event without
     /// touching the main thread; mutated only under `routeLock`.
@@ -138,6 +140,7 @@ final class AppSwitcher: ObservableObject {
             && UserDefaults.standard.bool(forKey: DefaultsKey.switcherEnabled)
         if enabled, Permissions.shared.accessibility {
             startObservingKeyboardLayout()
+            startObservingWake()
             installTap()
             // Build the panel and its SwiftUI tree now: the first hosting-view
             // render costs hundreds of milliseconds, far too slow to pay on
@@ -151,6 +154,7 @@ final class AppSwitcher: ObservableObject {
             }
         } else {
             stopObservingKeyboardLayout()
+            stopObservingWake()
             removeTap()
             WindowPreviewProvider.shared.stopWarming()
         }
@@ -159,7 +163,10 @@ final class AppSwitcher: ObservableObject {
     /// Force-stops the tap regardless of the preference. Used before the app
     /// resets its own permissions, so a revoked Accessibility grant can never
     /// leave a live tap behind.
-    func suspend() { removeTap() }
+    func suspend() {
+        stopObservingWake()
+        removeTap()
+    }
 
     /// While a shortcut field is listening, every key has to reach it, even
     /// the switcher's own combination. This is a flag the routing reads, not a
@@ -188,6 +195,48 @@ final class AppSwitcher: ObservableObject {
             DistributedNotificationCenter.default().removeObserver(keyboardLayoutObserver)
         }
         keyboardLayoutObserver = nil
+    }
+
+    private func startObservingWake() {
+        guard wakeObserver == nil else { return }
+        wakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in self?.recoverTapAfterWake() }
+    }
+
+    private func stopObservingWake() {
+        if let wakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(wakeObserver)
+        }
+        wakeObserver = nil
+        wakeRetry?.cancel()
+        wakeRetry = nil
+    }
+
+    private func recoverTapAfterWake() {
+        recoverTapIfNeeded()
+        wakeRetry?.cancel()
+        // Input services can settle after the workspace wake itself. Recheck
+        // once so a tap disabled during that window never stays silent.
+        let retry = DispatchWorkItem { [weak self] in self?.recoverTapIfNeeded() }
+        wakeRetry = retry
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: retry)
+    }
+
+    private func recoverTapIfNeeded() {
+        guard AppFeature.switcher.isAvailable,
+              UserDefaults.standard.bool(forKey: DefaultsKey.switcherEnabled),
+              Permissions.shared.accessibility else { return }
+        let needsRecovery = lifecycleLock.withLock {
+            guard !shouldStopTapThread else { return false }
+            guard let tap else { return true }
+            return !CFMachPortIsValid(tap) || !CGEvent.tapIsEnabled(tap: tap)
+        }
+        guard needsRecovery else { return }
+        removeTap()
+        installTap()
     }
 
     private func installTap() {

--- a/Sources/Vorssaint/UI/Settings/AppBundleList.swift
+++ b/Sources/Vorssaint/UI/Settings/AppBundleList.swift
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import SwiftUI
+
+/// The "apps this feature treats differently" block four Settings pages carry:
+/// a disclosure row with a count, one line per app with its icon and a minus
+/// button, an add button that opens the app picker, and a caption underneath.
+///
+/// Those pages differ only in where the list is kept, what a row shows next to
+/// the name and which apps the picker offers, so that is what they pass in.
+/// It stays a single quiet row while nothing is listed and comes up open when
+/// the feature already has entries, so a page with several of these never
+/// turns into a wall of lists (issues #358, #423).
+struct AppBundleList<Accessory: View>: View {
+    let title: String
+    let caption: String
+    let addTitle: String
+    let removeLabel: String
+    /// The listed bundle identifiers in any order; rows are sorted by name.
+    let bundleIDs: [String]
+    /// Whether the picker reaches every app instead of only the installed
+    /// ones: it browses Applications and offers what is running as well.
+    let reachesEveryApp: Bool
+    let onAdd: (String) -> Void
+    let onRemove: (String) -> Void
+    let accessory: (String) -> Accessory
+
+    @State private var isExpanded: Bool
+    @State private var showingAppPicker = false
+
+    init(title: String,
+         caption: String,
+         addTitle: String,
+         removeLabel: String,
+         bundleIDs: [String],
+         reachesEveryApp: Bool = false,
+         onAdd: @escaping (String) -> Void,
+         onRemove: @escaping (String) -> Void,
+         @ViewBuilder accessory: @escaping (String) -> Accessory) {
+        self.title = title
+        self.caption = caption
+        self.addTitle = addTitle
+        self.removeLabel = removeLabel
+        self.bundleIDs = bundleIDs
+        self.reachesEveryApp = reachesEveryApp
+        self.onAdd = onAdd
+        self.onRemove = onRemove
+        self.accessory = accessory
+        _isExpanded = State(initialValue: !bundleIDs.isEmpty)
+    }
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            ForEach(sortedBundleIDs, id: \.self) { bundleID in
+                HStack(spacing: 9) {
+                    Image(nsImage: InstalledApps.icon(for: bundleID))
+                        .resizable()
+                        .frame(width: 18, height: 18)
+                    Text(InstalledApps.name(for: bundleID))
+                        .lineLimit(1)
+                    Spacer(minLength: 8)
+                    accessory(bundleID)
+                    Button {
+                        onRemove(bundleID)
+                    } label: {
+                        Image(systemName: "minus.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(removeLabel)
+                }
+            }
+
+            Button {
+                showingAppPicker = true
+            } label: {
+                Label(addTitle, systemImage: "plus")
+            }
+            .controlSize(.small)
+            // Rows inside a disclosure group center themselves; the button
+            // belongs under the list it adds to.
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text(caption)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } label: {
+            HStack {
+                Text(title)
+                Spacer()
+                if !bundleIDs.isEmpty {
+                    Text("\(bundleIDs.count)")
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
+        }
+        .sheet(isPresented: $showingAppPicker) {
+            appPickerSheet
+        }
+    }
+
+    private var sortedBundleIDs: [String] {
+        bundleIDs.sorted {
+            InstalledApps.name(for: $0).localizedCaseInsensitiveCompare(InstalledApps.name(for: $1))
+                == .orderedAscending
+        }
+    }
+
+    private var appPickerSheet: some View {
+        let listed = Set(bundleIDs)
+        return AppPickerView(canBrowseApplications: reachesEveryApp) {
+            showingAppPicker = false
+        } onSelect: { url in
+            // Closed first: a bundle without an identifier is nothing to add,
+            // but the sheet still did its job and has to go away.
+            showingAppPicker = false
+            guard let bundleID = Bundle(url: url)?.bundleIdentifier else { return }
+            onAdd(bundleID)
+        } loadApps: {
+            InstalledApps.installedBundleApplications(excluding: listed,
+                                                       includeRunningApplications: reachesEveryApp)
+        }
+    }
+}
+
+extension AppBundleList where Accessory == EmptyView {
+    init(title: String,
+         caption: String,
+         addTitle: String,
+         removeLabel: String,
+         bundleIDs: [String],
+         reachesEveryApp: Bool = false,
+         onAdd: @escaping (String) -> Void,
+         onRemove: @escaping (String) -> Void) {
+        self.init(title: title,
+                  caption: caption,
+                  addTitle: addTitle,
+                  removeLabel: removeLabel,
+                  bundleIDs: bundleIDs,
+                  reachesEveryApp: reachesEveryApp,
+                  onAdd: onAdd,
+                  onRemove: onRemove,
+                  accessory: { _ in EmptyView() })
+    }
+}

--- a/Sources/Vorssaint/UI/Settings/ClipboardIgnoredAppsList.swift
+++ b/Sources/Vorssaint/UI/Settings/ClipboardIgnoredAppsList.swift
@@ -10,85 +10,18 @@ import SwiftUI
 struct ClipboardIgnoredAppsList: View {
     @ObservedObject private var l10n = L10n.shared
     @ObservedObject private var ignored = ClipboardIgnoredApps.shared
-    @State private var isExpanded: Bool
-    @State private var showingAppPicker = false
-
-    init() {
-        _isExpanded = State(initialValue: !ClipboardIgnoredApps.shared.apps.isEmpty)
-    }
 
     private var text: ClipboardIgnoredAppsStrings {
         FeatureStrings.clipboardIgnoredApps(l10n.language)
     }
 
     var body: some View {
-        DisclosureGroup(isExpanded: $isExpanded) {
-            ForEach(sortedApps, id: \.self) { bundleID in
-                HStack(spacing: 9) {
-                    Image(nsImage: InstalledApps.icon(for: bundleID))
-                        .resizable()
-                        .frame(width: 18, height: 18)
-                    Text(InstalledApps.name(for: bundleID))
-                    Spacer()
-                    Button {
-                        ignored.remove(bundleID)
-                    } label: {
-                        Image(systemName: "minus.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(text.removeButton)
-                }
-            }
-
-            Button {
-                showingAppPicker = true
-            } label: {
-                Label(text.addButton, systemImage: "plus")
-            }
-            .controlSize(.small)
-            // Rows inside a disclosure group center themselves; the button
-            // belongs under the list it adds to.
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            Text(text.caption)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } label: {
-            HStack {
-                Text(text.listTitle)
-                Spacer()
-                if !sortedApps.isEmpty {
-                    Text("\(sortedApps.count)")
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
-            }
-        }
-        .sheet(isPresented: $showingAppPicker) {
-            appPickerSheet
-        }
-    }
-
-    private var sortedApps: [String] {
-        ignored.apps.sorted {
-            InstalledApps.name(for: $0).localizedCaseInsensitiveCompare(InstalledApps.name(for: $1))
-                == .orderedAscending
-        }
-    }
-
-    private var appPickerSheet: some View {
-        let listed = Set(ignored.apps)
-        return AppPickerView {
-            showingAppPicker = false
-        } onSelect: { url in
-            showingAppPicker = false
-            guard let bundleID = Bundle(url: url)?.bundleIdentifier else { return }
-            ignored.add(bundleID)
-        } loadApps: {
-            InstalledApps.installedBundleApplications(excluding: listed)
-        }
+        AppBundleList(title: text.listTitle,
+                      caption: text.caption,
+                      addTitle: text.addButton,
+                      removeLabel: text.removeButton,
+                      bundleIDs: ignored.apps,
+                      onAdd: { ignored.add($0) },
+                      onRemove: { ignored.remove($0) })
     }
 }

--- a/Sources/Vorssaint/UI/Settings/MouseExceptionsList.swift
+++ b/Sources/Vorssaint/UI/Settings/MouseExceptionsList.swift
@@ -7,94 +7,22 @@ import SwiftUI
 /// section in Settings (issue #358), right under the switch it holds back, so
 /// the list is where the user is already looking. One list per feature: the
 /// same view with a different scope.
-///
-/// It stays a single quiet row while nothing is listed, and comes up open when
-/// the feature already has exceptions, so a page with every mouse feature on
-/// never turns into a wall of lists.
 struct MouseExceptionsList: View {
     let scope: MouseExceptionScope
 
     @ObservedObject private var l10n = L10n.shared
     @ObservedObject private var exceptions = MouseAppExceptions.shared
-    @State private var isExpanded: Bool
-    @State private var showingAppPicker = false
-
-    init(scope: MouseExceptionScope) {
-        self.scope = scope
-        _isExpanded = State(initialValue: !MouseAppExceptions.shared.list(scope).isEmpty)
-    }
 
     private var text: MouseExceptionStrings { FeatureStrings.mouseExceptions(l10n.language) }
 
     var body: some View {
-        DisclosureGroup(isExpanded: $isExpanded) {
-            ForEach(sortedApps, id: \.self) { bundleID in
-                HStack(spacing: 9) {
-                    Image(nsImage: InstalledApps.icon(for: bundleID))
-                        .resizable()
-                        .frame(width: 18, height: 18)
-                    Text(InstalledApps.name(for: bundleID))
-                    Spacer()
-                    Button {
-                        exceptions.remove(bundleID, from: scope)
-                    } label: {
-                        Image(systemName: "minus.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(text.removeButton)
-                }
-            }
-
-            Button {
-                showingAppPicker = true
-            } label: {
-                Label(text.addButton, systemImage: "plus")
-            }
-            .controlSize(.small)
-            // Rows inside a disclosure group center themselves; the button
-            // belongs under the list it adds to.
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            Text(text.caption(for: scope))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } label: {
-            HStack {
-                Text(text.listTitle)
-                Spacer()
-                if !sortedApps.isEmpty {
-                    Text("\(sortedApps.count)")
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
-            }
-        }
-        .sheet(isPresented: $showingAppPicker) {
-            appPickerSheet
-        }
-    }
-
-    private var sortedApps: [String] {
-        exceptions.list(scope).sorted {
-            InstalledApps.name(for: $0).localizedCaseInsensitiveCompare(InstalledApps.name(for: $1))
-                == .orderedAscending
-        }
-    }
-
-    private var appPickerSheet: some View {
-        let listed = Set(exceptions.list(scope))
-        return AppPickerView(canBrowseApplications: true) {
-            showingAppPicker = false
-        } onSelect: { url in
-            guard let bundleID = Bundle(url: url)?.bundleIdentifier else { return }
-            exceptions.add(bundleID, to: scope)
-            showingAppPicker = false
-        } loadApps: {
-            InstalledApps.installedBundleApplications(excluding: listed,
-                                                       includeRunningApplications: true)
-        }
+        AppBundleList(title: text.listTitle,
+                      caption: text.caption(for: scope),
+                      addTitle: text.addButton,
+                      removeLabel: text.removeButton,
+                      bundleIDs: exceptions.list(scope),
+                      reachesEveryApp: true,
+                      onAdd: { exceptions.add($0, to: scope) },
+                      onRemove: { exceptions.remove($0, from: scope) })
     }
 }

--- a/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
@@ -130,6 +130,7 @@ enum SettingsDirectory {
                                                  FeatureStrings.quickToggles(language).pageTitle,
                                                  FeatureStrings.quickToggles(language).darkModeToDark,
                                                  FeatureStrings.quickToggles(language).emptyTrashTitle,
+                                                 FeatureStrings.brightness(language).keyboardLight,
                                                  FeatureStrings.cameraPreview(language).pageTitle,
                                                  FeatureStrings.scratchpad(language).pageTitle]),
                 SettingsDirectoryItem(page: .screenshot,

--- a/Sources/Vorssaint/UI/Settings/SwitcherAppRulesList.swift
+++ b/Sources/Vorssaint/UI/Settings/SwitcherAppRulesList.swift
@@ -5,105 +5,42 @@ import SwiftUI
 
 struct SwitcherAppRulesList: View {
     @ObservedObject private var l10n = L10n.shared
-    @State private var rules: [String: SwitcherAppRule]
-    @State private var isExpanded: Bool
-    @State private var showingAppPicker = false
-
-    init() {
-        let rules = Self.savedRules
-        _rules = State(initialValue: rules)
-        _isExpanded = State(initialValue: !rules.isEmpty)
-    }
+    @State private var rules: [String: SwitcherAppRule] = Self.savedRules
 
     private var text: SwitcherAppRulesStrings {
         FeatureStrings.switcherAppRules(l10n.language)
     }
 
     var body: some View {
-        DisclosureGroup(isExpanded: $isExpanded) {
-            ForEach(sortedBundleIDs, id: \.self) { bundleID in
-                HStack(spacing: 9) {
-                    Image(nsImage: InstalledApps.icon(for: bundleID))
-                        .resizable()
-                        .frame(width: 18, height: 18)
-                    Text(InstalledApps.name(for: bundleID))
-                        .lineLimit(1)
-                    Spacer(minLength: 8)
-                    Picker(text.behaviorLabel, selection: binding(for: bundleID)) {
-                        Text(text.showWithoutWindows).tag(SwitcherAppRule.showWithoutWindows)
-                        Text(text.windowsOnly).tag(SwitcherAppRule.windowsOnly)
-                        Text(text.hidden).tag(SwitcherAppRule.hidden)
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.menu)
-                    Button {
-                        var updated = rules
-                        updated.removeValue(forKey: bundleID)
-                        save(updated)
-                    } label: {
-                        Image(systemName: "minus.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(text.removeButton)
-                }
+        AppBundleList(title: text.listTitle,
+                      caption: text.caption,
+                      addTitle: text.addButton,
+                      removeLabel: text.removeButton,
+                      bundleIDs: Array(rules.keys),
+                      reachesEveryApp: true,
+                      onAdd: { bundleID in
+                          var updated = rules
+                          updated[bundleID] = .showWithoutWindows
+                          save(updated)
+                      },
+                      onRemove: { bundleID in
+                          var updated = rules
+                          updated.removeValue(forKey: bundleID)
+                          save(updated)
+                      }) { bundleID in
+            Picker(text.behaviorLabel, selection: binding(for: bundleID)) {
+                Text(text.showWithoutWindows).tag(SwitcherAppRule.showWithoutWindows)
+                Text(text.windowsOnly).tag(SwitcherAppRule.windowsOnly)
+                Text(text.hidden).tag(SwitcherAppRule.hidden)
             }
-
-            Button {
-                showingAppPicker = true
-            } label: {
-                Label(text.addButton, systemImage: "plus")
-            }
-            .controlSize(.small)
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            Text(text.caption)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } label: {
-            HStack {
-                Text(text.listTitle)
-                Spacer()
-                if !rules.isEmpty {
-                    Text("\(rules.count)")
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
-            }
-        }
-        .sheet(isPresented: $showingAppPicker) {
-            appPickerSheet
+            .labelsHidden()
+            .pickerStyle(.menu)
         }
     }
 
     private static var savedRules: [String: SwitcherAppRule] {
         SwitcherAppRule.rules(
             storedValue: UserDefaults.standard.dictionary(forKey: DefaultsKey.switcherAppRules))
-    }
-
-    private var sortedBundleIDs: [String] {
-        rules.keys.sorted {
-            InstalledApps.name(for: $0).localizedCaseInsensitiveCompare(InstalledApps.name(for: $1))
-                == .orderedAscending
-        }
-    }
-
-    private var appPickerSheet: some View {
-        let listed = Set(rules.keys)
-        return AppPickerView(canBrowseApplications: true) {
-            showingAppPicker = false
-        } onSelect: { url in
-            guard let bundleID = Bundle(url: url)?.bundleIdentifier else { return }
-            var updated = rules
-            updated[bundleID] = .showWithoutWindows
-            save(updated)
-            showingAppPicker = false
-        } loadApps: {
-            InstalledApps.installedBundleApplications(excluding: listed,
-                                                       includeRunningApplications: true)
-        }
     }
 
     private func binding(for bundleID: String) -> Binding<SwitcherAppRule> {

--- a/Sources/Vorssaint/UI/Settings/WindowPreviewExclusionsList.swift
+++ b/Sources/Vorssaint/UI/Settings/WindowPreviewExclusionsList.swift
@@ -5,92 +5,25 @@ import SwiftUI
 
 struct WindowPreviewExclusionsList: View {
     @ObservedObject private var l10n = L10n.shared
-    @State private var apps: [String]
-    @State private var isExpanded: Bool
-    @State private var showingAppPicker = false
-
-    init() {
-        let apps = Self.savedApps
-        _apps = State(initialValue: apps)
-        _isExpanded = State(initialValue: !apps.isEmpty)
-    }
+    @State private var apps: [String] = Self.savedApps
 
     private var text: WindowPreviewExclusionStrings {
         FeatureStrings.windowPreviewExclusions(l10n.language)
     }
 
     var body: some View {
-        DisclosureGroup(isExpanded: $isExpanded) {
-            ForEach(sortedApps, id: \.self) { bundleID in
-                HStack(spacing: 9) {
-                    Image(nsImage: InstalledApps.icon(for: bundleID))
-                        .resizable()
-                        .frame(width: 18, height: 18)
-                    Text(InstalledApps.name(for: bundleID))
-                    Spacer()
-                    Button {
-                        save(apps.filter { $0 != bundleID })
-                    } label: {
-                        Image(systemName: "minus.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(text.removeButton)
-                }
-            }
-
-            Button {
-                showingAppPicker = true
-            } label: {
-                Label(text.addButton, systemImage: "plus")
-            }
-            .controlSize(.small)
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            Text(text.caption)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } label: {
-            HStack {
-                Text(text.listTitle)
-                Spacer()
-                if !sortedApps.isEmpty {
-                    Text("\(sortedApps.count)")
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
-            }
-        }
-        .sheet(isPresented: $showingAppPicker) {
-            appPickerSheet
-        }
+        AppBundleList(title: text.listTitle,
+                      caption: text.caption,
+                      addTitle: text.addButton,
+                      removeLabel: text.removeButton,
+                      bundleIDs: apps,
+                      onAdd: { save(apps + [$0]) },
+                      onRemove: { bundleID in save(apps.filter { $0 != bundleID }) })
     }
 
     private static var savedApps: [String] {
         Defaults.sanitizedBundleIdentifierList(
             UserDefaults.standard.stringArray(forKey: DefaultsKey.windowPreviewExcludedApps) ?? [])
-    }
-
-    private var sortedApps: [String] {
-        apps.sorted {
-            InstalledApps.name(for: $0).localizedCaseInsensitiveCompare(InstalledApps.name(for: $1))
-                == .orderedAscending
-        }
-    }
-
-    private var appPickerSheet: some View {
-        let listed = Set(apps)
-        return AppPickerView {
-            showingAppPicker = false
-        } onSelect: { url in
-            showingAppPicker = false
-            guard let bundleID = Bundle(url: url)?.bundleIdentifier else { return }
-            save(apps + [bundleID])
-        } loadApps: {
-            InstalledApps.installedBundleApplications(excluding: listed)
-        }
     }
 
     private func save(_ bundleIDs: [String]) {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9491,6 +9491,20 @@ struct MetricsTests {
                                                        fromCenter: true)
         expect(centered == CGRect(x: 30, y: 40, width: 40, height: 20),
                "option grows the selection from the center")
+        let cropBounds = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let cropDraft = CGRect(x: 120, y: 90, width: 400, height: 300)
+        expect(ScreenshotSupport.startsNewCropSelection(
+                    at: CGPoint(x: 300, y: 250), draft: cropBounds, within: cropBounds),
+               "dragging inside the initial full-image crop starts a new selection")
+        expect(!ScreenshotSupport.startsNewCropSelection(
+                    at: CGPoint(x: 300, y: 250), draft: cropDraft, within: cropBounds),
+               "dragging inside an adjusted crop keeps moving it")
+        expect(ScreenshotSupport.startsNewCropSelection(
+                    at: CGPoint(x: 700, y: 500), draft: cropDraft, within: cropBounds),
+               "dragging elsewhere in the image replaces an adjusted crop")
+        expect(!ScreenshotSupport.startsNewCropSelection(
+                    at: CGPoint(x: 900, y: 700), draft: cropDraft, within: cropBounds),
+               "a drag outside the image cannot start a crop")
         expect(ScreenshotSupport.isClick(from: CGPoint(x: 5, y: 5), to: CGPoint(x: 7, y: 8))
                 && !ScreenshotSupport.isClick(from: .zero, to: CGPoint(x: 12, y: 0)),
                "a tiny drag is a click, a real drag is not")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -273,9 +273,16 @@ struct MetricsTests {
                "clipboard editing preserves intentional outer spacing")
         expect(ClipboardHistoryEditing.storableText(" \n\t ") == nil,
                "clipboard editing rejects an empty text item")
+        let largeClipboardText = String(repeating: "long copied text ", count: 10_000)
+        expect(ClipboardHistoryEditing.storableText(largeClipboardText) == largeClipboardText,
+               "clipboard history keeps copied documents larger than the old short-text bound")
         expect(ClipboardHistoryEditing.storableText(
             String(repeating: "a", count: ClipboardHistoryEditing.maxCharacters + 1)) == nil,
                "clipboard editing keeps the history text size bound")
+        let largeClipboardPreview = ClipboardHistoryEntry(text: largeClipboardText).preview
+        expect(largeClipboardPreview.hasSuffix("…")
+                && largeClipboardPreview.count <= ClipboardHistoryEditing.previewCharacters + 1,
+               "clipboard rows keep very large text previews bounded")
         let previewID = UUID(uuidString: "00000000-0000-0000-0000-000000000101")!
         let nextPreviewID = UUID(uuidString: "00000000-0000-0000-0000-000000000102")!
         let updatedPreview = ClipboardHistoryEntry(id: previewID, text: "updated")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11175,6 +11175,22 @@ struct MetricsTests {
         expect(AppUpdatesSupport.tokens(in: mergedRows, selection: []).isEmpty
                 && !AppUpdatesSupport.hasStoreSelection(in: mergedRows, selection: []),
                "an empty selection asks for nothing")
+        expect(AppUpdatesSupport.singleStorePage(in: mergedRows, selection: everything)
+                == "https://apps.apple.com/app",
+               "one ticked store row hands off to its own page, where its own button goes")
+        let secondStoreRow = AppUpdatesSupport.Item(id: "store:com.example.notes",
+                                                    source: .appStore,
+                                                    name: "Notes",
+                                                    installedVersion: "1.0",
+                                                    latestVersion: "2.0",
+                                                    token: nil,
+                                                    bundlePath: nil,
+                                                    storePage: "https://apps.apple.com/notes")
+        let twoStoreRows = mergedRows + [secondStoreRow]
+        expect(AppUpdatesSupport.singleStorePage(in: twoStoreRows,
+                                                 selection: Set(twoStoreRows.map(\.id))) == nil
+                && AppUpdatesSupport.singleStorePage(in: mergedRows, selection: []) == nil,
+               "two store rows, or none, have no single page to land on")
 
         let keptSelection = AppUpdatesSupport.reconciledSelection(
             previous: [mergedRows[0].id, "gone:row"],


### PR DESCRIPTION
A store row's own button opens that app's product page (`trackViewUrl`, `AppUpdatesSupport.swift:244`). The **Update N** button never uses it: for any store selection it opens `macappstore://showUpdatesPage` (`AppUpdatesService.swift:346`). Same row, two buttons, two destinations — and when the store does not count that app among its updates, the batch one lands on a page with nothing on it, which reads as "Vorssaint made the update up" even when the product page has a real UPDATE button.

### The change

`AppUpdatesSupport.singleStorePage(in:selection:)` returns the page when the ticked rows contain exactly one store row, and `updateSelected()` hands off to it. Package rows are untouched — the same call still upgrades them in place first.

After: with one store row ticked, **Update N** and that row's own button land on the same product page.

### Trade-offs

- **Why only a single row.** The App Store shows one product at a time. With two or more store rows ticked there is no page that covers them, so the updates page stays the honest destination.
- **Opening every ticked page in turn** was the alternative: the store navigates to whichever URL arrives last, so it would look like the app picked one at random.
- **Dropping the updates-page fallback** was considered and rejected. It is the right destination for several rows, and the only one for a row whose lookup came back without a `trackViewUrl`.

### Not changed

How rows are found, how the store is queried, what the row buttons do, and the hand-off itself (`storeHandoffPending` still re-reads the list when the person comes back). No new strings.

### Tests

`./build.sh --test` 7091 checks OK (+2 pinning the one-row page and the none/two-rows fallback); `./build.sh` clean and `--selftest` OK.
