### PR TITLE
Stabilize and speed up CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,23 +19,20 @@ jobs:
           swiftc --version | grep -F "Apple Swift version 6.0.3"
           test "$(xcrun --sdk macosx --show-sdk-version)" = "15.2"
 
-      - name: Unit tests
-        run: ./build.sh --test
-
       - name: Build
         run: ./build.sh
 
       - name: Selftest
         run: ./build/Vorssaint --selftest
 
+      - name: Unit tests
+        run: ./build.sh --test
+
   build:
     name: Build & selftest
     runs-on: macos-26
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Unit tests
-        run: ./build.sh --test
 
       - name: Set up signing
         env:
@@ -51,6 +48,9 @@ jobs:
 
       - name: Package DMG
         run: ./Tools/make-dmg.sh
+
+      - name: Unit tests
+        run: ./build.sh --test
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
@@ -66,7 +66,7 @@ final class RecorderCaptureEngine: NSObject {
                capturesSystemAudio: Bool,
                excludedWindowNumbers: [Int],
                isCancelled: @escaping () -> Bool) async -> RecorderFailure? {
-        guard lifecycleLock.withLock({ stream == nil }), !isCancelled() else {
+        guard lifecycleLock.withLock({ self.stream == nil }), !isCancelled() else {
             return .streamFailed
         }
 

--- a/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
@@ -79,10 +79,14 @@ final class RecorderCaptureEngine: NSObject {
         }
         guard !isCancelled() else { return .streamFailed }
 
-        guard let filter = Self.filter(for: region,
-                                       in: content,
-                                       excluding: excludedWindowNumbers)
-        else { return .noContent }
+        // Keep the call and optional binding as separate type-checking targets.
+        // Older Swift compilers otherwise crash in their constraint walker when
+        // this expression sits inside the larger async start routine.
+        let preparedFilter: SCContentFilter? = Self.filter(
+            for: region,
+            in: content,
+            excluding: excludedWindowNumbers)
+        guard let filter = preparedFilter else { return .noContent }
 
         let configuration = SCStreamConfiguration()
         configuration.width = Int(region.pixelRect.width)

--- a/build.sh
+++ b/build.sh
@@ -120,7 +120,10 @@ if (( TEST )); then
     echo "▸ Building & running unit tests against $(basename "$SDK")…"
     rm -rf build
     mkdir -p build
-    swiftc -O -target "$TARGET" -sdk "$SDK" "${SDK_COMPAT_FLAGS[@]}" \
+    # The full app build below remains optimized and is the optimizer gate.
+    # Unit assertions do not need optimization; avoiding it cuts most of the
+    # test harness compile time without reducing the code the tests exercise.
+    swiftc -Onone -target "$TARGET" -sdk "$SDK" "${SDK_COMPAT_FLAGS[@]}" \
         Sources/Vorssaint/Services/Media/MediaSupport.swift \
         Sources/Vorssaint/Core/Defaults.swift \
         Sources/Vorssaint/Core/FeatureCatalog.swift \


### PR DESCRIPTION
## Summary
- avoid the compiler crash in the recording startup path
- run the optimized app build before the unit harness for faster failure feedback
- compile the unit harness without optimization while retaining the optimized app gate

## Validation
- `./build.sh --test`: 7,756 checks in 55.9 seconds
- both required remote jobs must finish successfully before integration