### PR TITLE
Fix Homebrew settings pane layout (#526)

### DIFF
--- a/Sources/Vorssaint/UI/Settings/HomebrewSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/HomebrewSettings.swift
@@ -15,25 +15,21 @@ struct HomebrewSettings: View {
     @State private var showOperationDetails = false
 
     var body: some View {
-        GeometryReader { proxy in
-            VStack(spacing: 0) {
-                pageHeader
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 12)
-                Divider()
-                Group {
-                    if homebrew.brewPath == nil {
-                        missingState
-                    } else {
-                        content
-                    }
+        VStack(spacing: 0) {
+            pageHeader
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+            Divider()
+            Group {
+                if homebrew.brewPath == nil {
+                    missingState
+                } else {
+                    content
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             }
-            // A long package list must scroll inside its pane instead of
-            // expanding the whole split view beyond the Settings window.
-            .frame(width: proxy.size.width, height: proxy.size.height)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .onAppear {
             if homebrew.installed.isEmpty {
                 homebrew.refreshInstalled()


### PR DESCRIPTION
## Summary

Fixes #526.

The Homebrew settings page was the only settings destination wrapped in GeometryReader that forced its root view to the proxy width and height. Inside NavigationSplitView detail, that greedy frame competed with the split-view layout and caused the sidebar/content area to render incorrectly.

This change removes the fixed GeometryReader frame and lets the root VStack fill the detail pane naturally. The package list and detail pane keep their existing internal scrolling.

## Verification

- ./build.sh --test — TESTS OK (7413 checks)
- ./build.sh --dev — release compilation, linking, bundle assembly and signing succeeded
- ./build/VorssaintDeveloper --selftest — SELFTEST OK
- Manual UI verification on the developer build: opened Homebrew, loaded 72 installed packages, viewed package details, searched jq (2 results), switched Cask/Formula, navigated away and back, and zoomed the Settings window; sidebar, list and detail pane remained correctly laid out.
