### PR TITLE
fix(dock-click): bring the app forward when a click restores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,15 +26,15 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Ki
   current and target RPM for every fan.
 
 ### Fixed
-- Clicking the Dock icon of a background app to restore its minimized windows now
-  brings that app forward, instead of leaving its windows behind whichever app was
-  already in front. Thanks to @PathGao.
 - Scratchpad tabs and the pin, close, new pad and pad actions buttons now respond
   across their whole area. Thanks to @AB-boi and @PathGao.
 - Fan Control now prepares stopped fans before taking manual control and keeps a
   failed attempt visible instead of silently returning to Automatic.
 - The grouped simple App Switcher now keeps every window title fully visible when
   using the window shortcut.
+- Clicking the Dock icon of a background app to restore its minimized windows now
+  brings that app forward, instead of leaving its windows behind whichever app was
+  already in front. Thanks to @PathGao.
 - The recording editor now trims reliably from the beginning of a video when
   dragging the left handle. Thanks to @lmilojevicc.
 - Screen recorder, Copy text from screen and Color picker can each take a shortcut

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Ki
   current and target RPM for every fan.
 
 ### Fixed
+- Clicking the Dock icon of a background app to restore its minimized windows now
+  brings that app forward, instead of leaving its windows behind whichever app was
+  already in front. Thanks to @PathGao.
 - Scratchpad tabs and the pin, close, new pad and pad actions buttons now respond
   across their whole area. Thanks to @AB-boi and @PathGao.
 - Fan Control now prepares stopped fans before taking manual control and keeps a

--- a/Sources/Vorssaint/Services/DockClick/DockClickService.swift
+++ b/Sources/Vorssaint/Services/DockClick/DockClickService.swift
@@ -631,10 +631,26 @@ final class DockClickService {
     }
 
     /// Brings an app forward from whatever queue the caller is on.
+    ///
+    /// A bare `activate()` is not enough here. Since macOS 14 an app that is
+    /// not itself frontmost cannot raise another one, and this tap swallowed
+    /// the click precisely so the Dock would not act — so nobody else is going
+    /// to. The restore then half-lands: unminimizing needs no activation
+    /// rights, so the windows come back and are immediately stacked under
+    /// whichever app is still active. Yielding this app's activation first is
+    /// what makes the request cooperative, the same sequence the Switcher,
+    /// Space hop and process list already use.
+    ///
+    /// Options stay empty on purpose: `restoreBackToFront` earns the batch's
+    /// stacking one window at a time, and `.activateAllWindows` would re-raise
+    /// the whole app over it — the flick issue #357 was about.
     private static func activate(pid: pid_t) {
         DispatchQueue.main.async {
             guard let app = NSRunningApplication(processIdentifier: pid), !app.isTerminated else { return }
-            app.activate()
+            NSApp.yieldActivation(to: app)
+            if !app.activate(from: NSRunningApplication.current, options: []) {
+                app.activate(options: [])
+            }
         }
     }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -6851,6 +6851,18 @@ struct MetricsTests {
                                        hasFullscreenWindows: false,
                                        hasModifiers: false) == .passThrough,
                "dock click lets the Dock activate apps that are not frontmost")
+        // The tap swallows a restoring click so the Dock will not open a new
+        // window, which leaves raising the app to this service. Since macOS 14
+        // that only lands if the request is cooperative, so pin the sequence
+        // rather than the bare call it replaced. Asserted positively: the call
+        // it must not use is named in the doc comment right above it.
+        let dockClickSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/DockClick/DockClickService.swift",
+            encoding: .utf8)) ?? ""
+        expect(dockClickSource.contains("NSApp.yieldActivation(to: app)"),
+               "a Dock click restore yields this app's activation first")
+        expect(dockClickSource.contains("app.activate(from: NSRunningApplication.current, options: [])"),
+               "a Dock click restore asks cooperatively before falling back")
         expect(DockClickSupport.action(appIsFrontmost: true,
                                        hasUnminimizedWindows: false,
                                        hasMinimizedWindows: true,


### PR DESCRIPTION
With "Click Dock icon to minimize" on, clicking the Dock icon of a background app whose windows are all minimized brings the windows back and then drops them straight behind whichever app was in front.

The tap swallows that click on purpose — letting the Dock act would open a brand-new window — which leaves activating the app to this feature. `activate(pid:)` did that with a bare `app.activate()`. Since macOS 14 an app that is not itself frontmost cannot raise another one, so the call is refused. Unminimizing needs no activation rights, so the windows do come back, and the window server then orders them under the app that is still active.

## What changed

`activate(pid:)` now uses the sequence the rest of the codebase already uses for this — `WindowActivator`, `SpaceHop` and `ProcessUsageService` all yield first:

```swift
NSApp.yieldActivation(to: app)
if !app.activate(from: NSRunningApplication.current, options: []) {
    app.activate(options: [])
}
```

Effect: a Dock click that restores an app now leaves that app in front, instead of leaving its windows visible but buried.

## Alternatives considered

`options: [.activateAllWindows]`, as `WindowActivator` uses for the switcher, was rejected here. `restoreBackToFront` earns the batch's stacking one window at a time so the right window lands on top by itself; raising every window of the app afterwards would undo that and reintroduce the flick behind issue #357. Empty options activate the app without reordering its windows.

## Not changed

The decision table, the restore ordering and the settling sweep are untouched. All three restore call sites share this one function, so the fix lands on each of them.

No test added: these are four AppKit calls with no branch to assert on. Existing coverage of `DockClickSupport.action` is unaffected.

Tests: no test changes; the suite runs green on the branch that stacks this one (`TESTS OK (7828 checks)`).
