### PR TITLE
Share one app list view across four Settings pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ All notable changes to this project are documented here. The format follows
 
 ### Summary
 Vorssaint 3.3.2 improves app discovery in the Command Bar, recording, Switcher,
-screenshot editing, clipboard history, screen text recognition, Window Layout, Cleaning Mode, Scratchpad, audio and display safety. It also refines app
-management, feedback, feature setup, Fan Control, Quit on close, network monitoring, power
-and peripheral battery readings, panel behavior and keyboard controls.
+screenshot editing, clipboard history, screen text recognition, Window Layout,
+Cleaning Mode, Scratchpad, audio and display safety. It also standardizes app
+lists in Settings and refines feedback, feature setup, Fan Control, Quit on close,
+network monitoring, power, peripheral battery readings, panel behavior and keyboard controls.
 
 ### Added
 - Emoji can open directly from a shortcut assigned to its Command Bar row.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and peripheral battery readings, panel behavior and keyboard controls.
   nothing reads them there. Thanks to @PathGao.
 - Showing Clipboard in the panel now sits on its own in Settings, since it keeps
   working while history capture is off. Thanks to @PathGao.
+- App lists in Settings now keep names on one line and align their add controls
+  consistently. Thanks to @PathGao.
 - The Command Bar now accepts Control-P and Control-N to move through results.
   Thanks to @theafox.
 

--- a/Sources/Vorssaint/UI/Settings/AppBundleList.swift
+++ b/Sources/Vorssaint/UI/Settings/AppBundleList.swift
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import SwiftUI
+
+/// The "apps this feature treats differently" block four Settings pages carry:
+/// a disclosure row with a count, one line per app with its icon and a minus
+/// button, an add button that opens the app picker, and a caption underneath.
+///
+/// Those pages differ only in where the list is kept, what a row shows next to
+/// the name and which apps the picker offers, so that is what they pass in.
+/// It stays a single quiet row while nothing is listed and comes up open when
+/// the feature already has entries, so a page with several of these never
+/// turns into a wall of lists (issues #358, #423).
+struct AppBundleList<Accessory: View>: View {
+    let title: String
+    let caption: String
+    let addTitle: String
+    let removeLabel: String
+    /// The listed bundle identifiers in any order; rows are sorted by name.
+    let bundleIDs: [String]
+    /// Whether the picker reaches every app instead of only the installed
+    /// ones: it browses Applications and offers what is running as well.
+    let reachesEveryApp: Bool
+    let onAdd: (String) -> Void
+    let onRemove: (String) -> Void
+    let accessory: (String) -> Accessory
+
+    @State private var isExpanded: Bool
+    @State private var showingAppPicker = false
+
+    init(title: String,
+         caption: String,
+         addTitle: String,
+         removeLabel: String,
+         bundleIDs: [String],
+         reachesEveryApp: Bool = false,
+         onAdd: @escaping (String) -> Void,
+         onRemove: @escaping (String) -> Void,
+         @ViewBuilder accessory: @escaping (String) -> Accessory) {
+        self.title = title
+        self.caption = caption
+        self.addTitle = addTitle
+        self.removeLabel = removeLabel
+        self.bundleIDs = bundleIDs
+        self.reachesEveryApp = reachesEveryApp
+        self.onAdd = onAdd
+        self.onRemove = onRemove
+        self.accessory = accessory
+        _isExpanded = State(initialValue: !bundleIDs.isEmpty)
+    }
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            ForEach(sortedBundleIDs, id: \.self) { bundleID in
+                HStack(spacing: 9) {
+                    Image(nsImage: InstalledApps.icon(for: bundleID))
+                        .resizable()
+                        .frame(width: 18, height: 18)
+                    Text(InstalledApps.name(for: bundleID))
+                        .lineLimit(1)
+                    Spacer(minLength: 8)
+                    accessory(bundleID)
+                    Button {
+                        onRemove(bundleID)
+                    } label: {
+                        Image(systemName: "minus.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(removeLabel)
+                }
+            }
+
+            Button {
+                showingAppPicker = true
+            } label: {
+                Label(addTitle, systemImage: "plus")
+            }
+            .controlSize(.small)
+            // Rows inside a disclosure group center themselves; the button
+            // belongs under the list it adds to.
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text(caption)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } label: {
+            HStack {
+                Text(title)
+                Spacer()
+                if !bundleIDs.isEmpty {
+                    Text("\(bundleIDs.count)")
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
+        }
+        .sheet(isPresented: $showingAppPicker) {
+            appPickerSheet
+        }
+    }
+
+    private var sortedBundleIDs: [String] {
+        bundleIDs.sorted {
+            InstalledApps.name(for: $0).localizedCaseInsensitiveCompare(InstalledApps.name(for: $1))
+                == .orderedAscending
+        }
+    }
+
+    private var appPickerSheet: some View {
+        let listed = Set(bundleIDs)
+        return AppPickerView(canBrowseApplications: reachesEveryApp) {
+            showingAppPicker = false
+        } onSelect: { url in
+            // Closed first: a bundle without an identifier is nothing to add,
+            // but the sheet still did its job and has to go away.
+            showingAppPicker = false
+            guard let bundleID = Bundle(url: url)?.bundleIdentifier else { return }
+            onAdd(bundleID)
+        } loadApps: {
+            InstalledApps.installedBundleApplications(excluding: listed,
+                                                       includeRunningApplications: reachesEveryApp)
+        }
+    }
+}
+
+extension AppBundleList where Accessory == EmptyView {
+    init(title: String,
+         caption: String,
+         addTitle: String,
+         removeLabel: String,
+         bundleIDs: [String],
+         reachesEveryApp: Bool = false,
+         onAdd: @escaping (String) -> Void,
+         onRemove: @escaping (String) -> Void) {
+        self.init(title: title,
+                  caption: caption,
+                  addTitle: addTitle,
+                  removeLabel: removeLabel,
+                  bundleIDs: bundleIDs,
+                  reachesEveryApp: reachesEveryApp,
+                  onAdd: onAdd,
+                  onRemove: onRemove,
+                  accessory: { _ in EmptyView() })
+    }
+}

--- a/Sources/Vorssaint/UI/Settings/ClipboardIgnoredAppsList.swift
+++ b/Sources/Vorssaint/UI/Settings/ClipboardIgnoredAppsList.swift
@@ -10,85 +10,18 @@ import SwiftUI
 struct ClipboardIgnoredAppsList: View {
     @ObservedObject private var l10n = L10n.shared
     @ObservedObject private var ignored = ClipboardIgnoredApps.shared
-    @State private var isExpanded: Bool
-    @State private var showingAppPicker = false
-
-    init() {
-        _isExpanded = State(initialValue: !ClipboardIgnoredApps.shared.apps.isEmpty)
-    }
 
     private var text: ClipboardIgnoredAppsStrings {
         FeatureStrings.clipboardIgnoredApps(l10n.language)
     }
 
     var body: some View {
-        DisclosureGroup(isExpanded: $isExpanded) {
-            ForEach(sortedApps, id: \.self) { bundleID in
-                HStack(spacing: 9) {
-                    Image(nsImage: InstalledApps.icon(for: bundleID))
-                        .resizable()
-                        .frame(width: 18, height: 18)
-                    Text(InstalledApps.name(for: bundleID))
-                    Spacer()
-                    Button {
-                        ignored.remove(bundleID)
-                    } label: {
-                        Image(systemName: "minus.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(text.removeButton)
-                }
-            }
-
-            Button {
-                showingAppPicker = true
-            } label: {
-                Label(text.addButton, systemImage: "plus")
-            }
-            .controlSize(.small)
-            // Rows inside a disclosure group center themselves; the button
-            // belongs under the list it adds to.
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            Text(text.caption)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } label: {
-            HStack {
-                Text(text.listTitle)
-                Spacer()
-                if !sortedApps.isEmpty {
-                    Text("\(sortedApps.count)")
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
-            }
-        }
-        .sheet(isPresented: $showingAppPicker) {
-            appPickerSheet
-        }
-    }
-
-    private var sortedApps: [String] {
-        ignored.apps.sorted {
-            InstalledApps.name(for: $0).localizedCaseInsensitiveCompare(InstalledApps.name(for: $1))
-                == .orderedAscending
-        }
-    }
-
-    private var appPickerSheet: some View {
-        let listed = Set(ignored.apps)
-        return AppPickerView {
-            showingAppPicker = false
-        } onSelect: { url in
-            showingAppPicker = false
-            guard let bundleID = Bundle(url: url)?.bundleIdentifier else { return }
-            ignored.add(bundleID)
-        } loadApps: {
-            InstalledApps.installedBundleApplications(excluding: listed)
-        }
+        AppBundleList(title: text.listTitle,
+                      caption: text.caption,
+                      addTitle: text.addButton,
+                      removeLabel: text.removeButton,
+                      bundleIDs: ignored.apps,
+                      onAdd: { ignored.add($0) },
+                      onRemove: { ignored.remove($0) })
     }
 }

--- a/Sources/Vorssaint/UI/Settings/MouseExceptionsList.swift
+++ b/Sources/Vorssaint/UI/Settings/MouseExceptionsList.swift
@@ -7,94 +7,22 @@ import SwiftUI
 /// section in Settings (issue #358), right under the switch it holds back, so
 /// the list is where the user is already looking. One list per feature: the
 /// same view with a different scope.
-///
-/// It stays a single quiet row while nothing is listed, and comes up open when
-/// the feature already has exceptions, so a page with every mouse feature on
-/// never turns into a wall of lists.
 struct MouseExceptionsList: View {
     let scope: MouseExceptionScope
 
     @ObservedObject private var l10n = L10n.shared
     @ObservedObject private var exceptions = MouseAppExceptions.shared
-    @State private var isExpanded: Bool
-    @State private var showingAppPicker = false
-
-    init(scope: MouseExceptionScope) {
-        self.scope = scope
-        _isExpanded = State(initialValue: !MouseAppExceptions.shared.list(scope).isEmpty)
-    }
 
     private var text: MouseExceptionStrings { FeatureStrings.mouseExceptions(l10n.language) }
 
     var body: some View {
-        DisclosureGroup(isExpanded: $isExpanded) {
-            ForEach(sortedApps, id: \.self) { bundleID in
-                HStack(spacing: 9) {
-                    Image(nsImage: InstalledApps.icon(for: bundleID))
-                        .resizable()
-                        .frame(width: 18, height: 18)
-                    Text(InstalledApps.name(for: bundleID))
-                    Spacer()
-                    Button {
-                        exceptions.remove(bundleID, from: scope)
-                    } label: {
-                        Image(systemName: "minus.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(text.removeButton)
-                }
-            }
-
-            Button {
-                showingAppPicker = true
-            } label: {
-                Label(text.addButton, systemImage: "plus")
-            }
-            .controlSize(.small)
-            // Rows inside a disclosure group center themselves; the button
-            // belongs under the list it adds to.
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            Text(text.caption(for: scope))
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } label: {
-            HStack {
-                Text(text.listTitle)
-                Spacer()
-                if !sortedApps.isEmpty {
-                    Text("\(sortedApps.count)")
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
-            }
-        }
-        .sheet(isPresented: $showingAppPicker) {
-            appPickerSheet
-        }
-    }
-
-    private var sortedApps: [String] {
-        exceptions.list(scope).sorted {
-            InstalledApps.name(for: $0).localizedCaseInsensitiveCompare(InstalledApps.name(for: $1))
-                == .orderedAscending
-        }
-    }
-
-    private var appPickerSheet: some View {
-        let listed = Set(exceptions.list(scope))
-        return AppPickerView(canBrowseApplications: true) {
-            showingAppPicker = false
-        } onSelect: { url in
-            guard let bundleID = Bundle(url: url)?.bundleIdentifier else { return }
-            exceptions.add(bundleID, to: scope)
-            showingAppPicker = false
-        } loadApps: {
-            InstalledApps.installedBundleApplications(excluding: listed,
-                                                       includeRunningApplications: true)
-        }
+        AppBundleList(title: text.listTitle,
+                      caption: text.caption(for: scope),
+                      addTitle: text.addButton,
+                      removeLabel: text.removeButton,
+                      bundleIDs: exceptions.list(scope),
+                      reachesEveryApp: true,
+                      onAdd: { exceptions.add($0, to: scope) },
+                      onRemove: { exceptions.remove($0, from: scope) })
     }
 }

--- a/Sources/Vorssaint/UI/Settings/SwitcherAppRulesList.swift
+++ b/Sources/Vorssaint/UI/Settings/SwitcherAppRulesList.swift
@@ -5,105 +5,42 @@ import SwiftUI
 
 struct SwitcherAppRulesList: View {
     @ObservedObject private var l10n = L10n.shared
-    @State private var rules: [String: SwitcherAppRule]
-    @State private var isExpanded: Bool
-    @State private var showingAppPicker = false
-
-    init() {
-        let rules = Self.savedRules
-        _rules = State(initialValue: rules)
-        _isExpanded = State(initialValue: !rules.isEmpty)
-    }
+    @State private var rules: [String: SwitcherAppRule] = Self.savedRules
 
     private var text: SwitcherAppRulesStrings {
         FeatureStrings.switcherAppRules(l10n.language)
     }
 
     var body: some View {
-        DisclosureGroup(isExpanded: $isExpanded) {
-            ForEach(sortedBundleIDs, id: \.self) { bundleID in
-                HStack(spacing: 9) {
-                    Image(nsImage: InstalledApps.icon(for: bundleID))
-                        .resizable()
-                        .frame(width: 18, height: 18)
-                    Text(InstalledApps.name(for: bundleID))
-                        .lineLimit(1)
-                    Spacer(minLength: 8)
-                    Picker(text.behaviorLabel, selection: binding(for: bundleID)) {
-                        Text(text.showWithoutWindows).tag(SwitcherAppRule.showWithoutWindows)
-                        Text(text.windowsOnly).tag(SwitcherAppRule.windowsOnly)
-                        Text(text.hidden).tag(SwitcherAppRule.hidden)
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.menu)
-                    Button {
-                        var updated = rules
-                        updated.removeValue(forKey: bundleID)
-                        save(updated)
-                    } label: {
-                        Image(systemName: "minus.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(text.removeButton)
-                }
+        AppBundleList(title: text.listTitle,
+                      caption: text.caption,
+                      addTitle: text.addButton,
+                      removeLabel: text.removeButton,
+                      bundleIDs: Array(rules.keys),
+                      reachesEveryApp: true,
+                      onAdd: { bundleID in
+                          var updated = rules
+                          updated[bundleID] = .showWithoutWindows
+                          save(updated)
+                      },
+                      onRemove: { bundleID in
+                          var updated = rules
+                          updated.removeValue(forKey: bundleID)
+                          save(updated)
+                      }) { bundleID in
+            Picker(text.behaviorLabel, selection: binding(for: bundleID)) {
+                Text(text.showWithoutWindows).tag(SwitcherAppRule.showWithoutWindows)
+                Text(text.windowsOnly).tag(SwitcherAppRule.windowsOnly)
+                Text(text.hidden).tag(SwitcherAppRule.hidden)
             }
-
-            Button {
-                showingAppPicker = true
-            } label: {
-                Label(text.addButton, systemImage: "plus")
-            }
-            .controlSize(.small)
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            Text(text.caption)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } label: {
-            HStack {
-                Text(text.listTitle)
-                Spacer()
-                if !rules.isEmpty {
-                    Text("\(rules.count)")
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
-            }
-        }
-        .sheet(isPresented: $showingAppPicker) {
-            appPickerSheet
+            .labelsHidden()
+            .pickerStyle(.menu)
         }
     }
 
     private static var savedRules: [String: SwitcherAppRule] {
         SwitcherAppRule.rules(
             storedValue: UserDefaults.standard.dictionary(forKey: DefaultsKey.switcherAppRules))
-    }
-
-    private var sortedBundleIDs: [String] {
-        rules.keys.sorted {
-            InstalledApps.name(for: $0).localizedCaseInsensitiveCompare(InstalledApps.name(for: $1))
-                == .orderedAscending
-        }
-    }
-
-    private var appPickerSheet: some View {
-        let listed = Set(rules.keys)
-        return AppPickerView(canBrowseApplications: true) {
-            showingAppPicker = false
-        } onSelect: { url in
-            guard let bundleID = Bundle(url: url)?.bundleIdentifier else { return }
-            var updated = rules
-            updated[bundleID] = .showWithoutWindows
-            save(updated)
-            showingAppPicker = false
-        } loadApps: {
-            InstalledApps.installedBundleApplications(excluding: listed,
-                                                       includeRunningApplications: true)
-        }
     }
 
     private func binding(for bundleID: String) -> Binding<SwitcherAppRule> {

--- a/Sources/Vorssaint/UI/Settings/WindowPreviewExclusionsList.swift
+++ b/Sources/Vorssaint/UI/Settings/WindowPreviewExclusionsList.swift
@@ -5,92 +5,25 @@ import SwiftUI
 
 struct WindowPreviewExclusionsList: View {
     @ObservedObject private var l10n = L10n.shared
-    @State private var apps: [String]
-    @State private var isExpanded: Bool
-    @State private var showingAppPicker = false
-
-    init() {
-        let apps = Self.savedApps
-        _apps = State(initialValue: apps)
-        _isExpanded = State(initialValue: !apps.isEmpty)
-    }
+    @State private var apps: [String] = Self.savedApps
 
     private var text: WindowPreviewExclusionStrings {
         FeatureStrings.windowPreviewExclusions(l10n.language)
     }
 
     var body: some View {
-        DisclosureGroup(isExpanded: $isExpanded) {
-            ForEach(sortedApps, id: \.self) { bundleID in
-                HStack(spacing: 9) {
-                    Image(nsImage: InstalledApps.icon(for: bundleID))
-                        .resizable()
-                        .frame(width: 18, height: 18)
-                    Text(InstalledApps.name(for: bundleID))
-                    Spacer()
-                    Button {
-                        save(apps.filter { $0 != bundleID })
-                    } label: {
-                        Image(systemName: "minus.circle.fill")
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(text.removeButton)
-                }
-            }
-
-            Button {
-                showingAppPicker = true
-            } label: {
-                Label(text.addButton, systemImage: "plus")
-            }
-            .controlSize(.small)
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            Text(text.caption)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        } label: {
-            HStack {
-                Text(text.listTitle)
-                Spacer()
-                if !sortedApps.isEmpty {
-                    Text("\(sortedApps.count)")
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
-            }
-        }
-        .sheet(isPresented: $showingAppPicker) {
-            appPickerSheet
-        }
+        AppBundleList(title: text.listTitle,
+                      caption: text.caption,
+                      addTitle: text.addButton,
+                      removeLabel: text.removeButton,
+                      bundleIDs: apps,
+                      onAdd: { save(apps + [$0]) },
+                      onRemove: { bundleID in save(apps.filter { $0 != bundleID }) })
     }
 
     private static var savedApps: [String] {
         Defaults.sanitizedBundleIdentifierList(
             UserDefaults.standard.stringArray(forKey: DefaultsKey.windowPreviewExcludedApps) ?? [])
-    }
-
-    private var sortedApps: [String] {
-        apps.sorted {
-            InstalledApps.name(for: $0).localizedCaseInsensitiveCompare(InstalledApps.name(for: $1))
-                == .orderedAscending
-        }
-    }
-
-    private var appPickerSheet: some View {
-        let listed = Set(apps)
-        return AppPickerView {
-            showingAppPicker = false
-        } onSelect: { url in
-            showingAppPicker = false
-            guard let bundleID = Bundle(url: url)?.bundleIdentifier else { return }
-            save(apps + [bundleID])
-        } loadApps: {
-            InstalledApps.installedBundleApplications(excluding: listed)
-        }
     }
 
     private func save(_ bundleIDs: [String]) {


### PR DESCRIPTION
Four Settings pages draw the same block by hand: a `DisclosureGroup` with a count on the right, one row per app (18pt icon, name, `minus.circle.fill`), a small **Add** button, a caption, and an `AppPickerView` sheet that adds by bundle identifier. `ClipboardIgnoredAppsList`, `WindowPreviewExclusionsList`, `MouseExceptionsList` and `SwitcherAppRulesList` differ only in where the list is stored, what a row shows next to the name, and which apps the picker offers — everything else is copied, including the "rows centre themselves, the button belongs under the list" fix, which lives in two of the four and was silently missing from the other two.

### The change

`AppBundleList` takes the four strings, the bundle identifiers, `reachesEveryApp`, `onAdd`/`onRemove`, and an optional per-row accessory view. The four pages keep their own state and become their storage plus one call. Net −120 lines.

- Sorting by display name moves into the shell (it was four identical closures).
- Each page keeps its `@ObservedObject`/`@State`, so nothing changes about when a list refreshes or where it is persisted.
- `SwitcherAppRulesList` passes its behaviour `Picker` as the accessory; the other three use the `EmptyView` overload.

### Two deliberate behaviour changes, both toward the better of the copies

- The app name now truncates instead of wrapping on all four (`SwitcherAppRulesList` already did).
- Picking an app whose bundle has no identifier now closes the sheet on all four. Clipboard and Window preview already did; Mouse and Switcher guarded first and left the sheet open with no feedback.

### Trade-offs

- **`reachesEveryApp` is one flag, not two.** `canBrowseApplications` and `includeRunningApplications` are always set together (both on for Mouse and Switcher, both off for the other two) and answer the same question — may the picker reach an app the scan did not list. Split them the moment a page needs one without the other.
- **The accessory is a generic parameter, not `AnyView`.** One extra generic on the type, no type erasure at the call sites; without it `SwitcherAppRulesList` stays a fourth copy and the next list becomes a fifth.
- **`isExpanded` still starts open when the list is non-empty**, computed once in the shell's `init` exactly as each page did.

### Not changed

No behaviour of any feature, no persistence format, no strings (every page keeps its own `FeatureStrings`), and `AppPickerView` itself. `SwitcherAppRulesList`'s picker options, defaults and `SwitcherAppRule` storage are untouched.

### Tests

`./build.sh` clean, `--selftest` OK, `./build.sh --test` 7089 checks OK (unchanged — these views are SwiftUI only and no test covered them before). Not verified on screen: I could not run the four pages side by side against a build of `main`, so the layout claims rest on the diff, which is why the two changes above are called out rather than folded in silently.
