### PR TITLE
fix(settings): keep the Screen capture page inside the window width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
 - Settings now lists Dock Preview and Dock click as separate named sections, and
   opening Dock click from the Features hub lands on its own controls rather than on
   the Dock Preview block. Thanks to @PathGao.
+- The Screen capture settings page now picks its tool from a pop-up menu. The four
+  tool names sat in a segmented control that cannot shrink, so in most languages the
+  page asked for more width than the window, and the sidebar and the page below it
+  were pushed off the window's edges. Thanks to @gaminbhoot and @PathGao.
 - Scratchpad tabs and the pin, close, new pad and pad actions buttons now respond
   across their whole area. Thanks to @AB-boi and @PathGao.
 - Dock Preview cards no longer draw the app icon on every thumbnail or repeat the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,13 +42,12 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
   keystroke. Thanks to @BenjaminD2023.
 - Scrolling screenshots now keep fixed page footers once at the end instead of
   repeating them after every scroll.
+- The Screen capture settings page now picks its tool from a pop-up menu, so the
+  four tool names can no longer ask for more width than the window and push the
+  sidebar off its edge. Thanks to @gaminbhoot and @PathGao.
 - Settings now lists Dock Preview and Dock click as separate named sections, and
   opening Dock click from the Features hub lands on its own controls rather than on
   the Dock Preview block. Thanks to @PathGao.
-- The Screen capture settings page now picks its tool from a pop-up menu. The four
-  tool names sat in a segmented control that cannot shrink, so in most languages the
-  page asked for more width than the window, and the sidebar and the page below it
-  were pushed off the window's edges. Thanks to @gaminbhoot and @PathGao.
 - Scratchpad tabs and the pin, close, new pad and pad actions buttons now respond
   across their whole area. Thanks to @AB-boi and @PathGao.
 - Dock Preview cards no longer draw the app icon on every thumbnail or repeat the

--- a/Sources/Vorssaint/UI/Settings/ScreenCaptureSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/ScreenCaptureSettings.swift
@@ -4,8 +4,8 @@
 import SwiftUI
 
 /// One Settings destination for every tool that starts from the screen.
-/// The shared shortcut stays fixed at the top; the segmented control only
-/// changes the feature-specific options shown below it.
+/// The shared shortcut stays fixed at the top; the tool picker only changes
+/// the feature-specific options shown below it.
 struct ScreenCaptureSettings: View {
     @ObservedObject private var l10n = L10n.shared
     @ObservedObject private var router = SettingsRouter.shared
@@ -30,6 +30,12 @@ struct ScreenCaptureSettings: View {
         Form {
             Section {
                 if availableTools.count > 1 {
+                    // A segmented control never compresses below the sum of its
+                    // segments, so four full tool names side by side asked for
+                    // more width than the window can guarantee and pushed the
+                    // whole split view off screen (issue #757). A pop-up asks
+                    // for one name at a time and truncates, so no translation
+                    // can outgrow the page.
                     Picker(strings.screenCaptureTitle, selection: toolSelection) {
                         ForEach(availableTools, id: \.self) { tool in
                             Label(tool.settingsTitle(l10n.s, language: l10n.language),
@@ -37,9 +43,8 @@ struct ScreenCaptureSettings: View {
                                 .tag(tool)
                         }
                     }
-                    .pickerStyle(.segmented)
+                    .pickerStyle(.menu)
                     .labelsHidden()
-                    .controlSize(.large)
                 }
 
                 Text(strings.screenCaptureCaption)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11515,6 +11515,23 @@ struct MetricsTests {
         expect(ScreenCaptureTool.available(isAvailable: captureFeatures.contains)
                 == [.screenshot, .recording, .text, .color],
                "the capture chooser keeps a stable order for every installed mode")
+        // A segmented control has no compressed size: it asks for the sum of
+        // its segments and overflows whatever it is given. The four capture
+        // tool names measured 816pt in Russian and 640pt in English, well past
+        // the 574pt the Settings window guarantees the detail column at its
+        // 772pt minimum, so the whole split view was laid out wider than the
+        // window and slid off its left edge (issue #757). Only a control that
+        // truncates may carry those names.
+        let screenCaptureSettingsSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/UI/Settings/ScreenCaptureSettings.swift",
+            encoding: .utf8)) ?? ""
+        let afterToolTitle = screenCaptureSettingsSource
+            .components(separatedBy: "tool.settingsTitle(").dropFirst().first ?? ""
+        let toolPickerStyle = afterToolTitle
+            .components(separatedBy: ".pickerStyle(").dropFirst().first?
+            .prefix { $0 != ")" } ?? ""
+        expect(toolPickerStyle == ".menu",
+               "the capture tool picker truncates instead of demanding room for every tool name")
         expect(!ScreenshotSupport.captureAvailabilityChanged(
                     activeTools: [.screenshot, .recording],
                     availableTools: [.screenshot, .recording])

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11516,12 +11516,10 @@ struct MetricsTests {
                 == [.screenshot, .recording, .text, .color],
                "the capture chooser keeps a stable order for every installed mode")
         // A segmented control has no compressed size: it asks for the sum of
-        // its segments and overflows whatever it is given. The four capture
-        // tool names measured 816pt in Russian and 640pt in English, well past
-        // the 574pt the Settings window guarantees the detail column at its
-        // 772pt minimum, so the whole split view was laid out wider than the
-        // window and slid off its left edge (issue #757). Only a control that
-        // truncates may carry those names.
+        // its segments. The four tool names measured 816pt in Russian against
+        // the 574pt the Settings window guarantees the detail column, so the
+        // split view was laid out wider than the window and slid off its left
+        // edge (issue #757). Only a control that truncates may carry them.
         let screenCaptureSettingsSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/UI/Settings/ScreenCaptureSettings.swift",
             encoding: .utf8)) ?? ""


### PR DESCRIPTION
Ref #757

## What was wrong

Settings › Screen capture was laid out wider than the window and slid left, clipping the sidebar labels off the left edge and the page controls off the right (#757). The cause is not animation: the four capture tools were a `.segmented` Picker, and a segmented control has no compressed size — it asks for the sum of its segments and pushes whatever contains it.

Measured by hosting the exact view from the file in an `NSHostingView` and reading `fittingSize.width`, all 13 shipped languages:

| language | segmented | menu | page overflows below |
|---|---|---|---|
| ru | 816pt | 246pt | 1014pt |
| de | 812pt | 245pt | 1010pt |
| it | 736pt | 226pt | 934pt |
| es | 732pt | 225pt | 930pt |
| fr | 720pt | 220pt | 918pt |
| tr | 688pt | 214pt | 886pt |
| ja | 648pt | 204pt | 846pt |
| en | 640pt | 202pt | 838pt |
| pt-BR | 576pt | 186pt | 774pt |
| ko | 492pt | 165pt | 690pt |
| zh-Hans / zh-TW / zh-HK | 412pt | 145pt | 610pt |

The Settings window has `minWidth: 772` and a sidebar that never goes below 198pt, so the detail column is guaranteed only 574pt. The page therefore overflows whenever the window is narrower than `segmented width + 198` — the last column above. That model matches the report: the reporter's window measures ~777pt in their screenshot, which for English predicts 61pt of overflow, about 30pt clipped on each side after centering, and that is what their screenshot shows. It also explains the reporting pattern — Chinese needs only 610pt, below the window minimum, so it can never overflow, and no zh user has reported this.

## What changed

The picker is `.pickerStyle(.menu)`: 246pt at its widest, with room to spare in every language, and a pop-up truncates when squeezed so no future translation can outgrow the page. It keeps the SF Symbols, the tool order, the deep links from the Features hub and the Command Bar, and the tool-specific sections below it.

What it costs: the other three tools are one click away instead of visible at a glance. Apple's HIG makes the same trade — a segmented control must fit its content, so it is the wrong control for localized full sentences like "Скопировать текст с экрана".

## What was considered and not done

**Dropping the icons and `.controlSize(.large)`.** Measured: the names still sit side by side and the page still overflows.

**Icon-only segments.** They fit easily but drop the tool names from the page.

**Raising `minWidth` to clear 816pt.** A ~1014pt minimum Settings window is a real cost on 13" displays, and the number would have to be revisited with every new translation.

## Not touched

All 17 remaining `.pickerStyle(.segmented)` sites across 10 Settings files were measured the same way, in all 13 languages, against the same 574pt budget. Two came back over:

- **General › window preview size overflows in Russian**, at 587pt against 574 — 13pt over in one language, versus 242pt over in eight for the capture tools. Left alone: switching it to a pop-up would trade a control that is right in twelve languages for 13pt in the thirteenth, and it belongs to a different page. Naming it here so the number exists; happy to send it separately.
- **Homebrew's installed filter clips its own labels today.** It is pinned to `.frame(width: 300)` but wants 297–321pt depending on language, so in en, pt-BR, tr, ru, es and fr the control is squeezed below its intrinsic width. That is self-inflicted by a fixed frame rather than page overflow, and out of scope.

Everything else fits with margin; the next widest are Command Bar › link kind at 471pt (ja) and Recorder › countdown at 466pt (es). This page's own colour format row stays segmented at 404pt worst case. Surfaces outside Settings size themselves independently and were not measured.

Tests: 8039 checks pass, `./build.sh` clean with no warnings, `--selftest` OK. The new check reads the picker style that follows `tool.settingsTitle(` out of the view source, so it pins the control rather than a line's spelling; reverting the one line fails it.

