### PR TITLE
fix(app-switcher): size grid cards from their parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@ Vorssaint 3.3.3-beta.1 introduces the opt-in beta release channel and in-app fee
   the window shortcut reach each window, even when showing one entry per app.
 - Windowless apps no longer repeat or misplace their name in the App Switcher's Small
   size. Thanks to @Yahddyyp.
+- App Switcher grid cards now give their thumbnail the 14 points their chrome
+  was reserving and not using, and their title band holds a subtitle without
+  clipping its descenders. Thanks to @PathGao.
 - Clicking the Dock icon of a background app to restore its minimized windows now
   brings that app forward, instead of leaving its windows behind whichever app was
   already in front. Thanks to @PathGao.

--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -1542,10 +1542,10 @@ struct SwitcherGrid: Equatable {
     let visibleRows: Int
     let panelSize: CGSize
 
-    // Base sizes and breathing room scale together, so making previews smaller
-    // also keeps the panel from spending that saved space on empty gaps.
-    static var cardWidth: CGFloat { 288 * PreviewSizing.scale }
-    static var cardHeight: CGFloat { 214 * PreviewSizing.scale }
+    // Breathing room scales with the cards, so making previews smaller also
+    // keeps the panel from spending that saved space on empty gaps.
+    static var cardWidth: CGFloat { SwitcherGridCard.width }
+    static var cardHeight: CGFloat { SwitcherGridCard.height }
     static var spacing: CGFloat { 12 * PreviewSizing.scale }
     static var padding: CGFloat { 20 * PreviewSizing.scale }
 

--- a/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
+++ b/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
@@ -123,6 +123,27 @@ struct SwitcherAppGroup: Identifiable, Equatable {
     var windowCount: Int { itemIDs.count }
 }
 
+/// What one App Switcher grid card is made of.
+///
+/// The card scales with the preview size; its chrome does not, because the
+/// chrome is two lines of text that are the same at every size. The thumbnail
+/// takes whatever is left, derived from the parts rather than from one number
+/// standing in for them — the number it used to be had drifted 16pt past what
+/// it stood for, and the card spent the difference on nothing.
+enum SwitcherGridCard {
+    static var width: CGFloat { 288 * PreviewSizing.scale }
+    static var height: CGFloat { 214 * PreviewSizing.scale }
+    static let padding: CGFloat = 10
+    static let titleSpacing: CGFloat = 7
+    /// One 13pt line over one 10.5pt line, 2pt apart, descenders included.
+    static let titleHeight: CGFloat = 31
+    static var thumbnailWidth: CGFloat { width - padding * 2 }
+    static var thumbnailHeight: CGFloat { height - padding * 2 - titleSpacing - titleHeight }
+    /// Stands in for a thumbnail that has not arrived, so it follows the
+    /// thumbnail's size rather than staying the one fixed picture on the card.
+    static var fallbackIconSize: CGFloat { 80 * PreviewSizing.scale }
+}
+
 struct SwitcherIconRowLayout: Equatable {
     let visibleIconCount: Int
     let appRowContentWidth: CGFloat

--- a/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
+++ b/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
@@ -139,8 +139,12 @@ enum SwitcherGridCard {
     static let titleHeight: CGFloat = 31
     static var thumbnailWidth: CGFloat { width - padding * 2 }
     static var thumbnailHeight: CGFloat { height - padding * 2 - titleSpacing - titleHeight }
-    /// Stands in for a thumbnail that has not arrived, so it follows the
-    /// thumbnail's size rather than staying the one fixed picture on the card.
+    /// The title band sits inside the thumbnail's width so a long name stops
+    /// short of the card's rounded corners.
+    static var titleWidth: CGFloat { thumbnailWidth - 8 }
+    /// Stands in for a thumbnail that has not arrived, so it has to stay
+    /// inside the thumbnail at every preview size (#793 gave it the scale;
+    /// naming it is what lets a test hold it to the thumbnail it sits in).
     static var fallbackIconSize: CGFloat { 80 * PreviewSizing.scale }
 }
 

--- a/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
+++ b/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
@@ -890,7 +890,7 @@ private struct WindowCard: View {
     private static let appBadgeArtworkInset: CGFloat = (appBadgeSize * 0.094).rounded()
 
     var body: some View {
-        VStack(spacing: 7) {
+        VStack(spacing: SwitcherGridCard.titleSpacing) {
             ZStack {
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
                     .fill(Color.white.opacity(0.06))
@@ -907,7 +907,8 @@ private struct WindowCard: View {
                     Image(nsImage: icon)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(width: 80 * PreviewSizing.scale, height: 80 * PreviewSizing.scale)
+                        .frame(width: SwitcherGridCard.fallbackIconSize,
+                               height: SwitcherGridCard.fallbackIconSize)
                         .switcherHiddenAppBadge(window.isAppHidden, size: 22 * PreviewSizing.scale)
                 }
 
@@ -946,8 +947,8 @@ private struct WindowCard: View {
                     Spacer()
                 }
             }
-            .frame(width: SwitcherGrid.cardWidth - 20,
-                   height: SwitcherGrid.cardHeight - 72)
+            .frame(width: SwitcherGridCard.thumbnailWidth,
+                   height: SwitcherGridCard.thumbnailHeight)
 
             VStack(spacing: 2) {
                 ScrollingTitle(text: window.displayTitle,
@@ -963,10 +964,10 @@ private struct WindowCard: View {
                         .foregroundStyle(.tertiary)
                 }
             }
-            .frame(height: 29, alignment: .top)
-                .frame(maxWidth: SwitcherGrid.cardWidth - 28)
+            .frame(height: SwitcherGridCard.titleHeight, alignment: .top)
+                .frame(maxWidth: SwitcherGridCard.thumbnailWidth - 8)
         }
-        .padding(10)
+        .padding(SwitcherGridCard.padding)
         .frame(width: SwitcherGrid.cardWidth, height: SwitcherGrid.cardHeight)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)

--- a/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
+++ b/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
@@ -953,7 +953,7 @@ private struct WindowCard: View {
             VStack(spacing: 2) {
                 ScrollingTitle(text: window.displayTitle,
                                weight: isSelected ? .semibold : .regular,
-                               width: SwitcherGrid.cardWidth - 28,
+                               width: SwitcherGridCard.titleWidth,
                                scrolls: isHovering)
                     .foregroundStyle(isSelected ? .primary : .secondary)
                 if let subtitle = window.displaySubtitle {
@@ -965,10 +965,10 @@ private struct WindowCard: View {
                 }
             }
             .frame(height: SwitcherGridCard.titleHeight, alignment: .top)
-                .frame(maxWidth: SwitcherGridCard.thumbnailWidth - 8)
+                .frame(maxWidth: SwitcherGridCard.titleWidth)
         }
         .padding(SwitcherGridCard.padding)
-        .frame(width: SwitcherGrid.cardWidth, height: SwitcherGrid.cardHeight)
+        .frame(width: SwitcherGridCard.width, height: SwitcherGridCard.height)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .fill(isSelected ? Color.white.opacity(0.14) : Color.clear)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -7198,13 +7198,17 @@ struct MetricsTests {
                     Double(DockPreviewSupport.cardPadding),
                     "Dock Preview Small previews tighten panel padding with the card's")
         // The grid card's chrome is two lines of text that do not change with
-        // the preview size, so the deduction it takes off the card must be the
-        // same at every size — and the thumbnail must take the whole rest.
-        let smallGridCardChrome = SwitcherGridCard.height - SwitcherGridCard.thumbnailHeight
-        let smallGridThumbnailHeight = SwitcherGridCard.thumbnailHeight
+        // the preview size. The card does, so the thumbnail has to take every
+        // point the chrome leaves, at whichever size is stored.
+        let smallGridScale = PreviewSizing.scale
+        let smallGridCardHeight = SwitcherGridCard.height
+        let smallGridCardChrome = smallGridCardHeight - SwitcherGridCard.thumbnailHeight
         expect(SwitcherGridCard.fallbackIconSize < SwitcherGridCard.thumbnailHeight,
                "App Switcher Small keeps the stand-in app icon inside its grid card thumbnail")
         UserDefaults.standard.set("xlarge", forKey: DefaultsKey.previewSize)
+        expectClose(Double(SwitcherGridCard.height / smallGridCardHeight),
+                    Double(PreviewSizing.scale / smallGridScale),
+                    "an App Switcher grid card's height follows the preview size")
         expectClose(Double(SwitcherGridCard.height - SwitcherGridCard.thumbnailHeight),
                     Double(smallGridCardChrome),
                     "an App Switcher grid card spends the same chrome at every preview size")
@@ -7213,9 +7217,6 @@ struct MetricsTests {
                             + SwitcherGridCard.titleSpacing
                             + SwitcherGridCard.titleHeight),
                     "the grid card's chrome is exactly the parts it is made of, not a number standing in for them")
-        expectClose(Double(SwitcherGridCard.thumbnailHeight / smallGridThumbnailHeight),
-                    Double((1.8 * 214 - smallGridCardChrome) / (0.75 * 214 - smallGridCardChrome)),
-                    "the grid card thumbnail takes every point the chrome does not")
         expect(SwitcherGridCard.titleHeight >= 31,
                "the grid card title band holds a 13pt line over a 10.5pt line without clipping")
         expect(SwitcherGridCard.fallbackIconSize < SwitcherGridCard.thumbnailHeight,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -7197,7 +7197,29 @@ struct MetricsTests {
         expectClose(Double(DockPreviewSupport.panelPadding),
                     Double(DockPreviewSupport.cardPadding),
                     "Dock Preview Small previews tighten panel padding with the card's")
+        // The grid card's chrome is two lines of text that do not change with
+        // the preview size, so the deduction it takes off the card must be the
+        // same at every size — and the thumbnail must take the whole rest.
+        let smallGridCardChrome = SwitcherGridCard.height - SwitcherGridCard.thumbnailHeight
+        let smallGridThumbnailHeight = SwitcherGridCard.thumbnailHeight
+        expect(SwitcherGridCard.fallbackIconSize < SwitcherGridCard.thumbnailHeight,
+               "App Switcher Small keeps the stand-in app icon inside its grid card thumbnail")
         UserDefaults.standard.set("xlarge", forKey: DefaultsKey.previewSize)
+        expectClose(Double(SwitcherGridCard.height - SwitcherGridCard.thumbnailHeight),
+                    Double(smallGridCardChrome),
+                    "an App Switcher grid card spends the same chrome at every preview size")
+        expectClose(Double(smallGridCardChrome),
+                    Double(SwitcherGridCard.padding * 2
+                            + SwitcherGridCard.titleSpacing
+                            + SwitcherGridCard.titleHeight),
+                    "the grid card's chrome is exactly the parts it is made of, not a number standing in for them")
+        expectClose(Double(SwitcherGridCard.thumbnailHeight / smallGridThumbnailHeight),
+                    Double((1.8 * 214 - smallGridCardChrome) / (0.75 * 214 - smallGridCardChrome)),
+                    "the grid card thumbnail takes every point the chrome does not")
+        expect(SwitcherGridCard.titleHeight >= 31,
+               "the grid card title band holds a 13pt line over a 10.5pt line without clipping")
+        expect(SwitcherGridCard.fallbackIconSize < SwitcherGridCard.thumbnailHeight,
+               "App Switcher Extra Large keeps the stand-in app icon inside its grid card thumbnail")
         let xlargeIconRowLayout = SwitcherIconRowLayout.compute(appCount: 6,
                                                                  selectedWindowCount: 1,
                                                                  screenVisibleFrame: screen)


### PR DESCRIPTION
Independent of #744 and #745 — different files, no conflicts, reviewable in any order.

## What was wrong

An App Switcher grid card sized its thumbnail by subtracting a hard-coded number from the card:

```swift
.frame(width: SwitcherGrid.cardWidth - 20,
       height: SwitcherGrid.cardHeight - 72)
```

The 20 is right: 10pt of padding on each side. The 72 is not. The chrome below the thumbnail is 10pt padding twice, 7pt of `VStack` spacing and a 29pt title block — 56pt, not 72. The card had been reserving 16pt it never used, at every preview size, because the parts are all fixed while the number that stood for them was never revisited.

The title block was short as well. Measured against the fonts it holds:

| | needs | had |
|---|---|---|
| 13pt title line | 16 | |
| 10.5pt subtitle line | 13 | |
| 2pt between them | 2 | |
| **total** | **31** | **29** |

With `alignment: .top` that clipped the bottom of the subtitle's descenders on every card that had one.

This is the same defect #720 removed from Dock Preview cards, where the comment reads "the old code hard-coded a 54pt deduction that no longer matched the parts it stood for". The same shape survived here because nothing pointed at it.

## What changed

The parts are named and the thumbnail is derived from them, so the two can no longer drift apart:

```swift
static let padding: CGFloat = 10
static let titleSpacing: CGFloat = 7
/// One 13pt line over one 10.5pt line, 2pt apart, descenders included.
static let titleHeight: CGFloat = 31
static var thumbnailHeight: CGFloat { height - padding * 2 - titleSpacing - titleHeight }
```

Net effect: the thumbnail gains 14pt of height at every preview size (16 recovered, 2 given to the title band), the card itself is unchanged, and the panel geometry around it is unchanged. Subtitles stop clipping.

#793 has since given that stand-in app icon its preview scale. Naming it here is what lets a test hold it to the thumbnail it sits in — the two only became comparable once both sides stopped being literals.

## Why the metrics moved file

They now live in `SwitcherSupport.swift` next to `SwitcherIconRowLayout`, which is where the other switcher layout math already is. `SwitcherGrid` keeps the panel geometry that needs an `NSScreen`; the card is pure arithmetic. That split is also what makes the relationship testable — the selftest target compiles a whitelist of pure-logic files, and `AppSwitcher.swift` is not on it.

## What was checked and left alone

The other two card layouts were audited for the same defect and do not have it. `SwitcherIconRowLayout`'s preview card deducts a fixed 16 and 38 that do decompose correctly (16 padding + 6 spacing + a 13pt line in 16pt of room), and its icon row already builds `rowHeight` from its parts with a comment explaining why the text must not shrink. `SwitcherIconRowLayout` also caps preview scaling at 1.15, so its cards never blow up at Large or Extra Large; `SwitcherGrid` deliberately does not, and that is unchanged here.

Tests: 8376 checks pass, 6 of them new. Baseline on `1d961c6b` is 8370.
