### PR TITLE
chore(tests): sweep the preference files a run leaves behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
 - Clicking a Dock icon now only restores the windows that Click Dock icon to minimize
   put away. Windows minimized any other way keep the Dock's own restore. Thanks to @PathGao.
 ### Fixed
+- `./build.sh --test` no longer leaves a preference file in
+  `~/Library/Preferences` for every defaults suite it uses; a run used to add two,
+  and they piled up unnoticed. Thanks to @PathGao.
 - Scrolling screenshots now keep fixed page footers once at the end instead of
   repeating them after every scroll.
 - Settings now lists Dock Preview and Dock click as separate named sections, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
   already in front. Thanks to @PathGao.
 - The recording editor now trims reliably from the beginning of a video when
   dragging the left handle. Thanks to @lmilojevicc.
+- A test run no longer leaves a preference file behind in `~/Library/Preferences`
+  for every defaults suite it uses.
 - Screen recorder, Copy text from screen and Color picker can each take a shortcut
   of their own again, opening screen capture already on that mode. Their Settings
   rows no longer record a combination that does nothing. Thanks to @wiidede and
@@ -73,8 +75,6 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
   system script. Thanks to @dbhorst.
 - The recording editor now reads composition duration directly without background
   queries. Thanks to @Bald-M.
-- A test run no longer leaves a preference file behind in `~/Library/Preferences`
-  for every defaults suite it uses.
 
 ## [3.3.2] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,6 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
 - Clicking a Dock icon now only restores the windows that Click Dock icon to minimize
   put away. Windows minimized any other way keep the Dock's own restore. Thanks to @PathGao.
 ### Fixed
-- `./build.sh --test` no longer leaves a preference file in
-  `~/Library/Preferences` for every defaults suite it uses; a run used to add two,
-  and they piled up unnoticed. Thanks to @PathGao.
 - Scrolling screenshots now keep fixed page footers once at the end instead of
   repeating them after every scroll.
 - Settings now lists Dock Preview and Dock click as separate named sections, and
@@ -76,6 +73,9 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
   system script. Thanks to @dbhorst.
 - The recording editor now reads composition duration directly without background
   queries. Thanks to @Bald-M.
+- `./build.sh --test` no longer leaves a preference file in
+  `~/Library/Preferences` for every defaults suite it uses; a run used to add two,
+  and they piled up unnoticed. Thanks to @PathGao.
 
 ## [3.3.2] - 2026-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,9 +73,8 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
   system script. Thanks to @dbhorst.
 - The recording editor now reads composition duration directly without background
   queries. Thanks to @Bald-M.
-- `./build.sh --test` no longer leaves a preference file in
-  `~/Library/Preferences` for every defaults suite it uses; a run used to add two,
-  and they piled up unnoticed. Thanks to @PathGao.
+- A test run no longer leaves a preference file behind in `~/Library/Preferences`
+  for every defaults suite it uses.
 
 ## [3.3.2] - 2026-08-20
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15711,6 +15711,43 @@ struct MetricsTests {
 
         // MARK: Result
 
+        // MARK: Every defaults suite stays inside a namespace build.sh sweeps
+        // A UserDefaults suite leaves an empty plist in ~/Library/Preferences
+        // even after `removePersistentDomain`, and cfprefsd writes that file
+        // back out around the time this process exits, so the run cannot delete
+        // it itself. `build.sh --test` clears them afterwards, by name prefix.
+        // A suite named outside those prefixes survives every run instead.
+        let testSource = (try? String(contentsOfFile: "Tests/MetricsTests.swift",
+                                      encoding: .utf8)) ?? ""
+        expect(!testSource.isEmpty, "the test file reads back for its own source checks")
+        // The prefixes are read out of the sweep itself, so the check and the
+        // thing it guards cannot drift apart.
+        let buildScript = (try? String(contentsOfFile: "build.sh", encoding: .utf8)) ?? ""
+        let sweepBody = buildScript.components(separatedBy: "discard_test_preferences() {")
+            .dropFirst().first?.components(separatedBy: "\n}").first ?? ""
+        let sweptNamespaces = sweepBody.components(separatedBy: "\"")
+            .enumerated().filter { $0.offset % 2 == 1 }.map(\.element)
+            .filter { $0.hasSuffix(".") }
+        expect(!sweptNamespaces.isEmpty, "the swept namespaces read back out of build.sh")
+        // Split so this needle is not itself a match in the text it scans.
+        let suiteCall = "UserDefaults(suiteName" + ": "
+        let suiteArguments = testSource.components(separatedBy: suiteCall)
+            .dropFirst()
+            .map { String($0.prefix { $0 != ")" && $0 != "," && !$0.isNewline }) }
+        expect(!suiteArguments.isEmpty, "the namespace check finds the suites it guards")
+        for argument in Set(suiteArguments) {
+            let name: String?
+            if argument.hasPrefix("\"") {
+                name = String(argument.dropFirst().prefix { $0 != "\"" })
+            } else {
+                name = testSource.components(separatedBy: "let \(argument) = \"")
+                    .dropFirst().first
+                    .map { String($0.prefix { $0 != "\"" }) }
+            }
+            expect(name.map { value in sweptNamespaces.contains { value.hasPrefix($0) } } == true,
+                   "defaults suite \(argument) is named inside a namespace build.sh sweeps")
+        }
+
         if failures.isEmpty {
             print("TESTS OK (\(checks) checks)")
             exit(0)

--- a/build.sh
+++ b/build.sh
@@ -141,6 +141,31 @@ if [[ "$SDK" == "$PINNED_SDK" ]]; then
     SDK_COMPAT_FLAGS=(-Xfrontend -interface-compiler-version -Xfrontend 6.3.2)
 fi
 
+# The defaults migrations under test need a real UserDefaults suite, and every
+# suite leaves an empty plist in ~/Library/Preferences. The tests already clear
+# the domains, but cfprefsd writes the emptied file back out around the time the
+# process that owned it exits, so only a caller that outlives the run can remove
+# them. `MetricsTests` keeps every suite name inside these two namespaces (a
+# check in the test file holds it to that), which is what makes this sweep
+# complete rather than a list to keep in step by hand.
+discard_test_preferences() {
+    local preferences="$HOME/Library/Preferences" name
+    for name in "vorss.tests." "com.vorssaint.tests."; do
+        find "$preferences" -maxdepth 1 -name "$name*.plist" -delete 2>/dev/null || true
+    done
+    # The harness has no bundle identifier, so `UserDefaults.standard` writes
+    # a file named after the executable.
+    rm -f "$preferences/metrics-tests.plist"
+    local survivors
+    survivors=$(find "$preferences" -maxdepth 1 \
+        \( -name "vorss.tests.*.plist" -o -name "com.vorssaint.tests.*.plist" \
+           -o -name "metrics-tests.plist" \) 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$survivors" != "0" ]]; then
+        echo "✗ the test run left $survivors preference file(s) in $preferences" >&2
+        return 1
+    fi
+}
+
 # --test: compile and run the standalone unit tests (pure helpers only: metrics,
 # Homebrew parsing, defaults, localization contracts; no app, no UI, no IOKit),
 # then exit. Fast and deterministic; no XCTest needed.
@@ -297,8 +322,11 @@ if (( TEST )); then
         Sources/Vorssaint/Services/ManagedDownloads/WhatsAppDownloadSupport.swift \
         Tests/MetricsTests.swift \
         -o build/metrics-tests
-    ./build/metrics-tests
-    exit $?
+    # `set -e` would end the script on a failing run before the sweep below.
+    test_status=0
+    ./build/metrics-tests || test_status=$?
+    discard_test_preferences || test_status=1
+    exit $test_status
 fi
 
 echo "▸ Compiling ($BUILD_CONFIGURATION) against $(basename "$SDK")…"


### PR DESCRIPTION
## What was wrong

Every `UserDefaults(suiteName:)` the unit tests create leaves an empty plist in `~/Library/Preferences`. The checks already call `removePersistentDomain`, so no data lingers — but cfprefsd writes the emptied file back out around the time the process that owned it exits, so a run cannot delete its own files. Two of the four suites are named with a fresh UUID per run, so the pile grows without bound.

Measured before the fix: 132 `com.vorssaint.tests.first-run.<UUID>.plist` and `com.vorssaint.tests.fan-migration.<UUID>.plist` files, plus `vorss.tests.switcher.shortcut.plist`, `vorss.tests.mixer.headphones.plist` and `metrics-tests.plist` — 66 runs' worth.

## What changed

The sweep runs in `build.sh`, after the test process is gone, and fails the build if anything survives.

The prefix list would then live in two places with nothing keeping them in step, so it does not: the test file reads the swept prefixes back out of `discard_test_preferences()` and asserts that every suite name in `MetricsTests` falls inside one. A suite named somewhere the sweep will not look is a failing check, not silent litter.

## What was considered and not done

Three in-process fixes, each tried and measured before the sweep moved out of the test binary:

| attempt | result |
| --- | --- |
| delete the file right after `removePersistentDomain` | file reappears — cfprefsd rewrites the still-registered domain |
| `synchronize()`, then sweep all suites at the end of `main()` | passes 3 runs in a row, then run 4 finds run 3's files |
| run the binary with a temporary `$HOME` | no effect — cfprefsd resolves the real home |

## Not touched

Test-side only; no app code changed, and no suite was renamed or removed. `zsh` treats `status` as read-only, hence `test_status` in the shell function.

Tests: 8023 checks pass across 6 consecutive `./build.sh --test` runs, with 0 files left in `~/Library/Preferences` after each. Both new checks were shown to bite: renaming a suite to `com.example.stray.headphones` turns the namespace check red and the file does survive the run; dropping `com.vorssaint.tests.` from the sweep turns it red for both suites and fires the survivor guard (`✗ the test run left 4 preference file(s)`).
