### PR TITLE
feat(kill-process): show listening ports

### DIFF
--- a/Sources/Vorssaint/Services/KillProcess/KillProcessService.swift
+++ b/Sources/Vorssaint/Services/KillProcess/KillProcessService.swift
@@ -19,6 +19,8 @@ struct KillProcessEntry: Identifiable, Equatable {
     let bundleURL: URL?
     let groupedCount: Int
     let isProtected: Bool
+    /// Listening TCP ports owned by this process, sorted and de-duplicated.
+    let ports: [Int]
 
     var id: pid_t { pid }
 }
@@ -77,10 +79,8 @@ final class KillProcessService: ObservableObject {
             }
             return ascending ? !result : result
         }
-        let needle = query.trimmingCharacters(in: .whitespaces).lowercased()
-        guard !needle.isEmpty else { return sorted }
         return sorted.filter {
-            $0.name.lowercased().contains(needle) || String($0.pid) == needle
+            KillProcessSupport.matches(query: query, name: $0.name, pid: $0.pid, ports: $0.ports)
         }
     }
 
@@ -324,13 +324,14 @@ final class KillProcessService: ObservableObject {
     private static func snapshot(grouped: Bool) -> [KillProcessEntry]? {
         let result = Shell.run("/bin/ps", ["-eo", "pid,ppid,pcpu,rss,comm"])
         guard result.status == 0 else { return nil }
-        let rows = parsePS(result.output)
+        let portsByPID = listeningTCPPorts()
+        let rows = parsePS(result.output, portsByPID: portsByPID)
         guard !rows.isEmpty else { return nil }
         return (grouped ? groupedByApp(rows) : rows).sorted { $0.cpuPercent > $1.cpuPercent }
     }
 
     /// Lines look like "  437     1  12.5  20480 /System/Library/.../WindowServer".
-    private static func parsePS(_ output: String) -> [KillProcessEntry] {
+    private static func parsePS(_ output: String, portsByPID: [pid_t: [Int]] = [:]) -> [KillProcessEntry] {
         var rows: [KillProcessEntry] = []
         for line in output.split(separator: "\n").dropFirst() {
             let columns = line.split(separator: " ", maxSplits: 4, omittingEmptySubsequences: true)
@@ -355,7 +356,8 @@ final class KillProcessService: ObservableObject {
                 isRegularApp: running?.activationPolicy == .regular,
                 bundleURL: running?.bundleURL,
                 groupedCount: 1,
-                isProtected: isProt))
+                isProtected: isProt,
+                ports: portsByPID[pid] ?? []))
         }
         return rows
     }
@@ -382,7 +384,17 @@ final class KillProcessService: ObservableObject {
                 isRegularApp: running?.activationPolicy == .regular,
                 bundleURL: running?.bundleURL,
                 groupedCount: members.count,
-                isProtected: isProt)
+                isProtected: isProt,
+                ports: KillProcessSupport.mergedPorts(members.map(\.ports)))
         }
+    }
+
+    /// Uses lsof's machine-readable field format so localized, padded table
+    /// output cannot corrupt PID/port parsing. Failure simply means the list
+    /// has no port annotations; process refresh itself remains usable.
+    private static func listeningTCPPorts() -> [pid_t: [Int]] {
+        let result = Shell.run("/usr/sbin/lsof", ["-nP", "-iTCP", "-sTCP:LISTEN", "-Fpn"])
+        guard result.status == 0 else { return [:] }
+        return KillProcessSupport.listeningTCPPorts(from: result.output)
     }
 }

--- a/Sources/Vorssaint/Services/KillProcess/KillProcessSupport.swift
+++ b/Sources/Vorssaint/Services/KillProcess/KillProcessSupport.swift
@@ -6,6 +6,42 @@ import Foundation
 /// Pure helpers for the Kill Process feature: protected system processes and
 /// safety boundaries.
 enum KillProcessSupport {
+    /// Parses `lsof -Fpn` output into sorted, de-duplicated listening ports.
+    static func listeningTCPPorts(from output: String) -> [pid_t: [Int]] {
+        var currentPID: pid_t?
+        var values: [pid_t: Set<Int>] = [:]
+        for line in output.split(separator: "\n") {
+            guard let prefix = line.first else { continue }
+            let value = line.dropFirst()
+            if prefix == "p" {
+                currentPID = pid_t(value)
+            } else if prefix == "n", let pid = currentPID,
+                      let separator = value.lastIndex(of: ":"),
+                      let port = Int(value[value.index(after: separator)...]),
+                      (1...65_535).contains(port) {
+                values[pid, default: []].insert(port)
+            }
+        }
+        return values.mapValues { $0.sorted() }
+    }
+
+    static func matches(query: String, name: String, pid: pid_t, ports: [Int]) -> Bool {
+        let needle = query.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !needle.isEmpty else { return true }
+        return name.lowercased().contains(needle)
+            || String(pid) == needle
+            || ports.contains { String($0) == needle }
+    }
+
+    static func mergedPorts(_ groups: [[Int]]) -> [Int] {
+        Array(Set(groups.flatMap { $0 })).sorted()
+    }
+
+    /// Header and rows reserve the same fixed width for metrics and actions.
+    static func processColumnWidth(availableWidth: CGFloat) -> CGFloat {
+        max(80, availableWidth - 442)
+    }
+
     /// Protects kernel, launchd, vital window/session infrastructure, and the
     /// app's own process from being terminated.
     static func isProtected(pid: pid_t, name: String = "", path: String = "") -> Bool {

--- a/Sources/Vorssaint/UI/KillProcess/KillProcessView.swift
+++ b/Sources/Vorssaint/UI/KillProcess/KillProcessView.swift
@@ -27,8 +27,6 @@ struct KillProcessView: View {
         VStack(spacing: 0) {
             header
             Divider()
-            columnHeader
-            Divider()
             list
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -106,20 +104,28 @@ struct KillProcessView: View {
 
     /// Mirrors `row(_:)`'s HStack widths exactly, so each label sits over its
     /// column: the leading `22`pt gap matches the row icon, and the trailing
-    /// `98`pt gap matches the Kill + "..." button cluster.
+    /// `82`pt port field and trailing `98`pt gap match the row's port value
+    /// plus the Kill + "..." button cluster.
     private var columnHeader: some View {
-        HStack(spacing: 10) {
-            Spacer().frame(width: 22)
-            columnHeaderButton(strings.columnProcess, column: .name)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            columnHeaderButton(strings.columnCPU, column: .cpu)
-                .frame(width: 52, alignment: .trailing)
-            columnHeaderButton(strings.columnMemory, column: .memory)
-                .frame(width: 72, alignment: .trailing)
-            columnHeaderButton(strings.columnPID, column: .pid)
-                .frame(width: 56, alignment: .trailing)
-            Spacer().frame(width: 98)
+        GeometryReader { geometry in
+            HStack(spacing: 10) {
+                Spacer().frame(width: 22)
+                columnHeaderButton(strings.columnProcess, column: .name)
+                    .frame(width: processColumnWidth(in: geometry.size.width), alignment: .leading)
+                columnHeaderButton(strings.columnCPU, column: .cpu)
+                    .frame(width: 52, alignment: .trailing)
+                columnHeaderButton(strings.columnMemory, column: .memory)
+                    .frame(width: 72, alignment: .trailing)
+                columnHeaderButton(strings.columnPID, column: .pid)
+                    .frame(width: 56, alignment: .trailing)
+                Text(portColumnTitle)
+                    .font(.system(size: 10.5, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 82, alignment: .center)
+                Spacer().frame(width: 98)
+            }
         }
+        .frame(height: 14)
         .padding(.horizontal, 16)
         .padding(.vertical, 6)
     }
@@ -146,18 +152,37 @@ struct KillProcessView: View {
     @ViewBuilder
     private var list: some View {
         if service.filteredEntries.isEmpty {
-            // A transient ps hiccup no longer clears `entries` (KillProcessService
-            // keeps the last good snapshot), so an empty list here means either
-            // the very first load hasn't landed yet, or a search genuinely
-            // matched nothing - two different messages, not one.
-            if service.hasLoadedOnce {
-                emptyState
-            } else {
-                loadingState
+            VStack(spacing: 0) {
+                columnHeader
+                Divider()
+                // A transient ps hiccup no longer clears `entries`
+                // (`KillProcessService` keeps the last good snapshot), so an
+                // empty list means either first load or no search matches.
+                if service.hasLoadedOnce {
+                    emptyState
+                } else {
+                    loadingState
+                }
             }
         } else {
-            List(service.filteredEntries) { entry in row(entry) }
-                .listStyle(.inset)
+            ScrollView {
+                LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+                    Section {
+                        ForEach(service.filteredEntries) { entry in
+                            row(entry)
+                            Divider()
+                        }
+                        .padding(.horizontal, 16)
+                    } header: {
+                        VStack(spacing: 0) {
+                            columnHeader
+                            Divider()
+                        }
+                        .background(Color(nsColor: .windowBackgroundColor))
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
     }
 
@@ -180,6 +205,13 @@ struct KillProcessView: View {
     }
 
     private func row(_ entry: KillProcessEntry) -> some View {
+        GeometryReader { geometry in
+            rowContent(entry, processWidth: processColumnWidth(in: geometry.size.width))
+        }
+        .frame(height: 38)
+    }
+
+    private func rowContent(_ entry: KillProcessEntry, processWidth: CGFloat) -> some View {
         HStack(spacing: 10) {
             Image(nsImage: ResponsibleProcess.icon(for: entry.pid))
                 .resizable().frame(width: 22, height: 22)
@@ -195,7 +227,7 @@ struct KillProcessView: View {
                     .font(.system(size: 10.5)).foregroundStyle(.tertiary)
                     .lineLimit(1).truncationMode(.head)
             }
-            Spacer()
+            .frame(width: processWidth, alignment: .leading)
             Text(String(format: "%.1f%%", entry.cpuPercent))
                 .font(.system(size: 11, design: .monospaced)).foregroundStyle(.secondary)
                 .frame(width: 52, alignment: .trailing)
@@ -205,6 +237,11 @@ struct KillProcessView: View {
             Text(String(entry.pid))
                 .font(.system(size: 11, design: .monospaced)).foregroundStyle(.secondary)
                 .frame(width: 56, alignment: .trailing)
+            Text(entry.ports.map(String.init).joined(separator: ", "))
+                .font(.system(size: 11, design: .monospaced)).foregroundStyle(.secondary)
+                .lineLimit(1).truncationMode(.tail)
+                .help(entry.ports.map(String.init).joined(separator: ", "))
+                .frame(width: 82, alignment: .center)
             Button(strings.killButton) {
                 pendingAction = .kill(entry, force: false)
             }
@@ -232,6 +269,7 @@ struct KillProcessView: View {
             .menuIndicator(.hidden)
             .frame(minWidth: 44)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .buttonStyle(.bordered)
         .controlSize(.small)
         .padding(.vertical, 2)
@@ -280,6 +318,21 @@ struct KillProcessView: View {
     private func copy(_ value: String) {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(value, forType: .string)
+    }
+
+    private var portColumnTitle: String {
+        switch l10n.language {
+        case .zhHans: return "端口"
+        case .zhTW, .zhHK: return "連接埠"
+        default: return "Port"
+        }
+    }
+
+    /// Fixed columns, controls and the seven 10pt gaps consume 442pt in both
+    /// the header and a row. Giving the remainder explicitly to the process
+    /// column makes their x coordinates identical regardless of ideal sizes.
+    private func processColumnWidth(in availableWidth: CGFloat) -> CGFloat {
+        KillProcessSupport.processColumnWidth(availableWidth: availableWidth)
     }
 
     /// Ticks only while this page is open AND its window is key, so the

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9931,6 +9931,41 @@ struct MetricsTests {
         expect(!KillProcessSupport.isProtected(pid: 12345, name: "Safari", path: "/Applications/Safari.app/Contents/MacOS/Safari"),
                "ordinary user app is not protected")
 
+        let lsofFields = """
+        p101
+        f4
+        n*:3000
+        f5
+        n127.0.0.1:3000
+        f6
+        n[::1]:8080
+        p202
+        f7
+        n*:65535
+        f8
+        n*:0
+        f9
+        n*:65536
+        f10
+        n*:not-a-port
+        """
+        let listeningPorts = KillProcessSupport.listeningTCPPorts(from: lsofFields)
+        expect(listeningPorts[101] == [3000, 8080]
+                && listeningPorts[202] == [65535],
+               "lsof fields parse valid IPv4, IPv6 and wildcard ports, de-duplicate, and reject invalid ranges")
+        expect(KillProcessSupport.listeningTCPPorts(from: "").isEmpty,
+               "empty lsof output has no listening ports")
+        expect(KillProcessSupport.matches(query: "8080", name: "Server", pid: 101, ports: [3000, 8080])
+                && KillProcessSupport.matches(query: "server", name: "Local Server", pid: 101, ports: [])
+                && KillProcessSupport.matches(query: "101", name: "Server", pid: 101, ports: [])
+                && !KillProcessSupport.matches(query: "80", name: "Server", pid: 101, ports: [8080]),
+               "Kill Process search matches exact ports and PIDs plus partial case-insensitive names")
+        expect(KillProcessSupport.mergedPorts([[8080, 3000], [3000, 9000], []]) == [3000, 8080, 9000],
+               "grouped process ports are sorted and de-duplicated")
+        expect(KillProcessSupport.processColumnWidth(availableWidth: 900) == 458
+                && KillProcessSupport.processColumnWidth(availableWidth: 500) == 80,
+               "process column consumes the remainder and respects its minimum width")
+
         for language in AppLanguage.allCases {
             let categoryValues = Mirror(reflecting: FeatureStrings.settingsCategories(language)).children
                 .compactMap { $0.value as? String }


### PR DESCRIPTION

<img width="1866" height="945" alt="PixPin_2026-08-23_01-52-21" src="https://github.com/user-attachments/assets/b6ca5029-b7b9-4e1b-ad43-0a73aeb239a1" />


## Summary

- Show listening TCP ports in the Kill Process table.
- Allow processes to be found by port number.
- Merge, sort, and de-duplicate ports when related processes are grouped.
- Keep the Process, CPU, Memory, PID, Port, and action columns aligned across window sizes.
- Add coverage for `lsof` parsing, port filtering, grouped ports, and column-width calculations.

## Testing

- `./build.sh` — passed
- `./build/Vorssaint --selftest` — passed
- Verified the Kill Process table and Port column in the built app
- `./build.sh --test` — the new tests passed; 5 pre-existing natural-language date parsing assertions still fail