### PR TITLE
feat(window-layout): add directional pointer layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ All notable changes to this project are documented here. The format follows
 ## [3.3.3]
 
 ### Summary
-Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, an opt-in Kill Process tool and
+Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional pointer window layout, an opt-in Kill Process tool and
  native input-source switching for the Super key and drag-to-place Dock previews. It keeps the grouped
  App Switcher clear, makes Scratchpad controls easier to click and restores reliable trimming from the
  start of a recording.
 
 ### Added
+- Window Layout now offers an opt-in Shortcut + pointer layout mode that places the active window toward
+  any of eight directions with a native glass-ring HUD. Thanks to @Bald-M.
 - The Super key can now use a quick press to switch between enabled input sources
   while a press-and-hold toggles Caps Lock. Thanks to @BenjaminD2023.
 - Dock Preview thumbnails can now be dragged to move windows freely or snap them

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -505,6 +505,8 @@ enum DefaultsKey {
 
     // Window Layout — snapping, global shortcuts and optional pointer gestures.
     static let windowLayoutShortcutsEnabled = "windowLayoutShortcutsEnabled"
+    static let windowDirectionalEnabled = "windowDirectionalEnabled"
+    static let windowDirectionalShortcut = "windowDirectionalShortcut"
     static let windowEdgeSnapEnabled = "windowEdgeSnapEnabled"
     static let windowGestureEnabled = "windowGestureEnabled"
     static let windowGestureModifiers = "windowGestureModifiers"
@@ -1145,6 +1147,8 @@ enum Defaults {
         DefaultsKey.screenshotSharingEnabled: true,
         DefaultsKey.panelUtilityScreenshot: true,
         DefaultsKey.windowLayoutShortcutsEnabled: false,
+        DefaultsKey.windowDirectionalEnabled: false,
+        DefaultsKey.windowDirectionalShortcut: GlobalShortcut.windowDirectionalDefault.storageValue,
         DefaultsKey.windowEdgeSnapEnabled: false,
         DefaultsKey.windowGestureEnabled: false,
         DefaultsKey.windowGestureModifiers: WindowGestureSupport.defaultModifierStorageValue,

--- a/Sources/Vorssaint/Core/GlobalShortcut.swift
+++ b/Sources/Vorssaint/Core/GlobalShortcut.swift
@@ -162,6 +162,8 @@ struct GlobalShortcut: Equatable, Hashable {
                                                                   modifiers: [.control, .option])
     static let windowLayoutNextDisplayDefault = GlobalShortcut(keyCode: Int64(kVK_RightArrow),
                                                                modifiers: [.control, .option, .command])
+    static let windowDirectionalDefault = GlobalShortcut(keyCode: Int64(kVK_Space),
+                                                         modifiers: [.control, .option])
     // Quick tools. Paste plain follows the universal "Paste and Match Style"
     // combination; the others use the free ⌃⌥⌘ letters.
     static let pastePlainDefault = GlobalShortcut(keyCode: Int64(kVK_ANSI_V),

--- a/Sources/Vorssaint/Core/WindowDirectionalStrings.swift
+++ b/Sources/Vorssaint/Core/WindowDirectionalStrings.swift
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+struct WindowDirectionalStrings {
+    let title: String
+    let caption: String
+
+    static func localized(_ language: AppLanguage) -> WindowDirectionalStrings {
+        switch language {
+        case .enUS: return .init(title: "Shortcut + pointer layout", caption: "Hold the shortcut, move the pointer toward an edge or corner, then release to place the active window.")
+        case .ptBR: return .init(title: "Atalho + ponteiro", caption: "Segure o atalho, mova o ponteiro para uma borda ou canto e solte para posicionar a janela ativa.")
+        case .tr: return .init(title: "Kestirme + işaretçi düzeni", caption: "Kestirmeyi basılı tutun, işaretçiyi bir kenara veya köşeye götürün ve etkin pencereyi yerleştirmek için bırakın.")
+        case .ru: return .init(title: "Сочетание + указатель", caption: "Удерживайте сочетание, переместите указатель к краю или углу и отпустите, чтобы разместить активное окно.")
+        case .es: return .init(title: "Atajo + puntero", caption: "Mantén el atajo, mueve el puntero hacia un borde o esquina y suéltalo para colocar la ventana activa.")
+        case .de: return .init(title: "Kürzel + Zeiger", caption: "Kürzel halten, Zeiger zu einem Rand oder einer Ecke bewegen und loslassen, um das aktive Fenster anzuordnen.")
+        case .fr: return .init(title: "Raccourci + pointeur", caption: "Maintenez le raccourci, déplacez le pointeur vers un bord ou un coin, puis relâchez pour placer la fenêtre active.")
+        case .it: return .init(title: "Scorciatoia + puntatore", caption: "Tieni premuta la scorciatoia, sposta il puntatore verso un bordo o angolo e rilascia per posizionare la finestra attiva.")
+        case .ja: return .init(title: "ショートカット＋ポインタ配置", caption: "ショートカットを押したままポインタを端または角へ動かし、放すとアクティブウインドウを配置します。")
+        case .ko: return .init(title: "단축키 + 포인터 배치", caption: "단축키를 누른 채 포인터를 가장자리나 모서리로 이동한 다음 놓아 활성 윈도우를 배치합니다.")
+        case .zhHans: return .init(title: "快捷键 + 鼠标布局", caption: "按住快捷键，将鼠标移向屏幕边缘或角落，松开后摆放当前窗口。")
+        case .zhTW: return .init(title: "快速鍵 + 滑鼠配置", caption: "按住快速鍵，將滑鼠移向螢幕邊緣或角落，放開後配置目前視窗。")
+        case .zhHK: return .init(title: "快捷鍵 + 滑鼠配置", caption: "按住快捷鍵，將滑鼠移向螢幕邊緣或角落，放開後配置目前視窗。")
+        }
+    }
+}

--- a/Sources/Vorssaint/Services/WindowLayout/WindowGestureSupport.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowGestureSupport.swift
@@ -277,6 +277,26 @@ enum WindowGestureSupport {
     }
 }
 
+/// Pure direction selection for the hold-shortcut pointer layout mode.
+enum WindowDirectionalGestureSupport {
+    static let activationDistance: CGFloat = 36
+
+    static func action(from origin: CGPoint,
+                       to point: CGPoint,
+                       activationDistance: CGFloat = activationDistance) -> WindowLayoutAction? {
+        let dx = point.x - origin.x
+        let dy = point.y - origin.y
+        guard hypot(dx, dy) >= activationDistance else { return nil }
+        let diagonal = min(abs(dx), abs(dy)) >= max(abs(dx), abs(dy)) * 0.45
+        if diagonal {
+            if dx < 0 { return dy < 0 ? .bottomLeft : .topLeft }
+            return dy < 0 ? .bottomRight : .topRight
+        }
+        if abs(dx) >= abs(dy) { return dx < 0 ? .leftHalf : .rightHalf }
+        return dy < 0 ? .bottomHalf : .topHalf
+    }
+}
+
 enum WindowEdgeDragClassification: Equatable {
     case waiting
     case moving

--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
@@ -32,6 +32,7 @@ final class WindowLayoutService: ObservableObject {
     /// whether it still owns the feedback slot.
     private var resultGeneration = 0
     @Published private(set) var failedShortcutActions: Set<WindowLayoutAction> = []
+    @Published private(set) var directionalShortcutRegistrationFailed = false
     @Published private(set) var isGestureRunning = false
 
     private var frameHistory = WindowLayoutHistory()
@@ -39,6 +40,11 @@ final class WindowLayoutService: ObservableObject {
     private var hotKeyRefs: [WindowLayoutAction: EventHotKeyRef] = [:]
     private var eventHandler: EventHandlerRef?
     private var registeredShortcuts: [WindowLayoutAction: GlobalShortcut] = [:]
+    private var directionalHotKeyRef: EventHotKeyRef?
+    private var registeredDirectionalShortcut: GlobalShortcut?
+    private var directionalSession: WindowDirectionalSession?
+    private var directionalTimer: Timer?
+    private var directionalIndicatorPanel: NSPanel?
     private var gestureTap: CFMachPort?
     private var gestureRunLoopSource: CFRunLoopSource?
     private var edgeSnapTap: CFMachPort?
@@ -82,6 +88,11 @@ final class WindowLayoutService: ObservableObject {
             && trusted
         wantsShortcuts ? registerHotkeys() : unregisterHotkeys()
 
+        let wantsDirectional = available
+            && UserDefaults.standard.bool(forKey: DefaultsKey.windowDirectionalEnabled)
+            && trusted
+        wantsDirectional ? registerDirectionalHotkey() : unregisterDirectionalHotkey()
+
         let wantsGesture = available
             && UserDefaults.standard.bool(forKey: DefaultsKey.windowGestureEnabled)
             && trusted
@@ -99,6 +110,7 @@ final class WindowLayoutService: ObservableObject {
     /// call it freely.
     func suspend() {
         unregisterHotkeys()
+        unregisterDirectionalHotkey()
         stopGestureTap()
         stopEdgeSnapTap()
         for timer in settleTimers.values { timer.invalidate() }
@@ -122,6 +134,13 @@ final class WindowLayoutService: ObservableObject {
         return WindowLayoutAction.shortcutActions.first {
             $0 != excluded && $0.savedShortcut == shortcut
         }?.title(text)
+    }
+
+    func directionalShortcutConflictTitle(_ shortcut: GlobalShortcut) -> String? {
+        if let role = GlobalShortcutRole.conflict(for: shortcut, excluding: nil) {
+            return role.title(L10n.shared.s)
+        }
+        return shortcutConflictTitle(shortcut)
     }
 
     @discardableResult
@@ -624,26 +643,7 @@ final class WindowLayoutService: ObservableObject {
         if !hotKeyRefs.isEmpty, shortcuts == registeredShortcuts { return }
         unregisterHotkeys()
 
-        if eventHandler == nil {
-            var spec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
-                                     eventKind: UInt32(kEventHotKeyPressed))
-            InstallEventHandler(GetEventDispatcherTarget(), { _, event, userData -> OSStatus in
-                guard let userData else { return OSStatus(eventNotHandledErr) }
-                var id = EventHotKeyID()
-                if let event {
-                    GetEventParameter(event, EventParamName(kEventParamDirectObject),
-                                      EventParamType(typeEventHotKeyID), nil,
-                                      MemoryLayout<EventHotKeyID>.size, nil, &id)
-                }
-                guard id.signature == 0x5655_574C,
-                      let action = WindowLayoutAction(shortcutID: id.id) else {
-                    return OSStatus(eventNotHandledErr)
-                }
-                let service = Unmanaged<WindowLayoutService>.fromOpaque(userData).takeUnretainedValue()
-                DispatchQueue.main.async { service.apply(action) }
-                return noErr
-            }, 1, &spec, Unmanaged.passUnretained(self).toOpaque(), &eventHandler)
-        }
+        ensureHotKeyEventHandler()
 
         var failures = Set<WindowLayoutAction>()
         for action in WindowLayoutAction.shortcutActions {
@@ -666,6 +666,41 @@ final class WindowLayoutService: ObservableObject {
         failedShortcutActions = failures
     }
 
+    private func ensureHotKeyEventHandler() {
+        if eventHandler == nil {
+            var specs = [
+                EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed)),
+                EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyReleased))
+            ]
+            InstallEventHandler(GetEventDispatcherTarget(), { _, event, userData -> OSStatus in
+                guard let userData else { return OSStatus(eventNotHandledErr) }
+                var id = EventHotKeyID()
+                if let event {
+                    GetEventParameter(event, EventParamName(kEventParamDirectObject),
+                                      EventParamType(typeEventHotKeyID), nil,
+                                      MemoryLayout<EventHotKeyID>.size, nil, &id)
+                }
+                let service = Unmanaged<WindowLayoutService>.fromOpaque(userData).takeUnretainedValue()
+                let kind = event.map(GetEventKind) ?? 0
+                if id.signature == 0x5655_5744 { // 'VUWD'
+                    DispatchQueue.main.async {
+                        kind == UInt32(kEventHotKeyPressed)
+                            ? service.beginDirectionalGesture()
+                            : service.finishDirectionalGesture()
+                    }
+                    return noErr
+                }
+                guard id.signature == 0x5655_574C,
+                      kind == UInt32(kEventHotKeyPressed),
+                      let action = WindowLayoutAction(shortcutID: id.id) else {
+                    return OSStatus(eventNotHandledErr)
+                }
+                DispatchQueue.main.async { service.apply(action) }
+                return noErr
+            }, specs.count, &specs, Unmanaged.passUnretained(self).toOpaque(), &eventHandler)
+        }
+    }
+
     /// Lets go of the layout keys while a shortcut field is listening, so the
     /// user can record a combination the layout actions already use. The
     /// gesture tap is left alone: it watches the mouse, not the keyboard. The
@@ -679,6 +714,132 @@ final class WindowLayoutService: ObservableObject {
         hotKeyRefs.removeAll()
         registeredShortcuts.removeAll()
         failedShortcutActions.removeAll()
+    }
+
+    private func registerDirectionalHotkey() {
+        guard let shortcut = UserDefaults.standard.string(forKey: DefaultsKey.windowDirectionalShortcut)
+            .flatMap(GlobalShortcut.init(storageValue:)) else {
+            directionalShortcutRegistrationFailed = true
+            return
+        }
+        if directionalHotKeyRef != nil, registeredDirectionalShortcut == shortcut { return }
+        unregisterDirectionalHotkey()
+        ensureHotKeyEventHandler()
+        var ref: EventHotKeyRef?
+        let id = EventHotKeyID(signature: 0x5655_5744, id: 56)
+        let status = RegisterEventHotKey(shortcut.carbonKeyCode, shortcut.carbonModifiers, id,
+                                         GetEventDispatcherTarget(), 0, &ref)
+        if status == noErr, let ref {
+            directionalHotKeyRef = ref
+            registeredDirectionalShortcut = shortcut
+            directionalShortcutRegistrationFailed = false
+        } else {
+            directionalShortcutRegistrationFailed = true
+        }
+    }
+
+    private func unregisterDirectionalHotkey() {
+        if let directionalHotKeyRef { UnregisterEventHotKey(directionalHotKeyRef) }
+        directionalHotKeyRef = nil
+        registeredDirectionalShortcut = nil
+        directionalShortcutRegistrationFailed = false
+        cancelDirectionalGesture()
+    }
+
+    private func beginDirectionalGesture() {
+        guard directionalSession == nil,
+              let target = focusedTarget(for: .leftHalf),
+              let screen = bestScreen(for: target.frame) else { return }
+        directionalSession = WindowDirectionalSession(target: target,
+                                                      visibleFrame: screen.visibleFrame,
+                                                      pointerOrigin: NSEvent.mouseLocation,
+                                                      action: nil)
+        showDirectionalIndicator(at: NSEvent.mouseLocation, action: nil)
+        directionalTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) {
+            [weak self] _ in self?.updateDirectionalGesture()
+        }
+    }
+
+    private func updateDirectionalGesture() {
+        guard var session = directionalSession else { return }
+        let action = WindowDirectionalGestureSupport.action(from: session.pointerOrigin,
+                                                            to: NSEvent.mouseLocation)
+        guard action != session.action else { return }
+        session.action = action
+        directionalSession = session
+        updateDirectionalIndicator(action: action)
+        guard let action else { hideEdgeSnapPreview(immediately: false); return }
+        let preview = placement(for: action, current: session.target.frame,
+                                visibleFrame: session.visibleFrame).rect
+        showEdgeSnapPreview(frame: preview)
+    }
+
+    private func finishDirectionalGesture() {
+        guard let session = directionalSession else { return }
+        directionalTimer?.invalidate()
+        directionalTimer = nil
+        directionalSession = nil
+        hideEdgeSnapPreview(immediately: true)
+        hideDirectionalIndicator()
+        guard let action = session.action else { return }
+        _ = applyPlacement(action, to: session.target, visibleFrame: session.visibleFrame,
+                           cyclesRepeatedAction: false)
+    }
+
+    private func cancelDirectionalGesture() {
+        directionalTimer?.invalidate()
+        directionalTimer = nil
+        directionalSession = nil
+        hideEdgeSnapPreview(immediately: true)
+        hideDirectionalIndicator()
+    }
+
+    private func showDirectionalIndicator(at pointer: CGPoint, action: WindowLayoutAction?) {
+        let size = CGSize(width: 196, height: 196)
+        let screenFrame = NSScreen.screens.first(where: { $0.frame.contains(pointer) })?.visibleFrame
+            ?? NSScreen.main?.visibleFrame ?? .zero
+        var origin = CGPoint(x: pointer.x - size.width / 2, y: pointer.y - size.height / 2)
+        origin.x = min(max(origin.x, screenFrame.minX + 8), screenFrame.maxX - size.width - 8)
+        origin.y = min(max(origin.y, screenFrame.minY + 8), screenFrame.maxY - size.height - 8)
+        let panel: NSPanel
+        if let directionalIndicatorPanel {
+            panel = directionalIndicatorPanel
+        } else {
+            panel = NSPanel(contentRect: .zero,
+                            styleMask: [.borderless, .nonactivatingPanel],
+                            backing: .buffered,
+                            defer: false)
+            panel.backgroundColor = .clear
+            panel.isOpaque = false
+            panel.hasShadow = true
+            panel.ignoresMouseEvents = true
+            panel.hidesOnDeactivate = false
+            panel.isReleasedWhenClosed = false
+            panel.level = .statusBar
+            panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary,
+                                        .transient, .ignoresCycle]
+            panel.animationBehavior = .none
+            panel.contentView = WindowDirectionalIndicatorView(frame: CGRect(origin: .zero, size: size))
+            directionalIndicatorPanel = panel
+        }
+        panel.setFrame(CGRect(origin: origin, size: size), display: true)
+        updateDirectionalIndicator(action: action)
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.1
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().alphaValue = 1
+        }
+    }
+
+    private func updateDirectionalIndicator(action: WindowLayoutAction?) {
+        guard let view = directionalIndicatorPanel?.contentView as? WindowDirectionalIndicatorView else { return }
+        view.action = action
+    }
+
+    private func hideDirectionalIndicator() {
+        directionalIndicatorPanel?.orderOut(nil)
     }
 
     // MARK: - Drag to screen edge
@@ -1633,6 +1794,278 @@ private struct WindowLayoutTarget {
     let frame: WindowLayoutFrame
 
     var windowID: CGWindowID { key.windowID }
+}
+
+private struct WindowDirectionalSession {
+    let target: WindowLayoutTarget
+    let visibleFrame: NSRect
+    let pointerOrigin: CGPoint
+    var action: WindowLayoutAction?
+}
+
+/// Native glass-ring container; no upstream artwork or media is bundled.
+private final class WindowDirectionalIndicatorView: NSView {
+    private let canvas: WindowDirectionalIndicatorCanvasView
+
+    var action: WindowLayoutAction? {
+        didSet { canvas.action = action }
+    }
+
+    override var isOpaque: Bool { false }
+
+    override init(frame frameRect: NSRect) {
+        let effect = NSVisualEffectView(frame: CGRect(origin: .zero, size: frameRect.size))
+        effect.material = .hudWindow
+        effect.blendingMode = .behindWindow
+        effect.state = .active
+        effect.autoresizingMask = [.width, .height]
+        canvas = WindowDirectionalIndicatorCanvasView(
+            frame: CGRect(origin: .zero, size: frameRect.size))
+        canvas.autoresizingMask = [.width, .height]
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.cornerRadius = frameRect.width / 2
+        layer?.cornerCurve = .continuous
+        layer?.masksToBounds = true
+        layer?.borderWidth = 0.5
+        layer?.borderColor = NSColor.white.withAlphaComponent(0.2).cgColor
+        addSubview(effect)
+        addSubview(canvas, positioned: .above, relativeTo: effect)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+}
+
+/// The canvas stays separate from `NSVisualEffectView`: AppKit may composite
+/// the material after a visual-effect subclass draws, hiding custom artwork.
+private final class WindowDirectionalIndicatorCanvasView: NSView {
+    var action: WindowLayoutAction? { didSet { needsDisplay = true } }
+
+    override var isOpaque: Bool { false }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        guard let context = NSGraphicsContext.current?.cgContext else { return }
+        let center = CGPoint(x: self.bounds.midX, y: self.bounds.midY)
+        let outerRadius: CGFloat = 96
+        let innerRadius: CGFloat = 62
+        let track = annulus(center: center, outer: outerRadius, inner: innerRadius)
+
+        // A continuous low-contrast glass track; directions are ticks, not
+        // eight separate buttons.
+        context.saveGState()
+        context.setShadow(offset: CGSize(width: 0, height: -10), blur: 26,
+                          color: NSColor.black.withAlphaComponent(0.38).cgColor)
+        context.addPath(track)
+        context.setFillColor(NSColor(calibratedRed: 15 / 255,
+                                    green: 20 / 255,
+                                    blue: 33 / 255,
+                                    alpha: 0.74).cgColor)
+        context.fillPath(using: .evenOdd)
+        context.restoreGState()
+
+        context.addPath(track)
+        context.setStrokeColor(NSColor.white.withAlphaComponent(0.22).cgColor)
+        context.setLineWidth(1)
+        context.strokePath()
+
+        if let direction = Direction(action: action) {
+            let highlight = sector(center: center,
+                                   outer: outerRadius - 1,
+                                   inner: innerRadius + 1,
+                                   centerAngle: direction.angle)
+            context.saveGState()
+            context.addPath(highlight)
+            context.clip()
+            context.setShadow(offset: .zero, blur: 12,
+                              color: NSColor.controlAccentColor.withAlphaComponent(0.55).cgColor)
+            let accent = NSColor.controlAccentColor
+            let colors = [
+                accent.blended(withFraction: 0.42, of: .white)!.withAlphaComponent(0.98).cgColor,
+                accent.withAlphaComponent(0.98).cgColor,
+                accent.blended(withFraction: 0.25, of: .systemPurple)!.withAlphaComponent(0.9).cgColor
+            ] as CFArray
+            let gradient = CGGradient(colorsSpace: CGColorSpaceCreateDeviceRGB(),
+                                      colors: colors,
+                                      locations: [0, 0.5, 1])!
+            context.drawLinearGradient(gradient,
+                                       start: CGPoint(x: center.x - outerRadius, y: center.y + outerRadius),
+                                       end: CGPoint(x: center.x + outerRadius, y: center.y - outerRadius),
+                                       options: [])
+            context.restoreGState()
+            drawOrbitMarker(direction: direction, center: center,
+                            radius: outerRadius - 1, context: context)
+        }
+
+        drawSeparators(center: center, inner: innerRadius + 3,
+                       outer: outerRadius - 3, context: context)
+        drawSpecular(center: center, inner: innerRadius + 7,
+                     outer: outerRadius - 5, context: context)
+        drawCenterControl(center: center, context: context)
+    }
+
+    private func annulus(center: CGPoint, outer: CGFloat, inner: CGFloat) -> CGPath {
+        let path = CGMutablePath()
+        path.addEllipse(in: CGRect(x: center.x - outer, y: center.y - outer,
+                                   width: outer * 2, height: outer * 2))
+        path.addEllipse(in: CGRect(x: center.x - inner, y: center.y - inner,
+                                   width: inner * 2, height: inner * 2))
+        return path
+    }
+
+    private func sector(center: CGPoint, outer: CGFloat, inner: CGFloat,
+                        centerAngle: CGFloat) -> CGPath {
+        let start = (centerAngle - 22.5) * .pi / 180
+        let end = (centerAngle + 22.5) * .pi / 180
+        let path = CGMutablePath()
+        path.addArc(center: center, radius: outer, startAngle: start,
+                    endAngle: end, clockwise: false)
+        path.addArc(center: center, radius: inner, startAngle: end,
+                    endAngle: start, clockwise: true)
+        path.closeSubpath()
+        return path
+    }
+
+    private func drawSeparators(center: CGPoint, inner: CGFloat, outer: CGFloat,
+                                context: CGContext) {
+        context.saveGState()
+        context.setStrokeColor(NSColor.white.withAlphaComponent(0.16).cgColor)
+        context.setLineWidth(0.7)
+        for angle in stride(from: CGFloat(22.5), to: 360, by: 45) {
+            let radians = angle * .pi / 180
+            context.move(to: CGPoint(x: center.x + cos(radians) * inner,
+                                     y: center.y + sin(radians) * inner))
+            context.addLine(to: CGPoint(x: center.x + cos(radians) * outer,
+                                        y: center.y + sin(radians) * outer))
+        }
+        context.strokePath()
+        context.restoreGState()
+    }
+
+    private func drawSpecular(center: CGPoint, inner: CGFloat, outer: CGFloat,
+                              context: CGContext) {
+        context.saveGState()
+        context.setStrokeColor(NSColor.white.withAlphaComponent(0.23).cgColor)
+        context.setLineWidth(3)
+        context.setLineCap(.round)
+        let radius = (inner + outer) / 2
+        context.addArc(center: center, radius: radius,
+                       startAngle: 115 * .pi / 180,
+                       endAngle: 160 * .pi / 180,
+                       clockwise: false)
+        context.strokePath()
+        context.restoreGState()
+    }
+
+    private func drawOrbitMarker(direction: Direction, center: CGPoint,
+                                 radius: CGFloat, context: CGContext) {
+        let radians = direction.angle * .pi / 180
+        let markerCenter = CGPoint(x: center.x + cos(radians) * radius,
+                                   y: center.y + sin(radians) * radius)
+        let marker = CGRect(x: markerCenter.x - 6, y: markerCenter.y - 6,
+                            width: 12, height: 12)
+        context.saveGState()
+        context.setShadow(offset: .zero, blur: 18,
+                          color: NSColor.controlAccentColor.withAlphaComponent(0.8).cgColor)
+        context.setFillColor(NSColor.controlAccentColor.blended(withFraction: 0.45, of: .white)!.cgColor)
+        context.fillEllipse(in: marker)
+        context.setStrokeColor(NSColor.white.withAlphaComponent(0.82).cgColor)
+        context.setLineWidth(0.8)
+        context.strokeEllipse(in: marker)
+        context.restoreGState()
+    }
+
+    private func drawCenterControl(center: CGPoint, context: CGContext) {
+        let radius: CGFloat = 56
+        let hub = CGRect(x: center.x - radius, y: center.y - radius,
+                         width: radius * 2, height: radius * 2)
+        context.saveGState()
+        context.setShadow(offset: CGSize(width: 0, height: -4), blur: 15,
+                          color: NSColor.black.withAlphaComponent(0.2).cgColor)
+        context.setFillColor(NSColor(calibratedRed: 18 / 255,
+                                    green: 24 / 255,
+                                    blue: 39 / 255,
+                                    alpha: 0.9).cgColor)
+        context.fillEllipse(in: hub)
+        context.restoreGState()
+        context.setStrokeColor(NSColor.white.withAlphaComponent(0.15).cgColor)
+        context.setLineWidth(1)
+        context.strokeEllipse(in: hub.insetBy(dx: 0.35, dy: 0.35))
+
+        context.setStrokeColor(NSColor.white.withAlphaComponent(0.09).cgColor)
+        context.setLineWidth(1)
+        context.strokeEllipse(in: hub.insetBy(dx: 8, dy: 8))
+        context.strokeEllipse(in: hub.insetBy(dx: 16, dy: 16))
+
+        let window = CGRect(x: center.x - 18.5, y: center.y - 14.5,
+                            width: 37, height: 29)
+        let outline = CGPath(roundedRect: window, cornerWidth: 7, cornerHeight: 7,
+                             transform: nil)
+        context.addPath(outline)
+        context.setStrokeColor(NSColor.controlAccentColor
+            .blended(withFraction: 0.36, of: .white)!.withAlphaComponent(0.9).cgColor)
+        context.setLineWidth(2)
+        context.strokePath()
+
+        guard let action, let region = glyphRegion(for: action, in: window.insetBy(dx: 3.5, dy: 3.5)) else { return }
+        context.addPath(CGPath(roundedRect: region, cornerWidth: 2.2,
+                               cornerHeight: 2.2, transform: nil))
+        context.setFillColor(NSColor.controlAccentColor.withAlphaComponent(0.9).cgColor)
+        context.fillPath()
+    }
+
+    private func glyphRegion(for action: WindowLayoutAction, in rect: CGRect) -> CGRect? {
+        switch action {
+        case .leftHalf: return CGRect(x: rect.minX, y: rect.minY, width: rect.width / 2, height: rect.height)
+        case .rightHalf: return CGRect(x: rect.midX, y: rect.minY, width: rect.width / 2, height: rect.height)
+        case .topHalf: return CGRect(x: rect.minX, y: rect.midY, width: rect.width, height: rect.height / 2)
+        case .bottomHalf: return CGRect(x: rect.minX, y: rect.minY, width: rect.width, height: rect.height / 2)
+        case .topLeft: return CGRect(x: rect.minX, y: rect.midY, width: rect.width / 2, height: rect.height / 2)
+        case .topRight: return CGRect(x: rect.midX, y: rect.midY, width: rect.width / 2, height: rect.height / 2)
+        case .bottomLeft: return CGRect(x: rect.minX, y: rect.minY, width: rect.width / 2, height: rect.height / 2)
+        case .bottomRight: return CGRect(x: rect.midX, y: rect.minY, width: rect.width / 2, height: rect.height / 2)
+        default: return nil
+        }
+    }
+
+    private enum Direction: CaseIterable {
+        case right, topRight, top, topLeft, left, bottomLeft, bottom, bottomRight
+
+        var angle: CGFloat {
+            switch self {
+            case .right: return 0
+            case .topRight: return 45
+            case .top: return 90
+            case .topLeft: return 135
+            case .left: return 180
+            case .bottomLeft: return 225
+            case .bottom: return 270
+            case .bottomRight: return 315
+            }
+        }
+
+        var action: WindowLayoutAction {
+            switch self {
+            case .right: return .rightHalf
+            case .topRight: return .topRight
+            case .top: return .topHalf
+            case .topLeft: return .topLeft
+            case .left: return .leftHalf
+            case .bottomLeft: return .bottomLeft
+            case .bottom: return .bottomHalf
+            case .bottomRight: return .bottomRight
+            }
+        }
+
+        init?(action: WindowLayoutAction?) {
+            guard let action, let value = Self.allCases.first(where: { $0.action == action }) else {
+                return nil
+            }
+            self = value
+        }
+    }
 }
 
 /// Everything the deferred settle verification needs to finish judging a

--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
@@ -1882,18 +1882,21 @@ private final class WindowDirectionalIndicatorCanvasView: NSView {
             context.setShadow(offset: .zero, blur: 12,
                               color: NSColor.controlAccentColor.withAlphaComponent(0.55).cgColor)
             let accent = NSColor.controlAccentColor
+            let lighterAccent = accent.blended(withFraction: 0.42, of: .white) ?? accent
+            let purpleAccent = accent.blended(withFraction: 0.25, of: .systemPurple) ?? accent
             let colors = [
-                accent.blended(withFraction: 0.42, of: .white)!.withAlphaComponent(0.98).cgColor,
+                lighterAccent.withAlphaComponent(0.98).cgColor,
                 accent.withAlphaComponent(0.98).cgColor,
-                accent.blended(withFraction: 0.25, of: .systemPurple)!.withAlphaComponent(0.9).cgColor
+                purpleAccent.withAlphaComponent(0.9).cgColor
             ] as CFArray
-            let gradient = CGGradient(colorsSpace: CGColorSpaceCreateDeviceRGB(),
-                                      colors: colors,
-                                      locations: [0, 0.5, 1])!
-            context.drawLinearGradient(gradient,
-                                       start: CGPoint(x: center.x - outerRadius, y: center.y + outerRadius),
-                                       end: CGPoint(x: center.x + outerRadius, y: center.y - outerRadius),
-                                       options: [])
+            if let gradient = CGGradient(colorsSpace: CGColorSpaceCreateDeviceRGB(),
+                                         colors: colors,
+                                         locations: [0, 0.5, 1]) {
+                context.drawLinearGradient(gradient,
+                                           start: CGPoint(x: center.x - outerRadius, y: center.y + outerRadius),
+                                           end: CGPoint(x: center.x + outerRadius, y: center.y - outerRadius),
+                                           options: [])
+            }
             context.restoreGState()
             drawOrbitMarker(direction: direction, center: center,
                             radius: outerRadius - 1, context: context)
@@ -1969,7 +1972,8 @@ private final class WindowDirectionalIndicatorCanvasView: NSView {
         context.saveGState()
         context.setShadow(offset: .zero, blur: 18,
                           color: NSColor.controlAccentColor.withAlphaComponent(0.8).cgColor)
-        context.setFillColor(NSColor.controlAccentColor.blended(withFraction: 0.45, of: .white)!.cgColor)
+        let markerColor = NSColor.controlAccentColor.blended(withFraction: 0.45, of: .white) ?? .controlAccentColor
+        context.setFillColor(markerColor.cgColor)
         context.fillEllipse(in: marker)
         context.setStrokeColor(NSColor.white.withAlphaComponent(0.82).cgColor)
         context.setLineWidth(0.8)
@@ -2004,8 +2008,9 @@ private final class WindowDirectionalIndicatorCanvasView: NSView {
         let outline = CGPath(roundedRect: window, cornerWidth: 7, cornerHeight: 7,
                              transform: nil)
         context.addPath(outline)
-        context.setStrokeColor(NSColor.controlAccentColor
-            .blended(withFraction: 0.36, of: .white)!.withAlphaComponent(0.9).cgColor)
+        let windowBorder = NSColor.controlAccentColor
+            .blended(withFraction: 0.36, of: .white) ?? .controlAccentColor
+        context.setStrokeColor(windowBorder.withAlphaComponent(0.9).cgColor)
         context.setLineWidth(2)
         context.strokePath()
 

--- a/Sources/Vorssaint/UI/Settings/WindowLayoutSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/WindowLayoutSettings.swift
@@ -9,6 +9,8 @@ struct WindowLayoutSettings: View {
     @ObservedObject private var service = WindowLayoutService.shared
     @AppStorage(DefaultsKey.panelUtilityWindowLayout) private var showInPanel = true
     @AppStorage(DefaultsKey.windowLayoutShortcutsEnabled) private var shortcutsEnabled = true
+    @AppStorage(DefaultsKey.windowDirectionalEnabled) private var directionalEnabled = false
+    @AppStorage(DefaultsKey.windowDirectionalShortcut) private var directionalShortcutRaw = GlobalShortcut.windowDirectionalDefault.storageValue
     @AppStorage(DefaultsKey.windowEdgeSnapEnabled) private var edgeSnapEnabled = false
     @AppStorage(DefaultsKey.windowGestureEnabled) private var gestureEnabled = false
     @AppStorage(DefaultsKey.windowGestureModifiers) private var gestureModifiers = WindowGestureSupport.defaultModifierStorageValue
@@ -100,6 +102,26 @@ struct WindowLayoutSettings: View {
                         .font(.caption)
                         .foregroundStyle(.orange)
                 }
+                Divider()
+                Toggle(WindowDirectionalStrings.localized(l10n.language).title,
+                       isOn: $directionalEnabled)
+                    .onChange(of: directionalEnabled) { _, _ in service.syncWithPreferences() }
+                Text(WindowDirectionalStrings.localized(l10n.language).caption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if directionalEnabled {
+                    ShortcutRecorderButton(shortcut: directionalShortcut,
+                                           isEnabled: permissions.accessibility,
+                                           waitingTitle: l10n.s.shortcutPressKeys,
+                                           invalidAction: {},
+                                           captureAction: saveDirectionalShortcut)
+                        .frame(width: 108)
+                    if service.directionalShortcutRegistrationFailed {
+                        Text(l10n.s.shortcutUnavailable)
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+                }
             }
 
             Section {
@@ -164,6 +186,16 @@ struct WindowLayoutSettings: View {
             for: NSApplication.didBecomeActiveNotification)) { _ in
             refreshSystemTilingState()
         }
+    }
+
+    private var directionalShortcut: GlobalShortcut {
+        GlobalShortcut(storageValue: directionalShortcutRaw) ?? .windowDirectionalDefault
+    }
+
+    private func saveDirectionalShortcut(_ shortcut: GlobalShortcut) {
+        guard service.directionalShortcutConflictTitle(shortcut) == nil else { return }
+        directionalShortcutRaw = shortcut.storageValue
+        service.syncWithPreferences()
     }
 
     private func refreshSystemTilingState() {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -4246,6 +4246,30 @@ struct MetricsTests {
         expect(pendingExits == 13 && pendingReplays == 9,
                "every way out of a held press either promotes it, replaces it or gives it back")
 
+        // MARK: Directional pointer layout
+
+        let dirOrigin = CGPoint(x: 200, y: 200)
+        expect(WindowDirectionalGestureSupport.action(from: dirOrigin, to: dirOrigin) == nil,
+               "stationary pointer does not trigger directional layout")
+        expect(WindowDirectionalGestureSupport.action(from: dirOrigin, to: CGPoint(x: 230, y: 200)) == nil,
+               "pointer movement below activation distance produces no action")
+        expect(WindowDirectionalGestureSupport.action(from: dirOrigin, to: CGPoint(x: 240, y: 200)) == .rightHalf,
+               "moving right triggers right half")
+        expect(WindowDirectionalGestureSupport.action(from: dirOrigin, to: CGPoint(x: 160, y: 200)) == .leftHalf,
+               "moving left triggers left half")
+        expect(WindowDirectionalGestureSupport.action(from: dirOrigin, to: CGPoint(x: 200, y: 240)) == .topHalf,
+               "moving up triggers top half")
+        expect(WindowDirectionalGestureSupport.action(from: dirOrigin, to: CGPoint(x: 200, y: 160)) == .bottomHalf,
+               "moving down triggers bottom half")
+        expect(WindowDirectionalGestureSupport.action(from: dirOrigin, to: CGPoint(x: 240, y: 240)) == .topRight,
+               "moving up-right triggers top right")
+        expect(WindowDirectionalGestureSupport.action(from: dirOrigin, to: CGPoint(x: 160, y: 240)) == .topLeft,
+               "moving up-left triggers top left")
+        expect(WindowDirectionalGestureSupport.action(from: dirOrigin, to: CGPoint(x: 240, y: 160)) == .bottomRight,
+               "moving down-right triggers bottom right")
+        expect(WindowDirectionalGestureSupport.action(from: dirOrigin, to: CGPoint(x: 160, y: 160)) == .bottomLeft,
+               "moving down-left triggers bottom left")
+
         expect(MediaImageFormat.sanitized("pdf") == .pdf,
                "Image converter accepts the PDF format")
         expect(MediaImageFormat.pdf.fileExtension == "pdf",
@@ -12859,6 +12883,15 @@ struct MetricsTests {
                    "every window preview exclusion string is set for \(language.rawValue)")
             expect(values.allSatisfy { !$0.contains("—") },
                    "no em-dash in visible window preview exclusion strings (\(language.rawValue))")
+        }
+
+        for language in AppLanguage.allCases {
+            let strings = WindowDirectionalStrings.localized(language)
+            let values = Mirror(reflecting: strings).children.compactMap { $0.value as? String }
+            expect(values.count == 2 && values.allSatisfy { !$0.isEmpty },
+                   "every directional layout string is set for \(language.rawValue)")
+            expect(values.allSatisfy { !$0.contains("—") },
+                   "no em-dash in directional layout strings (\(language.rawValue))")
         }
 
         // MARK: Settings backup

--- a/build.sh
+++ b/build.sh
@@ -285,6 +285,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/Metrics/SustainedAlertGate.swift \
         Sources/Vorssaint/Services/WindowLayout/WindowLayoutSupport.swift \
         Sources/Vorssaint/Services/WindowLayout/WindowGestureSupport.swift \
+        Sources/Vorssaint/Core/WindowDirectionalStrings.swift \
         Sources/Vorssaint/Services/CleaningMode/CleaningUnlockCounter.swift \
         Sources/Vorssaint/Services/Display/ExtraBrightnessSupport.swift \
         Sources/Vorssaint/Services/Display/BrightnessSupport.swift \


### PR DESCRIPTION
**Loop** is a tool that I am using to do the windows management. It's operated by shortcut and mouse. Currently we can only do the windows management by shortcut, and here's the solution: 

<img width="2558" height="1438" alt="PixPin_2026-08-22_01-51-49-ezgif com-optimize" src="https://github.com/user-attachments/assets/da347d02-97c0-4512-ba92-bd7863dd3d11" />

**Summary**

Add a native Swift “Shortcut + pointer layout” feature inspired by [Loop](https://github.com/MrKai77/Loop), built on Vorssaint’s existing Window Layout service.

Hold a configurable global shortcut, move the pointer toward an edge or corner, and release to place the active window using the existing layout actions.

Show a native glass-ring HUD that follows the selected direction, including directional highlighting, layout previews, and a center glyph representing the target placement.

Support all eight directions:

- Left, right, top, and bottom halves
- Top-left, top-right, bottom-left, and bottom-right quarters

Integrate the feature into Window Layout settings, shortcut conflict handling, Accessibility permission handling, application lifecycle, defaults, and the existing preview and placement pipeline.

Add localized settings text for every currently supported language.

**Testing**

- `./build.sh --dev` — passed
- `./build.sh` — passed without warnings
- `./build/stage/Vorssaint.app/Contents/MacOS/Vorssaint --selftest` — `SELFTEST OK`
- `git diff --cached --check` — passed
- `./build.sh --test` — ran 7,953 checks; 5 existing Command Bar natural-language date assertions failed because they depend on the current date. No Window Layout checks failed.

**Notes**

- Requires Accessibility permission before the shortcut can control windows.
- Reuses Vorssaint’s existing window targeting, geometry, placement history, and preview behavior.
- Uses public Accessibility, AppKit, CoreGraphics, QuartzCore, and Carbon hotkey APIs.
- Introduces no external dependencies, private APIs, Loop assets, icons, animations, or media.
- The interaction was inspired by Loop, but the implementation and HUD are written natively for Vorssaint under GPL-3.0-or-later.
- Manual testing is still recommended for all eight directions, multiple displays, negative-coordinate displays, shortcut conflicts, Accessibility revocation, and windows that reject resizing.
