### PR TITLE
fix(url-cleaner): let the Clean URL fields take a click across their row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,12 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Ki
   current and target RPM for every fan.
 
 ### Fixed
-- The Clean URL settings fields now span their whole row and draw a border. Their
-  hint used to render as a label beside a short strip of field, so clicking the
-  words did nothing. Thanks to @PathGao.
+- The Clean URL parameter list is now saved with a button instead of taking effect
+  as it is typed, and shows the names as the cleaner reads them. Half a name used
+  to apply for as long as it took to finish typing the rest, so a link copied at
+  that moment could lose a parameter that only matched the fragment. Both fields on
+  the page also span their whole row: their hint used to render as a label beside a
+  short strip of field, so clicking the words did nothing. Thanks to @PathGao.
 - Scratchpad tabs and the pin, close, new pad and pad actions buttons now respond
   across their whole area. Thanks to @AB-boi and @PathGao.
 - Fan Control now prepares stopped fans before taking manual control and keeps a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Ki
   current and target RPM for every fan.
 
 ### Fixed
-- The Clean URL settings fields now draw a border, so the extra parameter names and
-  the manual URL field read as fields you can type in. Thanks to @PathGao.
+- The Clean URL settings fields now span their whole row and draw a border. Their
+  hint used to render as a label beside a short strip of field, so clicking the
+  words did nothing. Thanks to @PathGao.
 - Scratchpad tabs and the pin, close, new pad and pad actions buttons now respond
   across their whole area. Thanks to @AB-boi and @PathGao.
 - Fan Control now prepares stopped fans before taking manual control and keeps a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,11 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Ki
   current and target RPM for every fan.
 
 ### Fixed
-- The Clean URL parameter list is now saved with a button instead of taking effect
-  as it is typed, and shows the names as the cleaner reads them. Half a name used
-  to apply for as long as it took to finish typing the rest, so a link copied at
-  that moment could lose a parameter that only matched the fragment. Both fields on
-  the page also span their whole row: their hint used to render as a label beside a
-  short strip of field, so clicking the words did nothing. Thanks to @PathGao.
+- The Clean URL settings fields now take a click anywhere across their row. Their
+  hint used to render as a row label beside a short strip of field, so clicking the
+  words did nothing. The parameter list also gained a Save button and shows the
+  names as the cleaner reads them, instead of applying each keystroke as it is
+  typed. Thanks to @PathGao.
 - Scratchpad tabs and the pin, close, new pad and pad actions buttons now respond
   across their whole area. Thanks to @AB-boi and @PathGao.
 - Fan Control now prepares stopped fans before taking manual control and keeps a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,15 +26,15 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Ki
   current and target RPM for every fan.
 
 ### Fixed
+- Scratchpad tabs and the pin, close, new pad and pad actions buttons now respond
+  across their whole area. Thanks to @AB-boi and @PathGao.
+- Fan Control now prepares stopped fans before taking manual control and keeps a
+  failed attempt visible instead of silently returning to Automatic.
 - The Clean URL settings fields now take a click anywhere across their row. Their
   hint used to render as a row label beside a short strip of field, so clicking the
   words did nothing. The parameter list also gained a Save button and shows the
   names as the cleaner reads them, instead of applying each keystroke as it is
   typed. Thanks to @PathGao.
-- Scratchpad tabs and the pin, close, new pad and pad actions buttons now respond
-  across their whole area. Thanks to @AB-boi and @PathGao.
-- Fan Control now prepares stopped fans before taking manual control and keeps a
-  failed attempt visible instead of silently returning to Automatic.
 - The grouped simple App Switcher now keeps every window title fully visible when
   using the window shortcut.
 - The recording editor now trims reliably from the beginning of a video when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Ki
   current and target RPM for every fan.
 
 ### Fixed
+- The Clean URL settings fields now draw a border, so the extra parameter names and
+  the manual URL field read as fields you can type in. Thanks to @PathGao.
 - Scratchpad tabs and the pin, close, new pad and pad actions buttons now respond
   across their whole area. Thanks to @AB-boi and @PathGao.
 - Fan Control now prepares stopped fans before taking manual control and keeps a

--- a/Sources/Vorssaint/Core/Localization.swift
+++ b/Sources/Vorssaint/Core/Localization.swift
@@ -1060,6 +1060,7 @@ struct Strings {
     let urlCleanerCustomTitle: String
     let urlCleanerCustomPlaceholder: String
     let urlCleanerCustomCaption: String
+    let urlCleanerCustomSaveButton: String
     let switcherSearchPin: String
     let switcherSearchPinCaption: String
     let invertVerticalScroll: String
@@ -1989,6 +1990,7 @@ extension Strings {
         urlCleanerCustomTitle: "Mais nomes para remover",
         urlCleanerCustomPlaceholder: "ref, origem",
         urlCleanerCustomCaption: "Separe os nomes dos parâmetros com vírgulas. Eles serão removidos de todos os links.",
+        urlCleanerCustomSaveButton: "Salvar",
         switcherSearchPin: "Fixar busca com S",
         switcherSearchPinCaption: "S inicia uma busca e fixa o alternador aberto, assim digitar não produz mais caracteres especiais quando o atalho usa ⌥, e uma busca que comece com Q ou W não fecha a janela nem encerra o app por engano.",
         invertVerticalScroll: "Inverter rolagem vertical",
@@ -2919,6 +2921,7 @@ extension Strings {
         urlCleanerCustomTitle: "More names to remove",
         urlCleanerCustomPlaceholder: "ref, source",
         urlCleanerCustomCaption: "Separate parameter names with commas. They are removed from every link.",
+        urlCleanerCustomSaveButton: "Save",
         switcherSearchPin: "Pin search with S",
         switcherSearchPinCaption: "S starts a search and pins the switcher open, so typing no longer produces special characters when your shortcut uses ⌥, and a search starting with Q or W no longer closes the window or quits the app by mistake.",
         invertVerticalScroll: "Invert vertical scrolling",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
@@ -916,6 +916,7 @@ extension Strings {
         urlCleanerCustomTitle: "添加要移除的名称",
         urlCleanerCustomPlaceholder: "ref, source",
         urlCleanerCustomCaption: "请用逗号分隔参数名称。它们会从所有链接中移除。",
+        urlCleanerCustomSaveButton: "保存",
         switcherSearchPin: "按 S 固定搜索",
         switcherSearchPinCaption: "浏览时按 S 启动搜索，固定切换器；避免自定义快捷键为 ⌥ 时打出特殊字符，以及 Q/W 开头误触发关闭/退出。",
         invertVerticalScroll: "反转垂直滚动",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
@@ -917,6 +917,7 @@ extension Strings {
         urlCleanerCustomTitle: "加入要移除的名稱",
         urlCleanerCustomPlaceholder: "ref, source",
         urlCleanerCustomCaption: "請用逗號分隔參數名稱。它們會從所有連結中移除。",
+        urlCleanerCustomSaveButton: "儲存",
         switcherSearchPin: "按 S 固定搜尋",
         switcherSearchPinCaption: "瀏覽時按 S 啟動搜尋，固定切換器；避免自訂快捷鍵為 ⌥ 時打出特殊字符，以及 Q/W 開頭誤觸發關閉/結束。",
         invertVerticalScroll: "反轉垂直捲動",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
@@ -917,6 +917,7 @@ extension Strings {
         urlCleanerCustomTitle: "加入要移除的名稱",
         urlCleanerCustomPlaceholder: "ref, source",
         urlCleanerCustomCaption: "請用逗號分隔參數名稱。它們會從所有連結中移除。",
+        urlCleanerCustomSaveButton: "儲存",
         switcherSearchPin: "按 S 固定搜尋",
         switcherSearchPinCaption: "瀏覽時按 S 啟動搜尋，固定切換器；避免自訂快捷鍵為 ⌥ 時打出特殊字元，以及 Q/W 開頭誤觸發關閉/結束。",
         invertVerticalScroll: "反轉垂直捲動",

--- a/Sources/Vorssaint/Core/Localizations/Strings+French.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+French.swift
@@ -916,6 +916,7 @@ extension Strings {
         urlCleanerCustomTitle: "Autres noms à retirer",
         urlCleanerCustomPlaceholder: "ref, source",
         urlCleanerCustomCaption: "Séparez les noms des paramètres par des virgules. Ils seront retirés de chaque lien.",
+        urlCleanerCustomSaveButton: "Enregistrer",
         switcherSearchPin: "Épingler la recherche avec S",
         switcherSearchPinCaption: "S lance une recherche et épingle le sélecteur ouvert : plus de caractères spéciaux tapés quand le raccourci utilise ⌥, et une recherche commençant par Q ou W ne ferme plus la fenêtre ni ne quitte l'app par erreur.",
         invertVerticalScroll: "Inverser le défilement vertical",

--- a/Sources/Vorssaint/Core/Localizations/Strings+German.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+German.swift
@@ -916,6 +916,7 @@ extension Strings {
         urlCleanerCustomTitle: "Weitere Namen zum Entfernen",
         urlCleanerCustomPlaceholder: "ref, quelle",
         urlCleanerCustomCaption: "Trenne Parameternamen durch Kommas. Sie werden aus jedem Link entfernt.",
+        urlCleanerCustomSaveButton: "Sichern",
         switcherSearchPin: "Suche mit S anpinnen",
         switcherSearchPinCaption: "S startet die Suche und pinnt den Umschalter an – so tippst du keine Sonderzeichen mehr, wenn dein Kurzbefehl ⌥ nutzt, und eine Suche, die mit Q oder W beginnt, schließt das Fenster oder die App nicht mehr versehentlich.",
         invertVerticalScroll: "Vertikales Scrollen umkehren",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
@@ -916,6 +916,7 @@ extension Strings {
         urlCleanerCustomTitle: "Altri nomi da rimuovere",
         urlCleanerCustomPlaceholder: "ref, origine",
         urlCleanerCustomCaption: "Separa i nomi dei parametri con virgole. Verranno rimossi da ogni link.",
+        urlCleanerCustomSaveButton: "Salva",
         switcherSearchPin: "Blocca la ricerca con S",
         switcherSearchPinCaption: "S avvia la ricerca e blocca il selettore aperto: niente più caratteri speciali quando la scorciatoia usa ⌥, e una ricerca che inizia con Q o W non chiude più la finestra né l'app per errore.",
         invertVerticalScroll: "Inverti lo scorrimento verticale",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
@@ -916,6 +916,7 @@ extension Strings {
         urlCleanerCustomTitle: "削除する名前を追加",
         urlCleanerCustomPlaceholder: "ref, source",
         urlCleanerCustomCaption: "パラメータ名をカンマで区切って入力します。すべてのリンクから削除されます。",
+        urlCleanerCustomSaveButton: "保存",
         switcherSearchPin: "S で検索欄を固定",
         switcherSearchPinCaption: "S を押すと検索を開始して切り替え画面を固定表示にします。ショートカットが ⌥ を使う場合の特殊文字入力も、Q や W で始める検索によるウインドウを閉じる/アプリを終了する誤動作も防げます。",
         invertVerticalScroll: "縦スクロールを反転",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
@@ -917,6 +917,7 @@ extension Strings {
         urlCleanerCustomTitle: "삭제할 이름 추가",
         urlCleanerCustomPlaceholder: "ref, source",
         urlCleanerCustomCaption: "매개변수 이름을 쉼표로 구분하세요. 모든 링크에서 삭제됩니다.",
+        urlCleanerCustomSaveButton: "저장",
         switcherSearchPin: "S로 검색창 고정",
         switcherSearchPinCaption: "S를 누르면 검색을 시작하고 전환기를 고정합니다. 단축키가 ⌥를 사용할 때 특수 문자가 입력되는 문제와, Q나 W로 시작하는 검색이 창을 닫거나 앱을 종료시키는 문제를 모두 막아줍니다.",
         invertVerticalScroll: "세로 스크롤 반전",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
@@ -917,6 +917,7 @@ extension Strings {
         urlCleanerCustomTitle: "Другие названия для удаления",
         urlCleanerCustomPlaceholder: "ref, source",
         urlCleanerCustomCaption: "Разделяйте названия параметров запятыми. Они будут удаляться из всех ссылок.",
+        urlCleanerCustomSaveButton: "Сохранить",
         switcherSearchPin: "Закрепить поиск по S",
         switcherSearchPinCaption: "S запускает поиск и закрепляет переключатель открытым. Печать больше не даёт специальные символы, если сочетание использует ⌥, а поиск, начинающийся с Q или W, больше не закрывает окно и не завершает приложение по ошибке.",
         invertVerticalScroll: "Инвертировать вертикальную прокрутку",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
@@ -916,6 +916,7 @@ extension Strings {
         urlCleanerCustomTitle: "Más nombres para eliminar",
         urlCleanerCustomPlaceholder: "ref, origen",
         urlCleanerCustomCaption: "Separa los nombres de parámetros con comas. Se eliminarán de todos los enlaces.",
+        urlCleanerCustomSaveButton: "Guardar",
         switcherSearchPin: "Fijar búsqueda con S",
         switcherSearchPinCaption: "S inicia una búsqueda y fija el selector abierto: al escribir ya no aparecen caracteres especiales cuando el atajo usa ⌥, y una búsqueda que empieza por Q o W ya no cierra la ventana ni cierra la app por error.",
         invertVerticalScroll: "Invertir el desplazamiento vertical",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
@@ -916,6 +916,7 @@ extension Strings {
         urlCleanerCustomTitle: "Kaldırılacak diğer adlar",
         urlCleanerCustomPlaceholder: "ref, kaynak",
         urlCleanerCustomCaption: "Parametre adlarını virgülle ayırın. Her bağlantıdan kaldırılırlar.",
+        urlCleanerCustomSaveButton: "Kaydet",
         switcherSearchPin: "S ile aramayı sabitle",
         switcherSearchPinCaption: "S, aramayı başlatır ve değiştiriciyi sabitler; kısayolun ⌥ kullanması durumunda özel karakter yazılmasını, Q veya W ile başlayan aramaların pencereyi kapatmasını veya uygulamadan çıkmasını önler.",
         invertVerticalScroll: "Dikey kaydırmayı ters çevir",

--- a/Sources/Vorssaint/UI/Settings/URLCleanerSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/URLCleanerSettings.swift
@@ -35,7 +35,14 @@ struct URLCleanerSettings: View {
             }
 
             Section(l10n.s.urlCleanerCustomTitle) {
-                TextField(l10n.s.urlCleanerCustomPlaceholder, text: $customParameters)
+                // A grouped Form turns a TextField's first argument into a
+                // leading label, not a placeholder: the words sat on the left
+                // while the field itself was a short strip on the right, and
+                // clicking the words did nothing. An empty label puts the
+                // field across the whole row, the shape the Command Bar and
+                // Screenshot pages already use for a field of their own.
+                TextField("", text: $customParameters,
+                          prompt: Text(l10n.s.urlCleanerCustomPlaceholder))
                     .textFieldStyle(.roundedBorder)
                     .accessibilityLabel(l10n.s.urlCleanerCustomTitle)
                 Text(l10n.s.urlCleanerCustomCaption)
@@ -45,7 +52,8 @@ struct URLCleanerSettings: View {
 
             Section(l10n.s.urlCleanerManualTitle) {
                 HStack(spacing: 8) {
-                    TextField(l10n.s.urlCleanerInputPlaceholder, text: $input)
+                    TextField("", text: $input,
+                              prompt: Text(l10n.s.urlCleanerInputPlaceholder))
                         .textFieldStyle(.roundedBorder)
                         .accessibilityLabel(l10n.s.urlCleanerInputPlaceholder)
                     Button {

--- a/Sources/Vorssaint/UI/Settings/URLCleanerSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/URLCleanerSettings.swift
@@ -36,6 +36,8 @@ struct URLCleanerSettings: View {
 
             Section(l10n.s.urlCleanerCustomTitle) {
                 TextField(l10n.s.urlCleanerCustomPlaceholder, text: $customParameters)
+                    .textFieldStyle(.roundedBorder)
+                    .accessibilityLabel(l10n.s.urlCleanerCustomTitle)
                 Text(l10n.s.urlCleanerCustomCaption)
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -44,6 +46,8 @@ struct URLCleanerSettings: View {
             Section(l10n.s.urlCleanerManualTitle) {
                 HStack(spacing: 8) {
                     TextField(l10n.s.urlCleanerInputPlaceholder, text: $input)
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel(l10n.s.urlCleanerInputPlaceholder)
                     Button {
                         clearInput()
                     } label: {

--- a/Sources/Vorssaint/UI/Settings/URLCleanerSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/URLCleanerSettings.swift
@@ -9,10 +9,26 @@ struct URLCleanerSettings: View {
     @ObservedObject private var cleaner = URLCleanerService.shared
     @AppStorage(DefaultsKey.urlCleanerEnabled) private var enabled = false
     @AppStorage(DefaultsKey.urlCleanerCustomParameters) private var customParameters = ""
+    /// Typing is kept out of the stored value on purpose. `@AppStorage` writes
+    /// every keystroke and the cleaner re-reads the list on its next poll, so a
+    /// half-typed `source` briefly removed a `?s=` parameter from anything
+    /// copied at that moment.
+    @State private var customDraft = ""
     @State private var input = ""
     @State private var output = ""
     @State private var message: String?
     private var canClearInput: Bool { !input.isEmpty || !output.isEmpty || message != nil }
+    /// What the draft actually parses to: lowercased, trimmed and deduplicated,
+    /// which is what the cleaner will match on.
+    private var draftParameters: [String] {
+        URLCleaning.customParameters(from: customDraft).sorted()
+    }
+    /// Compared as parsed sets, so stray spacing or a trailing comma does not
+    /// light the button up with nothing to save.
+    private var draftDiffers: Bool {
+        URLCleaning.customParameters(from: customDraft)
+            != URLCleaning.customParameters(from: customParameters)
+    }
 
     var body: some View {
         Form {
@@ -41,10 +57,25 @@ struct URLCleanerSettings: View {
                 // clicking the words did nothing. An empty label puts the
                 // field across the whole row, the shape the Command Bar and
                 // Screenshot pages already use for a field of their own.
-                TextField("", text: $customParameters,
-                          prompt: Text(l10n.s.urlCleanerCustomPlaceholder))
-                    .textFieldStyle(.roundedBorder)
-                    .accessibilityLabel(l10n.s.urlCleanerCustomTitle)
+                HStack(spacing: 8) {
+                    TextField("", text: $customDraft,
+                              prompt: Text(l10n.s.urlCleanerCustomPlaceholder))
+                        .textFieldStyle(.roundedBorder)
+                        .accessibilityLabel(l10n.s.urlCleanerCustomTitle)
+                        .onSubmit { commitCustomParameters() }
+                    // Return commits too, but a visible button is what says so.
+                    Button(l10n.s.urlCleanerCustomSaveButton) { commitCustomParameters() }
+                        .disabled(!draftDiffers)
+                }
+                // The names as the cleaner will see them. Duplicates, casing and
+                // stray spacing all disappear here, which is the only place the
+                // difference between what was typed and what was kept shows.
+                if !draftParameters.isEmpty {
+                    Text(draftParameters.joined(separator: ", "))
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
                 Text(l10n.s.urlCleanerCustomCaption)
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -94,6 +125,15 @@ struct URLCleanerSettings: View {
             }
         }
         .formStyle(.grouped)
+        .onAppear { customDraft = customParameters }
+        // A settings restore replaces the stored list; the field has to follow
+        // it rather than keep showing a draft the app no longer uses.
+        .onChange(of: customParameters) { _, stored in customDraft = stored }
+    }
+
+    private func commitCustomParameters() {
+        guard draftDiffers else { return }
+        customParameters = draftParameters.joined(separator: ", ")
     }
 
     private func paste() {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -8104,6 +8104,19 @@ struct MetricsTests {
                                               customParameters: customURLParameters) ?? "",
                     "https://example.com/?reference=one",
                     "URL cleaner does not treat custom parameter names as prefixes")
+        // A grouped Form renders a TextField's first argument as a leading
+        // label, so the words sat beside a short strip of field and clicking
+        // them did nothing. The hint has to travel as `prompt:` and the label
+        // has to stay empty for the field to own its whole row.
+        let urlCleanerSettingsSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/UI/Settings/URLCleanerSettings.swift",
+            encoding: .utf8)) ?? ""
+        expect(urlCleanerSettingsSource.contains("prompt: Text(l10n.s.urlCleanerCustomPlaceholder)")
+                && urlCleanerSettingsSource.contains("prompt: Text(l10n.s.urlCleanerInputPlaceholder)"),
+               "the Clean URL fields carry their hint as a prompt, not as a row label")
+        expect(!urlCleanerSettingsSource.contains("TextField(l10n.s."),
+               "no Clean URL field spends its row on a label instead of the field")
+
         expect(Defaults.registeredDefaults[DefaultsKey.urlCleanerCustomParameters] as? String == ""
                 && SettingsBackupSupport.exportKeys().contains(DefaultsKey.urlCleanerCustomParameters),
                "custom URL cleaner parameters start empty and travel in Settings backups")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -8116,6 +8116,10 @@ struct MetricsTests {
                "the Clean URL fields carry their hint as a prompt, not as a row label")
         expect(!urlCleanerSettingsSource.contains("TextField(l10n.s."),
                "no Clean URL field spends its row on a label instead of the field")
+        expect(urlCleanerSettingsSource.contains("TextField(\"\", text: $customDraft,"),
+               "the custom parameter field edits a draft of its own")
+        expect(!urlCleanerSettingsSource.contains("text: $customParameters"),
+               "typing never reaches the list the cleaner reads on its next poll")
 
         expect(Defaults.registeredDefaults[DefaultsKey.urlCleanerCustomParameters] as? String == ""
                 && SettingsBackupSupport.exportKeys().contains(DefaultsKey.urlCleanerCustomParameters),


### PR DESCRIPTION
The extra-parameter field on the Clean URL page could not be clicked where it looked like it should be. In a grouped Form a `TextField`'s first argument renders as a leading row label rather than a placeholder, so "ref, source" sat on the left as static words while the editable strip was a short run on the right. Clicking the words did nothing, and the field's own frame started well past the middle of the row, so most of the row was dead. It reads as a description of built-in behaviour rather than as something to fill in.

The manual clean-now field on the same page had the same shape.

## What changed

Both fields pass their hint as `prompt:` with an empty label, so each owns its whole row and takes a click anywhere across it. That is the shape the Command Bar and Screenshot pages already use for a field of their own.

With the field usable, two things were finished off in the same section:

- **A Save button.** The list was bound straight to its stored value, so every keystroke was a saved setting and `URLCleanerService` picked it up on its next 0.8 s poll — typing `source` published `s`, then `so`, on the way. The field now edits a draft; Save commits it, Return commits it too, and the button enables only when the draft parses to a different set. Small window, but "when did this apply?" now has an answer.
- **The parsed names are shown** under the field, which is where lowercasing, trimming and de-duplication become visible. What is committed is that normalised list, so the stored value, the field and the live rules always read the same.

## Alternatives considered

**Keep the label and just add a border.** That was the first attempt and it is not enough: a border makes the short strip visible without making the rest of the row live. The words on the left stay unclickable, which is the actual complaint.

**Commit on Return and focus loss, with no button.** Rejected: this page was just fixed for a control whose only affordance was invisible. Return still works; the button is what says so.

**Render the parsed names as chips.** Rejected: SwiftUI has no wrapping stack on this deployment target, so chips mean writing a `Layout` for a row that usually holds two to five names. A monospaced separated line wraps for free.

## Not changed

The stored format is still one comma-separated string, so nothing migrates and settings backups keep working. `URLCleaning` and the cleaner service are untouched. The built-in rules and the clean-now flow behave as before.

Tests: `TESTS OK (7939 checks)`, plus a full `./build.sh` for the view. Assertions pin the hint travelling as a prompt, no field spending its row on a label, and typing reaching a draft rather than the stored list.
