### PR TITLE
feat(snippets): add a visual date/time builder

### DIFF
--- a/Sources/Vorssaint/Core/SnippetStrings.swift
+++ b/Sources/Vorssaint/Core/SnippetStrings.swift
@@ -43,6 +43,31 @@ struct SnippetFeatureStrings {
     let folderPlaceholder: String
     let showInLibraryLabel: String
     let variablesFormatCaption: String
+    let editorFormatCaption: String
+    let dateTimeInsertButton: String
+    let dateTimeEditButton: String
+    let dateTimeTypeLabel: String
+    let dateTimeKindDate: String
+    let dateTimeKindTime: String
+    let dateTimeKindDateTime: String
+    let dateTimeStyleLabel: String
+    let dateTimeStyleShort: String
+    let dateTimeStyleMedium: String
+    let dateTimeStyleLong: String
+    let dateTimeStyleFull: String
+    let dateTimeStyleISO8601: String
+    let dateTimeStyleCustom: String
+    let dateTimeStyleLocaleNote: String
+    let dateTimeTimezoneLabel: String
+    let dateTimeTimezoneDeviceDefault: String
+    let dateTimeTimezoneValid: String
+    let dateTimeTimezoneInvalid: String
+    let dateTimeTimezoneClear: String
+    let dateTimeTimezoneSearchPlaceholder: String
+    let dateTimePatternLabel: String
+    let dateTimePreviewLabel: String
+    let dateTimeConfirmInsert: String
+    let dateTimeConfirmUpdate: String
 }
 
 extension FeatureStrings {
@@ -102,7 +127,32 @@ extension SnippetFeatureStrings {
         folderLabel: "폴더",
         folderPlaceholder: "업무",
         showInLibraryLabel: "빠른 메뉴에 표시",
-        variablesFormatCaption: "콜론 뒤에 형식을 적으면 원하는 모양이 됩니다. 예: {{date:yyyy-MM-dd}}"
+        variablesFormatCaption: "콜론 뒤에 형식을 적으면 원하는 모양이 됩니다. 예: {{date:yyyy-MM-dd}}. 시간대는 {{date-tz(America/New_York):yyyy-MM-dd}}처럼 -tz(...)로 지정합니다.",
+        editorFormatCaption: "콜론 뒤에 형식을 적으면 원하는 모양이 됩니다. 예: {{date:yyyy-MM-dd}}. 또는 위의 날짜/시간 버튼을 사용하세요. 시간대는 {{date-tz(America/New_York):yyyy-MM-dd}}처럼 -tz(...)로 지정합니다.",
+        dateTimeInsertButton: "날짜/시간 삽입",
+        dateTimeEditButton: "날짜/시간 편집",
+        dateTimeTypeLabel: "유형",
+        dateTimeKindDate: "날짜",
+        dateTimeKindTime: "시간",
+        dateTimeKindDateTime: "날짜시간",
+        dateTimeStyleLabel: "스타일",
+        dateTimeStyleShort: "짧게",
+        dateTimeStyleMedium: "보통",
+        dateTimeStyleLong: "길게",
+        dateTimeStyleFull: "전체",
+        dateTimeStyleISO8601: "ISO 8601",
+        dateTimeStyleCustom: "사용자 지정",
+        dateTimeStyleLocaleNote: "이름이 있는 형식은 Mac의 지역 표기를 지금 그대로 저장합니다.",
+        dateTimeTimezoneLabel: "시간대",
+        dateTimeTimezoneDeviceDefault: "기기 기본값",
+        dateTimeTimezoneValid: "유효한 시간대",
+        dateTimeTimezoneInvalid: "인식할 수 없는 시간대",
+        dateTimeTimezoneClear: "시간대 지우기",
+        dateTimeTimezoneSearchPlaceholder: "시간대 검색",
+        dateTimePatternLabel: "패턴",
+        dateTimePreviewLabel: "미리보기",
+        dateTimeConfirmInsert: "삽입",
+        dateTimeConfirmUpdate: "업데이트"
     )
 }
 
@@ -143,7 +193,32 @@ extension SnippetFeatureStrings {
         folderLabel: "Folder",
         folderPlaceholder: "Work",
         showInLibraryLabel: "Show in the quick menu",
-        variablesFormatCaption: "A format after a colon picks how they look, like {{date:yyyy-MM-dd}}."
+        variablesFormatCaption: "A format after a colon picks how they look, like {{date:yyyy-MM-dd}}. A -tz(...) part sets the timezone, like {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        editorFormatCaption: "A format after a colon picks how they look, like {{date:yyyy-MM-dd}}, or use the date/time button above. A -tz(...) part sets the timezone, like {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        dateTimeInsertButton: "Insert date/time",
+        dateTimeEditButton: "Edit date/time",
+        dateTimeTypeLabel: "Type",
+        dateTimeKindDate: "Date",
+        dateTimeKindTime: "Time",
+        dateTimeKindDateTime: "DateTime",
+        dateTimeStyleLabel: "Style",
+        dateTimeStyleShort: "Short",
+        dateTimeStyleMedium: "Medium",
+        dateTimeStyleLong: "Long",
+        dateTimeStyleFull: "Full",
+        dateTimeStyleISO8601: "ISO 8601",
+        dateTimeStyleCustom: "Custom",
+        dateTimeStyleLocaleNote: "A named style saves the format your Mac's region uses right now.",
+        dateTimeTimezoneLabel: "Timezone",
+        dateTimeTimezoneDeviceDefault: "Device default",
+        dateTimeTimezoneValid: "Valid timezone",
+        dateTimeTimezoneInvalid: "Unrecognized timezone",
+        dateTimeTimezoneClear: "Clear timezone",
+        dateTimeTimezoneSearchPlaceholder: "Search timezones",
+        dateTimePatternLabel: "Pattern",
+        dateTimePreviewLabel: "Preview",
+        dateTimeConfirmInsert: "Insert",
+        dateTimeConfirmUpdate: "Update"
     )
 
     static let ptBR = SnippetFeatureStrings(
@@ -182,7 +257,32 @@ extension SnippetFeatureStrings {
         folderLabel: "Pasta",
         folderPlaceholder: "Trabalho",
         showInLibraryLabel: "Mostrar no menu rápido",
-        variablesFormatCaption: "Um formato depois de dois pontos escolhe a aparência, como {{date:yyyy-MM-dd}}."
+        variablesFormatCaption: "Um formato depois de dois pontos escolhe a aparência, como {{date:yyyy-MM-dd}}. Uma parte -tz(...) define o fuso horário, como {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        editorFormatCaption: "Um formato depois de dois pontos escolhe a aparência, como {{date:yyyy-MM-dd}}, ou use o botão de data/hora acima. Uma parte -tz(...) define o fuso horário, como {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        dateTimeInsertButton: "Inserir data/hora",
+        dateTimeEditButton: "Editar data/hora",
+        dateTimeTypeLabel: "Tipo",
+        dateTimeKindDate: "Data",
+        dateTimeKindTime: "Hora",
+        dateTimeKindDateTime: "Data e hora",
+        dateTimeStyleLabel: "Estilo",
+        dateTimeStyleShort: "Curto",
+        dateTimeStyleMedium: "Médio",
+        dateTimeStyleLong: "Longo",
+        dateTimeStyleFull: "Completo",
+        dateTimeStyleISO8601: "ISO 8601",
+        dateTimeStyleCustom: "Personalizado",
+        dateTimeStyleLocaleNote: "Um estilo nomeado salva o formato que a região do seu Mac usa agora.",
+        dateTimeTimezoneLabel: "Fuso horário",
+        dateTimeTimezoneDeviceDefault: "Padrão do dispositivo",
+        dateTimeTimezoneValid: "Fuso horário válido",
+        dateTimeTimezoneInvalid: "Fuso horário não reconhecido",
+        dateTimeTimezoneClear: "Limpar fuso horário",
+        dateTimeTimezoneSearchPlaceholder: "Buscar fusos horários",
+        dateTimePatternLabel: "Padrão",
+        dateTimePreviewLabel: "Pré-visualização",
+        dateTimeConfirmInsert: "Inserir",
+        dateTimeConfirmUpdate: "Atualizar"
     )
 
     static let tr = SnippetFeatureStrings(
@@ -221,7 +321,32 @@ extension SnippetFeatureStrings {
         folderLabel: "Klasör",
         folderPlaceholder: "İş",
         showInLibraryLabel: "Hızlı menüde göster",
-        variablesFormatCaption: "İki noktadan sonra yazılan biçim görünümü belirler, örneğin {{date:yyyy-MM-dd}}."
+        variablesFormatCaption: "İki noktadan sonra yazılan biçim görünümü belirler, örneğin {{date:yyyy-MM-dd}}. -tz(...) bölümü saat dilimini belirler, örneğin {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        editorFormatCaption: "İki noktadan sonra yazılan biçim görünümü belirler, örneğin {{date:yyyy-MM-dd}}, veya yukarıdaki tarih/saat düğmesini kullanın. -tz(...) bölümü saat dilimini belirler, örneğin {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        dateTimeInsertButton: "Tarih/saat ekle",
+        dateTimeEditButton: "Tarih/saati düzenle",
+        dateTimeTypeLabel: "Tür",
+        dateTimeKindDate: "Tarih",
+        dateTimeKindTime: "Saat",
+        dateTimeKindDateTime: "Tarih ve saat",
+        dateTimeStyleLabel: "Stil",
+        dateTimeStyleShort: "Kısa",
+        dateTimeStyleMedium: "Orta",
+        dateTimeStyleLong: "Uzun",
+        dateTimeStyleFull: "Tam",
+        dateTimeStyleISO8601: "ISO 8601",
+        dateTimeStyleCustom: "Özel",
+        dateTimeStyleLocaleNote: "Adlandırılmış bir biçem, Mac'inizin bölge gösterimini şu anki haliyle kaydeder.",
+        dateTimeTimezoneLabel: "Saat dilimi",
+        dateTimeTimezoneDeviceDefault: "Cihaz varsayılanı",
+        dateTimeTimezoneValid: "Geçerli saat dilimi",
+        dateTimeTimezoneInvalid: "Tanınmayan saat dilimi",
+        dateTimeTimezoneClear: "Saat dilimini temizle",
+        dateTimeTimezoneSearchPlaceholder: "Saat dilimi ara",
+        dateTimePatternLabel: "Desen",
+        dateTimePreviewLabel: "Önizleme",
+        dateTimeConfirmInsert: "Ekle",
+        dateTimeConfirmUpdate: "Güncelle"
     )
 
     static let ru = SnippetFeatureStrings(
@@ -260,7 +385,32 @@ extension SnippetFeatureStrings {
         folderLabel: "Папка",
         folderPlaceholder: "Работа",
         showInLibraryLabel: "Показывать в быстром меню",
-        variablesFormatCaption: "Формат после двоеточия задаёт вид, например {{date:yyyy-MM-dd}}."
+        variablesFormatCaption: "Формат после двоеточия задаёт вид, например {{date:yyyy-MM-dd}}. Часть -tz(...) задаёт часовой пояс, например {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        editorFormatCaption: "Формат после двоеточия задаёт вид, например {{date:yyyy-MM-dd}}, или используйте кнопку даты и времени выше. Часть -tz(...) задаёт часовой пояс, например {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        dateTimeInsertButton: "Вставить дату/время",
+        dateTimeEditButton: "Изменить дату/время",
+        dateTimeTypeLabel: "Тип",
+        dateTimeKindDate: "Дата",
+        dateTimeKindTime: "Время",
+        dateTimeKindDateTime: "Дата и время",
+        dateTimeStyleLabel: "Стиль",
+        dateTimeStyleShort: "Короткий",
+        dateTimeStyleMedium: "Средний",
+        dateTimeStyleLong: "Длинный",
+        dateTimeStyleFull: "Полный",
+        dateTimeStyleISO8601: "ISO 8601",
+        dateTimeStyleCustom: "Свой",
+        dateTimeStyleLocaleNote: "Именованный стиль сохраняет формат, который регион вашего Mac использует сейчас.",
+        dateTimeTimezoneLabel: "Часовой пояс",
+        dateTimeTimezoneDeviceDefault: "По умолчанию на устройстве",
+        dateTimeTimezoneValid: "Допустимый часовой пояс",
+        dateTimeTimezoneInvalid: "Нераспознанный часовой пояс",
+        dateTimeTimezoneClear: "Очистить часовой пояс",
+        dateTimeTimezoneSearchPlaceholder: "Поиск часовых поясов",
+        dateTimePatternLabel: "Шаблон",
+        dateTimePreviewLabel: "Предпросмотр",
+        dateTimeConfirmInsert: "Вставить",
+        dateTimeConfirmUpdate: "Обновить"
     )
 
     static let es = SnippetFeatureStrings(
@@ -299,7 +449,32 @@ extension SnippetFeatureStrings {
         folderLabel: "Carpeta",
         folderPlaceholder: "Trabajo",
         showInLibraryLabel: "Mostrar en el menú rápido",
-        variablesFormatCaption: "Un formato después de dos puntos elige la apariencia, como {{date:yyyy-MM-dd}}."
+        variablesFormatCaption: "Un formato después de dos puntos elige la apariencia, como {{date:yyyy-MM-dd}}. Una parte -tz(...) define la zona horaria, como {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        editorFormatCaption: "Un formato después de dos puntos elige la apariencia, como {{date:yyyy-MM-dd}}, o usa el botón de fecha/hora de arriba. Una parte -tz(...) define la zona horaria, como {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        dateTimeInsertButton: "Insertar fecha/hora",
+        dateTimeEditButton: "Editar fecha/hora",
+        dateTimeTypeLabel: "Tipo",
+        dateTimeKindDate: "Fecha",
+        dateTimeKindTime: "Hora",
+        dateTimeKindDateTime: "Fecha y hora",
+        dateTimeStyleLabel: "Estilo",
+        dateTimeStyleShort: "Corto",
+        dateTimeStyleMedium: "Medio",
+        dateTimeStyleLong: "Largo",
+        dateTimeStyleFull: "Completo",
+        dateTimeStyleISO8601: "ISO 8601",
+        dateTimeStyleCustom: "Personalizado",
+        dateTimeStyleLocaleNote: "Un estilo con nombre guarda el formato que usa la región de tu Mac ahora mismo.",
+        dateTimeTimezoneLabel: "Zona horaria",
+        dateTimeTimezoneDeviceDefault: "Predeterminada del dispositivo",
+        dateTimeTimezoneValid: "Zona horaria válida",
+        dateTimeTimezoneInvalid: "Zona horaria no reconocida",
+        dateTimeTimezoneClear: "Borrar zona horaria",
+        dateTimeTimezoneSearchPlaceholder: "Buscar zonas horarias",
+        dateTimePatternLabel: "Patrón",
+        dateTimePreviewLabel: "Vista previa",
+        dateTimeConfirmInsert: "Insertar",
+        dateTimeConfirmUpdate: "Actualizar"
     )
 
     static let de = SnippetFeatureStrings(
@@ -338,7 +513,32 @@ extension SnippetFeatureStrings {
         folderLabel: "Ordner",
         folderPlaceholder: "Arbeit",
         showInLibraryLabel: "Im Schnellmenü zeigen",
-        variablesFormatCaption: "Ein Format nach einem Doppelpunkt bestimmt das Aussehen, etwa {{date:yyyy-MM-dd}}."
+        variablesFormatCaption: "Ein Format nach einem Doppelpunkt bestimmt das Aussehen, etwa {{date:yyyy-MM-dd}}. Ein -tz(...)-Teil legt die Zeitzone fest, etwa {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        editorFormatCaption: "Ein Format nach einem Doppelpunkt bestimmt das Aussehen, etwa {{date:yyyy-MM-dd}}, oder verwende die Datum/Uhrzeit-Schaltfläche oben. Ein -tz(...)-Teil legt die Zeitzone fest, etwa {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        dateTimeInsertButton: "Datum/Uhrzeit einfügen",
+        dateTimeEditButton: "Datum/Uhrzeit bearbeiten",
+        dateTimeTypeLabel: "Typ",
+        dateTimeKindDate: "Datum",
+        dateTimeKindTime: "Uhrzeit",
+        dateTimeKindDateTime: "Datum und Uhrzeit",
+        dateTimeStyleLabel: "Stil",
+        dateTimeStyleShort: "Kurz",
+        dateTimeStyleMedium: "Mittel",
+        dateTimeStyleLong: "Lang",
+        dateTimeStyleFull: "Vollständig",
+        dateTimeStyleISO8601: "ISO 8601",
+        dateTimeStyleCustom: "Benutzerdefiniert",
+        dateTimeStyleLocaleNote: "Ein benannter Stil speichert das Format, das die Region deines Mac jetzt verwendet.",
+        dateTimeTimezoneLabel: "Zeitzone",
+        dateTimeTimezoneDeviceDefault: "Gerätestandard",
+        dateTimeTimezoneValid: "Gültige Zeitzone",
+        dateTimeTimezoneInvalid: "Unbekannte Zeitzone",
+        dateTimeTimezoneClear: "Zeitzone löschen",
+        dateTimeTimezoneSearchPlaceholder: "Zeitzonen suchen",
+        dateTimePatternLabel: "Muster",
+        dateTimePreviewLabel: "Vorschau",
+        dateTimeConfirmInsert: "Einfügen",
+        dateTimeConfirmUpdate: "Aktualisieren"
     )
 
     static let fr = SnippetFeatureStrings(
@@ -377,7 +577,32 @@ extension SnippetFeatureStrings {
         folderLabel: "Dossier",
         folderPlaceholder: "Travail",
         showInLibraryLabel: "Afficher dans le menu rapide",
-        variablesFormatCaption: "Un format après deux-points choisit l'apparence, par exemple {{date:yyyy-MM-dd}}."
+        variablesFormatCaption: "Un format après deux-points choisit l'apparence, par exemple {{date:yyyy-MM-dd}}. Une partie -tz(...) définit le fuseau horaire, par exemple {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        editorFormatCaption: "Un format après deux-points choisit l'apparence, par exemple {{date:yyyy-MM-dd}}, ou utilisez le bouton date/heure ci-dessus. Une partie -tz(...) définit le fuseau horaire, par exemple {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        dateTimeInsertButton: "Insérer date/heure",
+        dateTimeEditButton: "Modifier date/heure",
+        dateTimeTypeLabel: "Type",
+        dateTimeKindDate: "Date",
+        dateTimeKindTime: "Heure",
+        dateTimeKindDateTime: "Date et heure",
+        dateTimeStyleLabel: "Style",
+        dateTimeStyleShort: "Court",
+        dateTimeStyleMedium: "Moyen",
+        dateTimeStyleLong: "Long",
+        dateTimeStyleFull: "Complet",
+        dateTimeStyleISO8601: "ISO 8601",
+        dateTimeStyleCustom: "Personnalisé",
+        dateTimeStyleLocaleNote: "Un style nommé enregistre le format utilisé par la région de votre Mac.",
+        dateTimeTimezoneLabel: "Fuseau horaire",
+        dateTimeTimezoneDeviceDefault: "Par défaut de l'appareil",
+        dateTimeTimezoneValid: "Fuseau horaire valide",
+        dateTimeTimezoneInvalid: "Fuseau horaire non reconnu",
+        dateTimeTimezoneClear: "Effacer le fuseau horaire",
+        dateTimeTimezoneSearchPlaceholder: "Rechercher un fuseau horaire",
+        dateTimePatternLabel: "Motif",
+        dateTimePreviewLabel: "Aperçu",
+        dateTimeConfirmInsert: "Insérer",
+        dateTimeConfirmUpdate: "Mettre à jour"
     )
 
     static let it = SnippetFeatureStrings(
@@ -416,7 +641,32 @@ extension SnippetFeatureStrings {
         folderLabel: "Cartella",
         folderPlaceholder: "Lavoro",
         showInLibraryLabel: "Mostra nel menu rapido",
-        variablesFormatCaption: "Un formato dopo i due punti sceglie l'aspetto, ad esempio {{date:yyyy-MM-dd}}."
+        variablesFormatCaption: "Un formato dopo i due punti sceglie l'aspetto, ad esempio {{date:yyyy-MM-dd}}. Una parte -tz(...) imposta il fuso orario, ad esempio {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        editorFormatCaption: "Un formato dopo i due punti sceglie l'aspetto, ad esempio {{date:yyyy-MM-dd}}, oppure usa il pulsante data/ora qui sopra. Una parte -tz(...) imposta il fuso orario, ad esempio {{date-tz(America/New_York):yyyy-MM-dd}}.",
+        dateTimeInsertButton: "Inserisci data/ora",
+        dateTimeEditButton: "Modifica data/ora",
+        dateTimeTypeLabel: "Tipo",
+        dateTimeKindDate: "Data",
+        dateTimeKindTime: "Ora",
+        dateTimeKindDateTime: "Data e ora",
+        dateTimeStyleLabel: "Stile",
+        dateTimeStyleShort: "Breve",
+        dateTimeStyleMedium: "Medio",
+        dateTimeStyleLong: "Lungo",
+        dateTimeStyleFull: "Completo",
+        dateTimeStyleISO8601: "ISO 8601",
+        dateTimeStyleCustom: "Personalizzato",
+        dateTimeStyleLocaleNote: "Uno stile con nome salva il formato usato ora dalla regione del tuo Mac.",
+        dateTimeTimezoneLabel: "Fuso orario",
+        dateTimeTimezoneDeviceDefault: "Predefinito del dispositivo",
+        dateTimeTimezoneValid: "Fuso orario valido",
+        dateTimeTimezoneInvalid: "Fuso orario non riconosciuto",
+        dateTimeTimezoneClear: "Cancella fuso orario",
+        dateTimeTimezoneSearchPlaceholder: "Cerca fusi orari",
+        dateTimePatternLabel: "Modello",
+        dateTimePreviewLabel: "Anteprima",
+        dateTimeConfirmInsert: "Inserisci",
+        dateTimeConfirmUpdate: "Aggiorna"
     )
 
     static let ja = SnippetFeatureStrings(
@@ -455,7 +705,32 @@ extension SnippetFeatureStrings {
         folderLabel: "フォルダ",
         folderPlaceholder: "仕事",
         showInLibraryLabel: "クイックメニューに表示",
-        variablesFormatCaption: "コロンの後に形式を書くと表示を選べます。例: {{date:yyyy-MM-dd}}"
+        variablesFormatCaption: "コロンの後に形式を書くと表示を選べます。例: {{date:yyyy-MM-dd}}。-tz(...) で時間帯を指定できます。例: {{date-tz(America/New_York):yyyy-MM-dd}}",
+        editorFormatCaption: "コロンの後に形式を書くと表示を選べます。例: {{date:yyyy-MM-dd}}。または上の日付/時刻ボタンを使ってください。-tz(...) で時間帯を指定できます。例: {{date-tz(America/New_York):yyyy-MM-dd}}",
+        dateTimeInsertButton: "日付/時刻を挿入",
+        dateTimeEditButton: "日付/時刻を編集",
+        dateTimeTypeLabel: "種類",
+        dateTimeKindDate: "日付",
+        dateTimeKindTime: "時刻",
+        dateTimeKindDateTime: "日付と時刻",
+        dateTimeStyleLabel: "スタイル",
+        dateTimeStyleShort: "短い",
+        dateTimeStyleMedium: "標準",
+        dateTimeStyleLong: "長い",
+        dateTimeStyleFull: "完全",
+        dateTimeStyleISO8601: "ISO 8601",
+        dateTimeStyleCustom: "カスタム",
+        dateTimeStyleLocaleNote: "名前付きの形式は、Macの地域の表記をそのまま保存します。",
+        dateTimeTimezoneLabel: "タイムゾーン",
+        dateTimeTimezoneDeviceDefault: "デバイスの既定値",
+        dateTimeTimezoneValid: "有効なタイムゾーン",
+        dateTimeTimezoneInvalid: "認識できないタイムゾーン",
+        dateTimeTimezoneClear: "タイムゾーンを消去",
+        dateTimeTimezoneSearchPlaceholder: "タイムゾーンを検索",
+        dateTimePatternLabel: "パターン",
+        dateTimePreviewLabel: "プレビュー",
+        dateTimeConfirmInsert: "挿入",
+        dateTimeConfirmUpdate: "更新"
     )
 
     static let zhHans = SnippetFeatureStrings(
@@ -494,7 +769,32 @@ extension SnippetFeatureStrings {
         folderLabel: "文件夹",
         folderPlaceholder: "工作",
         showInLibraryLabel: "在快捷菜单中显示",
-        variablesFormatCaption: "冒号后加上格式就能自定样式，例如 {{date:yyyy-MM-dd}}。"
+        variablesFormatCaption: "冒号后加上格式就能自定样式，例如 {{date:yyyy-MM-dd}}。用 -tz(...) 指定时区，例如 {{date-tz(America/New_York):yyyy-MM-dd}}。",
+        editorFormatCaption: "冒号后加上格式就能自定样式，例如 {{date:yyyy-MM-dd}}，或使用上方的日期/时间按钮。用 -tz(...) 指定时区，例如 {{date-tz(America/New_York):yyyy-MM-dd}}。",
+        dateTimeInsertButton: "插入日期/时间",
+        dateTimeEditButton: "编辑日期/时间",
+        dateTimeTypeLabel: "类型",
+        dateTimeKindDate: "日期",
+        dateTimeKindTime: "时间",
+        dateTimeKindDateTime: "日期和时间",
+        dateTimeStyleLabel: "样式",
+        dateTimeStyleShort: "简短",
+        dateTimeStyleMedium: "中等",
+        dateTimeStyleLong: "较长",
+        dateTimeStyleFull: "完整",
+        dateTimeStyleISO8601: "ISO 8601",
+        dateTimeStyleCustom: "自定义",
+        dateTimeStyleLocaleNote: "命名样式会保存 Mac 地区此刻使用的格式。",
+        dateTimeTimezoneLabel: "时区",
+        dateTimeTimezoneDeviceDefault: "设备默认",
+        dateTimeTimezoneValid: "有效时区",
+        dateTimeTimezoneInvalid: "无法识别的时区",
+        dateTimeTimezoneClear: "清除时区",
+        dateTimeTimezoneSearchPlaceholder: "搜索时区",
+        dateTimePatternLabel: "格式",
+        dateTimePreviewLabel: "预览",
+        dateTimeConfirmInsert: "插入",
+        dateTimeConfirmUpdate: "更新"
     )
 
     static let zhTW = SnippetFeatureStrings(
@@ -533,7 +833,32 @@ extension SnippetFeatureStrings {
         folderLabel: "檔案夾",
         folderPlaceholder: "工作",
         showInLibraryLabel: "在快捷選單中顯示",
-        variablesFormatCaption: "冒號後加上格式就能自訂樣式,例如 {{date:yyyy-MM-dd}}。"
+        variablesFormatCaption: "冒號後加上格式就能自訂樣式,例如 {{date:yyyy-MM-dd}}。用 -tz(...) 指定時區,例如 {{date-tz(America/New_York):yyyy-MM-dd}}。",
+        editorFormatCaption: "冒號後加上格式就能自訂樣式,例如 {{date:yyyy-MM-dd}},或使用上方的日期/時間按鈕。用 -tz(...) 指定時區,例如 {{date-tz(America/New_York):yyyy-MM-dd}}。",
+        dateTimeInsertButton: "插入日期/時間",
+        dateTimeEditButton: "編輯日期/時間",
+        dateTimeTypeLabel: "類型",
+        dateTimeKindDate: "日期",
+        dateTimeKindTime: "時間",
+        dateTimeKindDateTime: "日期和時間",
+        dateTimeStyleLabel: "樣式",
+        dateTimeStyleShort: "簡短",
+        dateTimeStyleMedium: "中等",
+        dateTimeStyleLong: "較長",
+        dateTimeStyleFull: "完整",
+        dateTimeStyleISO8601: "ISO 8601",
+        dateTimeStyleCustom: "自訂",
+        dateTimeStyleLocaleNote: "命名樣式會儲存 Mac 地區此刻使用的格式。",
+        dateTimeTimezoneLabel: "時區",
+        dateTimeTimezoneDeviceDefault: "裝置預設",
+        dateTimeTimezoneValid: "有效時區",
+        dateTimeTimezoneInvalid: "無法辨識的時區",
+        dateTimeTimezoneClear: "清除時區",
+        dateTimeTimezoneSearchPlaceholder: "搜尋時區",
+        dateTimePatternLabel: "格式",
+        dateTimePreviewLabel: "預覽",
+        dateTimeConfirmInsert: "插入",
+        dateTimeConfirmUpdate: "更新"
     )
 
     static let zhHK = SnippetFeatureStrings(
@@ -572,6 +897,31 @@ extension SnippetFeatureStrings {
         folderLabel: "檔案夾",
         folderPlaceholder: "工作",
         showInLibraryLabel: "在快捷選單中顯示",
-        variablesFormatCaption: "喺冒號後加上格式就可以自訂樣式,例如 {{date:yyyy-MM-dd}}。"
+        variablesFormatCaption: "喺冒號後加上格式就可以自訂樣式,例如 {{date:yyyy-MM-dd}}。用 -tz(...) 指定時區,例如 {{date-tz(America/New_York):yyyy-MM-dd}}。",
+        editorFormatCaption: "喺冒號後加上格式就可以自訂樣式,例如 {{date:yyyy-MM-dd}},或者用返上面嘅日期/時間掣。用 -tz(...) 指定時區,例如 {{date-tz(America/New_York):yyyy-MM-dd}}。",
+        dateTimeInsertButton: "插入日期/時間",
+        dateTimeEditButton: "編輯日期/時間",
+        dateTimeTypeLabel: "類型",
+        dateTimeKindDate: "日期",
+        dateTimeKindTime: "時間",
+        dateTimeKindDateTime: "日期和時間",
+        dateTimeStyleLabel: "樣式",
+        dateTimeStyleShort: "簡短",
+        dateTimeStyleMedium: "中等",
+        dateTimeStyleLong: "較長",
+        dateTimeStyleFull: "完整",
+        dateTimeStyleISO8601: "ISO 8601",
+        dateTimeStyleCustom: "自訂",
+        dateTimeStyleLocaleNote: "命名樣式會儲存 Mac 地區而家用緊嘅格式。",
+        dateTimeTimezoneLabel: "時區",
+        dateTimeTimezoneDeviceDefault: "裝置預設",
+        dateTimeTimezoneValid: "有效時區",
+        dateTimeTimezoneInvalid: "無法辨識嘅時區",
+        dateTimeTimezoneClear: "清除時區",
+        dateTimeTimezoneSearchPlaceholder: "搜尋時區",
+        dateTimePatternLabel: "格式",
+        dateTimePreviewLabel: "預覽",
+        dateTimeConfirmInsert: "插入",
+        dateTimeConfirmUpdate: "更新"
     )
 }

--- a/Sources/Vorssaint/Services/Snippets/TextSnippetSupport.swift
+++ b/Sources/Vorssaint/Services/Snippets/TextSnippetSupport.swift
@@ -141,12 +141,37 @@ enum TextSnippetSupport {
     /// system's own date-format language: {{date:yyyy-MM-dd}}, and the same
     /// for time and datetime so every spelling works. The pattern keeps the
     /// user's locale, so month and weekday names come out in their language.
-    private static let formattedDatePrefixes = ["{{date:", "{{time:", "{{datetime:"]
+    /// A variant with an explicit IANA identifier after the kind,
+    /// {{date-tz(America/New_York):yyyy-MM-dd}}, overrides the device's
+    /// current time zone for that one token.
+    private static let formattedDateKinds = ["date", "time", "datetime"]
+
+    /// Configures a DateFormatter's pattern and timezone override. Called by
+    /// both expandingFormattedDates and configuredFormatter to ensure a single
+    /// place decides how these two properties map from pattern and identifier.
+    private static func configure(_ formatter: DateFormatter,
+                                  pattern: String,
+                                  timeZoneIdentifier: String?) {
+        formatter.dateFormat = pattern
+        formatter.timeZone = timeZoneIdentifier.flatMap { TimeZone(identifier: $0) }
+    }
+
+    /// A fresh formatter for one-off use (a preview), as opposed to
+    /// expandingFormattedDates's single instance reused across a whole
+    /// replacement string's tokens.
+    private static func configuredFormatter(pattern: String,
+                                            timeZoneIdentifier: String?,
+                                            locale: Locale) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        configure(formatter, pattern: pattern, timeZoneIdentifier: timeZoneIdentifier)
+        return formatter
+    }
 
     private static func expandingFormattedDates(_ text: String,
                                                 date: Date,
                                                 locale: Locale) -> String {
-        guard formattedDatePrefixes.contains(where: text.contains) else { return text }
+        guard formattedDateKinds.contains(where: { text.contains("{{\($0)") }) else { return text }
         let formatter = DateFormatter()
         formatter.locale = locale
         var result = ""
@@ -155,25 +180,290 @@ enum TextSnippetSupport {
             result += rest[..<start.lowerBound]
             let tail = rest[start.lowerBound...]
             guard let close = tail.range(of: "}}"),
-                  let pattern = formattedPattern(in: tail[..<close.lowerBound]) else {
+                  let match = formattedPattern(in: tail[..<close.lowerBound]) else {
                 result += "{{"
                 rest = rest[start.upperBound...]
                 continue
             }
-            formatter.dateFormat = pattern
+            configure(formatter, pattern: match.pattern, timeZoneIdentifier: match.timeZoneIdentifier)
             result += formatter.string(from: date)
             rest = rest[close.upperBound...]
         }
         return result + rest
     }
 
-    /// The pattern inside one "{{name:pattern" chunk, nil when the tag is not
-    /// a date variable or the pattern is empty (both stay visible, like any
-    /// unknown tag).
-    private static func formattedPattern(in tag: Substring) -> String? {
-        for prefix in formattedDatePrefixes where tag.hasPrefix(prefix) {
-            let pattern = String(tag.dropFirst(prefix.count))
-            return pattern.isEmpty ? nil : pattern
+    /// The kind, pattern and optional time zone inside one "{{name:pattern"
+    /// or "{{name-tz(identifier):pattern" chunk, nil when the tag is not a
+    /// date variable, malformed, or the pattern is empty (all stay visible,
+    /// like any unknown tag).
+    private static func formattedPattern(in tag: Substring) -> (kind: String, pattern: String, timeZoneIdentifier: String?)? {
+        for kind in formattedDateKinds {
+            let tzPrefix = "{{\(kind)-tz("
+            if tag.hasPrefix(tzPrefix) {
+                let afterPrefix = tag.dropFirst(tzPrefix.count)
+                guard let closeParen = afterPrefix.firstIndex(of: ")") else { return nil }
+                let identifier = String(afterPrefix[..<closeParen])
+                let afterIdentifier = afterPrefix[afterPrefix.index(after: closeParen)...]
+                guard afterIdentifier.hasPrefix(":") else { return nil }
+                let pattern = String(afterIdentifier.dropFirst())
+                // An identifier this Mac cannot resolve leaves the tag
+                // literal rather than quietly formatting in the device's
+                // own zone: a plausible-looking wrong time is worse than a
+                // tag the user can see is wrong, and the captions now
+                // invite typing these by hand.
+                guard !pattern.isEmpty, TimeZone(identifier: identifier) != nil else { return nil }
+                return (kind, pattern, identifier)
+            }
+            let plainPrefix = "{{\(kind):"
+            if tag.hasPrefix(plainPrefix) {
+                let pattern = String(tag.dropFirst(plainPrefix.count))
+                return pattern.isEmpty ? nil : (kind, pattern, nil)
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Date variable builder
+
+    /// The three shapes a date/time snippet variable can take.
+    enum DateVariableKind: String, CaseIterable {
+        case date, time, datetime
+    }
+
+    /// How a date/time variable's pattern gets chosen: one of the system's
+    /// built-in styles, the fixed ISO 8601 shape, or a hand-typed pattern.
+    enum DateVariableStyle: String, CaseIterable {
+        case short, medium, long, full, iso8601, custom
+
+        /// The styles that resolve through the current locale, so the
+        /// pattern saved in the token is the one that locale used at the
+        /// time. iso8601 and custom are fixed patterns and carry no such
+        /// dependency.
+        static let localeDependent: Set<DateVariableStyle> = [.short, .medium, .long, .full]
+    }
+
+    private static let isoPatterns: [DateVariableKind: String] = [
+        .date: "yyyy-MM-dd",
+        .time: "HH:mm:ssXXX",
+        .datetime: "yyyy-MM-dd'T'HH:mm:ssXXX"
+    ]
+
+    private static func systemStyle(_ style: DateVariableStyle) -> DateFormatter.Style {
+        switch style {
+        case .short: return .short
+        case .medium: return .medium
+        case .long: return .long
+        case .full: return .full
+        case .iso8601, .custom: return .none
+        }
+    }
+
+    /// The ICU pattern a builder selection resolves to: the raw text for
+    /// Custom, a fixed shape for ISO 8601, or whatever DateFormatter reports
+    /// for a system style at this locale.
+    static func resolvedDatePattern(kind: DateVariableKind,
+                                    style: DateVariableStyle,
+                                    customPattern: String,
+                                    locale: Locale) -> String {
+        switch style {
+        case .custom:
+            return customPattern
+        case .iso8601:
+            return isoPatterns[kind] ?? ""
+        case .short, .medium, .long, .full:
+            let formatter = DateFormatter()
+            formatter.locale = locale
+            let dateStyle = systemStyle(style)
+            switch kind {
+            case .date:
+                formatter.dateStyle = dateStyle
+                formatter.timeStyle = .none
+            case .time:
+                formatter.dateStyle = .none
+                formatter.timeStyle = dateStyle
+            case .datetime:
+                formatter.dateStyle = dateStyle
+                formatter.timeStyle = dateStyle
+            }
+            return formatter.dateFormat
+        }
+    }
+
+    /// The literal "{{kind:pattern}}" (or "{{kind-tz(id):pattern}}") text a
+    /// builder selection inserts into a snippet's replacement.
+    static func dateVariableText(kind: DateVariableKind,
+                                 style: DateVariableStyle,
+                                 customPattern: String,
+                                 timeZoneIdentifier: String?,
+                                 locale: Locale) -> String {
+        let pattern = resolvedDatePattern(kind: kind, style: style,
+                                          customPattern: customPattern, locale: locale)
+        let tzPart = timeZoneIdentifier.map { "-tz(\($0))" } ?? ""
+        return "{{\(kind.rawValue)\(tzPart):\(pattern)}}"
+    }
+
+    /// What a builder selection would format the given date as, using the
+    /// same formatter configuration expandingFormattedDates uses, so the
+    /// preview always matches what expansion actually produces.
+    static func dateVariablePreview(kind: DateVariableKind,
+                                    style: DateVariableStyle,
+                                    customPattern: String,
+                                    timeZoneIdentifier: String?,
+                                    date: Date,
+                                    locale: Locale) -> String {
+        let pattern = resolvedDatePattern(kind: kind, style: style,
+                                          customPattern: customPattern, locale: locale)
+        guard !pattern.isEmpty else { return "" }
+        let formatter = configuredFormatter(pattern: pattern,
+                                            timeZoneIdentifier: timeZoneIdentifier,
+                                            locale: locale)
+        return formatter.string(from: date)
+    }
+
+    /// Reconstructs which Style an already-built pattern came from, by
+    /// comparing it against what each style would resolve to right now.
+    /// Falls back to Custom when nothing matches (e.g. a hand-typed
+    /// pattern, or a system style whose OS-resolved text has since
+    /// changed).
+    static func matchingDateStyle(pattern: String,
+                                  kind: DateVariableKind,
+                                  locale: Locale) -> DateVariableStyle {
+        let candidates: [DateVariableStyle] = [.iso8601, .short, .medium, .long, .full]
+        for candidate in candidates {
+            if resolvedDatePattern(kind: kind, style: candidate,
+                                   customPattern: "", locale: locale) == pattern {
+                return candidate
+            }
+        }
+        return .custom
+    }
+
+    /// Lowercased with underscores folded to spaces, so "New_York" and
+    /// "new york" compare equal: identifiers spell city names with
+    /// underscores, but nobody types a timezone query that way.
+    private static func normalizedTimeZoneText(_ value: String) -> String {
+        value.lowercased().replacingOccurrences(of: "_", with: " ")
+    }
+
+    /// How well an identifier answers a query, lowest first, so that a
+    /// zone whose city the user actually typed leads the list instead of
+    /// whichever zone merely contains those letters earliest in the
+    /// alphabet.
+    private static func timeZoneMatchRank(_ identifier: String, query: String) -> Int {
+        let normalized = normalizedTimeZoneText(identifier)
+        if normalized == query { return 0 }
+        // The city is what people type; it is the part after the region.
+        let city = normalized.split(separator: "/").last.map(String.init) ?? normalized
+        if city == query { return 1 }
+        if city.hasPrefix(query) { return 2 }
+        if normalized.hasPrefix(query) { return 3 }
+        return 4
+    }
+
+    /// Every timezone identifier whose name or common abbreviation
+    /// contains the query, case- and separator-insensitive, best matches
+    /// first. Uncapped: the picker scrolls, and any cap drops the very
+    /// identifier a broad query is looking for.
+    static func matchingTimeZoneIdentifiers(for query: String) -> [String] {
+        guard !query.isEmpty else { return [] }
+        let normalizedQuery = normalizedTimeZoneText(query)
+        var seen = Set<String>()
+        var matches: [String] = []
+        for identifier in TimeZone.knownTimeZoneIdentifiers
+        where normalizedTimeZoneText(identifier).contains(normalizedQuery) {
+            if seen.insert(identifier).inserted { matches.append(identifier) }
+        }
+        for (abbreviation, identifier) in TimeZone.abbreviationDictionary
+        where normalizedTimeZoneText(abbreviation).contains(normalizedQuery) {
+            if seen.insert(identifier).inserted { matches.append(identifier) }
+        }
+        return matches.sorted {
+            let left = timeZoneMatchRank($0, query: normalizedQuery)
+            let right = timeZoneMatchRank($1, query: normalizedQuery)
+            return left == right ? $0 < $1 : left < right
+        }
+    }
+
+    /// The single timezone identifier the query unambiguously names, if
+    /// any: an exact match on a full identifier or a common abbreviation
+    /// (e.g. "PST"), or the one candidate left when the substring search
+    /// in matchingTimeZoneIdentifiers(for:) narrows to exactly one result
+    /// (e.g. "new york" narrows to only "America/New_York", so it counts
+    /// as confirmed even though it isn't a literal identifier spelling).
+    /// Never a raw UTC offset: several cities can share one offset, and
+    /// daylight saving makes the mapping depend on the date, so an offset
+    /// alone doesn't name one timezone.
+    /// Pass `matches` when the caller already has the list for this same
+    /// query (the picker renders it), so the search is not repeated.
+    static func resolvedTimeZoneIdentifier(for query: String,
+                                           matches: [String]? = nil) -> String? {
+        guard !query.isEmpty else { return nil }
+        let normalizedQuery = normalizedTimeZoneText(query)
+        if let identifier = TimeZone.knownTimeZoneIdentifiers.first(where: {
+            normalizedTimeZoneText($0) == normalizedQuery
+        }) {
+            return identifier
+        }
+        if let abbreviation = TimeZone.abbreviationDictionary.first(where: {
+            normalizedTimeZoneText($0.key) == normalizedQuery
+        }) {
+            return abbreviation.value
+        }
+        let candidates = matches ?? matchingTimeZoneIdentifiers(for: query)
+        return candidates.count == 1 ? candidates.first : nil
+    }
+
+    struct DetectedDateToken: Equatable {
+        /// Character offsets, not String.Index: the editor holds this
+        /// across the popover's lifetime and uses it to splice the text
+        /// afterwards, and an index is only valid against the exact string
+        /// it was computed from.
+        let offsets: Range<Int>
+        let kind: DateVariableKind
+        let pattern: String
+        let timeZoneIdentifier: String?
+    }
+
+    /// Turns the editor's tracked selection offsets into a range of `text`,
+    /// clamping them to it. The offsets are recorded against whatever the
+    /// text was when the selection last moved, so an edit that shortened
+    /// the text since then leaves them pointing past the end; nil means
+    /// nothing is tracked yet and the caret belongs at the end.
+    static func selectionRange(in text: String, offsets: Range<Int>?) -> Range<String.Index> {
+        let count = text.count
+        let lower = min(max(offsets?.lowerBound ?? count, 0), count)
+        let upper = min(max(offsets?.upperBound ?? count, lower), count)
+        return text.index(text.startIndex, offsetBy: lower)
+            ..< text.index(text.startIndex, offsetBy: upper)
+    }
+
+    /// The recognized date/time tag containing `index`, if any: used by the
+    /// snippet editor to tell whether the cursor sits inside an existing
+    /// token (so the builder edits it) or not (so it inserts a new one).
+    /// Mirrors expandingFormattedDates's own traversal (skip past a bare
+    /// "{{" on any mismatch, rather than jumping to an unrelated "}}"), so
+    /// an earlier malformed or unrecognized tag never swallows a later
+    /// well-formed one.
+    static func dateToken(in text: String, at index: String.Index) -> DetectedDateToken? {
+        var rest = Substring(text)
+        while let start = rest.range(of: "{{") {
+            let tail = rest[start.lowerBound...]
+            guard let close = tail.range(of: "}}"),
+                  let match = formattedPattern(in: tail[..<close.lowerBound]),
+                  let kind = DateVariableKind(rawValue: match.kind) else {
+                rest = rest[start.upperBound...]
+                continue
+            }
+            let tagEnd = close.upperBound
+            if index > start.lowerBound, index < tagEnd {
+                return DetectedDateToken(
+                    offsets: text.distance(from: text.startIndex, to: start.lowerBound)
+                        ..< text.distance(from: text.startIndex, to: tagEnd),
+                    kind: kind,
+                    pattern: match.pattern,
+                    timeZoneIdentifier: match.timeZoneIdentifier)
+            }
+            rest = rest[tagEnd...]
         }
         return nil
     }

--- a/Sources/Vorssaint/UI/PlainTextEditor.swift
+++ b/Sources/Vorssaint/UI/PlainTextEditor.swift
@@ -6,7 +6,9 @@ import SwiftUI
 
 /// An AppKit text view configured as a pure plain-text surface: no smart
 /// quotes or dashes, no substitutions, no rich paste, with undo. SwiftUI's
-/// editor cannot switch all of that off.
+/// editor cannot switch all of that off, and its TextEditor(text:selection:)
+/// would cover the caret tracking below but needs macOS 15, a version past
+/// this app's floor.
 struct PlainTextEditor: NSViewRepresentable {
     /// Both shared with callers that overlay their own text on the editor,
     /// so a placeholder can be positioned from the same numbers as the
@@ -18,6 +20,11 @@ struct PlainTextEditor: NSViewRepresentable {
     static let lineFragmentPadding: CGFloat = 5
 
     @Binding var text: String
+    /// Character offsets rather than String.Index: an index computed
+    /// against one version of the text is undefined behavior to read back
+    /// against another, and this binding outlives the edit that produced
+    /// it. Offsets can simply be clamped by whoever reads them.
+    var selectedRange: Binding<Range<Int>?>?
     /// Appearance is applied when the view is made, not on update, so
     /// these are configuration rather than state: a caller that derives
     /// one from something that changes will not see it re-applied.
@@ -27,10 +34,12 @@ struct PlainTextEditor: NSViewRepresentable {
     var onCreate: ((NSTextView) -> Void)?
 
     init(text: Binding<String>,
+         selectedRange: Binding<Range<Int>?>? = nil,
          textColor: NSColor? = nil,
          textContainerInset: NSSize? = nil,
          onCreate: ((NSTextView) -> Void)? = nil) {
         self._text = text
+        self.selectedRange = selectedRange
         self.textColor = textColor
         self.textContainerInset = textContainerInset
         self.onCreate = onCreate
@@ -42,7 +51,6 @@ struct PlainTextEditor: NSViewRepresentable {
         scroll.hasVerticalScroller = true
         scroll.autohidesScrollers = true
         guard let textView = scroll.documentView as? NSTextView else { return scroll }
-        textView.delegate = context.coordinator
         textView.drawsBackground = false
         textView.font = .systemFont(ofSize: Self.fontSize)
         textView.textContainer?.lineFragmentPadding = Self.lineFragmentPadding
@@ -64,6 +72,10 @@ struct PlainTextEditor: NSViewRepresentable {
             textView.textContainerInset = textContainerInset
         }
         textView.string = text
+        // Delegate last: assigning .string posts a selection notification
+        // synchronously, and makeNSView runs inside SwiftUI's update pass,
+        // where writing state is undefined behavior.
+        textView.delegate = context.coordinator
         onCreate?(textView)
         return scroll
     }
@@ -72,7 +84,11 @@ struct PlainTextEditor: NSViewRepresentable {
         guard let textView = nsView.documentView as? NSTextView,
               textView.string != text,
               !textView.hasMarkedText() else { return }
+        // Setting .string posts a selection notification, and answering it
+        // here would write state from inside a view update.
+        context.coordinator.isApplyingExternalText = true
         textView.string = text
+        context.coordinator.isApplyingExternalText = false
         // Programmatic replaces (load, retention, restore) invalidate undo
         // entries recorded against the old storage; replaying one would
         // resurrect cleared text or throw a range exception.
@@ -80,19 +96,45 @@ struct PlainTextEditor: NSViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text)
+        Coordinator(text: $text, selectedRange: selectedRange)
     }
 
     final class Coordinator: NSObject, NSTextViewDelegate {
         private let text: Binding<String>
+        private let selectedRange: Binding<Range<Int>?>?
+        var isApplyingExternalText = false
 
-        init(text: Binding<String>) {
+        init(text: Binding<String>, selectedRange: Binding<Range<Int>?>?) {
             self.text = text
+            self.selectedRange = selectedRange
         }
 
         func textDidChange(_ notification: Notification) {
-            guard let textView = notification.object as? NSTextView else { return }
-            text.wrappedValue = textView.string
+            guard !isApplyingExternalText, let textView = notification.object as? NSTextView else { return }
+            let current = textView.string
+            if text.wrappedValue != current { text.wrappedValue = current }
+            publishSelection(of: textView, in: current)
+        }
+
+        /// Publishes the caret only. Never writes the text binding: a caret
+        /// move would then republish whatever the view currently holds,
+        /// which for a caller that reloads its text out-of-band means
+        /// writing stale content back over the fresh content.
+        func textViewDidChangeSelection(_ notification: Notification) {
+            guard !isApplyingExternalText,
+                  selectedRange != nil,
+                  let textView = notification.object as? NSTextView else { return }
+            publishSelection(of: textView, in: textView.string)
+        }
+
+        private func publishSelection(of textView: NSTextView, in current: String) {
+            guard let selectedRange else { return }
+            // A selection that will not convert leaves the last known caret
+            // alone, since nil here would read as "caret at the end".
+            guard let converted = Range(textView.selectedRange(), in: current) else { return }
+            selectedRange.wrappedValue =
+                current.distance(from: current.startIndex, to: converted.lowerBound)
+                    ..< current.distance(from: current.startIndex, to: converted.upperBound)
         }
     }
 }

--- a/Sources/Vorssaint/UI/Settings/DateVariableBuilder.swift
+++ b/Sources/Vorssaint/UI/Settings/DateVariableBuilder.swift
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import SwiftUI
+
+/// The Insert/Edit date-time popover: picks a Type and Style (or a raw
+/// custom pattern) and an optional specific timezone, then hands the
+/// caller the literal {{...}} token text to splice into a snippet.
+struct DateVariableBuilder: View {
+    let text: SnippetFeatureStrings
+    let cancelLabel: String
+    let locale: Locale
+    let initial: TextSnippetSupport.DetectedDateToken?
+    let confirm: (String) -> Void
+    let cancel: () -> Void
+
+    @State private var kind: TextSnippetSupport.DateVariableKind
+    @State private var style: TextSnippetSupport.DateVariableStyle
+    @State private var timeZoneIdentifier: String?
+    @State private var customPattern: String
+    @State private var timeZoneQuery = ""
+
+    init(text: SnippetFeatureStrings,
+         cancelLabel: String,
+         locale: Locale,
+         initial: TextSnippetSupport.DetectedDateToken?,
+         confirm: @escaping (String) -> Void,
+         cancel: @escaping () -> Void) {
+        self.text = text
+        self.cancelLabel = cancelLabel
+        self.locale = locale
+        self.initial = initial
+        self.confirm = confirm
+        self.cancel = cancel
+        let resolvedKind = initial?.kind ?? .datetime
+        _kind = State(initialValue: resolvedKind)
+        _timeZoneIdentifier = State(initialValue: initial?.timeZoneIdentifier)
+        if let initial {
+            let matchedStyle = TextSnippetSupport.matchingDateStyle(pattern: initial.pattern,
+                                                                     kind: resolvedKind, locale: locale)
+            _style = State(initialValue: matchedStyle)
+            _customPattern = State(initialValue: matchedStyle == .custom ? initial.pattern : "")
+        } else {
+            _style = State(initialValue: .iso8601)
+            _customPattern = State(initialValue: "")
+        }
+    }
+
+    /// The suggestion list and the live checkmark/X both come from one
+    /// search, computed once per render: it scans the whole timezone
+    /// database and the field re-renders on every keystroke.
+    private var timeZoneSearch: (matches: [String], typed: String?) {
+        let matches = TextSnippetSupport.matchingTimeZoneIdentifiers(for: timeZoneQuery)
+        return (matches,
+                TextSnippetSupport.resolvedTimeZoneIdentifier(for: timeZoneQuery, matches: matches))
+    }
+
+    private func confirmTypedTimeZone() {
+        guard let match = timeZoneSearch.typed else { return }
+        timeZoneIdentifier = match
+        timeZoneQuery = ""
+    }
+
+    private var previewText: String {
+        TextSnippetSupport.dateVariablePreview(kind: kind, style: style, customPattern: customPattern,
+                                               timeZoneIdentifier: timeZoneIdentifier, date: Date(),
+                                               locale: locale)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Picker(text.dateTimeTypeLabel, selection: $kind) {
+                Text(text.dateTimeKindDate).tag(TextSnippetSupport.DateVariableKind.date)
+                Text(text.dateTimeKindTime).tag(TextSnippetSupport.DateVariableKind.time)
+                Text(text.dateTimeKindDateTime).tag(TextSnippetSupport.DateVariableKind.datetime)
+            }
+            .pickerStyle(.segmented)
+
+            Picker(text.dateTimeStyleLabel, selection: $style) {
+                Text(text.dateTimeStyleShort).tag(TextSnippetSupport.DateVariableStyle.short)
+                Text(text.dateTimeStyleMedium).tag(TextSnippetSupport.DateVariableStyle.medium)
+                Text(text.dateTimeStyleLong).tag(TextSnippetSupport.DateVariableStyle.long)
+                Text(text.dateTimeStyleFull).tag(TextSnippetSupport.DateVariableStyle.full)
+                Text(text.dateTimeStyleISO8601).tag(TextSnippetSupport.DateVariableStyle.iso8601)
+                Text(text.dateTimeStyleCustom).tag(TextSnippetSupport.DateVariableStyle.custom)
+            }
+
+            // The named styles resolve to the current locale's pattern and
+            // that pattern is what gets saved, so say so: the labels on
+            // their own read as if the token would follow the language.
+            if TextSnippetSupport.DateVariableStyle.localeDependent.contains(style) {
+                Text(text.dateTimeStyleLocaleNote)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            // Offered for every type, Date included: the calendar date
+            // itself differs across zones, and the captions teach the
+            // -tz(...) syntax with a date example.
+            VStack(alignment: .leading, spacing: 4) {
+                Text(text.dateTimeTimezoneLabel)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if let timeZoneIdentifier {
+                    HStack {
+                        Text(timeZoneIdentifier)
+                            .font(.body.monospaced())
+                        Spacer()
+                        Button {
+                            self.timeZoneIdentifier = nil
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                        }
+                        .buttonStyle(.plain)
+                        .help(text.dateTimeTimezoneClear)
+                        .accessibilityLabel(text.dateTimeTimezoneClear)
+                    }
+                } else {
+                    Text(text.dateTimeTimezoneDeviceDefault)
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                }
+                let search = timeZoneSearch
+                HStack {
+                    TextField(text.dateTimeTimezoneSearchPlaceholder, text: $timeZoneQuery)
+                        .onSubmit { confirmTypedTimeZone() }
+                    // Marked only when the query has actually settled one
+                    // way or the other. A query that still matches several
+                    // zones is not wrong, and a red X above a list of valid
+                    // suggestions reads as though it were.
+                    if !timeZoneQuery.isEmpty, search.typed != nil || search.matches.isEmpty {
+                        let valid = search.typed != nil
+                        Image(systemName: valid ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(valid ? .green : .red)
+                            .accessibilityLabel(valid
+                                ? text.dateTimeTimezoneValid
+                                : text.dateTimeTimezoneInvalid)
+                    }
+                }
+                if !search.matches.isEmpty {
+                    let matches = search.matches
+                    ScrollView {
+                        // Lazy: a broad query like "america" matches well
+                        // over a hundred zones, and the list is no longer
+                        // capped.
+                        LazyVStack(alignment: .leading, spacing: 0) {
+                            ForEach(matches, id: \.self) { identifier in
+                                Button {
+                                    timeZoneIdentifier = identifier
+                                    timeZoneQuery = ""
+                                } label: {
+                                    Text(identifier)
+                                        .font(.body.monospaced())
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                }
+                                .buttonStyle(.plain)
+                                .padding(.vertical, 2)
+                            }
+                        }
+                    }
+                    .frame(height: min(140, CGFloat(matches.count) * 22))
+                }
+            }
+
+            if style == .custom {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(text.dateTimePatternLabel)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField(text.dateTimePatternLabel, text: $customPattern)
+                        .font(.body.monospaced())
+                }
+            }
+
+            HStack(alignment: .firstTextBaseline) {
+                Text(text.dateTimePreviewLabel)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(previewText)
+                    .font(.body.monospaced())
+            }
+
+            HStack {
+                Spacer()
+                Button(cancelLabel, action: cancel)
+                Button(initial == nil ? text.dateTimeConfirmInsert : text.dateTimeConfirmUpdate) {
+                    confirm(TextSnippetSupport.dateVariableText(kind: kind, style: style,
+                                                                customPattern: customPattern,
+                                                                timeZoneIdentifier: timeZoneIdentifier,
+                                                                locale: locale))
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(style == .custom && customPattern.isEmpty)
+            }
+        }
+        .padding(16)
+    }
+}

--- a/Sources/Vorssaint/UI/Settings/TextSnippetsSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/TextSnippetsSettings.swift
@@ -188,6 +188,12 @@ private struct SnippetRow: View {
     }
 }
 
+/// Holds the replacement field's text view so the date/time builder can
+/// edit through it. Weak, since the view belongs to the editor sheet.
+private final class EditorHandle {
+    weak var view: NSTextView?
+}
+
 private struct SnippetEditor: View {
     let text: SnippetFeatureStrings
     @State var snippet: TextSnippet
@@ -197,6 +203,13 @@ private struct SnippetEditor: View {
     let delete: (() -> Void)?
     @Environment(\.dismiss) private var dismiss
     @ObservedObject private var l10n = L10n.shared
+    @State private var replacementSelection: Range<Int>?
+    @State private var showingDateBuilder = false
+    @State private var dateBuilderInitial: TextSnippetSupport.DetectedDateToken?
+    /// @State so the handle outlives a view rebuild, and a class so the
+    /// text view can be stored into it while it is being made without
+    /// publishing a change from inside a view update.
+    @State private var replacementEditor = EditorHandle()
 
     private var sanitizedTrigger: String {
         TextSnippetSupport.sanitizedTrigger(snippet.trigger)
@@ -217,6 +230,37 @@ private struct SnippetEditor: View {
 
     private var folderSuggestions: [String] {
         TextSnippetSupport.folderSuggestions(others)
+    }
+
+    private var selectedRange: Range<String.Index> {
+        TextSnippetSupport.selectionRange(in: snippet.replacement,
+                                          offsets: replacementSelection)
+    }
+
+    private var detectedTokenAtCursor: TextSnippetSupport.DetectedDateToken? {
+        TextSnippetSupport.dateToken(in: snippet.replacement, at: selectedRange.lowerBound)
+    }
+
+    /// Splices the built token into the replacement text, replacing an
+    /// existing token in edit mode or the current selection otherwise.
+    /// Edits through the text view rather than the binding so the insert
+    /// joins its undo stack and leaves the caret after the token; going
+    /// through the binding replaces the whole string, which drops the
+    /// caret at the end and discards everything the user could undo.
+    private func insertDateToken(_ tokenText: String) {
+        let text = snippet.replacement
+        let range = TextSnippetSupport.selectionRange(
+            in: text, offsets: dateBuilderInitial?.offsets ?? replacementSelection)
+        guard let textView = replacementEditor.view else {
+            snippet.replacement.replaceSubrange(range, with: tokenText)
+            return
+        }
+        let target = NSRange(range, in: text)
+        guard textView.shouldChangeText(in: target, replacementString: tokenText) else { return }
+        textView.replaceCharacters(in: target, with: tokenText)
+        textView.didChangeText()
+        textView.setSelectedRange(
+            NSRange(location: target.location + (tokenText as NSString).length, length: 0))
     }
 
     var body: some View {
@@ -248,9 +292,34 @@ private struct SnippetEditor: View {
                 }
                 Toggle(text.showInLibraryLabel, isOn: $snippet.showsInLibrary)
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(text.replacementLabel)
-                    TextEditor(text: $snippet.replacement)
-                        .font(.body)
+                    HStack {
+                        Text(text.replacementLabel)
+                        Spacer()
+                        Button {
+                            dateBuilderInitial = detectedTokenAtCursor
+                            showingDateBuilder = true
+                        } label: {
+                            Label(detectedTokenAtCursor == nil ? text.dateTimeInsertButton : text.dateTimeEditButton,
+                                  systemImage: "calendar.badge.plus")
+                        }
+                        .popover(isPresented: $showingDateBuilder) {
+                            DateVariableBuilder(
+                                text: text,
+                                cancelLabel: l10n.s.uninstallerCancel,
+                                locale: .current,
+                                initial: dateBuilderInitial,
+                                confirm: { tokenText in
+                                    insertDateToken(tokenText)
+                                    showingDateBuilder = false
+                                },
+                                cancel: { showingDateBuilder = false }
+                            )
+                            .frame(width: 340)
+                        }
+                    }
+                    PlainTextEditor(text: $snippet.replacement,
+                                    selectedRange: $replacementSelection,
+                                    onCreate: { replacementEditor.view = $0 })
                         .frame(minHeight: 76)
                         .overlay(
                             RoundedRectangle(cornerRadius: 6, style: .continuous)
@@ -259,7 +328,7 @@ private struct SnippetEditor: View {
                     Text(text.variablesHint)
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Text(text.variablesFormatCaption)
+                    Text(text.editorFormatCaption)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11969,6 +11969,230 @@ struct MetricsTests {
                                          clipboard: "{{date:yyyy}}") == "clip: {{date:yyyy}}",
                "pasted clipboard text is never re-expanded")
 
+        // Timezone-qualified date variables
+        var tzTestCalendar = Calendar(identifier: .gregorian)
+        tzTestCalendar.timeZone = TimeZone(identifier: "UTC")!
+        let zonedDate = tzTestCalendar.date(from: DateComponents(year: 2025, month: 7, day: 1,
+                                                                 hour: 12, minute: 30, second: 15))!
+        expect(TextSnippetSupport.expand("{{datetime-tz(UTC):yyyy-MM-dd'T'HH:mm:ss}}",
+                                         date: zonedDate, clipboard: nil, locale: enUS)
+                == "2025-07-01T12:30:15",
+               "a UTC-tagged datetime token formats in UTC regardless of the device's zone")
+        expect(TextSnippetSupport.expand("{{date-tz(UTC):yyyy-MM-dd}}",
+                                         date: zonedDate, clipboard: nil, locale: enUS) == "2025-07-01",
+               "a UTC-tagged date token formats in UTC")
+        expect(TextSnippetSupport.expand("{{time-tz(UTC):HH:mm:ss}}",
+                                         date: zonedDate, clipboard: nil, locale: enUS) == "12:30:15",
+               "a UTC-tagged time token formats in UTC")
+        expect(TextSnippetSupport.expand("{{datetime-tz(Asia/Tokyo):yyyy-MM-dd HH:mm}}",
+                                         date: zonedDate, clipboard: nil, locale: enUS)
+                == "2025-07-01 21:30",
+               "a token tagged with a specific zone shifts the clock by that zone's offset")
+        // Asserted against a fixed non-UTC zone rather than the device's:
+        // CI runners are UTC, where a leak and no leak look identical.
+        expect(TextSnippetSupport.expand("{{time-tz(Asia/Tokyo):HH:mm}} then {{time-tz(UTC):HH:mm}}",
+                                         date: zonedDate, clipboard: nil, locale: enUS)
+                == "21:30 then 12:30",
+               "a time zone on one token does not leak into a later token with its own")
+        // The likelier leak: one shared DateFormatter has to be reset back
+        // to the device zone for a plain token following a zoned one.
+        // Compared against the plain token's own output so it holds on
+        // CI's UTC runners as well as a machine in any other zone.
+        expect(TextSnippetSupport.expand("{{time-tz(Asia/Tokyo):HH:mm}}|{{time:HH:mm}}",
+                                         date: zonedDate, clipboard: nil, locale: enUS)
+                == "21:30|" + TextSnippetSupport.expand("{{time:HH:mm}}", date: zonedDate,
+                                                        clipboard: nil, locale: enUS),
+               "a zoned token does not leak into a later plain one")
+        expect(TextSnippetSupport.expand("{{datetime-tz(Not/ARealZone):yyyy-MM-dd HH:mm}}",
+                                         date: zonedDate, clipboard: nil, locale: enUS)
+                == "{{datetime-tz(Not/ARealZone):yyyy-MM-dd HH:mm}}",
+               "an unrecognized time zone stays a literal tag instead of quietly using the device zone")
+        expect(TextSnippetSupport.expand("{{datetime-tz(America/New York):yyyy-MM-dd HH:mm}}",
+                                         date: zonedDate, clipboard: nil, locale: enUS)
+                == "{{datetime-tz(America/New York):yyyy-MM-dd HH:mm}}",
+               "a space where the identifier needs an underscore is visibly wrong, not silently local")
+
+        // Date variable builder logic
+        expect(TextSnippetSupport.resolvedDatePattern(kind: .date, style: .iso8601,
+                                                       customPattern: "", locale: enUS) == "yyyy-MM-dd",
+               "ISO 8601 date style resolves to the fixed ISO date pattern")
+        expect(TextSnippetSupport.resolvedDatePattern(kind: .time, style: .iso8601,
+                                                       customPattern: "", locale: enUS) == "HH:mm:ssXXX",
+               "ISO 8601 time style resolves to the fixed ISO time pattern with an offset token")
+        expect(TextSnippetSupport.resolvedDatePattern(kind: .datetime, style: .iso8601,
+                                                       customPattern: "", locale: enUS)
+                == "yyyy-MM-dd'T'HH:mm:ssXXX",
+               "ISO 8601 datetime style resolves to the fixed ISO datetime pattern")
+        expect(TextSnippetSupport.resolvedDatePattern(kind: .date, style: .custom,
+                                                       customPattern: "dd/MM/yyyy", locale: enUS)
+                == "dd/MM/yyyy",
+               "custom style passes the raw pattern through untouched")
+        expect(!TextSnippetSupport.resolvedDatePattern(kind: .date, style: .medium,
+                                                        customPattern: "", locale: enUS).isEmpty,
+               "a system style resolves to some non-empty pattern (exact text is OS/locale dependent)")
+
+        expect(TextSnippetSupport.dateVariableText(kind: .date, style: .iso8601, customPattern: "",
+                                                    timeZoneIdentifier: nil, locale: enUS)
+                == "{{date:yyyy-MM-dd}}",
+               "building a token with no timezone omits the -tz(...) suffix")
+        expect(TextSnippetSupport.dateVariableText(kind: .datetime, style: .iso8601, customPattern: "",
+                                                    timeZoneIdentifier: "UTC", locale: enUS)
+                == "{{datetime-tz(UTC):yyyy-MM-dd'T'HH:mm:ssXXX}}",
+               "building a token with a timezone adds the -tz(...) suffix")
+        expect(TextSnippetSupport.dateVariableText(kind: .time, style: .custom, customPattern: "HH:mm",
+                                                    timeZoneIdentifier: "Asia/Tokyo", locale: enUS)
+                == "{{time-tz(Asia/Tokyo):HH:mm}}",
+               "a custom pattern with a timezone builds the same tagged token shape")
+
+        expect(TextSnippetSupport.dateVariablePreview(kind: .datetime, style: .iso8601, customPattern: "",
+                                                       timeZoneIdentifier: "UTC", date: zonedDate,
+                                                       locale: enUS) == "2025-07-01T12:30:15Z",
+               "the preview matches what expansion would produce for the same settings")
+        expect(TextSnippetSupport.dateVariablePreview(kind: .date, style: .custom, customPattern: "",
+                                                       timeZoneIdentifier: nil, date: zonedDate,
+                                                       locale: enUS).isEmpty,
+               "an empty custom pattern previews as empty rather than crashing on an empty date format")
+
+        // Date variable token detection
+        let tokenSample = "Hi {{date:MMM d}} and {{datetime-tz(UTC):yyyy}} end"
+        let insideDate = tokenSample.index(tokenSample.startIndex, offsetBy: 6)
+        let detectedDate = TextSnippetSupport.dateToken(in: tokenSample, at: insideDate)
+        expect(detectedDate?.kind == .date && detectedDate?.pattern == "MMM d"
+                && detectedDate?.timeZoneIdentifier == nil,
+               "the cursor inside a plain date token detects its kind and pattern")
+
+        let insideZoned = tokenSample.range(of: "UTC")!.lowerBound
+        let detectedZoned = TextSnippetSupport.dateToken(in: tokenSample, at: insideZoned)
+        expect(detectedZoned?.kind == .datetime && detectedZoned?.pattern == "yyyy"
+                && detectedZoned?.timeZoneIdentifier == "UTC",
+               "the cursor inside a timezone-qualified token detects its kind, pattern and zone")
+
+        expect(TextSnippetSupport.dateToken(in: tokenSample, at: tokenSample.startIndex) == nil,
+               "a cursor outside any tag detects nothing")
+
+        // The detected range is what the editor later splices over, and it
+        // reaches that splice as offsets so it cannot be read against a
+        // string it was not measured from.
+        expect(detectedDate.map {
+            String(tokenSample[TextSnippetSupport.selectionRange(in: tokenSample, offsets: $0.offsets)])
+        } == "{{date:MMM d}}",
+               "a detected token's offsets span exactly the token, braces included")
+        expect(detectedZoned.map {
+            String(tokenSample[TextSnippetSupport.selectionRange(in: tokenSample, offsets: $0.offsets)])
+        } == "{{datetime-tz(UTC):yyyy}}",
+               "a timezone-qualified token's offsets span the whole tag")
+
+        // The editor keeps the selection as offsets recorded when the
+        // selection last moved, so an edit that shortened the text since
+        // leaves them past the end. They must clamp, never trap.
+        let selectionText = "abcdef"
+        expect(TextSnippetSupport.selectionRange(in: selectionText, offsets: 2..<4)
+                == selectionText.index(selectionText.startIndex, offsetBy: 2)
+                    ..< selectionText.index(selectionText.startIndex, offsetBy: 4),
+               "an in-range selection maps to exactly those characters")
+        expect(TextSnippetSupport.selectionRange(in: selectionText, offsets: nil)
+                == selectionText.endIndex..<selectionText.endIndex,
+               "no tracked selection puts the caret at the end")
+        expect(TextSnippetSupport.selectionRange(in: "ab", offsets: 5..<9)
+                == "ab".endIndex..<"ab".endIndex,
+               "offsets left over from longer text clamp to the end instead of trapping")
+        expect(TextSnippetSupport.selectionRange(in: "abcd", offsets: 2..<99)
+                == "abcd".index("abcd".startIndex, offsetBy: 2)..<"abcd".endIndex,
+               "a selection running past the end clamps only its upper bound")
+        expect(TextSnippetSupport.selectionRange(in: "", offsets: 3..<7)
+                == "".startIndex..<"".startIndex,
+               "empty text clamps every offset to the start")
+        expect(TextSnippetSupport.selectionRange(in: "e\u{301}fg", offsets: 1..<2)
+                == "e\u{301}fg".index("e\u{301}fg".startIndex, offsetBy: 1)
+                    ..< "e\u{301}fg".index("e\u{301}fg".startIndex, offsetBy: 2),
+               "offsets count characters, so a combining mark stays with its base")
+
+        let unknownTagText = "see {{clipboard}} here"
+        let insideUnknown = unknownTagText.index(unknownTagText.startIndex, offsetBy: 6)
+        expect(TextSnippetSupport.dateToken(in: unknownTagText, at: insideUnknown) == nil,
+               "a cursor inside a non-date tag like clipboard detects nothing")
+
+        let unclosedText = "start {{date:yyyy no close"
+        let insideUnclosed = unclosedText.index(unclosedText.startIndex, offsetBy: 10)
+        expect(TextSnippetSupport.dateToken(in: unclosedText, at: insideUnclosed) == nil,
+               "a cursor inside an unclosed tag detects nothing")
+
+        expect(TextSnippetSupport.dateToken(in: "", at: "".startIndex) == nil,
+               "empty text detects nothing")
+
+        let afterFirstTag = tokenSample.range(of: "{{date:MMM d}}")!.upperBound
+        expect(TextSnippetSupport.dateToken(in: tokenSample, at: afterFirstTag) == nil,
+               "a cursor immediately after a token's closing braces is not inside that token")
+        let beforeFirstTag = tokenSample.range(of: "{{date:MMM d}}")!.lowerBound
+        expect(TextSnippetSupport.dateToken(in: tokenSample, at: beforeFirstTag) == nil,
+               "a cursor immediately before a token's opening braces is not inside that token")
+
+        // Date variable builder support (timezone search and style matching)
+        expect(TextSnippetSupport.matchingDateStyle(pattern: "yyyy-MM-dd", kind: .date, locale: enUS) == .iso8601,
+               "the ISO 8601 date pattern is recognized as that style")
+        expect(TextSnippetSupport.matchingDateStyle(pattern: "not a real pattern", kind: .date, locale: enUS) == .custom,
+               "an unrecognized pattern falls back to Custom")
+
+        expect(TextSnippetSupport.matchingTimeZoneIdentifiers(for: "").isEmpty,
+               "an empty query matches nothing")
+        // Asserted as containment, not equality: the set of identifiers
+        // comes from the OS timezone database, so a future release adding
+        // another "New York" zone must not fail this.
+        expect(TextSnippetSupport.matchingTimeZoneIdentifiers(for: "new york").contains("America/New_York"),
+               "a city name with a space matches the underscored identifier")
+        // A broad query matches well over a hundred zones. The obvious
+        // answer has to be reachable, and near the top: an alphabetical
+        // list capped for the picker used to drop it entirely.
+        let americaMatches = TextSnippetSupport.matchingTimeZoneIdentifiers(for: "america")
+        expect(americaMatches.contains("America/New_York"),
+               "a broad region query still lists the major city zones")
+        // "york" and the full identifier both narrow to a single match, so
+        // neither can observe the ordering. "st" matches dozens, most of
+        // which merely contain the letters, so only ranking puts a city
+        // beginning with them at the head.
+        expect(TextSnippetSupport.matchingTimeZoneIdentifiers(for: "st").first?
+                .split(separator: "/").last?.lowercased().hasPrefix("st") == true,
+               "a city starting with the query outranks zones that merely contain it")
+        expect(TextSnippetSupport.matchingTimeZoneIdentifiers(for: "america/new_york").first
+                == "America/New_York",
+               "an exactly typed identifier resolves to itself")
+        expect(TextSnippetSupport.matchingTimeZoneIdentifiers(for: "xyz-nonsense").isEmpty,
+               "a query matching nothing returns an empty list")
+
+        expect(TextSnippetSupport.resolvedTimeZoneIdentifier(for: "America/New_York") == "America/New_York",
+               "a full identifier resolves to itself")
+        expect(TextSnippetSupport.resolvedTimeZoneIdentifier(for: "america/new york") == "America/New_York",
+               "the full identifier resolves case- and separator-insensitively")
+        expect(TextSnippetSupport.resolvedTimeZoneIdentifier(for: "new york", matches: ["America/New_York"])
+                == "America/New_York",
+               "a city name that narrows the suggestion list to exactly one result resolves to it")
+        expect(TextSnippetSupport.resolvedTimeZoneIdentifier(
+                for: "new", matches: ["America/New_York", "Europe/Newtown"]) == nil,
+               "a query still matching several identifiers stays unresolved")
+        expect(TextSnippetSupport.resolvedTimeZoneIdentifier(for: "pst") == "America/Los_Angeles",
+               "a common abbreviation resolves to its canonical identifier")
+        expect(TextSnippetSupport.resolvedTimeZoneIdentifier(for: "utc") == "UTC",
+               "UTC resolves even though it is not itself in TimeZone.knownTimeZoneIdentifiers")
+        expect(TextSnippetSupport.resolvedTimeZoneIdentifier(for: "budapest")?.hasSuffix("Budapest") == true,
+               "a query with no exact match but exactly one substring match resolves to it")
+        expect(TextSnippetSupport.resolvedTimeZoneIdentifier(for: "america") == nil,
+               "a query matching many identifiers with no exact hit stays unresolved")
+        expect(TextSnippetSupport.resolvedTimeZoneIdentifier(for: "xyz-nonsense") == nil,
+               "a query matching nothing is unresolved")
+
+        // A built token round-trips back through detection unchanged: this is
+        // exactly the path the Insert/Edit button depends on.
+        for kind in TextSnippetSupport.DateVariableKind.allCases {
+            for timeZoneIdentifier in [nil, "UTC", "Asia/Tokyo"] as [String?] {
+                let built = TextSnippetSupport.dateVariableText(kind: kind, style: .iso8601, customPattern: "",
+                                                                 timeZoneIdentifier: timeZoneIdentifier, locale: enUS)
+                let midpoint = built.index(built.startIndex, offsetBy: built.count / 2)
+                let detected = TextSnippetSupport.dateToken(in: built, at: midpoint)
+                expect(detected?.kind == kind && detected?.timeZoneIdentifier == timeZoneIdentifier,
+                       "a built \(kind.rawValue) token with timezone \(timeZoneIdentifier ?? "nil") round-trips through dateToken unchanged")
+            }
+        }
+
         // Per-snippet capitalization option (issue #304)
         let caseless = TextSnippet(name: "Caseless", trigger: ";email", replacement: "me@x.com",
                                    expansion: .afterDelimiter, enabled: true, ignoresCase: true)


### PR DESCRIPTION
## Summary

Putting a date or time into a snippet meant knowing DateFormatter's pattern syntax. This adds a popover that picks the type and the style, previews the result against the current time, and can pin a timezone searchable by identifier or by common abbreviation. The existing `{{date:...}}` syntax is unchanged and still works typed by hand.

It is built on `DateFormatter` and `TimeZone`, both already used here, and adds no dependency and nothing that runs at rest: the popover exists only while open. Permanent surface is one new UI file and the token grammar below.

**This changes what a saved snippet can contain.** A `-tz(...)` part is new syntax, so a snippet using it renders literally on any build older than this. Both format captions document it in all 13 languages. An identifier this Mac cannot resolve leaves the tag literal rather than quietly formatting in the device's own zone, so a typo stays visible the way every other unknown tag does.

Named styles (Short through Full) resolve to the pattern the Mac's region uses at the moment you build the token, and that literal is what gets saved. The popover says so, since the labels on their own suggest the opposite.

Inserting at the caret needs the caret, which SwiftUI's `TextEditor` only reports from macOS 15. The shared plain-text editor from #944 gains that as an optional binding, tracked as character offsets so an insert cannot read positions measured against text that has since changed.

## Testing

```sh
./build.sh                     # exit 0, no warnings
./build/Vorssaint --selftest   # SELFTEST OK
./build.sh --test              # 1 of 8663 fails, see below
```

The one failing check is `the dispatch pool starvation this check needs was actually reached`, which is not from this branch: it fails identically on a clean `main` checkout here, and passes on `main` from before #989 added it. It occupies 64 global-queue threads and asserts the pool is genuinely starved; on a machine with more cores that precondition is not met, so the assertion fails rather than the behavior under test. Everything else passes.

Checked on Apple Silicon against a release build, in English with a Gregorian regional calendar. The builder was used by hand earlier in development: typing timezone queries, inserting tokens and reopening them to edit. Since that pass the insert was rewritten to go through the text view, the timezone list was ranked and uncapped, and timezones were allowed on the Date type, and those three are covered by tests rather than by use.

Not tried on macOS 14 or 15, which matters more here than usual: the caret tracking exists because `TextEditor(text:selection:)` needs macOS 15. Also not tried with a non-Gregorian regional calendar or another app language.

## Anything else

Rebased onto current `main` now that #944 has merged, so this is a single commit against it.