### PR TITLE
feat(url-cleaner): clean site-specific tracking parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Ki
  start of a recording.
 
 ### Added
-- Clean URL now removes the tracking parameters that YouTube, X, Instagram, Spotify,
-  Reddit, TikTok, Bilibili and Xiaohongshu add to their own share links, while leaving
-  the same parameter names alone on every other site. Thanks to @PathGao.
 - The Super key can now use a quick press to switch between enabled input sources
   while a press-and-hold toggles Caps Lock. Thanks to @BenjaminD2023.
 - Dock Preview thumbnails can now be dragged to move windows freely or snap them
   to screen regions. Thanks to @PathGao.
+- Clean URL now removes the tracking parameters that YouTube, X, Instagram, Spotify,
+  Reddit, TikTok, Bilibili and Xiaohongshu add to their own share links, while leaving
+  the same parameter names alone on every other site. Thanks to @PathGao.
 - An opt-in Kill Process feature searches running processes to force quit, restart or terminate
   process trees from Settings and the Command Bar. It ships uninstalled. Thanks to @naveenkrdy.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Ki
  start of a recording.
 
 ### Added
-- Clean URL now removes the tracking parameters that Bilibili, YouTube, X, Instagram,
-  Spotify, TikTok, Reddit and Xiaohongshu add to their own share links, while leaving
+- Clean URL now removes the tracking parameters that YouTube, X, Instagram, Spotify,
+  Reddit, TikTok, Bilibili and Xiaohongshu add to their own share links, while leaving
   the same parameter names alone on every other site. Thanks to @PathGao.
 - The Super key can now use a quick press to switch between enabled input sources
   while a press-and-hold toggles Caps Lock. Thanks to @BenjaminD2023.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Ki
  start of a recording.
 
 ### Added
+- Clean URL now removes the tracking parameters that Bilibili, YouTube, X, Instagram,
+  Spotify, TikTok, Reddit and Xiaohongshu add to their own share links, while leaving
+  the same parameter names alone on every other site. Thanks to @PathGao.
 - The Super key can now use a quick press to switch between enabled input sources
   while a press-and-hold toggles Caps Lock. Thanks to @BenjaminD2023.
 - Dock Preview thumbnails can now be dragged to move windows freely or snap them

--- a/Sources/Vorssaint/Core/URLCleaning.swift
+++ b/Sources/Vorssaint/Core/URLCleaning.swift
@@ -26,9 +26,14 @@ enum URLCleaning {
         "x.com": ["s", "t", "cn", "src", "refsrc", "ref_src", "ref_url"],
         "instagram.com": ["igsh"],
         "spotify.com": ["si"],
+        // Reddit's share sheet routes through branch.io, whose deep link fields
+        // start with a literal `$`. Links often carry them percent-encoded as
+        // `%24…`, but only the decoded spelling is listed: names arrive here
+        // from `URLComponents.queryItems`, which has already decoded them.
+        // ClearURLs lists both because it matches the raw query with regex.
         "reddit.com": [
             "correlation_id", "ref_campaign", "ref_source", "rdt", "share_id",
-            "_branch_match_id",
+            "_branch_match_id", "$deep_link", "$3p", "$original_url",
         ],
         "tiktok.com": [
             "u_code", "preview_pb", "_d", "_t", "_r", "timestamp", "user_id",

--- a/Sources/Vorssaint/Core/URLCleaning.swift
+++ b/Sources/Vorssaint/Core/URLCleaning.swift
@@ -13,18 +13,56 @@ enum URLCleaning {
         "fb_action_ids", "fb_action_types", "fb_source", "mibextid",
     ]
 
+    /// Trackers that only one site uses. A global list cannot hold these: `si`
+    /// is a share token on YouTube but a real parameter elsewhere, and `t` is a
+    /// tracker on X while it is the playback position on YouTube. Matching on
+    /// the host is what keeps removing one from breaking the other.
+    ///
+    /// Keys match the host itself or any subdomain of it.
+    private static let hostParameters: [String: Set<String>] = [
+        "bilibili.com": [
+            "spm_id_from", "from_spmid", "from_source", "share_source", "share_from",
+            "share_medium", "share_plat", "share_tag", "share_session_id", "msource",
+            "refer_from", "seid", "unique_k", "vd_source", "plat_id", "buvid", "bbid",
+            "up_id", "is_story_h5", "timestamp", "ts", "visit_id", "session_id",
+            "broadcast_type", "is_room_feed",
+        ],
+        "youtube.com": ["si", "pp", "feature", "kw"],
+        "youtu.be": ["si", "pp", "feature", "kw"],
+        "twitter.com": ["s", "t", "cn", "src", "refsrc", "ref_src", "ref_url"],
+        "x.com": ["s", "t", "cn", "src", "refsrc", "ref_src", "ref_url"],
+        "instagram.com": ["igsh"],
+        "spotify.com": ["si"],
+        "tiktok.com": [
+            "u_code", "preview_pb", "_d", "_t", "_r", "timestamp", "user_id",
+            "share_app_name", "share_iid",
+        ],
+        "reddit.com": [
+            "correlation_id", "ref_campaign", "ref_source", "rdt", "share_id",
+            "_branch_match_id",
+        ],
+        "xiaohongshu.com": [
+            "xhsshare", "author_share", "xsec_source", "share_from_user_hidden",
+            "shareRedId", "share_id", "exSource", "app_version", "app_platform",
+            "apptime", "appuid",
+        ],
+    ]
+
     static func cleanedString(from text: String, customParameters: Set<String> = []) -> String? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard var components = URLComponents(string: trimmed),
               let scheme = components.scheme?.lowercased(),
               (scheme == "http" || scheme == "https"),
-              components.host != nil else {
+              let host = components.host else {
             return nil
         }
 
         if let items = components.queryItems {
+            let hostParameters = Self.hostParameters(for: host)
             let kept = items.filter { item in
-                !shouldRemove(parameter: item.name, customParameters: customParameters)
+                !shouldRemove(parameter: item.name,
+                              customParameters: customParameters,
+                              hostParameters: hostParameters)
             }
             components.queryItems = kept.isEmpty ? nil : kept
         }
@@ -39,11 +77,25 @@ enum URLCleaning {
             .filter { !$0.isEmpty })
     }
 
+    /// Site rules are additive: `open.spotify.com` picks up the `spotify.com`
+    /// set, and a host that matches nothing keeps only the global rules.
+    private static func hostParameters(for host: String) -> Set<String> {
+        let normalized = host.lowercased()
+        var names: Set<String> = []
+        for (suffix, parameters) in hostParameters
+        where normalized == suffix || normalized.hasSuffix("." + suffix) {
+            names.formUnion(parameters)
+        }
+        return Set(names.map { $0.lowercased() })
+    }
+
     private static func shouldRemove(parameter name: String,
-                                     customParameters: Set<String>) -> Bool {
+                                     customParameters: Set<String>,
+                                     hostParameters: Set<String>) -> Bool {
         let normalized = name.lowercased()
         return trackedParameters.contains(normalized)
             || normalized.hasPrefix("utm_")
+            || hostParameters.contains(normalized)
             || customParameters.contains(normalized)
     }
 }

--- a/Sources/Vorssaint/Core/URLCleaning.swift
+++ b/Sources/Vorssaint/Core/URLCleaning.swift
@@ -20,26 +20,26 @@ enum URLCleaning {
     ///
     /// Keys match the host itself or any subdomain of it.
     private static let hostParameters: [String: Set<String>] = [
-        "bilibili.com": [
-            "spm_id_from", "from_spmid", "from_source", "share_source", "share_from",
-            "share_medium", "share_plat", "share_tag", "share_session_id", "msource",
-            "refer_from", "seid", "unique_k", "vd_source", "plat_id", "buvid", "bbid",
-            "up_id", "is_story_h5", "timestamp", "ts", "visit_id", "session_id",
-            "broadcast_type", "is_room_feed",
-        ],
         "youtube.com": ["si", "pp", "feature", "kw"],
         "youtu.be": ["si", "pp", "feature", "kw"],
         "twitter.com": ["s", "t", "cn", "src", "refsrc", "ref_src", "ref_url"],
         "x.com": ["s", "t", "cn", "src", "refsrc", "ref_src", "ref_url"],
         "instagram.com": ["igsh"],
         "spotify.com": ["si"],
+        "reddit.com": [
+            "correlation_id", "ref_campaign", "ref_source", "rdt", "share_id",
+            "_branch_match_id",
+        ],
         "tiktok.com": [
             "u_code", "preview_pb", "_d", "_t", "_r", "timestamp", "user_id",
             "share_app_name", "share_iid",
         ],
-        "reddit.com": [
-            "correlation_id", "ref_campaign", "ref_source", "rdt", "share_id",
-            "_branch_match_id",
+        "bilibili.com": [
+            "spm_id_from", "from_spmid", "from_source", "share_source", "share_from",
+            "share_medium", "share_plat", "share_tag", "share_session_id", "msource",
+            "refer_from", "seid", "unique_k", "vd_source", "plat_id", "buvid", "bbid",
+            "up_id", "is_story_h5", "timestamp", "ts", "visit_id", "session_id",
+            "broadcast_type", "is_room_feed",
         ],
         "xiaohongshu.com": [
             "xhsshare", "author_share", "xsec_source", "share_from_user_hidden",

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -8109,6 +8109,31 @@ struct MetricsTests {
                "custom URL cleaner parameters start empty and travel in Settings backups")
         expect(URLCleaning.cleanedString(from: "not a url") == nil,
                "URL cleaner rejects plain text")
+        expectEqual(URLCleaning.cleanedString(
+            from: "https://www.bilibili.com/video/BV1TY8J67EUB/?spm_id_from=333.1007.tianma.1-1-1.click&vd_source=3b2eea5") ?? "",
+                    "https://www.bilibili.com/video/BV1TY8J67EUB/",
+                    "URL cleaner strips Bilibili share tracking")
+        expectEqual(URLCleaning.cleanedString(from: "https://www.bilibili.com/video/BV1xx411c7mD/?p=3&t=90&vd_source=abc") ?? "",
+                    "https://www.bilibili.com/video/BV1xx411c7mD/?p=3&t=90",
+                    "URL cleaner keeps the Bilibili part number and playback position")
+        expectEqual(URLCleaning.cleanedString(from: "https://search.bilibili.com/all?keyword=swift&from_source=webtop_search") ?? "",
+                    "https://search.bilibili.com/all?keyword=swift",
+                    "URL cleaner keeps the Bilibili search keyword")
+        expectEqual(URLCleaning.cleanedString(from: "https://youtu.be/TImSMeurR84?si=Xq1&t=42") ?? "",
+                    "https://youtu.be/TImSMeurR84?t=42",
+                    "URL cleaner strips the YouTube share token and keeps the timestamp")
+        expectEqual(URLCleaning.cleanedString(from: "https://www.youtube.com/watch?v=TImSMeurR84") ?? "",
+                    "https://www.youtube.com/watch?v=TImSMeurR84",
+                    "URL cleaner leaves a bare YouTube watch link alone")
+        expectEqual(URLCleaning.cleanedString(from: "https://x.com/user/status/1?s=20&t=abc") ?? "",
+                    "https://x.com/user/status/1",
+                    "URL cleaner strips X share tracking")
+        expectEqual(URLCleaning.cleanedString(from: "https://example.com/?si=keep&t=keep&s=keep") ?? "",
+                    "https://example.com/?si=keep&t=keep&s=keep",
+                    "site rules never leak onto other hosts")
+        expectEqual(URLCleaning.cleanedString(from: "https://open.spotify.com/track/abc?si=xyz") ?? "",
+                    "https://open.spotify.com/track/abc",
+                    "site rules match subdomains")
 
         // MARK: Homebrew command building and parsing
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -8134,6 +8134,10 @@ struct MetricsTests {
         expectEqual(URLCleaning.cleanedString(from: "https://open.spotify.com/track/abc?si=xyz") ?? "",
                     "https://open.spotify.com/track/abc",
                     "site rules match subdomains")
+        expectEqual(URLCleaning.cleanedString(
+            from: "https://www.reddit.com/r/swift/comments/abc/?%24deep_link=true&%243p=x&share_id=y&sort=new") ?? "",
+                    "https://www.reddit.com/r/swift/comments/abc/?sort=new",
+                    "URL cleaner strips Reddit's deep-link tracking in either spelling")
 
         // MARK: Homebrew command building and parsing
 


### PR DESCRIPTION
Clean URL only recognises cross-site ad parameters (`utm_*`, `fbclid`, `gclid` and friends). The trackers the big platforms add to their own share links go through untouched: a YouTube share link keeps `si`, an X link keeps `s` and `t`, a Reddit link keeps `share_id`.

The existing "More names to remove" field cannot cover this. It is a global name list, and these names are only trackers on one site: `si` is a share token on YouTube and Spotify but an ordinary parameter elsewhere, and `t` is a tracker on X while it is the playback position on YouTube. Adding either one globally breaks other sites, so there is no safe way for a user to express a platform rule today.

## What changed

`URLCleaning` gains a host → parameter-name table, applied on top of the global rules when the URL's host equals the key or is a subdomain of it. Names come from the ClearURLs upstream ruleset, covering youtube/youtu.be, x/twitter, instagram, spotify, reddit, tiktok, bilibili and xiaohongshu.

Behaviour you can check against:

- `youtu.be/ID?si=…&t=42` → `youtu.be/ID?t=42` — the playback position survives
- `x.com/user/status/1?s=20&t=…` → `x.com/user/status/1`
- `example.com/?si=x&t=x&s=x` → unchanged; site rules never leak onto other hosts
- `search.bilibili.com/all?keyword=…&from_source=…` → the search keyword survives, which is the case the alternative below gets wrong

## Alternatives considered

**Drop the whole query string on known share hosts.** Rejected: YouTube puts `v`, `t` and `list` in the query, and search pages put the query term there. Cutting at `?` turns working links into broken ones. Share links only *look* like "delete everything after ?" because their entire query happens to be tracking.

**Bundle the full ClearURLs ruleset** (206 providers). Rejected: it needs a regex engine plus `exceptions` and `rawRules` handling, and a bundled snapshot goes stale — keeping it current means fetching rules, which contradicts the feature's own "Local. No network." promise.

Three names in ClearURLs' Bilibili list — `mid`, `from` and `callback` — are left in place: they are functional parameters on that site's `space.` and `api.` subdomains.

## Not changed

Taobao, Amazon and AliExpress are not covered — they need prefix patterns (`scm_*`, `algo_*`) and path cleaning (`/ref=…`), which is a different mechanism. The global table, the custom-parameter field, case handling and fragment preservation are untouched.

Tests: `TESTS OK (7834 checks)`, 8 added (7826 baseline), two of them the cut-at-`?` counterexamples above.

