### PR TITLE
fix(switcher): tolerate duplicate windowIDs from ScreenCaptureKit

### DIFF
--- a/Sources/Vorssaint/Services/Switcher/WindowPreviewProvider.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowPreviewProvider.swift
@@ -152,7 +152,7 @@ final class WindowPreviewProvider {
             guard let content = try? await SCShareableContent.excludingDesktopWindows(false,
                                                                                       onScreenWindowsOnly: false)
             else { return }
-            let scWindows = Dictionary(uniqueKeysWithValues: content.windows.map { ($0.windowID, $0) })
+            let scWindows = Dictionary(content.windows.map { ($0.windowID, $0) }, uniquingKeysWith: { first, _ in first })
 
             for target in pending {
                 guard !Task.isCancelled else { return }


### PR DESCRIPTION
## Crash

`WindowPreviewProvider.scheduleWarm()` built its `SCWindow` lookup table with:

```swift
Dictionary(uniqueKeysWithValues: content.windows.map { ($0.windowID, $0) })
```

`uniqueKeysWithValues:` traps on any duplicate key. When `SCShareableContent`
returns two `SCWindow` entries sharing the same `windowID`, this crashes with:

```
EXC_BREAKPOINT (SIGTRAP)
_NativeDictionary.merge(_:uniquingKeysWith:)
WindowPreviewProvider.scheduleWarm(...)
```

## Repro conditions

Shortly after a reboot, `ScreenCaptureKit` can return a duplicate `windowID`
in `SCShareableContent.excludingDesktopWindows(_:onScreenWindowsOnly:)` before
the window server has finished settling. This makes the crash reliably
reproducible right after boot rather than a purely theoretical edge case —
any switcher preview warm-up in that window brings the app down.

## Fix

Replace the unique-keys initializer with the uniquing form, keeping the first
match for a given `windowID`:

```diff
- let scWindows = Dictionary(uniqueKeysWithValues: content.windows.map { ($0.windowID, $0) })
+ let scWindows = Dictionary(content.windows.map { ($0.windowID, $0) }, uniquingKeysWith: { first, _ in first })
```

This matches the existing safe pattern already used in
`SwitcherSupport.firstValuesByPID(_:)` (`SwitcherSupport.swift`), which
resolves potential duplicate keys the same way.

## Testing

- `./build.sh` completes without warnings
- `./build/Vorssaint --selftest` → `SELFTEST OK`