### PR TITLE
fix(storage): store user data owner-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Ki
   @PathGao.
 - App Switcher window preview warm-up no longer crashes right after startup when
   the system returns duplicate window identifiers. Thanks to @james-rose.
+- Clipboard history, its copied images, shelf files, recordings and temporary share
+  records are now stored so only your own account can read them. Folders an earlier
+  version left readable by other accounts on the Mac are corrected on the next
+  write. Thanks to @ThomasWaldmann.
 
 ## [3.3.2] - 2026-08-20
 

--- a/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
+++ b/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
@@ -779,13 +779,7 @@ final class ClipboardHistoryService: ObservableObject {
     /// pushes back past a few megabytes, which a large history of long texts
     /// can reach. Without a resolvable home the blob stays in UserDefaults.
     private static var storeURL: URL? {
-        guard let base = FileManager.default.urls(for: .applicationSupportDirectory,
-                                                  in: .userDomainMask).first,
-              let bundleID = Bundle.main.bundleIdentifier
-        else { return nil }
-        return base
-            .appendingPathComponent(bundleID, isDirectory: true)
-            .appendingPathComponent("ClipboardHistory.json")
+        PrivateFileStore.containerURL?.appendingPathComponent("ClipboardHistory.json")
     }
 
     private static func storedHistoryData(at url: URL) -> Data? {
@@ -865,11 +859,10 @@ final class ClipboardHistoryService: ObservableObject {
                 sweepAfterPersist()
                 return
             }
-            try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
-                                                     withIntermediateDirectories: true)
+            PrivateFileStore.createDirectory(at: url.deletingLastPathComponent())
             // Only a write that really landed retires the legacy blob, so a
             // failed save leaves the history readable from somewhere.
-            guard (try? data.write(to: url, options: .atomic)) != nil else { return }
+            guard PrivateFileStore.write(data, to: url) else { return }
             sweepAfterPersist()
             if retireLegacyBlob {
                 UserDefaults.standard.removeObject(forKey: DefaultsKey.clipboardHistoryEntries)
@@ -1296,22 +1289,15 @@ enum ClipboardImageStore {
     }()
 
     static var directory: URL? {
-        guard let base = FileManager.default.urls(for: .applicationSupportDirectory,
-                                                  in: .userDomainMask).first,
-              let bundleID = Bundle.main.bundleIdentifier
-        else { return nil }
-        return base
-            .appendingPathComponent(bundleID, isDirectory: true)
+        PrivateFileStore.containerURL?
             .appendingPathComponent("ClipboardImages", isDirectory: true)
     }
 
     static func store(_ data: Data) -> String? {
         guard let directory else { return nil }
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        PrivateFileStore.createDirectory(at: directory)
         let name = UUID().uuidString + ".png"
-        do {
-            try data.write(to: directory.appendingPathComponent(name), options: .atomic)
-        } catch {
+        guard PrivateFileStore.write(data, to: directory.appendingPathComponent(name)) else {
             return nil
         }
         return name

--- a/Sources/Vorssaint/Services/PrivateFileStore.swift
+++ b/Sources/Vorssaint/Services/PrivateFileStore.swift
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+/// The app's Application Support container and the only way its contents are
+/// created.
+///
+/// Everything kept there is the user's own material: clipboard history, shelf
+/// files, recordings and the deletion tokens for temporary share links. A plain
+/// `createDirectory` and `Data.write` take whatever the process umask gives,
+/// typically 0755 and 0644, which leaves that material readable by every other
+/// account on the Mac. Directories are created owner-only, files are written
+/// owner-only, and both are set again on every write, so a container an earlier
+/// version left readable heals itself.
+enum PrivateFileStore {
+    private static let directoryPermissions = 0o700
+    private static let filePermissions = 0o600
+
+    /// `~/Library/Application Support/<bundle id>`, nil outside a real bundle.
+    /// Building the URL touches no disk; `createDirectory(at:)` does that.
+    static var containerURL: URL? {
+        guard let base = FileManager.default.urls(for: .applicationSupportDirectory,
+                                                  in: .userDomainMask).first,
+              let bundleID = Bundle.main.bundleIdentifier
+        else { return nil }
+        return base.appendingPathComponent(bundleID, isDirectory: true)
+    }
+
+    /// Creates `url` and its parents owner-only. `container` bounds how far up
+    /// the tightening walks and exists so tests can name their own root.
+    @discardableResult
+    static func createDirectory(at url: URL, container: URL? = containerURL) -> Bool {
+        let manager = FileManager.default
+        guard (try? manager.createDirectory(
+            at: url,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: directoryPermissions])) != nil
+        else { return false }
+        for directory in directoriesToTighten(from: url, container: container) {
+            try? manager.setAttributes([.posixPermissions: directoryPermissions],
+                                       ofItemAtPath: directory.path)
+        }
+        return true
+    }
+
+    /// Atomic, owner-only write. `.atomic` swaps in a freshly created file, so
+    /// the mode belongs after every write rather than once at creation.
+    @discardableResult
+    static func write(_ data: Data, to url: URL) -> Bool {
+        guard (try? data.write(to: url, options: .atomic)) != nil else { return false }
+        try? FileManager.default.setAttributes([.posixPermissions: filePermissions],
+                                               ofItemAtPath: url.path)
+        return true
+    }
+
+    /// `url` plus every directory between it and `container`, the container
+    /// included. `createDirectory` leaves directories that already exist with
+    /// the mode they were created with, so a container from a version that made
+    /// it world readable is only fixed by setting the whole chain. Nothing above
+    /// the container is ever touched: that part belongs to macOS, not to us.
+    static func directoriesToTighten(from url: URL, container: URL?) -> [URL] {
+        var chain = [url.standardizedFileURL]
+        guard let containerPath = container?.standardizedFileURL.path else { return chain }
+        var current = chain[0]
+        while current.path != containerPath, current.path.hasPrefix(containerPath + "/") {
+            let parent = current.deletingLastPathComponent()
+            guard parent.path != current.path else { break }
+            chain.append(parent)
+            current = parent
+        }
+        return chain
+    }
+}

--- a/Sources/Vorssaint/Services/QuickTools/ScratchpadService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScratchpadService.swift
@@ -122,12 +122,7 @@ final class ScratchpadService: ObservableObject {
     /// The former single-buffer file is read once and removed only after the
     /// replacement document has been written and read back successfully.
     private static var legacyStoreURL: URL? {
-        guard let base = FileManager.default.urls(for: .applicationSupportDirectory,
-                                                  in: .userDomainMask).first,
-              let bundleID = Bundle.main.bundleIdentifier else { return nil }
-        return base
-            .appendingPathComponent(bundleID, isDirectory: true)
-            .appendingPathComponent("Scratchpad.txt")
+        PrivateFileStore.containerURL?.appendingPathComponent("Scratchpad.txt")
     }
 
     private func loadApplyingRetention() {

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotShareService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotShareService.swift
@@ -177,12 +177,7 @@ final class ScreenshotShareService: ObservableObject {
     }
 
     private var storageDirectory: URL? {
-        guard let base = FileManager.default.urls(for: .applicationSupportDirectory,
-                                                  in: .userDomainMask).first
-        else { return nil }
-        return base
-            .appendingPathComponent(Bundle.main.bundleIdentifier ?? "com.vorssaint.utils",
-                                    isDirectory: true)
+        PrivateFileStore.containerURL?
             .appendingPathComponent("TemporaryScreenshotLinks", isDirectory: true)
     }
 
@@ -203,20 +198,10 @@ final class ScreenshotShareService: ObservableObject {
         guard let directory = storageDirectory else {
             throw ScreenshotShareError.localStorage
         }
-        let manager = FileManager.default
-        do {
-            try manager.createDirectory(at: directory,
-                                        withIntermediateDirectories: true,
-                                        attributes: [.posixPermissions: 0o700])
-            try manager.setAttributes([.posixPermissions: 0o700],
-                                      ofItemAtPath: directory.path)
-            let file = directory.appendingPathComponent("records.json")
-            try encoder.encode(records).write(to: file, options: .atomic)
-            try manager.setAttributes([.posixPermissions: 0o600],
-                                      ofItemAtPath: file.path)
-        } catch {
-            throw ScreenshotShareError.localStorage
-        }
+        guard PrivateFileStore.createDirectory(at: directory),
+              let data = try? encoder.encode(records),
+              PrivateFileStore.write(data, to: directory.appendingPathComponent("records.json"))
+        else { throw ScreenshotShareError.localStorage }
     }
 
     private func normalizedRecords(_ candidates: [ScreenshotShareRecord],

--- a/Sources/Vorssaint/Services/Recorder/RecorderTakeStore.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderTakeStore.swift
@@ -31,12 +31,7 @@ final class RecorderTakeStore: @unchecked Sendable {
     // MARK: - Location
 
     private var root: URL? {
-        guard let base = manager.urls(for: .applicationSupportDirectory,
-                                      in: .userDomainMask).first,
-              let bundleID = Bundle.main.bundleIdentifier
-        else { return nil }
-        return base
-            .appendingPathComponent(bundleID, isDirectory: true)
+        PrivateFileStore.containerURL?
             .appendingPathComponent("Recordings", isDirectory: true)
     }
 
@@ -58,8 +53,7 @@ final class RecorderTakeStore: @unchecked Sendable {
         let id = UUID()
         let folder = root.appendingPathComponent(RecorderSupport.takeFolderName(id: id),
                                                  isDirectory: true)
-        guard (try? manager.createDirectory(at: folder, withIntermediateDirectories: true)) != nil
-        else { return nil }
+        guard PrivateFileStore.createDirectory(at: folder) else { return nil }
         return Take(id: id, folder: folder)
     }
 

--- a/Sources/Vorssaint/Services/Recorder/RecordingShareService.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecordingShareService.swift
@@ -175,12 +175,7 @@ final class RecordingShareService: ObservableObject {
     }
 
     private var storageDirectory: URL? {
-        guard let base = FileManager.default.urls(for: .applicationSupportDirectory,
-                                                  in: .userDomainMask).first
-        else { return nil }
-        return base
-            .appendingPathComponent(Bundle.main.bundleIdentifier ?? "com.vorssaint.utils",
-                                    isDirectory: true)
+        PrivateFileStore.containerURL?
             .appendingPathComponent("TemporaryRecordingLinks", isDirectory: true)
     }
 
@@ -201,20 +196,10 @@ final class RecordingShareService: ObservableObject {
         guard let directory = storageDirectory else {
             throw RecordingShareError.localStorage
         }
-        let manager = FileManager.default
-        do {
-            try manager.createDirectory(at: directory,
-                                        withIntermediateDirectories: true,
-                                        attributes: [.posixPermissions: 0o700])
-            try manager.setAttributes([.posixPermissions: 0o700],
-                                      ofItemAtPath: directory.path)
-            let file = directory.appendingPathComponent("records.json")
-            try encoder.encode(records).write(to: file, options: .atomic)
-            try manager.setAttributes([.posixPermissions: 0o600],
-                                      ofItemAtPath: file.path)
-        } catch {
-            throw RecordingShareError.localStorage
-        }
+        guard PrivateFileStore.createDirectory(at: directory),
+              let data = try? encoder.encode(records),
+              PrivateFileStore.write(data, to: directory.appendingPathComponent("records.json"))
+        else { throw RecordingShareError.localStorage }
     }
 
     private func normalizedRecords(_ candidates: [RecordingShareRecord],

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -213,15 +213,8 @@ final class ShelfService: ObservableObject {
     /// Application Support/<bundle id>/ShelfFiles. They used to live in the
     /// system temp dir, but persistent items cannot (the OS, or our own
     /// startup sweep, could delete them at any point).
-    private static let storeDirectory: URL? = {
-        guard let base = FileManager.default.urls(for: .applicationSupportDirectory,
-                                                  in: .userDomainMask).first,
-              let bundleID = Bundle.main.bundleIdentifier
-        else { return nil }
-        return base
-            .appendingPathComponent(bundleID, isDirectory: true)
-            .appendingPathComponent("ShelfFiles", isDirectory: true)
-    }()
+    private static let storeDirectory: URL? = PrivateFileStore.containerURL?
+        .appendingPathComponent("ShelfFiles", isDirectory: true)
 
     /// Writes coalesce per mutation cycle already; the JSON encode itself
     /// also stays off the main thread (a full shelf of large texts is real
@@ -1418,17 +1411,13 @@ final class ShelfService: ObservableObject {
     private func storePayloadData(_ data: Data, fileExtension: String) -> URL? {
         let directory: URL
         if let store = Self.storeDirectory {
-            try? FileManager.default.createDirectory(at: store, withIntermediateDirectories: true)
+            PrivateFileStore.createDirectory(at: store)
             directory = store
         } else {
             directory = tempDir
         }
         let url = directory.appendingPathComponent("\(UUID().uuidString).\(fileExtension)")
-        do {
-            try data.write(to: url, options: .atomic)
-        } catch {
-            return nil
-        }
+        guard PrivateFileStore.write(data, to: url) else { return nil }
         return url
     }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15442,6 +15442,46 @@ struct MetricsTests {
                 ScreenCaptureTool.allCases.contains { $0.dedicatedShortcut?.role == role }
                },
                "no capture tool's shortcut row is left without something to register it")
+        // MARK: Private file store
+
+        let privateRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PrivateFileStoreTests-\(UUID().uuidString)", isDirectory: true)
+        let privateLeaf = privateRoot.appendingPathComponent("Sub", isDirectory: true)
+        expect(PrivateFileStore.directoriesToTighten(from: privateLeaf, container: privateRoot)
+                .map(\.lastPathComponent) == ["Sub", privateRoot.lastPathComponent],
+               "tightening walks a container path up to the container itself")
+        expect(PrivateFileStore.directoriesToTighten(from: privateRoot, container: privateRoot)
+                .map(\.lastPathComponent) == [privateRoot.lastPathComponent],
+               "the container is tightened without climbing past it")
+        expect(PrivateFileStore.directoriesToTighten(
+                from: privateLeaf,
+                container: FileManager.default.temporaryDirectory
+                    .appendingPathComponent(privateRoot.lastPathComponent + "-other",
+                                            isDirectory: true)).count == 1,
+               "a path outside the container tightens only itself, never a sibling's parents")
+
+        // A container an earlier version created world readable, and a file
+        // written into it, both end up owner-only.
+        try? FileManager.default.createDirectory(at: privateRoot,
+                                                 withIntermediateDirectories: true,
+                                                 attributes: [.posixPermissions: 0o755])
+        let privateFile = privateLeaf.appendingPathComponent("records.json")
+        let privateCreated = PrivateFileStore.createDirectory(at: privateLeaf,
+                                                              container: privateRoot)
+        let privateWritten = PrivateFileStore.write(Data([0x7B, 0x7D]), to: privateFile)
+        func privateMode(_ url: URL) -> Int? {
+            (try? FileManager.default.attributesOfItem(atPath: url.path))?[.posixPermissions]
+                .flatMap { ($0 as? NSNumber)?.intValue }
+        }
+        expect(privateCreated && privateMode(privateLeaf) == 0o700,
+               "a created store directory is owner-only")
+        expect(privateWritten
+                && privateMode(privateFile) == 0o600
+                && (try? Data(contentsOf: privateFile)) == Data([0x7B, 0x7D]),
+               "a stored file lands complete and owner-only")
+        expect(privateMode(privateRoot) == 0o700,
+               "a container an earlier version left world readable is tightened on the next write")
+        try? FileManager.default.removeItem(at: privateRoot)
 
         // MARK: Result
 

--- a/build.sh
+++ b/build.sh
@@ -160,6 +160,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/KillProcess/KillProcessSupport.swift \
         Sources/Vorssaint/Services/Recorder/RecorderSupport.swift \
         Sources/Vorssaint/Services/Recorder/RecordingSharingSupport.swift \
+        Sources/Vorssaint/Services/PrivateFileStore.swift \
         Sources/Vorssaint/Services/Recorder/RecorderTakeStore.swift \
         Sources/Vorssaint/Services/Recorder/RecorderMotion.swift \
         Sources/Vorssaint/Services/Recorder/RecorderPointerTrack.swift \


### PR DESCRIPTION
Ref #520

Everything the app keeps in `~/Library/Application Support/<bundle id>` is the
user's own material, and five of the seven stores there created directories and
wrote files with no permission attributes, so they took the process umask:
`0755` directories and `0644` files, readable by every other account on the Mac.
Clipboard history and its copied images (`ClipboardHistoryService.swift:781`,
`:1273`), shelf payloads (`ShelfService.swift:216`) and recording takes
(`RecorderTakeStore.swift:51`).

The other two did the opposite on purpose. `ScreenshotShareService` and
`RecordingShareService` create `0700` and write `0600`, with a comment
explaining that the private deletion token needs a safe place to live. So the
same question had two answers in one codebase, and the answer that lost covers
the larger amount of private data. `RecorderTakeStore` even documents its takes
as "the same private, disposable master a screen recording gets" while creating
them world readable. Reported by @ThomasWaldmann in #520, who read the source
and found the inconsistency.

### The change

`PrivateFileStore` becomes the single place that builds paths inside the
container and the only way its contents are created: directories `0700`, files
`0600`. The six stores lose their own copy of the same five-line path builder
and the two share services lose their inline permission block.

Both modes are set again on **every** write, not once at creation, for two
separate reasons:

- `createDirectory` leaves a directory that already exists with the mode it was
  created with, so an install from any earlier version would keep `0755`
  forever. Walking from the written path up to the container corrects it on the
  next write, with no migration step and no version stamp.
- `Data.write(options: .atomic)` swaps in a freshly created file each time, so a
  mode applied once would not survive the next save.

After: the container and every store folder under it are `drwx------`, and
`ClipboardHistory.json`, the `ClipboardImages` PNGs, `ShelfFiles` payloads and
both `records.json` are `-rw-------`, on a fresh install and on an existing one
alike. Nothing above the container is touched; the walk stops there.

### Trade-offs

- **Tightening only `ClipboardHistory.json`**, the file the report names, was
  the smaller change. The neighbouring stores hold the same class of data
  through the same mistake, so that fix would leave the report half true.
- **Tightening only the container and leaving file modes alone** would block
  other accounts just as effectively, since `0700` stops traversal. Rejected
  because it contradicts the two share services, which already write `0600`,
  and would reinstate the inconsistency this removes.
- **A one-shot migration at launch** was the alternative to setting the mode on
  every write. Rejected: it needs a version stamp and an ordering guarantee
  against the first store access, and it cannot heal a container that something
  outside the app loosens later.

### Not changed

- `UpdateService`, which writes a downloaded installer and a helper script.
  That is not user data and the updater deserves its own look.
- The Scratchpad export path (`ScratchpadService.swift:329`), which writes where
  the user picks in a save panel. A file exported to Documents should get
  ordinary permissions.
- Files already on disk are not swept. Each is corrected when its store is next
  written, which is the first copy, drop or recording after updating.
- The `Bundle.main.bundleIdentifier ?? "com.vorssaint.utils"` fallback that only
  the two share services carried is gone. The container is now nil outside a
  real bundle, as it already was for the other five stores.

### Tests

`./build.sh --test` 7832 checks OK (7826 before) · `./build.sh --dev` clean ·
`--selftest` OK. MacBookAir (M5), macOS 26.5.2.

The new checks pin the path walk as a pure function, then exercise the real
`FileManager`: a root created `0755` on purpose, a store directory and a file
written into it, asserting `0700`, `0600`, the file's contents, and that the
container itself was tightened.
