### PR TITLE
fix(dock-preview): give the thumbnail the room duplicates took

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,6 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Ki
   process trees from Settings and the Command Bar. It ships uninstalled. Thanks to @naveenkrdy.
 
 ### Changed
-- Dock Preview cards no longer draw the app icon on every thumbnail or repeat the
-  window title over it, leaving the thumbnail more of the card, and a card now
-  badges a window that lives on another desktop. Thanks to @PathGao.
 - Fan Control now offers System, continuous Manual control from 0% to 100% and
   editable temperature curves with multiple SoC, CPU and GPU rules. It also shows
   current and target RPM for every fan.
@@ -31,6 +28,9 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Ki
 ### Fixed
 - Scratchpad tabs and the pin, close, new pad and pad actions buttons now respond
   across their whole area. Thanks to @AB-boi and @PathGao.
+- Dock Preview cards no longer draw the app icon on every thumbnail or repeat the
+  window title over it, leaving the thumbnail more of the card, and a card now
+  badges a window that lives on another desktop. Thanks to @PathGao.
 - Fan Control now prepares stopped fans before taking manual control and keeps a
   failed attempt visible instead of silently returning to Automatic.
 - The grouped simple App Switcher now keeps every window title fully visible when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Ki
   process trees from Settings and the Command Bar. It ships uninstalled. Thanks to @naveenkrdy.
 
 ### Changed
+- Dock Preview cards no longer draw the app icon on every thumbnail or repeat the
+  window title over it, leaving the thumbnail more of the card, and a card now
+  badges a window that lives on another desktop. Thanks to @PathGao.
 - Fan Control now offers System, continuous Manual control from 0% to 100% and
   editable temperature curves with multiple SoC, CPU and GPU rules. It also shows
   current and target RPM for every fan.

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewSupport.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewSupport.swift
@@ -139,8 +139,19 @@ enum DockPreviewSupport {
         )
     }
 
-    static var cardWidth: CGFloat { 204 * PreviewSizing.scale }
-    static var cardHeight: CGFloat { 152 * PreviewSizing.scale }
+    /// Card metrics. The thumbnail gets whatever the fixed chrome does not
+    /// take, so the card can be resized or the title band retuned without
+    /// leaving a stale magic number behind — the old code hard-coded a 54pt
+    /// deduction that no longer matched the parts it stood for.
+    static var cardWidth: CGFloat { 176 * PreviewSizing.scale }
+    static var cardHeight: CGFloat { 134 * PreviewSizing.scale }
+    static var cardPadding: CGFloat { 8 * PreviewSizing.scale }
+    static var cardTitleSpacing: CGFloat { 5 * PreviewSizing.scale }
+    /// One line of 12pt semibold, with just enough room for descenders.
+    static var cardTitleHeight: CGFloat { 17 * PreviewSizing.scale }
+    static var cardThumbnailHeight: CGFloat {
+        cardHeight - cardPadding * 2 - cardTitleSpacing - cardTitleHeight
+    }
     static var cardSpacing: CGFloat { 8 * PreviewSizing.scale }
     static var panelPadding: CGFloat { 12 * PreviewSizing.scale }
     static let panelHeaderHeight: CGFloat = 28

--- a/Sources/Vorssaint/Services/Switcher/SwitcherModels.swift
+++ b/Sources/Vorssaint/Services/Switcher/SwitcherModels.swift
@@ -54,6 +54,26 @@ struct SwitcherItem: Identifiable, Equatable {
         return displayTitle
     }
 
+    /// Whether this entry stands for the app itself because it has no window
+    /// to switch to. Those entries have no thumbnail to draw and no window to
+    /// name, so several places have to present them differently.
+    var isAppEntry: Bool { windowID == nil }
+
+    /// What the screen reader hears. An app entry replaces the window title
+    /// with its state on screen, so the label has to carry that state too or
+    /// the entry sounds identical to a window of the same app.
+    ///
+    /// Lives on the model rather than beside one view: the Dock preview card
+    /// draws the same badges and owes its reader the same sentence.
+    func spokenLabel(noOpenWindow: String,
+                     hiddenApp: String,
+                     otherDesktop: String) -> String {
+        var label = isAppEntry ? "\(appName), \(noOpenWindow)" : accessibilityTitle
+        if isAppHidden { label += ", \(hiddenApp)" }
+        if isOnHiddenSpace { label += ", \(otherDesktop)" }
+        return label
+    }
+
     var appIcon: NSImage? {
         NSRunningApplication(processIdentifier: pid)?.icon
     }

--- a/Sources/Vorssaint/UI/Switcher/DockPreviewPanelView.swift
+++ b/Sources/Vorssaint/UI/Switcher/DockPreviewPanelView.swift
@@ -313,11 +313,11 @@ private struct DockPreviewCard: View {
     }
 
     private var hasStatusBadges: Bool {
-        window.isMinimized || window.isFullscreen
+        window.isMinimized || window.isFullscreen || window.isOnHiddenSpace
     }
 
     var body: some View {
-        VStack(spacing: 7) {
+        VStack(spacing: DockPreviewSupport.cardTitleSpacing) {
             ZStack {
                 RoundedRectangle(cornerRadius: 9, style: .continuous)
                     .fill(Color.white.opacity(0.07))
@@ -335,20 +335,6 @@ private struct DockPreviewCard: View {
                         .frame(width: 52, height: 52)
                 }
 
-                if preview != nil, let icon = window.appIcon {
-                    VStack {
-                        Spacer()
-                        HStack {
-                            Spacer()
-                            Image(nsImage: icon)
-                                .resizable()
-                                .frame(width: 24, height: 24)
-                                .shadow(radius: 2)
-                                .padding(6)
-                        }
-                    }
-                }
-
                 if hasStatusBadges {
                     VStack {
                         Spacer()
@@ -360,20 +346,20 @@ private struct DockPreviewCard: View {
                     }
                 }
 
-                previewTitleBar
+                previewControlBar
             }
-            .frame(width: DockPreviewSupport.cardWidth - 18,
-                   height: DockPreviewSupport.cardHeight - 54)
+            .frame(width: DockPreviewSupport.cardWidth - DockPreviewSupport.cardPadding * 2,
+                   height: DockPreviewSupport.cardThumbnailHeight)
 
             Text(window.displayTitle)
                 .font(.system(size: 12, weight: .semibold))
                 .lineLimit(1)
                 .truncationMode(.middle)
                 .foregroundStyle(.primary)
-                .frame(height: 24)
-                .frame(maxWidth: DockPreviewSupport.cardWidth - 22)
+                .frame(height: DockPreviewSupport.cardTitleHeight)
+                .frame(maxWidth: DockPreviewSupport.cardWidth - DockPreviewSupport.cardPadding * 2 - 4)
         }
-        .padding(9)
+        .padding(DockPreviewSupport.cardPadding)
         .frame(width: DockPreviewSupport.cardWidth, height: DockPreviewSupport.cardHeight)
         .background(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
@@ -394,7 +380,9 @@ private struct DockPreviewCard: View {
         .onHover { isHovering = $0 }
         .animation(.spring(response: 0.2, dampingFraction: 0.82), value: isSelected)
         .animation(.easeOut(duration: 0.12), value: showsPreviewControls)
-        .accessibilityLabel(window.accessibilityTitle)
+        .accessibilityLabel(window.spokenLabel(noOpenWindow: l10n.s.switcherNoOpenWindow,
+                                               hiddenApp: l10n.s.panelHiddenItem,
+                                               otherDesktop: l10n.s.switcherOtherDesktop))
     }
 
     @ViewBuilder
@@ -419,14 +407,15 @@ private struct DockPreviewCard: View {
         }
     }
 
-    private var previewTitleBar: some View {
+    /// Window controls only. The title used to live here too, which put the same
+    /// string on screen twice — once floating over the thumbnail, once in the
+    /// band below it. The band keeps it, because a title that is only there
+    /// while the pointer is on the card cannot tell six windows of one app
+    /// apart, which is the whole job of this panel.
+    private var previewControlBar: some View {
         VStack {
             HStack(spacing: 6) {
-                Text(window.displayTitle)
-                    .font(.system(size: 11, weight: .semibold))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .foregroundStyle(Color.white.opacity(0.92))
+                Spacer(minLength: 0)
                 if isPanelPinned, isSelected {
                     Text(l10n.s.dockPreviewPinned)
                         .font(.system(size: 9, weight: .semibold))
@@ -435,14 +424,14 @@ private struct DockPreviewCard: View {
                         .padding(.vertical, 1)
                         .background(Capsule().fill(Color.white.opacity(0.12)))
                 }
-                Spacer(minLength: 2)
                 closeButton
                 minimizeButton
             }
-            .padding(.leading, 9)
+            .padding(.leading, 7)
             .padding(.trailing, 5)
             .padding(.vertical, 5)
-            .frame(height: 30)
+            .fixedSize(horizontal: true, vertical: false)
+            .frame(height: 28)
             .background(
                 Capsule(style: .continuous)
                     .fill(Color.black.opacity(0.44))
@@ -452,8 +441,9 @@ private struct DockPreviewCard: View {
                     )
             )
             .shadow(color: Color.black.opacity(0.18), radius: 6, y: 2)
-            .padding(.horizontal, 7)
+            .padding(.trailing, 7)
             .padding(.top, 7)
+            .frame(maxWidth: .infinity, alignment: .trailing)
             .opacity(showsPreviewControls ? 1 : 0)
             .allowsHitTesting(showsPreviewControls)
             Spacer()
@@ -467,6 +457,9 @@ private struct DockPreviewCard: View {
         }
         if window.isFullscreen {
             statusBadge(systemName: "arrow.up.left.and.arrow.down.right")
+        }
+        if window.isOnHiddenSpace {
+            statusBadge(systemName: "rectangle.stack")
         }
     }
 

--- a/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
+++ b/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
@@ -15,25 +15,6 @@ private enum SwitcherIconStyle {
     static let thumbnailBackground = Color.primary.opacity(0.055)
 }
 
-private extension SwitcherItem {
-    /// Whether this entry stands for the app itself because it has no window
-    /// to switch to. Those entries have no thumbnail to draw and no window to
-    /// name, so several places have to present them differently.
-    var isAppEntry: Bool { windowID == nil }
-
-    /// What the screen reader hears. An app entry replaces the window title
-    /// with its state on screen, so the label has to carry that state too or
-    /// the entry sounds identical to a window of the same app.
-    func spokenLabel(noOpenWindow: String,
-                     hiddenApp: String,
-                     otherDesktop: String) -> String {
-        var label = isAppEntry ? "\(appName), \(noOpenWindow)" : accessibilityTitle
-        if isAppHidden { label += ", \(hiddenApp)" }
-        if isOnHiddenSpace { label += ", \(otherDesktop)" }
-        return label
-    }
-}
-
 private struct SwitcherHiddenAppBadge: ViewModifier {
     let isHidden: Bool
     let size: CGFloat

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -2124,6 +2124,31 @@ struct MetricsTests {
         expect(!DockPreviewSupport.canDragToPlace(hasWindowID: false, isOnScreen: false,
                                                   isMinimized: false, isFullscreen: false),
                "an entry without a window has nothing to move")
+        // The thumbnail is derived from the card, so a constant changed on its
+        // own must not silently eat into it or leave the card short.
+        expectClose(Double(DockPreviewSupport.cardThumbnailHeight
+                            + DockPreviewSupport.cardPadding * 2
+                            + DockPreviewSupport.cardTitleSpacing
+                            + DockPreviewSupport.cardTitleHeight),
+                    Double(DockPreviewSupport.cardHeight),
+                    "a Dock Preview card's chrome and thumbnail add up to the card")
+        expect(DockPreviewSupport.cardThumbnailHeight
+                > DockPreviewSupport.cardHeight * 0.7,
+               "the thumbnail keeps most of the Dock Preview card")
+
+        // The card used to draw the app icon on every thumbnail and the window
+        // title both over the thumbnail and under it. In a panel every card
+        // belongs to one app, so both said the same thing once per window.
+        let dockPreviewCardSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/UI/Switcher/DockPreviewPanelView.swift",
+            encoding: .utf8)) ?? ""
+        expect(dockPreviewCardSource.components(separatedBy: "Text(window.displayTitle)").count - 1 == 1,
+               "a Dock Preview card names its window once")
+        expect(dockPreviewCardSource.components(separatedBy: "window.appIcon").count - 1 == 1,
+               "a Dock Preview card only falls back to the app icon when it has no thumbnail")
+        expect(dockPreviewCardSource.contains("window.isOnHiddenSpace"),
+               "a Dock Preview card badges a window that lives on another desktop")
+
         let dockDropScreen = CGRect(x: -1440, y: 24, width: 1440, height: 876)
         expect(DockPreviewSupport.dragOrigin(pointer: CGPoint(x: -700, y: 500),
                                              windowSize: CGSize(width: 600, height: 400),


### PR DESCRIPTION
Every card in a Dock preview panel belongs to the app whose icon is under the pointer, so two of the things each card drew carried no information — and both sat on top of the one thing that does.

- The app icon was stamped into the bottom-right corner of every thumbnail. Hover Chrome with six windows open and the same Chrome icon is drawn six times, over the six pictures the user came to look at.
- The window title was drawn twice: once in a capsule floating over the thumbnail, once in the band below it. On hover, the same string is on screen twice.

Between them they covered the top 44pt and a 36pt corner of a 98pt-tall thumbnail.

## What changed

- **Icon badge removed.** It belongs to a mixed-app list like the App Switcher, where it says which app a card is; here it says the same thing on every card.
- **Floating title removed**, leaving a control cluster that hugs its two buttons at the top-right instead of spanning the card. The band below keeps the title: a title that only appears while the pointer is on a card cannot tell six windows of one app apart, which is this panel's whole job.
- **Title band 24pt → 17pt.** One line of 12pt semibold needs the descenders, not seven points of air.
- **Card 204×152 → 176×134.** A panel of a given width now fits roughly one more card.
- **`isOnHiddenSpace` now gets a badge.** This is not a new idea: the App Switcher badges all three window states with `rectangle.stack` for this one, and this panel's copy of that rule only checked two. Which of six Chrome windows lives on another desktop was computed and then thrown away.

Result: the thumbnail goes from 64% to 78% of the card's height, and nothing is drawn on top of it except two buttons that fade in on hover.

The thumbnail's height stops being a hard-coded `cardHeight - 54` and is derived from the chrome around it. The old constant stood for parts that add up to 49, so it had been carrying a five-point discrepancy nobody could account for; resizing the card or the title band would have widened it silently.

## Accessibility

All three status badges are `accessibilityHidden`, and the card announced `accessibilityTitle`, which carries no window state — a minimized window sounded identical to a visible one. The card now announces `spokenLabel(noOpenWindow:hiddenApp:otherDesktop:)`, the label the App Switcher already uses. No new strings, so nothing to translate in the 13 language files.

## Alternatives considered

**Keep the floating title and drop the band instead.** That is the denser option — the thumbnail would reach 122pt and the card could fall to 128 — and it was rejected on purpose. The floating title is the redundant copy; the persistent one is how a user picks a window out of six without sweeping the pointer across all of them.

## Not changed

Preview sizing still scales off `PreviewSizing.scale`, so the four size options keep working. Hover, tap, context menu, pinning and the close/minimize buttons behave exactly as before. The App Switcher's own card is untouched — the icon badge is still correct there.

Tests: `TESTS OK (7826 checks)`, none added. This is layout and one restored branch of an existing, already-tested rule.
