### PR TITLE
Let Settings search find the keyboard light toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project are documented here. The format follows
 
 ### Summary
 Vorssaint 3.3.2 improves app discovery in the Command Bar, recording, Switcher,
-screenshots, clipboard history, screen text recognition, Window Layout, Cleaning Mode, Scratchpad, audio and display safety. It also refines app
+screenshot editing, clipboard history, screen text recognition, Window Layout, Cleaning Mode, Scratchpad, audio and display safety. It also refines app
 management, feedback, feature setup, Fan Control, Quit on close, network monitoring, power
 and peripheral battery readings, panel behavior and keyboard controls.
 
@@ -31,6 +31,7 @@ and peripheral battery readings, panel behavior and keyboard controls.
   Thanks to @theafox.
 
 ### Fixed
+- The screenshot editor now lets you draw a new crop directly over the image.
 - Clipboard history now keeps large copied documents instead of silently
   dropping text after 20,000 characters.
 - Window Layout now centers fixed-size windows and stops pending placements from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and peripheral battery readings, panel behavior and keyboard controls.
   Thanks to @PathGao.
 - The App Switcher now shows its configured shortcut in the large icon mode label.
   Thanks to @liuxxxu.
+- The App Switcher now keeps its shortcut working after your Mac wakes from sleep.
 - The App Switcher now restores minimized windows when selected.
 - The app no longer quits while typing when the Switcher's Windows shortcut uses a
   key whose label comes from the keyboard layout. Thanks to @eioz.

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift
@@ -118,6 +118,7 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
     private var activeHandle: ScreenshotSupport.Handle?
     private var cropResizeOrigin: CGRect?
     private var cropMoveOrigin: CGRect?
+    private var cropSelectionOrigin: CGRect?
     private var dragRegistered = false
     private var editingSelectedAnnotation = false
     private var newTextID: UUID?
@@ -478,12 +479,17 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
         case .select:
             beginSelectDrag(at: point)
         case .crop:
+            let bounds = CGRect(origin: .zero, size: imageSize)
             if let draft = cropDraft,
                let handle = ScreenshotSupport.handle(at: point, rect: draft,
                                                      tolerance: 14 * scale) {
                 activeHandle = handle
                 cropResizeOrigin = draft
                 cropLoupePoint = handle.position(in: draft)
+            } else if let draft = cropDraft,
+                      ScreenshotSupport.startsNewCropSelection(
+                        at: point, draft: draft, within: bounds) {
+                cropSelectionOrigin = draft
             } else if let draft = cropDraft, draft.contains(point) {
                 cropMoveOrigin = draft
             }
@@ -571,6 +577,10 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
                 let clamped = ScreenshotSupport.clamp(rect, to: bounds)
                 cropDraft = clamped
                 cropLoupePoint = handle.position(in: clamped)
+            } else if cropSelectionOrigin != nil {
+                cropDraft = ScreenshotSupport.clamp(
+                    ScreenshotSupport.selectionRect(from: dragStart, to: point),
+                    to: bounds)
             } else if let origin = cropMoveOrigin {
                 let delta = CGPoint(x: point.x - dragStart.x, y: point.y - dragStart.y)
                 cropDraft = ScreenshotSupport.movedRect(origin, by: delta, within: bounds)
@@ -629,6 +639,7 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
             activeHandle = nil
             cropResizeOrigin = nil
             cropMoveOrigin = nil
+            cropSelectionOrigin = nil
             cropLoupePoint = nil
             dragRegistered = false
             editingSelectedAnnotation = false
@@ -691,7 +702,9 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
         case .select:
             finishSelectDrag(at: point, isTap: isTap)
         case .crop:
-            break
+            if isTap, let origin = cropSelectionOrigin {
+                cropDraft = origin
+            }
         }
     }
 

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
@@ -246,6 +246,15 @@ enum ScreenshotSupport {
                       width: abs(dx), height: abs(dy))
     }
 
+    /// A full-image crop cannot move, so an interior drag must start a new
+    /// selection. Dragging outside an existing crop replaces it as well.
+    static func startsNewCropSelection(at point: CGPoint,
+                                       draft: CGRect,
+                                       within bounds: CGRect) -> Bool {
+        bounds.contains(point)
+            && (draft.standardized == bounds.standardized || !draft.contains(point))
+    }
+
     static func clamp(_ rect: CGRect, to bounds: CGRect) -> CGRect {
         var result = rect.intersection(bounds)
         if result.isNull { result = .zero }

--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -73,6 +73,8 @@ final class AppSwitcher: ObservableObject {
     private var pendingStartAfterStop = false
     /// Alive only while the Switcher's tap needs layout labels off main.
     private var keyboardLayoutObserver: NSObjectProtocol?
+    private var wakeObserver: NSObjectProtocol?
+    private var wakeRetry: DispatchWorkItem?
 
     /// The little state the tap thread needs to route an event without
     /// touching the main thread; mutated only under `routeLock`.
@@ -138,6 +140,7 @@ final class AppSwitcher: ObservableObject {
             && UserDefaults.standard.bool(forKey: DefaultsKey.switcherEnabled)
         if enabled, Permissions.shared.accessibility {
             startObservingKeyboardLayout()
+            startObservingWake()
             installTap()
             // Build the panel and its SwiftUI tree now: the first hosting-view
             // render costs hundreds of milliseconds, far too slow to pay on
@@ -151,6 +154,7 @@ final class AppSwitcher: ObservableObject {
             }
         } else {
             stopObservingKeyboardLayout()
+            stopObservingWake()
             removeTap()
             WindowPreviewProvider.shared.stopWarming()
         }
@@ -159,7 +163,10 @@ final class AppSwitcher: ObservableObject {
     /// Force-stops the tap regardless of the preference. Used before the app
     /// resets its own permissions, so a revoked Accessibility grant can never
     /// leave a live tap behind.
-    func suspend() { removeTap() }
+    func suspend() {
+        stopObservingWake()
+        removeTap()
+    }
 
     /// While a shortcut field is listening, every key has to reach it, even
     /// the switcher's own combination. This is a flag the routing reads, not a
@@ -188,6 +195,48 @@ final class AppSwitcher: ObservableObject {
             DistributedNotificationCenter.default().removeObserver(keyboardLayoutObserver)
         }
         keyboardLayoutObserver = nil
+    }
+
+    private func startObservingWake() {
+        guard wakeObserver == nil else { return }
+        wakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in self?.recoverTapAfterWake() }
+    }
+
+    private func stopObservingWake() {
+        if let wakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(wakeObserver)
+        }
+        wakeObserver = nil
+        wakeRetry?.cancel()
+        wakeRetry = nil
+    }
+
+    private func recoverTapAfterWake() {
+        recoverTapIfNeeded()
+        wakeRetry?.cancel()
+        // Input services can settle after the workspace wake itself. Recheck
+        // once so a tap disabled during that window never stays silent.
+        let retry = DispatchWorkItem { [weak self] in self?.recoverTapIfNeeded() }
+        wakeRetry = retry
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: retry)
+    }
+
+    private func recoverTapIfNeeded() {
+        guard AppFeature.switcher.isAvailable,
+              UserDefaults.standard.bool(forKey: DefaultsKey.switcherEnabled),
+              Permissions.shared.accessibility else { return }
+        let needsRecovery = lifecycleLock.withLock {
+            guard !shouldStopTapThread else { return false }
+            guard let tap else { return true }
+            return !CFMachPortIsValid(tap) || !CGEvent.tapIsEnabled(tap: tap)
+        }
+        guard needsRecovery else { return }
+        removeTap()
+        installTap()
     }
 
     private func installTap() {

--- a/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
@@ -130,6 +130,7 @@ enum SettingsDirectory {
                                                  FeatureStrings.quickToggles(language).pageTitle,
                                                  FeatureStrings.quickToggles(language).darkModeToDark,
                                                  FeatureStrings.quickToggles(language).emptyTrashTitle,
+                                                 FeatureStrings.brightness(language).keyboardLight,
                                                  FeatureStrings.cameraPreview(language).pageTitle,
                                                  FeatureStrings.scratchpad(language).pageTitle]),
                 SettingsDirectoryItem(page: .screenshot,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9491,6 +9491,20 @@ struct MetricsTests {
                                                        fromCenter: true)
         expect(centered == CGRect(x: 30, y: 40, width: 40, height: 20),
                "option grows the selection from the center")
+        let cropBounds = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let cropDraft = CGRect(x: 120, y: 90, width: 400, height: 300)
+        expect(ScreenshotSupport.startsNewCropSelection(
+                    at: CGPoint(x: 300, y: 250), draft: cropBounds, within: cropBounds),
+               "dragging inside the initial full-image crop starts a new selection")
+        expect(!ScreenshotSupport.startsNewCropSelection(
+                    at: CGPoint(x: 300, y: 250), draft: cropDraft, within: cropBounds),
+               "dragging inside an adjusted crop keeps moving it")
+        expect(ScreenshotSupport.startsNewCropSelection(
+                    at: CGPoint(x: 700, y: 500), draft: cropDraft, within: cropBounds),
+               "dragging elsewhere in the image replaces an adjusted crop")
+        expect(!ScreenshotSupport.startsNewCropSelection(
+                    at: CGPoint(x: 900, y: 700), draft: cropDraft, within: cropBounds),
+               "a drag outside the image cannot start a crop")
         expect(ScreenshotSupport.isClick(from: CGPoint(x: 5, y: 5), to: CGPoint(x: 7, y: 8))
                 && !ScreenshotSupport.isClick(from: .zero, to: CGPoint(x: 12, y: 0)),
                "a tiny drag is a click, a real drag is not")


### PR DESCRIPTION
Ref #595

Settings › Quick tools shows a **Keyboard light** toggle on Macs that have one (`QuickToolsSettings.swift:81`), but searching the sidebar for it finds nothing: the label is registered as a keyword on no page at all. Its two neighbours in the same section are — dark mode, and Empty Trash, which is not even on the page.

One line: `FeatureStrings.brightness(language).keyboardLight` joins the Quick tools keywords. No new strings; every language already ships the label for the toggle itself.

### Not changed

The other seven quick actions that live only in the panel (Eject, Hidden files, Desktop icons, Lock screen, Display off, Screen saver) are deliberately left out. The Command Bar already runs each of them directly (`CommandBarCatalog.swift:516`), and these keywords also feed its settings rows (`settingsEntries`), so registering them would add a second hit that opens a page where the action cannot be configured. Whether those actions belong in Settings at all is the open question in #595 and this PR does not answer it.

### Tests

`./build.sh` clean, `--selftest` OK, `./build.sh --test` 7092 checks OK (unchanged — the directory is data, and search matching is already pinned in `SettingsSearchSupport`).
