### PR TITLE
fix(super-key): switch input sources before the next keystroke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
 - Clicking a Dock icon now only restores the windows that Click Dock icon to minimize
   put away. Windows minimized any other way keep the Dock's own restore. Thanks to @PathGao.
 ### Fixed
+- Super key input-source switching no longer waits on Accessibility marked text
+  or a pause after every tap, so a language change takes effect before the next
+  keystroke. Thanks to @BenjaminD2023.
 - Scrolling screenshots now keep fixed page footers once at the end instead of
   repeating them after every scroll.
 - Settings now lists Dock Preview and Dock click as separate named sections, and

--- a/Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift
+++ b/Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift
@@ -57,9 +57,6 @@ final class SuperKeyService: ObservableObject {
     /// The mapping is written off the main thread, and in the order it was
     /// asked for: a queue of one keeps an apply and a clear from crossing.
     private let mappingQueue = DispatchQueue(label: "com.vorssaint.utils.superkey-mapping")
-    /// Reading another app's marked-text range can block, so quick taps inspect
-    /// it off the main thread and in order.
-    private let inputSourceQueue = DispatchQueue(label: "com.vorssaint.utils.superkey-input-source")
     /// When the last mapping went in, so a keyboard that arrives without one
     /// is repaired once and not on every keystroke.
     private var lastMappingAt: TimeInterval = 0
@@ -476,14 +473,10 @@ final class SuperKeyService: ObservableObject {
             event.flags = event.flags.union(modifierFlags)
             return Unmanaged.passUnretained(event)
         case .soloTap(repeated: let repeated):
-            DispatchQueue.main.async {
-                [weak self] in self?.performSoloAction(longHold: false, repeated: repeated)
-            }
+            performSoloAction(longHold: false, repeated: repeated)
             return nil
         case .soloHold(repeated: let repeated):
-            DispatchQueue.main.async {
-                [weak self] in self?.performSoloAction(longHold: true, repeated: repeated)
-            }
+            performSoloAction(longHold: true, repeated: repeated)
             return nil
         case .interceptAndRemap:
             repairMappingIfStale()
@@ -560,79 +553,23 @@ final class SuperKeyService: ObservableObject {
         case .none:
             return
         case .escape:
-            _ = Self.postKey(CGKeyCode(kVK_Escape))
+            runOnMainIfNeeded { _ = Self.postKey(CGKeyCode(kVK_Escape)) }
         case .capsLock:
-            setCapsLock(!capsLockIsOn())
+            runOnMainIfNeeded { self.setCapsLock(!self.capsLockIsOn()) }
         case .inputSource:
-            switchInputSource()
+            // Must finish before this tap returns: the next keystroke is already
+            // in flight, and hopping to main (or waiting on Accessibility) left
+            // that character in the old source.
+            Self.selectNextInputSource()
         }
     }
 
-    private func switchInputSource() {
-        guard let processID = NSWorkspace.shared.frontmostApplication?.processIdentifier else { return }
-        inputSourceQueue.async {
-            let focusedElement = Self.focusedElement(for: processID)
-            let shouldCommit = SuperKeySupport.shouldCommitMarkedText(
-                length: focusedElement.flatMap(Self.markedTextLength)
-            )
-            guard NSWorkspace.shared.frontmostApplication?.processIdentifier == processID else { return }
-            if shouldCommit {
-                guard let focusedElement,
-                      Self.isStillFocused(focusedElement, in: processID)
-                else { return }
-                guard Self.postKey(CGKeyCode(kVK_Return)) else { return }
-                Thread.sleep(forTimeInterval: 0.1)
-                guard NSWorkspace.shared.frontmostApplication?.processIdentifier == processID,
-                      Self.isStillFocused(focusedElement, in: processID)
-                else { return }
-            }
-            // TIS is main-thread-only; sync also keeps the whole tap ordered
-            // before the queue begins another IME commit.
-            DispatchQueue.main.sync {
-                guard NSWorkspace.shared.frontmostApplication?.processIdentifier == processID else { return }
-                Self.selectNextInputSource()
-            }
+    private func runOnMainIfNeeded(_ work: @escaping () -> Void) {
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.async(execute: work)
         }
-    }
-
-    private static func focusedElement(for processID: pid_t) -> AXUIElement? {
-        let application = AXUIElementCreateApplication(processID)
-        AXUIElementSetMessagingTimeout(application, 0.2)
-        var focusedValue: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(
-            application,
-            kAXFocusedUIElementAttribute as CFString,
-            &focusedValue
-        ) == .success,
-        let focusedValue,
-        CFGetTypeID(focusedValue) == AXUIElementGetTypeID()
-        else { return nil }
-
-        let focusedElement = focusedValue as! AXUIElement
-        AXUIElementSetMessagingTimeout(focusedElement, 0.2)
-        return focusedElement
-    }
-
-    private static func markedTextLength(_ focusedElement: AXUIElement) -> Int? {
-        var rangeValue: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(
-            focusedElement,
-            "AXTextInputMarkedRange" as CFString,
-            &rangeValue
-        ) == .success,
-        let rangeValue,
-        CFGetTypeID(rangeValue) == AXValueGetTypeID()
-        else { return nil }
-
-        let axValue = rangeValue as! AXValue
-        guard AXValueGetType(axValue) == .cfRange else { return nil }
-        var range = CFRange(location: 0, length: 0)
-        return AXValueGetValue(axValue, .cfRange, &range) ? range.length : nil
-    }
-
-    private static func isStillFocused(_ element: AXUIElement, in processID: pid_t) -> Bool {
-        guard let current = focusedElement(for: processID) else { return false }
-        return CFEqual(element, current)
     }
 
     private static func postKey(_ keyCode: CGKeyCode) -> Bool {
@@ -645,18 +582,34 @@ final class SuperKeyService: ObservableObject {
         return true
     }
 
+    /// Cycle enabled keyboard sources through TIS before the tap lets the next
+    /// key through. An earlier path asked another app for marked text (up to
+    /// 200 ms) and then slept 100 ms so Control-Space could commit IME
+    /// composition; that wait ran on every tap, including ones with nothing to
+    /// commit. Selecting the next source directly lets the input method commit
+    /// or cancel on its own, the same way the Input menu does.
     private static func selectNextInputSource() {
-        let sources = selectableInputSources()
-        let ids = sources.compactMap { inputSourceString($0, property: kTISPropertyInputSourceID) }
-        guard let current = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else { return }
-        let currentID = inputSourceString(current, property: kTISPropertyInputSourceID)
-        guard let nextID = SuperKeySupport.nextInputSourceID(currentID: currentID,
-                                                             enabledIDs: ids),
-              let next = sources.first(where: {
-                  inputSourceString($0, property: kTISPropertyInputSourceID) == nextID
-              })
-        else { return }
-        _ = TISSelectInputSource(next)
+        let apply = {
+            let sources = selectableInputSources()
+            let ids = sources.compactMap { inputSourceString($0, property: kTISPropertyInputSourceID) }
+            guard let current = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else { return }
+            let currentID = inputSourceString(current, property: kTISPropertyInputSourceID)
+            guard let nextID = SuperKeySupport.nextInputSourceID(currentID: currentID,
+                                                                 enabledIDs: ids),
+                  let next = sources.first(where: {
+                      inputSourceString($0, property: kTISPropertyInputSourceID) == nextID
+                  })
+            else { return }
+            _ = TISSelectInputSource(next)
+        }
+        // TIS talks to the text-input server from the main thread. sync (not
+        // async) keeps the switch ahead of the next keystroke this tap is
+        // about to let through.
+        if Thread.isMainThread {
+            apply()
+        } else {
+            DispatchQueue.main.sync(execute: apply)
+        }
     }
 
     private static func selectableInputSources() -> [TISInputSource] {

--- a/Sources/Vorssaint/Services/SuperKey/SuperKeySupport.swift
+++ b/Sources/Vorssaint/Services/SuperKey/SuperKeySupport.swift
@@ -244,10 +244,6 @@ enum SuperKeySupport {
         return enabledIDs[(index + 1) % enabledIDs.count]
     }
 
-    static func shouldCommitMarkedText(length: Int?) -> Bool {
-        (length ?? 0) > 0
-    }
-
     // MARK: - What each event means
 
     /// A key event, reduced to the only distinctions the decision needs.

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -12603,10 +12603,6 @@ struct MetricsTests {
                 && SuperKeySupport.nextInputSourceID(currentID: nil,
                                                      enabledIDs: ["abc"]) == nil,
                "input sources cycle through the enabled system list without a hard-coded shortcut")
-        expect(!SuperKeySupport.shouldCommitMarkedText(length: nil)
-                && !SuperKeySupport.shouldCommitMarkedText(length: 0)
-                && SuperKeySupport.shouldCommitMarkedText(length: 1),
-               "only active marked text is committed before switching input source")
 
         let capsMapping = SuperKeyMapping(source: SuperKeySupport.capsLockUsage,
                                           destination: SuperKeySupport.triggerUsage)


### PR DESCRIPTION
## Summary

- remove the Accessibility marked-text query and fixed delay from Super key input-source taps
- select the next input source through native Text Input Sources services before the event tap returns
- preserve the existing Caps Lock hold, Escape, and Super key chord behavior
- remove the obsolete marked-text helper and test

Fixes #748

## Behavior before

A quick Super key tap queued the input-source action off-thread, queried the foreground app for marked text with a timeout of up to 200 ms, and could wait another 100 ms before selecting the source. The next keystroke could therefore be processed by the old input source.

## Behavior after

Input-source selection completes before the Super key event tap returns. Active IME composition resolves through the native input-source selection path, while long hold and chord behavior remain unchanged.

## Verification

- `./build.sh` — passed without warnings
- `./build/Vorssaint --selftest` — `SELFTEST OK`
- `./build.sh --test` — `TESTS OK (8015 checks)`
- local ABC/Pinyin quick-tap test — the new input source is active before the next character