### PR TITLE
Fix closing Switcher windows on other desktops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project are documented here. The format follows
 ### Summary
 Vorssaint 3.3.2 adds batch image conversion, local Command Bar scripts, recent captures,
 desktop window controls and edge-activated Shelf access. It also improves capture, app discovery,
-conversions, volume, Switcher navigation, menu bar sizing and compatibility with older development tools.
+conversions, volume, Switcher behavior, menu bar sizing and compatibility with older development tools.
 
 ### Added
 - Media now converts images in batches with resizing, watermarks, renaming and
@@ -109,6 +109,7 @@ conversions, volume, Switcher navigation, menu bar sizing and compatibility with
   Thanks to @liuxxxu.
 - The App Switcher now keeps its shortcut working after your Mac wakes from sleep.
 - The App Switcher now restores minimized windows when selected.
+- The App Switcher can now close windows kept on another desktop. Thanks to @AB-boi.
 - Full-screen video windows now remain available in App Switcher and Dock Preview.
 - The app no longer quits while typing when the Switcher's Windows shortcut uses a
   key whose label comes from the keyboard layout. Thanks to @eioz.

--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -108,6 +108,7 @@ final class AppSwitcher: ObservableObject {
     /// gone. Releasing the shortcut skips them, so they are never raised on
     /// the way out.
     private var closingItemIDs: Set<String> = []
+    private var commitPendingForClose = false
 
     // Virtual key codes handled during a session.
     private enum KeyCode {
@@ -805,18 +806,23 @@ final class AppSwitcher: ObservableObject {
         guard sessionActive,
               windows.contains(where: { $0.id == item.id }),
               !closingItemIDs.contains(item.id),
-              let windowID = item.windowID,
-              WindowActivator.closeWindow(windowID: windowID,
-                                           appPID: item.pid,
-                                           windowOwnerPID: item.windowOwnerPID)
+              let windowID = item.windowID
         else { return }
 
         closingItemIDs.insert(item.id)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) { [weak self] in
-            self?.finishClosingWindow(itemID: item.id,
-                                      windowID: windowID,
-                                      pid: item.pid,
-                                      attempt: 0)
+        WindowActivator.closeWindowIncludingHiddenSpace(item) { [weak self] didClose in
+            guard let self else { return }
+            guard didClose else {
+                self.closingItemIDs.remove(item.id)
+                self.resumePendingCommitAfterClose()
+                return
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) { [weak self] in
+                self?.finishClosingWindow(itemID: item.id,
+                                          windowID: windowID,
+                                          pid: item.pid,
+                                          attempt: 0)
+            }
         }
     }
 
@@ -900,6 +906,7 @@ final class AppSwitcher: ObservableObject {
             // normal entry again and the release may raise it.
             guard attempt < 2 else {
                 closingItemIDs.remove(itemID)
+                resumePendingCommitAfterClose()
                 return
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
@@ -938,6 +945,7 @@ final class AppSwitcher: ObservableObject {
                 selectedIndex = 0
                 recomputeLayouts(for: windows)
                 resizePanel()
+                resumePendingCommitAfterClose()
             }
             return
         }
@@ -945,6 +953,7 @@ final class AppSwitcher: ObservableObject {
         selectedIndex = state.selectedIndex
         recomputeLayouts(for: windows)
         resizePanel()
+        resumePendingCommitAfterClose()
     }
 
     /// Row jump (↑/↓): moves without wrapping so the selection stays put at
@@ -967,6 +976,10 @@ final class AppSwitcher: ObservableObject {
     /// Activates the current selection. Also used by the panel on click.
     func commitSession() {
         guard sessionActive else { return }
+        guard closingItemIDs.isEmpty else {
+            commitPendingForClose = true
+            return
+        }
         // A window that was just closed is still listed for a moment; letting
         // go right after must land on what takes its place, never on it.
         let selection = SwitcherSupport.commitTargetID(itemIDs: windows.map(\.id),
@@ -984,6 +997,12 @@ final class AppSwitcher: ObservableObject {
                                      sourceWindowID: source?.isFullscreen == true ? nil : source?.windowID,
                                      sourceWindowOwnerPID: source?.windowOwnerPID)
         }
+    }
+
+    private func resumePendingCommitAfterClose() {
+        guard commitPendingForClose, closingItemIDs.isEmpty, sessionActive else { return }
+        commitPendingForClose = false
+        commitSession()
     }
 
     private func cancelSession() {
@@ -1014,6 +1033,7 @@ final class AppSwitcher: ObservableObject {
         sessionScope = .allApps
         shiftBackNavigationHeld = false
         closingItemIDs = []
+        commitPendingForClose = false
     }
 
     // MARK: - Panel

--- a/Sources/Vorssaint/Services/Switcher/WindowActivator.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowActivator.swift
@@ -14,6 +14,7 @@ enum WindowActivator {
     private static let focusRetryDelay: TimeInterval = 0.12
     private static let fullscreenFocusRetryDelays: [TimeInterval] = [0.18, 0.38, 0.68]
     private static var pendingMinimizeRestore: SwitcherWindowMinimizeRestore?
+    private static var pendingWindowClose: SwitcherPendingWindowClose?
 
     static func activate(_ item: SwitcherItem,
                          retry: Bool = true,
@@ -228,6 +229,39 @@ enum WindowActivator {
 
         AutoQuitService.shared.recordProgrammaticCloseRequest(pid: appPID)
         return AXUIElementPerformAction(closeButton, kAXPressAction as CFString) == .success
+    }
+
+    /// Keeps the regular close path immediate. A hidden target reuses the
+    /// existing verified Space hop, then closes only after Accessibility can
+    /// resolve that exact window on arrival.
+    static func closeWindowIncludingHiddenSpace(_ item: SwitcherItem,
+                                                completion: @escaping (Bool) -> Void) {
+        guard let windowID = item.windowID else {
+            completion(false)
+            return
+        }
+        if closeWindow(windowID: windowID,
+                       appPID: item.pid,
+                       windowOwnerPID: item.windowOwnerPID) {
+            completion(true)
+            return
+        }
+        guard SpaceWindowBridge.isParkedOnHiddenSpace(windowID) else {
+            completion(false)
+            return
+        }
+        pendingWindowClose?.cancel()
+        let pending = SwitcherPendingWindowClose(item: item, completion: completion)
+        pendingWindowClose = pending
+        pending.start()
+    }
+
+    fileprivate static func finishPendingWindowClose(_ pending: SwitcherPendingWindowClose,
+                                                     success: Bool) {
+        guard pendingWindowClose === pending else { return }
+        pendingWindowClose = nil
+        SpaceHop.cancelPending()
+        pending.finish(success: success)
     }
 
     private static func activateOwnWindow(_ item: SwitcherItem) {
@@ -595,6 +629,56 @@ enum WindowActivator {
             return CFBooleanGetValue((minimized as! CFBoolean))
         }
         return minimized as? Bool
+    }
+}
+
+/// Lives only while one explicit close request is travelling to another Space.
+/// The existing Space hop owns the transition; this object merely waits for
+/// the exact window to become reachable and then uses the normal close path.
+fileprivate final class SwitcherPendingWindowClose {
+    private static let pollInterval: TimeInterval = 0.1
+    private static let timeout: TimeInterval = 4.0
+
+    private let item: SwitcherItem
+    private let completion: (Bool) -> Void
+    private let deadline: DispatchTime
+    private var completed = false
+
+    init(item: SwitcherItem, completion: @escaping (Bool) -> Void) {
+        self.item = item
+        self.completion = completion
+        self.deadline = .now() + Self.timeout
+    }
+
+    func start() {
+        WindowActivator.activate(item, retry: false)
+        poll()
+    }
+
+    func cancel() {
+        WindowActivator.finishPendingWindowClose(self, success: false)
+    }
+
+    func finish(success: Bool) {
+        guard !completed else { return }
+        completed = true
+        completion(success)
+    }
+
+    private func poll() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.pollInterval) { [weak self] in
+            guard let self, !self.completed, let windowID = self.item.windowID else { return }
+            if !SpaceWindowBridge.isParkedOnHiddenSpace(windowID),
+               WindowActivator.closeWindow(windowID: windowID,
+                                           appPID: self.item.pid,
+                                           windowOwnerPID: self.item.windowOwnerPID) {
+                WindowActivator.finishPendingWindowClose(self, success: true)
+            } else if DispatchTime.now() < self.deadline {
+                self.poll()
+            } else {
+                WindowActivator.finishPendingWindowClose(self, success: false)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- close Switcher windows on hidden desktops through the existing Space transition
- wait for the asynchronous close before completing the Switcher session

## Validation
- `./build.sh --test` (7355 checks)
- Developer build, installed selftest and strict signature verification
- physical two-desktop close test

Tracks #659