### PR TITLE
feat(audio): add one-click Core Audio recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The rest bends the same way: panel sections reorder and hide, the compact layout
 - **Per app output.** Send your music to the speakers and a call to your headset at the same time.
 - **Output switcher.** Cycle between chosen outputs with one shortcut, and drop the volume automatically when headphones disconnect.
 - **Microphone tools.** Pin your favorite input so the Mac stops guessing, and mute every microphone at once with a click or shortcut, whichever one an app is using.
+- **Audio recovery.** Restart macOS Core Audio with one click when sound crackles, stutters or disappears. Vorssaint asks for administrator access only when you use it and stores no credentials.
 - **Music app blocker.** Stops the Music app from bursting in when headphones connect. You can still open it yourself.
 
 ### Know what your Mac is doing

--- a/Sources/Vorssaint/Core/Localization.swift
+++ b/Sources/Vorssaint/Core/Localization.swift
@@ -648,6 +648,13 @@ struct Strings {
 
     // MARK: Panel — volume mixer
     let mixerSection: String
+    let audioRecoveryTitle: String
+    let audioRecoveryCaption: String
+    let audioRecoveryButton: String
+    let audioRecoveryResetting: String
+    let audioRecoverySuccess: String
+    let audioRecoveryFailure: String
+    let audioRecoveryAdminPrompt: String
     let mixerEmpty: String
     let mixerUnavailable: String
     let mixerPermissionBody: String
@@ -1626,6 +1633,13 @@ extension Strings {
         breakdownMeasuring: "Medindo…",
 
         mixerSection: "Mixer de volume",
+        audioRecoveryTitle: "Reiniciar o Core Audio",
+        audioRecoveryCaption: "Reinicia o serviço de áudio do macOS quando o som estala, falha ou desaparece.",
+        audioRecoveryButton: "Reiniciar áudio",
+        audioRecoveryResetting: "Reiniciando…",
+        audioRecoverySuccess: "Core Audio reiniciado.",
+        audioRecoveryFailure: "Não foi possível reiniciar o Core Audio.",
+        audioRecoveryAdminPrompt: "O Vorssaint reiniciará o Core Audio do macOS para recuperar o som. Uma senha de administrador pode ser necessária.",
         mixerEmpty: "Apps que usam áudio aparecem aqui",
         mixerUnavailable: "Disponível a partir do macOS 14.4",
         mixerPermissionBody: "Para ajustar o volume por app, permita “Gravação de Tela e Áudio do Sistema” nos Ajustes do Sistema. O áudio nunca é gravado.",
@@ -2586,6 +2600,13 @@ extension Strings {
         breakdownMeasuring: "Measuring…",
 
         mixerSection: "Volume mixer",
+        audioRecoveryTitle: "Reset Core Audio",
+        audioRecoveryCaption: "Restarts macOS’s audio service when sound is crackling, stuttering or missing.",
+        audioRecoveryButton: "Reset audio",
+        audioRecoveryResetting: "Resetting…",
+        audioRecoverySuccess: "Core Audio restarted.",
+        audioRecoveryFailure: "Could not restart Core Audio.",
+        audioRecoveryAdminPrompt: "Vorssaint will restart macOS Core Audio to recover sound. An administrator password may be required.",
         mixerEmpty: "Apps that use audio show up here",
         mixerUnavailable: "Available on macOS 14.4 and later",
         mixerPermissionBody: "To adjust per-app volume, allow “Screen & System Audio Recording” in System Settings. Audio is never recorded.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
@@ -523,6 +523,13 @@ extension Strings {
         breakdownMeasuring: "测量中…",
 
         mixerSection: "音量混音器",
+        audioRecoveryTitle: "重启 Core Audio",
+        audioRecoveryCaption: "声音出现杂音、卡顿或消失时，重启 macOS 音频服务。",
+        audioRecoveryButton: "重启音频",
+        audioRecoveryResetting: "正在重启…",
+        audioRecoverySuccess: "Core Audio 已重启。",
+        audioRecoveryFailure: "无法重启 Core Audio。",
+        audioRecoveryAdminPrompt: "Vorssaint 将重启 macOS Core Audio 以恢复声音，可能需要管理员密码。",
         mixerEmpty: "使用音频的 App 会显示在这里",
         mixerUnavailable: "需 macOS 14.4 及更高版本",
         mixerPermissionBody: "若要调整各 App 的音量，请在“系统设置”中允许“屏幕与系统音频录制”。绝不会录制音频。",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
@@ -524,6 +524,13 @@ extension Strings {
         breakdownMeasuring: "測量中…",
 
         mixerSection: "音量混音器",
+        audioRecoveryTitle: "重新啟動 Core Audio",
+        audioRecoveryCaption: "聲音出現雜音、卡頓或消失時，重新啟動 macOS 音訊服務。",
+        audioRecoveryButton: "重新啟動音訊",
+        audioRecoveryResetting: "正在重新啟動…",
+        audioRecoverySuccess: "Core Audio 已重新啟動。",
+        audioRecoveryFailure: "無法重新啟動 Core Audio。",
+        audioRecoveryAdminPrompt: "Vorssaint 將重新啟動 macOS Core Audio 以恢復聲音，可能需要管理員密碼。",
         mixerEmpty: "正在使用音訊的 App 會顯示在這裡",
         mixerUnavailable: "需要 macOS 14.4 及更高版本",
         mixerPermissionBody: "若要調整各 App 的音量，請在「系統設定」中允許「螢幕與系統音訊錄製」。絕不會錄製音訊。",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
@@ -524,6 +524,13 @@ extension Strings {
         breakdownMeasuring: "測量中…",
 
         mixerSection: "音量混音器",
+        audioRecoveryTitle: "重新啟動 Core Audio",
+        audioRecoveryCaption: "聲音出現雜音、卡頓或消失時，重新啟動 macOS 音訊服務。",
+        audioRecoveryButton: "重新啟動音訊",
+        audioRecoveryResetting: "正在重新啟動…",
+        audioRecoverySuccess: "Core Audio 已重新啟動。",
+        audioRecoveryFailure: "無法重新啟動 Core Audio。",
+        audioRecoveryAdminPrompt: "Vorssaint 將重新啟動 macOS Core Audio 以恢復聲音，可能需要管理員密碼。",
         mixerEmpty: "正在使用音訊的 App 會顯示在這裡",
         mixerUnavailable: "需要 macOS 14.4 及更高版本",
         mixerPermissionBody: "若要調整各 App 的音量，請在「系統設定」中允許「螢幕與系統音訊錄製」。絕不會錄製音訊。",

--- a/Sources/Vorssaint/Core/Localizations/Strings+French.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+French.swift
@@ -523,6 +523,13 @@ extension Strings {
         breakdownMeasuring: "Mesure…",
 
         mixerSection: "Mélangeur de volume",
+        audioRecoveryTitle: "Réinitialiser Core Audio",
+        audioRecoveryCaption: "Redémarre le service audio de macOS lorsque le son grésille, saccade ou disparaît.",
+        audioRecoveryButton: "Réinitialiser l’audio",
+        audioRecoveryResetting: "Réinitialisation…",
+        audioRecoverySuccess: "Core Audio a été redémarré.",
+        audioRecoveryFailure: "Impossible de redémarrer Core Audio.",
+        audioRecoveryAdminPrompt: "Vorssaint va redémarrer Core Audio de macOS pour rétablir le son. Le mot de passe administrateur peut être demandé.",
         mixerEmpty: "Les apps qui utilisent l’audio apparaissent ici",
         mixerUnavailable: "Disponible à partir de macOS 14.4",
         mixerPermissionBody: "Pour régler le volume par app, autorisez « Enregistrement de l’écran et de l’audio du système » dans les Réglages Système. L’audio n’est jamais enregistré.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+German.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+German.swift
@@ -523,6 +523,13 @@ extension Strings {
         breakdownMeasuring: "Wird gemessen…",
 
         mixerSection: "Lautstärkemixer",
+        audioRecoveryTitle: "Core Audio neu starten",
+        audioRecoveryCaption: "Startet den macOS-Audiodienst neu, wenn der Ton knistert, stottert oder ausfällt.",
+        audioRecoveryButton: "Audio neu starten",
+        audioRecoveryResetting: "Wird neu gestartet…",
+        audioRecoverySuccess: "Core Audio wurde neu gestartet.",
+        audioRecoveryFailure: "Core Audio konnte nicht neu gestartet werden.",
+        audioRecoveryAdminPrompt: "Vorssaint startet macOS Core Audio neu, um den Ton wiederherzustellen. Möglicherweise ist ein Administratorpasswort erforderlich.",
         mixerEmpty: "Apps, die Audio nutzen, erscheinen hier",
         mixerUnavailable: "Verfügbar ab macOS 14.4",
         mixerPermissionBody: "Um die Lautstärke je App anzupassen, erlaube „Aufnahme von Bildschirm und Systemaudio“ in den Systemeinstellungen. Audio wird nie aufgenommen.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
@@ -523,6 +523,13 @@ extension Strings {
         breakdownMeasuring: "Misurazione…",
 
         mixerSection: "Mixer del volume",
+        audioRecoveryTitle: "Riavvia Core Audio",
+        audioRecoveryCaption: "Riavvia il servizio audio di macOS quando l’audio crepita, scatta o scompare.",
+        audioRecoveryButton: "Riavvia audio",
+        audioRecoveryResetting: "Riavvio…",
+        audioRecoverySuccess: "Core Audio riavviato.",
+        audioRecoveryFailure: "Impossibile riavviare Core Audio.",
+        audioRecoveryAdminPrompt: "Vorssaint riavvierà Core Audio di macOS per ripristinare l’audio. Potrebbe essere richiesta la password di amministratore.",
         mixerEmpty: "Le app che usano l'audio compaiono qui",
         mixerUnavailable: "Disponibile su macOS 14.4 e successivi",
         mixerPermissionBody: "Per regolare il volume per ogni app, consenti «Registrazione schermo e audio di sistema» in Impostazioni di Sistema. L'audio non viene mai registrato.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
@@ -523,6 +523,13 @@ extension Strings {
         breakdownMeasuring: "計測中…",
 
         mixerSection: "音量ミキサー",
+        audioRecoveryTitle: "Core Audioを再起動",
+        audioRecoveryCaption: "音が割れたり途切れたり聞こえなくなったときに、macOSのオーディオサービスを再起動します。",
+        audioRecoveryButton: "オーディオを再起動",
+        audioRecoveryResetting: "再起動中…",
+        audioRecoverySuccess: "Core Audioを再起動しました。",
+        audioRecoveryFailure: "Core Audioを再起動できませんでした。",
+        audioRecoveryAdminPrompt: "Vorssaintはサウンドを復旧するためmacOSのCore Audioを再起動します。管理者パスワードが必要な場合があります。",
         mixerEmpty: "オーディオを使用するアプリがここに表示されます",
         mixerUnavailable: "macOS 14.4 以降で利用できます",
         mixerPermissionBody: "アプリごとの音量を調整するには、システム設定で「画面とシステムオーディオ収録」を許可してください。オーディオが記録されることはありません。",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
@@ -524,6 +524,13 @@ extension Strings {
         breakdownMeasuring: "측정 중…",
 
         mixerSection: "볼륨 믹서",
+        audioRecoveryTitle: "Core Audio 재시동",
+        audioRecoveryCaption: "소리가 깨지거나 끊기거나 사라질 때 macOS 오디오 서비스를 재시동합니다.",
+        audioRecoveryButton: "오디오 재시동",
+        audioRecoveryResetting: "재시동 중…",
+        audioRecoverySuccess: "Core Audio를 재시동했습니다.",
+        audioRecoveryFailure: "Core Audio를 재시동하지 못했습니다.",
+        audioRecoveryAdminPrompt: "Vorssaint가 사운드를 복구하기 위해 macOS Core Audio를 재시동합니다. 관리자 암호가 필요할 수 있습니다.",
         mixerEmpty: "오디오를 사용하는 앱이 여기에 표시됩니다",
         mixerUnavailable: "macOS 14.4 이상에서 사용할 수 있습니다",
         mixerPermissionBody: "앱별 볼륨을 조절하려면 시스템 설정에서 ‘화면 및 시스템 오디오 녹음’을 허용하세요. 오디오는 기록되지 않습니다.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
@@ -524,6 +524,13 @@ extension Strings {
         breakdownMeasuring: "Измерение…",
 
         mixerSection: "Микшер громкости",
+        audioRecoveryTitle: "Перезапустить Core Audio",
+        audioRecoveryCaption: "Перезапускает аудиослужбу macOS, если звук трещит, прерывается или пропал.",
+        audioRecoveryButton: "Перезапустить звук",
+        audioRecoveryResetting: "Перезапуск…",
+        audioRecoverySuccess: "Core Audio перезапущен.",
+        audioRecoveryFailure: "Не удалось перезапустить Core Audio.",
+        audioRecoveryAdminPrompt: "Vorssaint перезапустит Core Audio macOS для восстановления звука. Может потребоваться пароль администратора.",
         mixerEmpty: "Здесь появятся приложения, которые воспроизводят звук",
         mixerUnavailable: "Доступно в macOS 14.4 и новее",
         mixerPermissionBody: "Чтобы регулировать громкость по приложениям, разрешите «Запись экрана и системного аудио» в Системных настройках. Аудио никогда не записывается.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
@@ -523,6 +523,13 @@ extension Strings {
         breakdownMeasuring: "Midiendo…",
 
         mixerSection: "Mezclador de volumen",
+        audioRecoveryTitle: "Reiniciar Core Audio",
+        audioRecoveryCaption: "Reinicia el servicio de audio de macOS cuando el sonido cruje, se entrecorta o desaparece.",
+        audioRecoveryButton: "Reiniciar audio",
+        audioRecoveryResetting: "Reiniciando…",
+        audioRecoverySuccess: "Core Audio reiniciado.",
+        audioRecoveryFailure: "No se pudo reiniciar Core Audio.",
+        audioRecoveryAdminPrompt: "Vorssaint reiniciará Core Audio de macOS para recuperar el sonido. Puede requerirse la contraseña de administrador.",
         mixerEmpty: "Las apps que usan audio aparecen aquí",
         mixerUnavailable: "Disponible en macOS 14.4 y posteriores",
         mixerPermissionBody: "Para ajustar el volumen por app, permite «Grabación de pantalla y audio del sistema» en Ajustes del Sistema. El audio nunca se graba.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
@@ -523,6 +523,13 @@ extension Strings {
         breakdownMeasuring: "Ölçülüyor…",
 
         mixerSection: "Ses mikseri",
+        audioRecoveryTitle: "Core Audio'yu sıfırla",
+        audioRecoveryCaption: "Ses çatladığında, kesildiğinde veya kaybolduğunda macOS ses hizmetini yeniden başlatır.",
+        audioRecoveryButton: "Sesi sıfırla",
+        audioRecoveryResetting: "Sıfırlanıyor…",
+        audioRecoverySuccess: "Core Audio yeniden başlatıldı.",
+        audioRecoveryFailure: "Core Audio yeniden başlatılamadı.",
+        audioRecoveryAdminPrompt: "Vorssaint sesi kurtarmak için macOS Core Audio'yu yeniden başlatacak. Yönetici parolası gerekebilir.",
         mixerEmpty: "Ses kullanan uygulamalar burada görünür",
         mixerUnavailable: "macOS 14.4 ve sonrasında kullanılabilir",
         mixerPermissionBody: "Uygulama başına ses düzeyini ayarlamak için Sistem Ayarları'nda “Ekran ve Sistem Sesi Kaydı”na izin ver. Ses hiçbir zaman kaydedilmez.",

--- a/Sources/Vorssaint/Services/Audio/AudioRecoveryService.swift
+++ b/Sources/Vorssaint/Services/Audio/AudioRecoveryService.swift
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Combine
+import Foundation
+
+enum AudioRecoveryResult: Equatable {
+    case succeeded
+    case failed
+}
+
+/// Restarts macOS' Core Audio daemon on demand when the audio stack is stuck.
+/// The existing AdminShell owns the password prompt and serializes privileged
+/// requests, so this feature never stores credentials or shells through sudo.
+final class AudioRecoveryService: ObservableObject {
+    static let shared = AudioRecoveryService()
+
+    @Published private(set) var isResetting = false
+    @Published private(set) var lastResult: AudioRecoveryResult?
+
+    private init() {}
+
+    func resetAudio() {
+        guard !isResetting else { return }
+        isResetting = true
+        lastResult = nil
+
+        let prompt = L10n.shared.s.audioRecoveryAdminPrompt
+        AdminShell.run(AudioRecoverySupport.resetCommand, prompt: prompt) { [weak self] succeeded in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.isResetting = false
+                self.lastResult = succeeded ? .succeeded : .failed
+            }
+        }
+    }
+}

--- a/Sources/Vorssaint/Services/Audio/AudioRecoverySupport.swift
+++ b/Sources/Vorssaint/Services/Audio/AudioRecoverySupport.swift
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+/// The small, explicit command used by the on-demand audio recovery action.
+/// Keeping it in a pure helper makes the privileged operation easy to audit
+/// and keeps the command-line test harness independent of AppKit.
+enum AudioRecoverySupport {
+    static let processName = "coreaudiod"
+    static let resetCommand = "/usr/bin/killall \(processName)"
+}

--- a/Sources/Vorssaint/UI/MenuPanel/MixerSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/MixerSection.swift
@@ -13,6 +13,7 @@ struct MixerSection: View {
     @ObservedObject private var mixer = AppVolumeMixer.shared
     @ObservedObject private var inputManager = AudioInputDeviceManager.shared
     @ObservedObject private var outputSwitcher = SoundOutputSwitcher.shared
+    @ObservedObject private var audioRecovery = AudioRecoveryService.shared
     @ObservedObject private var preciseVolumeRoller = PreciseVolumeRollerService.shared
     @ObservedObject private var permissions = Permissions.shared
     @AppStorage(DefaultsKey.mixerHideInactiveApps)
@@ -71,6 +72,7 @@ struct MixerSection: View {
 
     private var audioDevicesSection: some View {
         VStack(alignment: .leading, spacing: 6) {
+            audioRecoveryControl
             universalOutputPicker
             systemSoundOutputPicker
             microphonePicker
@@ -116,6 +118,49 @@ struct MixerSection: View {
                     }
                 }
                 .padding(.leading, 19)
+            }
+        }
+    }
+
+    private var audioRecoveryControl: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Label {
+                    Text(l10n.s.audioRecoveryTitle)
+                        .font(.system(size: 11.5, weight: .medium))
+                } icon: {
+                    Image(systemName: "arrow.clockwise.circle")
+                        .font(.system(size: 10.5, weight: .semibold))
+                }
+                .foregroundStyle(.secondary)
+
+                Spacer(minLength: 6)
+
+                Button {
+                    audioRecovery.resetAudio()
+                } label: {
+                    Label(audioRecovery.isResetting
+                          ? l10n.s.audioRecoveryResetting
+                          : l10n.s.audioRecoveryButton,
+                          systemImage: audioRecovery.isResetting ? "hourglass" : "arrow.clockwise")
+                }
+                .controlSize(.small)
+                .disabled(audioRecovery.isResetting)
+                .help(l10n.s.audioRecoveryCaption)
+            }
+
+            Text(l10n.s.audioRecoveryCaption)
+                .font(.system(size: 9.5))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let result = audioRecovery.lastResult {
+                inputMessage(result == .succeeded
+                             ? l10n.s.audioRecoverySuccess
+                             : l10n.s.audioRecoveryFailure,
+                             systemImage: result == .succeeded
+                                 ? "checkmark.circle"
+                                 : "exclamationmark.triangle")
             }
         }
     }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -40,6 +40,13 @@ struct MetricsTests {
             if actual != expected { failures.append("\(label): got \(actual), expected \(expected)") }
         }
 
+        // MARK: Audio recovery
+
+        expectEqual(AudioRecoverySupport.processName, "coreaudiod",
+                    "audio recovery targets Core Audio")
+        expectEqual(AudioRecoverySupport.resetCommand, "/usr/bin/killall coreaudiod",
+                    "audio recovery uses the audited absolute command")
+
         // MARK: Byte / rate formatting
 
         expectEqual(MetricFormat.bytes(0), "0 B", "bytes zero")

--- a/build.sh
+++ b/build.sh
@@ -236,6 +236,7 @@ if (( TEST )); then
         Sources/Vorssaint/Core/URLCleaning.swift \
         Sources/Vorssaint/Services/GeneralPasteboardAccess.swift \
         Sources/Vorssaint/Services/Audio/MixerRoutingSupport.swift \
+        Sources/Vorssaint/Services/Audio/AudioRecoverySupport.swift \
         Sources/Vorssaint/Services/Audio/MusicLaunchSupport.swift \
         Sources/Vorssaint/Services/Bluetooth/BluetoothSleepSupport.swift \
         Sources/Vorssaint/UI/MenuPanel/MixerPercentNativeTextField.swift \


### PR DESCRIPTION
## Summary
- add a localized Reset Core Audio control to the current Mixer section
- reuse Vorssaint’s serialized AdminShell prompt and run the audited absolute `/usr/bin/killall coreaudiod` command only on explicit user action
- show in-panel progress and success/failure feedback without storing credentials
- keep the pure command coverage and documentation

## Permission model
Restarting `coreaudiod` is a system-level operation, so macOS may require administrator authentication. The prompt appears only after the user clicks Reset audio; credentials are not stored.

## Relationship with #813
This PR and #813 are independent audio features. PR 704 performs an explicit daemon recovery action and owns no audio monitoring or playback state. PR 813 observes Core Audio activity and controls the selected music player through Automation. If both land, a reset may temporarily interrupt audio observations, but neither feature depends on the other and PR 813 can resume on its next evaluation.

## Merge order
Merge PR 704 before PR 821. PR 704 adds fields to the existing `Strings` contract, while PR 821 introduces the Vietnamese localization whose completeness is compiler-enforced. Vietnamese translations for fields from PR 704 and the other pending localization PRs should be added as part of PR 821 when it lands last.

## Validation
- rebased onto current `main`
- `./build.sh --test` — TESTS OK (8,390 checks)
- `./build.sh` — release bundle assembled and ad-hoc signature verified
- `git diff --check`