### PR TITLE
fix(settings): name each Dock section after its feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Ki
   current and target RPM for every fan.
 
 ### Fixed
+- Settings now lists Dock Preview and Dock click as separate named sections, and
+  opening Dock click from the Features hub lands on its own controls rather than on
+  the Dock Preview block. Thanks to @PathGao.
 - Scratchpad tabs and the pin, close, new pad and pad actions buttons now respond
   across their whole area. Thanks to @AB-boi and @PathGao.
 - Fan Control now prepares stopped fans before taking manual control and keeps a

--- a/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
@@ -29,6 +29,7 @@ enum SettingsSectionAnchor: String, CaseIterable, Hashable {
     case middleClick
     case switcher
     case dock
+    case dockClick
     case finderCutPaste
     case finderRename
     case clipboardHistory
@@ -52,7 +53,7 @@ enum SettingsSectionAnchor: String, CaseIterable, Hashable {
         case .scrollDirection, .focusFollowsMouse, .smoothScroll, .mouseNavigation, .mouseButtonShortcuts,
              .middleClick:
             return .mouse
-        case .switcher, .dock: return .switcher
+        case .switcher, .dock, .dockClick: return .switcher
         case .finderCutPaste, .finderRename: return .cutPaste
         case .clipboardHistory, .pastePlain: return .clipboard
         case .quickLauncher, .quickToggles, .micMute, .cameraPreview, .scratchpad:
@@ -131,8 +132,8 @@ extension AppFeature {
     var settingsDestination: FeatureSettingsDestination {
         switch self {
         case .switcher: return FeatureSettingsDestination(.switcher, sectionAnchor: .switcher)
-        case .dockPreview, .dockClick:
-            return FeatureSettingsDestination(.switcher, sectionAnchor: .dock)
+        case .dockPreview: return FeatureSettingsDestination(.switcher, sectionAnchor: .dock)
+        case .dockClick: return FeatureSettingsDestination(.switcher, sectionAnchor: .dockClick)
         case .windowMaximizer:
             return FeatureSettingsDestination(.general, sectionAnchor: .panelConfiguration)
         case .windowLayout: return FeatureSettingsDestination(.windowLayout)

--- a/Sources/Vorssaint/UI/Settings/SettingsView.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsView.swift
@@ -939,9 +939,9 @@ struct SwitcherSettings: View {
                 }
                 .settingsSectionAnchor(.switcher)
             }
-            if AppFeature.dockPreview.isAvailable || AppFeature.dockClick.isAvailable {
+            if AppFeature.dockPreview.isAvailable {
                 Section {
-                    if AppFeature.dockPreview.isAvailable {
+                    do {
                         Toggle(l10n.s.dockPreviewEnable, isOn: $dockPreviewEnabled)
                             .onChange(of: dockPreviewEnabled) { _, _ in
                                 DockPreviewService.shared.syncWithPreferences()
@@ -963,7 +963,17 @@ struct SwitcherSettings: View {
                             SettingsCaptionText(l10n.s.dockPreviewBackgroundOpacityCaption)
                         }
                     }
-                    if AppFeature.dockClick.isAvailable {
+                } header: {
+                    Text(l10n.s.dockPreviewName)
+                }
+                .settingsSectionAnchor(.dock)
+            }
+            // Clicking a Dock icon is its own installable feature in the hub, so
+            // it gets its own section here. It used to sit under the Dock Preview
+            // header, which named one feature over the controls of two.
+            if AppFeature.dockClick.isAvailable {
+                Section {
+                    do {
                         Toggle(l10n.s.dockClickMinimize, isOn: $dockClickMinimize)
                             .onChange(of: dockClickMinimize) { _, enabled in
                                 if enabled { dockClickHide = false }
@@ -989,9 +999,9 @@ struct SwitcherSettings: View {
                             .foregroundStyle(.secondary)
                     }
                 } header: {
-                    Text(l10n.s.dockPreviewName)
+                    Text(FeatureStrings.hub(l10n.language).titleDockClick)
                 }
-                .settingsSectionAnchor(.dock)
+                .settingsSectionAnchor(.dockClick)
             }
             if AppFeature.switcher.isAvailable || AppFeature.dockPreview.isAvailable {
                 Section {


### PR DESCRIPTION
Ref #595

One section on the Switcher page was headed "Dock Preview" and held the controls of two separate features: the Dock Preview toggle and its panel opacity, then the three "click the Dock icon to…" switches, which belong to Dock Click. Both are independently installable in the Features hub, so the header named one feature over the controls of two.

The `.dock` section anchor had the same problem. Both features routed to it, so jumping to Dock Click from the hub landed on the Dock Preview block and left the user to find the right switches.

## What changed

The section splits in two along the line the Features hub already draws. Dock Preview keeps its header and the `.dock` anchor; Dock Click gets a section headed `titleDockClick` and a new `.dockClick` anchor, and its hub entry now routes there.

Both headers come from strings that already exist in all 13 languages, so there is nothing to translate.

Effect: opening the page with both features installed shows two named blocks that match the hub, and "open at its Settings controls" from the hub lands on the right one.

## Alternatives considered

**Rename the shared header to cover both** — something like "Dock". Rejected: it would name a grouping that exists nowhere else in the app, while the hub, the availability keys and the services all treat these as two features. The split costs the same and agrees with everything around it.

## Not changed

The page is still called Switcher and still hosts all three features, including the window-thumbnail section that Switcher and Dock Preview genuinely share. Whether the page itself should split, what it should be called, and where the shared section belongs are open questions in #595 — this change is only the header that misnamed its own contents.

Tests: `TESTS OK (7826 checks)`. `SettingsSectionAnchor` is exhaustive by design, so the new case had to be routed before this compiled.
