### PR TITLE
fix(dock-preview): enlarge thumbnails and strip card chrome (tested on v3.3.3-beta.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
   the next icon takes 100 ms instead of 250 ms. Thanks to @PathGao.
 
 ### Fixed
+- Dock Preview cards now keep a full title band at every preview size instead of
+  scaling it with the card, so Large and Extra Large no longer leave one line of
+  text adrift in empty space and Small no longer squeezes it. The app icon that
+  stands in for a thumbnail that has not arrived follows the preview size too.
+  Thanks to @PathGao.
+
 - Scrolling screenshots now keep fixed page footers once at the end instead of
   repeating them after every scroll.
 - Settings now lists Dock Preview and Dock click as separate named sections, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,12 +48,9 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
 - Dock Preview cards no longer draw the app icon on every thumbnail or repeat the
   window title over it, leaving the thumbnail more of the card, and a card now
   badges a window that lives on another desktop. Thanks to @PathGao.
-- Dock Preview cards now keep a full title band at every preview size instead of
-  scaling it with the card, so Large and Extra Large no longer leave one line of
-  text adrift in empty space and Small no longer squeezes it. The app icon that
-  stands in for a thumbnail that has not arrived follows the preview size too,
-  and is drawn as a watermark so the capture replacing it fills the space in
-  rather than jumping into it. Thanks to @PathGao.
+- Dock Preview cards now keep a full title band at every preview size rather than
+  scaling it with the card, and the app icon standing in for a thumbnail that has
+  not arrived follows the preview size as a watermark. Thanks to @PathGao.
 - Fan Control now prepares stopped fans before taking manual control and keeps a
   failed attempt visible instead of silently returning to Automatic.
 - The Clean URL settings fields now take a click anywhere across their row. Their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,13 +38,6 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
   the next icon takes 100 ms instead of 250 ms. Thanks to @PathGao.
 
 ### Fixed
-- Dock Preview cards now keep a full title band at every preview size instead of
-  scaling it with the card, so Large and Extra Large no longer leave one line of
-  text adrift in empty space and Small no longer squeezes it. The app icon that
-  stands in for a thumbnail that has not arrived follows the preview size too,
-  and is drawn as a watermark so the capture replacing it fills the space in
-  rather than jumping into it. Thanks to @PathGao.
-
 - Scrolling screenshots now keep fixed page footers once at the end instead of
   repeating them after every scroll.
 - Settings now lists Dock Preview and Dock click as separate named sections, and
@@ -55,6 +48,12 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
 - Dock Preview cards no longer draw the app icon on every thumbnail or repeat the
   window title over it, leaving the thumbnail more of the card, and a card now
   badges a window that lives on another desktop. Thanks to @PathGao.
+- Dock Preview cards now keep a full title band at every preview size instead of
+  scaling it with the card, so Large and Extra Large no longer leave one line of
+  text adrift in empty space and Small no longer squeezes it. The app icon that
+  stands in for a thumbnail that has not arrived follows the preview size too,
+  and is drawn as a watermark so the capture replacing it fills the space in
+  rather than jumping into it. Thanks to @PathGao.
 - Fan Control now prepares stopped fans before taking manual control and keeps a
   failed attempt visible instead of silently returning to Automatic.
 - The Clean URL settings fields now take a click anywhere across their row. Their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,9 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
 - Dock Preview cards now keep a full title band at every preview size instead of
   scaling it with the card, so Large and Extra Large no longer leave one line of
   text adrift in empty space and Small no longer squeezes it. The app icon that
-  stands in for a thumbnail that has not arrived follows the preview size too.
-  Thanks to @PathGao.
+  stands in for a thumbnail that has not arrived follows the preview size too,
+  and is drawn as a watermark so the capture replacing it fills the space in
+  rather than jumping into it. Thanks to @PathGao.
 
 - Scrolling screenshots now keep fixed page footers once at the end instead of
   repeating them after every scroll.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
 - Dock Preview cards now keep a full title band at every preview size rather than
   scaling it with the card, and the app icon standing in for a thumbnail that has
   not arrived follows the preview size as a watermark. Thanks to @PathGao.
+
+- Dock Preview thumbnails are now 16:10 and near three times the area, with the close
+  and minimize buttons moved off the picture into the title band. A panel showing one
+  window drops its header, and pinning one is now a named item in a card's menu.
 - Fan Control now prepares stopped fans before taking manual control and keeps a
   failed attempt visible instead of silently returning to Automatic.
 - The Clean URL settings fields now take a click anywhere across their row. Their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,9 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
 - Clicking a Dock icon now only restores the windows that Click Dock icon to minimize
   put away. Windows minimized any other way keep the Dock's own restore. Thanks to @PathGao.
 
-- A Dock Preview now opens once the pointer has rested on an icon for 200 ms instead of
-  400 ms, and reads the app's windows while that wait runs rather than after it. Settings
-  carries the wait as an adjustable Open delay. Thanks to @PathGao.
+- A Dock Preview now opens after 200 ms of rest on an icon instead of 400 ms, and
+  Settings carries that wait as an adjustable Open delay. Handing an open preview to
+  the next icon takes 100 ms instead of 250 ms. Thanks to @PathGao.
 
 ### Fixed
 - Scrolling screenshots now keep fixed page footers once at the end instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ Vorssaint 3.3.3 adds full manual and temperature-based Fan Control, directional 
 
 - Clicking a Dock icon now only restores the windows that Click Dock icon to minimize
   put away. Windows minimized any other way keep the Dock's own restore. Thanks to @PathGao.
+
+- A Dock Preview now opens once the pointer has rested on an icon for 200 ms instead of
+  400 ms, and reads the app's windows while that wait runs rather than after it. Settings
+  carries the wait as an adjustable Open delay. Thanks to @PathGao.
+
 ### Fixed
 - Scrolling screenshots now keep fixed page footers once at the end instead of
   repeating them after every scroll.

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -70,6 +70,7 @@ enum DefaultsKey {
     static let switcherShowShortcutHints = "switcherShowShortcutHints" // show the shortcut bar under the large-icon switcher
     static let dockPreviewEnabled = "dockPreviewEnabled"
     static let dockPreviewBackgroundOpacity = "dockPreviewBackgroundOpacity" // how solid the preview panel's material is drawn (DockPreviewSupport.backgroundOpacityRange)
+    static let dockPreviewOpenDelay = "dockPreviewOpenDelay" // milliseconds the cursor must rest on a Dock icon before its panel opens (DockPreviewSupport.openDelayMillisecondsRange)
     static let dockClickMinimize = "dockClickMinimize"    // click the active app's Dock icon to minimize its windows
     static let dockClickHide = "dockClickHide"            // click the active app's Dock icon to hide the app
     static let dockClickCycleWindows = "dockClickCycleWindows" // click the active app's Dock icon to cycle through its windows
@@ -778,6 +779,7 @@ enum Defaults {
         DefaultsKey.switcherShowShortcutHints: true,
         DefaultsKey.dockPreviewEnabled: false,
         DefaultsKey.dockPreviewBackgroundOpacity: 1.0,
+        DefaultsKey.dockPreviewOpenDelay: DockPreviewSupport.defaultOpenDelayMilliseconds,
         DefaultsKey.dockClickMinimize: false,
         DefaultsKey.dockClickHide: false,
         DefaultsKey.dockClickCycleWindows: false,

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -691,13 +691,17 @@ enum PreviewSizing {
         Defaults.allowedPreviewSizes.contains(value) ? value : "normal"
     }
 
-    static var scale: CGFloat {
-        switch sanitized(UserDefaults.standard.string(forKey: DefaultsKey.previewSize) ?? "normal") {
+    static func scale(for value: String) -> CGFloat {
+        switch sanitized(value) {
         case "small": return 0.75
         case "large": return 1.4
         case "xlarge": return 1.8
         default: return 1.0
         }
+    }
+
+    static var scale: CGFloat {
+        scale(for: UserDefaults.standard.string(forKey: DefaultsKey.previewSize) ?? "normal")
     }
 }
 

--- a/Sources/Vorssaint/Core/Localization.swift
+++ b/Sources/Vorssaint/Core/Localization.swift
@@ -336,6 +336,8 @@ struct Strings {
     let dockPreviewEnableCaption: String
     let dockPreviewBackgroundOpacity: String
     let dockPreviewBackgroundOpacityCaption: String
+    let dockPreviewOpenDelay: String
+    let dockPreviewOpenDelayCaption: String
     let dockClickMinimize: String
     let dockClickMinimizeCaption: String
     let dockClickCycleWindows: String
@@ -1294,6 +1296,8 @@ extension Strings {
         dockPreviewEnableCaption: "Passe o mouse em um app aberto no Dock para ver suas janelas e clique na que quiser abrir.",
         dockPreviewBackgroundOpacity: "Fundo do painel",
         dockPreviewBackgroundOpacityCaption: "Diminua para ver mais do que está atrás do painel.",
+        dockPreviewOpenDelay: "Atraso de abertura",
+        dockPreviewOpenDelayCaption: "Quanto tempo o ponteiro precisa ficar sobre um ícone antes de o painel abrir.",
         dockClickMinimize: "Clicar no Dock minimiza",
         dockClickMinimizeCaption: "As janelas do app ativo são minimizadas ao clicar no ícone dele no Dock. Clique de novo para trazê-las de volta.",
         dockClickCycleWindows: "Clicar no Dock alterna janelas",
@@ -2225,6 +2229,8 @@ extension Strings {
         dockPreviewEnableCaption: "Hover over an open app in the Dock to see its windows, then click the one you want.",
         dockPreviewBackgroundOpacity: "Panel background",
         dockPreviewBackgroundOpacityCaption: "Turn it down to see more of what sits behind the panel.",
+        dockPreviewOpenDelay: "Open delay",
+        dockPreviewOpenDelayCaption: "How long the pointer has to rest on an icon before its panel opens.",
         dockClickMinimize: "Click the Dock icon to minimize",
         dockClickMinimizeCaption: "The active app's windows minimize when you click its Dock icon. Click again to bring them back.",
         dockClickCycleWindows: "Click the Dock icon to cycle windows",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
@@ -220,6 +220,8 @@ extension Strings {
         dockPreviewEnableCaption: "将指针悬停在 Dock 中已打开的 App 上查看窗口，然后点按要打开的窗口。",
         dockPreviewBackgroundOpacity: "面板背景",
         dockPreviewBackgroundOpacityCaption: "调低后可以看到更多面板后面的内容。",
+        dockPreviewOpenDelay: "打开延迟",
+        dockPreviewOpenDelayCaption: "指针停在图标上多久之后才打开面板。",
         dockClickMinimize: "点按 Dock 图标最小化",
         dockClickMinimizeCaption: "点按最前面 App 的 Dock 图标可将其窗口最小化。再次点按即可恢复。",
         dockClickCycleWindows: "点按 Dock 图标切换窗口",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
@@ -221,6 +221,8 @@ extension Strings {
         dockPreviewEnableCaption: "將指標停在 Dock 中已開啟的 App 上查看視窗，然後點按要開啟的視窗。",
         dockPreviewBackgroundOpacity: "面板背景",
         dockPreviewBackgroundOpacityCaption: "調低後可以看到更多面板後面的內容。",
+        dockPreviewOpenDelay: "開啟延遲",
+        dockPreviewOpenDelayCaption: "指標停在圖示上多久之後才打開面板。",
         dockClickMinimize: "點按 Dock 圖示最小化",
         dockClickMinimizeCaption: "點按最前面 App 的 Dock 圖示可將其視窗最小化。再點按一次即可還原。",
         dockClickCycleWindows: "點按 Dock 圖示切換視窗",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
@@ -221,6 +221,8 @@ extension Strings {
         dockPreviewEnableCaption: "將游標停在 Dock 中已開啟的 App 上查看視窗，然後點按要開啟的視窗。",
         dockPreviewBackgroundOpacity: "面板背景",
         dockPreviewBackgroundOpacityCaption: "調低後可以看到更多面板後面的內容。",
+        dockPreviewOpenDelay: "開啟延遲",
+        dockPreviewOpenDelayCaption: "指標停在圖示上多久之後才打開面板。",
         dockClickMinimize: "點按 Dock 圖示最小化",
         dockClickMinimizeCaption: "點按最前方 App 的 Dock 圖示可將其視窗最小化。再點按一次即可還原。",
         dockClickCycleWindows: "點按 Dock 圖示切換視窗",

--- a/Sources/Vorssaint/Core/Localizations/Strings+French.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+French.swift
@@ -220,6 +220,8 @@ extension Strings {
         dockPreviewEnableCaption: "Survolez une app ouverte dans le Dock pour voir ses fenêtres, puis cliquez sur celle à ouvrir.",
         dockPreviewBackgroundOpacity: "Fond du panneau",
         dockPreviewBackgroundOpacityCaption: "Baissez-le pour voir davantage ce qui se trouve derrière le panneau.",
+        dockPreviewOpenDelay: "Délai d'ouverture",
+        dockPreviewOpenDelayCaption: "Combien de temps le pointeur doit rester sur une icône avant que le panneau s'ouvre.",
         dockClickMinimize: "Réduire d'un clic sur le Dock",
         dockClickMinimizeCaption: "Les fenêtres de l'app active se réduisent d'un clic sur son icône du Dock. Cliquez à nouveau pour les faire revenir.",
         dockClickCycleWindows: "Clic sur le Dock pour alterner les fenêtres",

--- a/Sources/Vorssaint/Core/Localizations/Strings+German.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+German.swift
@@ -220,6 +220,8 @@ extension Strings {
         dockPreviewEnableCaption: "Zeige auf eine geöffnete App im Dock, um ihre Fenster zu sehen, und klicke dann auf das gewünschte.",
         dockPreviewBackgroundOpacity: "Hintergrund des Panels",
         dockPreviewBackgroundOpacityCaption: "Verringere ihn, um mehr von dem zu sehen, was hinter dem Panel liegt.",
+        dockPreviewOpenDelay: "Öffnungsverzögerung",
+        dockPreviewOpenDelayCaption: "Wie lange der Zeiger auf einem Symbol ruhen muss, bevor sich das Panel öffnet.",
         dockClickMinimize: "Klick aufs Dock-Symbol minimiert",
         dockClickMinimizeCaption: "Die Fenster der aktiven App werden beim Klick auf ihr Dock-Symbol im Dock abgelegt. Ein weiterer Klick holt sie zurück.",
         dockClickCycleWindows: "Klick aufs Dock-Symbol wechselt Fenster",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
@@ -220,6 +220,8 @@ extension Strings {
         dockPreviewEnableCaption: "Passa il mouse su un'app aperta nel Dock per vedere le sue finestre, poi fai clic su quella da aprire.",
         dockPreviewBackgroundOpacity: "Sfondo del pannello",
         dockPreviewBackgroundOpacityCaption: "Abbassalo per vedere di più di ciò che sta dietro al pannello.",
+        dockPreviewOpenDelay: "Ritardo di apertura",
+        dockPreviewOpenDelayCaption: "Quanto a lungo il puntatore deve restare su un'icona prima che il pannello si apra.",
         dockClickMinimize: "Riduci con un clic sul Dock",
         dockClickMinimizeCaption: "Le finestre dell'app attiva si riducono nel Dock cliccando la sua icona. Fai clic di nuovo per ripristinarle.",
         dockClickCycleWindows: "Clic sul Dock per alternare le finestre",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
@@ -220,6 +220,8 @@ extension Strings {
         dockPreviewEnableCaption: "Dock の開いているアプリにポインタを重ねてウインドウを確認し、開きたいウインドウをクリックします。",
         dockPreviewBackgroundOpacity: "パネルの背景",
         dockPreviewBackgroundOpacityCaption: "下げると、パネルの後ろにあるものがより見えるようになります。",
+        dockPreviewOpenDelay: "表示までの待ち時間",
+        dockPreviewOpenDelayCaption: "ポインタをアイコンに置いてからパネルが開くまでの時間です。",
         dockClickMinimize: "Dock クリックでしまう",
         dockClickMinimizeCaption: "手前のアプリの Dock アイコンをクリックするとウインドウをしまいます。もう一度クリックすると戻ります。",
         dockClickCycleWindows: "Dock クリックでウインドウを切り替え",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
@@ -221,6 +221,8 @@ extension Strings {
         dockPreviewEnableCaption: "Dock의 열린 앱 위에 포인터를 올려 윈도우를 확인한 다음 원하는 윈도우를 클릭하세요.",
         dockPreviewBackgroundOpacity: "패널 배경",
         dockPreviewBackgroundOpacityCaption: "낮추면 패널 뒤에 있는 것이 더 많이 보입니다.",
+        dockPreviewOpenDelay: "열림 지연",
+        dockPreviewOpenDelayCaption: "포인터가 아이콘 위에 머문 뒤 패널이 열리기까지의 시간입니다.",
         dockClickMinimize: "Dock 클릭으로 최소화",
         dockClickMinimizeCaption: "앞에 있는 앱의 Dock 아이콘을 클릭하면 윈도우를 최소화합니다. 다시 클릭하면 복원됩니다.",
         dockClickCycleWindows: "Dock 클릭으로 윈도우 전환",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
@@ -221,6 +221,8 @@ extension Strings {
         dockPreviewEnableCaption: "Наведите указатель на открытое приложение в Dock, чтобы увидеть его окна, затем нажмите нужное.",
         dockPreviewBackgroundOpacity: "Фон панели",
         dockPreviewBackgroundOpacityCaption: "Уменьшите, чтобы видеть больше того, что находится за панелью.",
+        dockPreviewOpenDelay: "Задержка открытия",
+        dockPreviewOpenDelayCaption: "Сколько указатель должен оставаться на значке, прежде чем откроется панель.",
         dockClickMinimize: "Сворачивать кликом по Dock",
         dockClickMinimizeCaption: "Окна активного приложения сворачиваются при клике по его значку в Dock. Кликните ещё раз, чтобы вернуть их.",
         dockClickCycleWindows: "Кликом по Dock переключать окна",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
@@ -220,6 +220,8 @@ extension Strings {
         dockPreviewEnableCaption: "Pasa el cursor sobre una app abierta en el Dock para ver sus ventanas y haz clic en la que quieras abrir.",
         dockPreviewBackgroundOpacity: "Fondo del panel",
         dockPreviewBackgroundOpacityCaption: "Bájalo para ver más de lo que hay detrás del panel.",
+        dockPreviewOpenDelay: "Retardo de apertura",
+        dockPreviewOpenDelayCaption: "Cuánto tiempo debe reposar el puntero sobre un icono antes de que se abra el panel.",
         dockClickMinimize: "Clic en el Dock para minimizar",
         dockClickMinimizeCaption: "Las ventanas de la app activa se minimizan al hacer clic en su icono del Dock. Vuelve a hacer clic para recuperarlas.",
         dockClickCycleWindows: "Clic en el Dock para alternar ventanas",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
@@ -220,6 +220,8 @@ extension Strings {
         dockPreviewEnableCaption: "Pencerelerini görmek için Dock'taki açık bir uygulamanın üzerine gel, ardından açmak istediğin pencereye tıkla.",
         dockPreviewBackgroundOpacity: "Panel arka planı",
         dockPreviewBackgroundOpacityCaption: "Panelin arkasındakileri daha çok görmek için azalt.",
+        dockPreviewOpenDelay: "Açılma gecikmesi",
+        dockPreviewOpenDelayCaption: "Panelin açılması için imlecin bir simgenin üzerinde ne kadar bekleyeceği.",
         dockClickMinimize: "Dock simgesine tıklayınca küçült",
         dockClickMinimizeCaption: "Etkin uygulamanın pencereleri Dock simgesine tıklandığında küçülür. Geri getirmek için yeniden tıklayın.",
         dockClickCycleWindows: "Dock simgesine tıklayınca pencere değiştir",

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
@@ -557,7 +557,12 @@ final class DockPreviewService: ObservableObject {
 
     // MARK: - Sessions
 
-    private func scheduleHover(_ hit: DockHit, delay: TimeInterval = DockPreviewSupport.hoverDelay) {
+    private var openDelay: TimeInterval {
+        DockPreviewSupport.openDelay(
+            milliseconds: UserDefaults.standard.integer(forKey: DefaultsKey.dockPreviewOpenDelay))
+    }
+
+    private func scheduleHover(_ hit: DockHit, delay: TimeInterval? = nil) {
         // Same app already arming: let the existing timer run to completion rather
         // than restarting it on every move, so a resting cursor isn't starved by
         // a one-frame Dock hit-test miss.
@@ -568,12 +573,46 @@ final class DockPreviewService: ObservableObject {
         }
 
         cancelPendingHover()
+        let delay = delay ?? openDelay
         let token = UUID()
         let work = DispatchWorkItem { [weak self] in
             self?.beginHoverIfStillValid(token: token, initialHit: hit)
         }
         pendingHover = PendingHover(token: token, app: hit.app, iconFrame: hit.iconFrame, workItem: work)
         DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+        schedulePrefetch(token: token, pid: hit.app.processIdentifier, delay: delay)
+    }
+
+    /// Reads the app's window list part-way through the arming delay, so the
+    /// panel the timer opens has one ready instead of paying for it once the
+    /// user is already waiting to see something.
+    ///
+    /// Only for a panel that has to be opened. Handing an open panel to the next
+    /// app runs on a delay as short as the reading's own head start, which would
+    /// put the reading at the moment the cursor lands — and a cursor landing on
+    /// a Dock icon with a panel already up is most often on its way along the
+    /// Dock, not stopping. A reading already under way cannot be called back, so
+    /// a single sweep would pay for every icon it crossed. The switch is quick
+    /// because the panel never left the screen, not because the list was read
+    /// early.
+    private func schedulePrefetch(token: UUID, pid: pid_t, delay: TimeInterval) {
+        guard !isVisible else { return }
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.pendingHover?.token == token else { return }
+            let list = Self.previewableWindows(for: pid)
+            // The list took Accessibility round trips to read: the hover it was
+            // taken for can have been cancelled or handed on in the meantime.
+            guard self.pendingHover?.token == token else { return }
+            self.pendingHover?.windows = list
+        }
+        pendingHover?.prefetchWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + DockPreviewSupport.prefetchDelay(openDelay: delay),
+                                      execute: work)
+    }
+
+    private static func previewableWindows(for pid: pid_t) -> [SwitcherItem] {
+        WindowEnumerator.listWindows(for: pid, maximumCount: 12)
+            .filter { $0.windowID != nil }
     }
 
     private func beginHoverIfStillValid(token: UUID, initialHit: DockHit) {
@@ -590,11 +629,16 @@ final class DockPreviewService: ObservableObject {
 
     private func beginSession(_ hit: DockHit) {
         guard !(isPinned && isVisible) else { return }
+        // A prefetched list counts only for the app it was taken for: a hover
+        // handed over to a neighbouring icon must not open on the previous
+        // app's windows.
+        let prefetched = pendingHover.flatMap {
+            $0.app.processIdentifier == hit.app.processIdentifier ? $0.windows : nil
+        }
         cancelPendingHover()
         cancelPendingHide()
 
-        let list = WindowEnumerator.listWindows(for: hit.app.processIdentifier, maximumCount: 12)
-            .filter { $0.windowID != nil }
+        let list = prefetched ?? Self.previewableWindows(for: hit.app.processIdentifier)
         // An app with no real windows shows nothing; if a panel is already up
         // (the user moved here from another app), close it cleanly.
         guard !list.isEmpty else {
@@ -660,6 +704,7 @@ final class DockPreviewService: ObservableObject {
 
     private func cancelPendingHover() {
         pendingHover?.workItem.cancel()
+        pendingHover?.prefetchWorkItem?.cancel()
         pendingHover = nil
     }
 
@@ -1193,6 +1238,12 @@ private struct PendingHover {
     let app: NSRunningApplication
     let iconFrame: CGRect
     let workItem: DispatchWorkItem
+    /// Listing an app's windows blocks on Accessibility, so it runs while the
+    /// arming delay is still counting down rather than after it, where the wait
+    /// would be added to the time before anything appears. Nil until that work
+    /// lands, and dropped with the hover it belongs to.
+    var prefetchWorkItem: DispatchWorkItem?
+    var windows: [SwitcherItem]?
 }
 
 private enum DockPreviewMinimizeConfirmation {

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
@@ -584,17 +584,11 @@ final class DockPreviewService: ObservableObject {
     }
 
     /// Reads the app's window list part-way through the arming delay, so the
-    /// panel the timer opens has one ready instead of paying for it once the
-    /// user is already waiting to see something.
+    /// panel the timer opens has one ready instead of reading it on the way up.
     ///
-    /// Only for a panel that has to be opened. Handing an open panel to the next
-    /// app runs on a delay as short as the reading's own head start, which would
-    /// put the reading at the moment the cursor lands — and a cursor landing on
-    /// a Dock icon with a panel already up is most often on its way along the
-    /// Dock, not stopping. A reading already under way cannot be called back, so
-    /// a single sweep would pay for every icon it crossed. The switch is quick
-    /// because the panel never left the screen, not because the list was read
-    /// early.
+    /// Skipped while a panel is up: a switch runs on a delay as short as the
+    /// reading's own head start, so the reading would land the moment the
+    /// cursor does, and a reading under way cannot be called back.
     private func schedulePrefetch(token: UUID, pid: pid_t, delay: TimeInterval) {
         guard !isVisible else { return }
         let work = DispatchWorkItem { [weak self] in
@@ -1238,10 +1232,8 @@ private struct PendingHover {
     let app: NSRunningApplication
     let iconFrame: CGRect
     let workItem: DispatchWorkItem
-    /// Listing an app's windows blocks on Accessibility, so it runs while the
-    /// arming delay is still counting down rather than after it, where the wait
-    /// would be added to the time before anything appears. Nil until that work
-    /// lands, and dropped with the hover it belongs to.
+    /// The reading armed by `schedulePrefetch`. Nil until it lands, and dropped
+    /// with the hover it belongs to.
     var prefetchWorkItem: DispatchWorkItem?
     var windows: [SwitcherItem]?
 }

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
@@ -819,7 +819,9 @@ final class DockPreviewService: ObservableObject {
     private func showPanel(for hit: DockHit, itemCount: Int) {
         let panel = ensurePanel()
         let screenVisibleFrame = visibleFrameForScreen(containing: hit.iconFrame)
-        let size = DockPreviewSupport.panelSize(itemCount: itemCount, screenVisibleFrame: screenVisibleFrame)
+        let size = DockPreviewSupport.panelSize(itemCount: itemCount,
+                                                screenVisibleFrame: screenVisibleFrame,
+                                                isPinned: false)
         let gap = hit.preferences.autohide ? DockPreviewSupport.autohidePanelGap : DockPreviewSupport.panelGap
         let frame = DockPreviewSupport.panelFrame(anchor: hit.iconFrame,
                                                   panelSize: size,
@@ -848,7 +850,9 @@ final class DockPreviewService: ObservableObject {
         else { return }
 
         let screenVisibleFrame = visibleFrameForScreen(containing: iconFrame)
-        let size = DockPreviewSupport.panelSize(itemCount: windows.count, screenVisibleFrame: screenVisibleFrame)
+        let size = DockPreviewSupport.panelSize(itemCount: windows.count,
+                                                screenVisibleFrame: screenVisibleFrame,
+                                                isPinned: false)
         let gap = preferences.autohide ? DockPreviewSupport.autohidePanelGap : DockPreviewSupport.panelGap
         let frame = DockPreviewSupport.panelFrame(anchor: iconFrame,
                                                   panelSize: size,
@@ -1499,7 +1503,8 @@ final class DockPreviewPinnedPanel: ObservableObject, Identifiable {
     private func resizePanel() {
         guard let panel else { return }
         let size = DockPreviewSupport.panelSize(itemCount: windows.count,
-                                                screenVisibleFrame: visibleFrameForScreen(containing: panel.frame))
+                                                screenVisibleFrame: visibleFrameForScreen(containing: panel.frame),
+                                                isPinned: true)
         var frame = panel.frame
         frame.size = size
         panel.setFrame(clampedPanelFrame(frame), display: true, animate: true)

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewSupport.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewSupport.swift
@@ -89,10 +89,46 @@ struct HoverCorridor: Equatable {
 }
 
 enum DockPreviewSupport {
-    static let hoverDelay: TimeInterval = 0.4
-    /// Shorter than the first-open delay: once a panel is already up, handing it
-    /// to the app under the cursor should feel immediate, not like a fresh open.
-    static let switchDelay: TimeInterval = 0.25
+    /// How long the cursor must rest on an icon before its panel opens. Long
+    /// enough that the Dock can be crossed on the way somewhere else without a
+    /// panel jumping out, short enough that a cursor that stopped is answered
+    /// rather than waited on. Adjustable, because where that line falls is a
+    /// matter of how fast someone drives their pointer.
+    static let defaultOpenDelayMilliseconds = 200
+    /// The floor is the shortest wait that still holds two promises. The window
+    /// list is read `prefetchLead` before the panel, so a shorter wait would
+    /// read it the moment the cursor landed and charge a Dock crossed on the way
+    /// somewhere else for every icon it passed. And a switch costs its own delay
+    /// plus the reading it does inline, which has to stay under the shortest
+    /// opening, or handing an open panel on would come out slower than opening
+    /// one from nothing.
+    static let openDelayMillisecondsRange: ClosedRange<Int> = 200 ... 900
+
+    static func sanitizedOpenDelay(milliseconds: Int) -> Int {
+        min(max(milliseconds, openDelayMillisecondsRange.lowerBound),
+            openDelayMillisecondsRange.upperBound)
+    }
+
+    static func openDelay(milliseconds: Int) -> TimeInterval {
+        TimeInterval(sanitizedOpenDelay(milliseconds: milliseconds)) / 1000
+    }
+
+    /// Handing an already open panel to the app under the cursor: shorter than
+    /// opening one, because the panel is on screen and only has to re-point.
+    /// Never longer than the shortest open delay on offer, so switching cannot
+    /// come out slower than opening at any setting.
+    static let switchDelay: TimeInterval = 0.1
+
+    /// How far ahead of the panel the window list is read. Enough for an
+    /// ordinary list, so the panel opens on one already in hand rather than
+    /// stopping to read it, and no further ahead than that, so what it opens on
+    /// is still true. Half the shortest wait, which leaves the other half as the
+    /// stillness a cursor has to show before the reading is worth making.
+    static let prefetchLead: TimeInterval = 0.1
+
+    static func prefetchDelay(openDelay: TimeInterval) -> TimeInterval {
+        max(0, openDelay - prefetchLead)
+    }
     static let hideDelay: TimeInterval = 0.22
     /// A little slack around the panel so the cursor grazing its edge doesn't
     /// flicker the session between "inside" and "leaving".

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewSupport.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewSupport.swift
@@ -178,15 +178,20 @@ enum DockPreviewSupport {
     // smallest, which is the one thing here that was actually wrong.
     static var cardPadding: CGFloat { 8 * PreviewSizing.scale }
     static var cardTitleSpacing: CGFloat { 5 * PreviewSizing.scale }
-    /// One line of 12pt semibold, with just enough room for descenders. Fixed:
-    /// the line it holds is the same at every preview size.
-    static let cardTitleHeight: CGFloat = 17
+    /// One line of 12pt semibold beside the two 16pt window controls, with just
+    /// enough room for descenders. Fixed: what it holds is the same at every
+    /// preview size.
+    static let cardTitleHeight: CGFloat = 20
     static var cardSpacing: CGFloat { 8 * PreviewSizing.scale }
     static var panelPadding: CGFloat { 12 * PreviewSizing.scale }
     static let panelHeaderHeight: CGFloat = 28
 
+    /// 16:10, the shape of the screen the captured window came from, so a
+    /// full-height window fills the thumbnail instead of sitting between two
+    /// bars. The picture inside keeps a 4pt inset, which is why this is 248x158
+    /// rather than 240x150.
     static func cardThumbnailSize(scale: CGFloat) -> CGSize {
-        CGSize(width: 160 * scale, height: 96 * scale)
+        CGSize(width: 248 * scale, height: 158 * scale)
     }
 
     static func cardSize(scale: CGFloat) -> CGSize {
@@ -195,6 +200,16 @@ enum DockPreviewSupport {
         return CGSize(width: thumbnail.width + padding * 2,
                       height: thumbnail.height + padding * 2 + 5 * scale + cardTitleHeight)
     }
+
+    /// The picture's inset inside the thumbnail well. It scales with the well,
+    /// so the 16:10 the well is cut to survives every preview size.
+    static func cardPictureSize(scale: CGFloat) -> CGSize {
+        let thumbnail = cardThumbnailSize(scale: scale)
+        let inset = 4 * scale
+        return CGSize(width: thumbnail.width - inset * 2, height: thumbnail.height - inset * 2)
+    }
+
+    static var cardThumbnailInset: CGFloat { 4 * PreviewSizing.scale }
 
     /// Stands in for the thumbnail when there is no capture, so it follows the
     /// thumbnail rather than staying the one fixed picture on a scaling card.
@@ -292,8 +307,24 @@ enum DockPreviewSupport {
         return CGRect(x: x, y: y, width: width, height: height)
     }
 
+    /// Whether the panel draws a header row. It holds which window of how many
+    /// is selected and the steppers between them, so one window leaves it with
+    /// nothing to say. A pinned panel keeps it at any count: there it is also
+    /// the drag handle and the only way to unpin or close.
+    static func showsPanelHeader(itemCount: Int, isPinned: Bool) -> Bool {
+        isPinned || itemCount > 1
+    }
+
+    /// Whether a card draws its close and minimize buttons. A pinned panel
+    /// counted as permanent hover, which held both open on every card it
+    /// showed for as long as it stayed up.
+    static func showsCardControls(isHovering: Bool, isSelected: Bool) -> Bool {
+        isHovering || isSelected
+    }
+
     static func panelSize(itemCount: Int,
                           screenVisibleFrame: CGRect,
+                          isPinned: Bool,
                           padding: CGFloat = panelPadding,
                           cardWidth: CGFloat = cardWidth,
                           cardHeight: CGFloat = cardHeight,
@@ -304,7 +335,8 @@ enum DockPreviewSupport {
         let availableCards = max(1, Int((maxWidth - padding * 2 + spacing) / (cardWidth + spacing)))
         let visibleCards = min(count, availableCards)
         let width = CGFloat(visibleCards) * cardWidth + CGFloat(max(0, visibleCards - 1)) * spacing + padding * 2
-        return CGSize(width: min(width, maxWidth), height: cardHeight + padding * 2 + panelHeaderHeight)
+        let header = showsPanelHeader(itemCount: count, isPinned: isPinned) ? panelHeaderHeight : 0
+        return CGSize(width: min(width, maxWidth), height: cardHeight + padding * 2 + header)
     }
 
     static func windowPositionText(selectedWindowID: CGWindowID?, windowIDs: [CGWindowID]) -> String? {

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewSupport.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewSupport.swift
@@ -168,22 +168,45 @@ enum DockPreviewSupport {
         )
     }
 
-    /// Card metrics. The thumbnail gets whatever the fixed chrome does not
-    /// take, so the card can be resized or the title band retuned without
-    /// leaving a stale magic number behind — the old code hard-coded a 54pt
-    /// deduction that no longer matched the parts it stood for.
-    static var cardWidth: CGFloat { 176 * PreviewSizing.scale }
-    static var cardHeight: CGFloat { 134 * PreviewSizing.scale }
+    // Card metrics. The preview size setting sizes what the card shows, so the
+    // thumbnail and the icon standing in for it follow it, and so do the gaps
+    // around them, which hold nothing of their own. What does not follow it is
+    // anything sized by fixed content: the title band is one line of 12pt
+    // semibold at every setting, and the panel header holds a 16pt icon beside
+    // the same 12pt. Scaling the band with the card left that line adrift in
+    // 31pt of nothing at the largest size and squeezed into 13pt at the
+    // smallest, which is the one thing here that was actually wrong.
     static var cardPadding: CGFloat { 8 * PreviewSizing.scale }
     static var cardTitleSpacing: CGFloat { 5 * PreviewSizing.scale }
-    /// One line of 12pt semibold, with just enough room for descenders.
-    static var cardTitleHeight: CGFloat { 17 * PreviewSizing.scale }
-    static var cardThumbnailHeight: CGFloat {
-        cardHeight - cardPadding * 2 - cardTitleSpacing - cardTitleHeight
-    }
+    /// One line of 12pt semibold, with just enough room for descenders. Fixed:
+    /// the line it holds is the same at every preview size.
+    static let cardTitleHeight: CGFloat = 17
     static var cardSpacing: CGFloat { 8 * PreviewSizing.scale }
     static var panelPadding: CGFloat { 12 * PreviewSizing.scale }
     static let panelHeaderHeight: CGFloat = 28
+
+    static func cardThumbnailSize(scale: CGFloat) -> CGSize {
+        CGSize(width: 160 * scale, height: 96 * scale)
+    }
+
+    static func cardSize(scale: CGFloat) -> CGSize {
+        let thumbnail = cardThumbnailSize(scale: scale)
+        let padding = 8 * scale
+        return CGSize(width: thumbnail.width + padding * 2,
+                      height: thumbnail.height + padding * 2 + 5 * scale + cardTitleHeight)
+    }
+
+    /// Stands in for the thumbnail when there is no capture, so it follows the
+    /// thumbnail rather than staying the one fixed picture on a scaling card.
+    static func cardFallbackIconSize(scale: CGFloat) -> CGFloat {
+        52 * scale
+    }
+
+    static var cardThumbnailWidth: CGFloat { cardThumbnailSize(scale: PreviewSizing.scale).width }
+    static var cardThumbnailHeight: CGFloat { cardThumbnailSize(scale: PreviewSizing.scale).height }
+    static var cardWidth: CGFloat { cardSize(scale: PreviewSizing.scale).width }
+    static var cardHeight: CGFloat { cardSize(scale: PreviewSizing.scale).height }
+    static var cardFallbackIconSize: CGFloat { cardFallbackIconSize(scale: PreviewSizing.scale) }
 
     /// How solid the panel's frosted background is drawn, as a fraction. The
     /// floor is not zero on purpose: the panel's title sits straight on the

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewSupport.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewSupport.swift
@@ -90,18 +90,14 @@ struct HoverCorridor: Equatable {
 
 enum DockPreviewSupport {
     /// How long the cursor must rest on an icon before its panel opens. Long
-    /// enough that the Dock can be crossed on the way somewhere else without a
-    /// panel jumping out, short enough that a cursor that stopped is answered
-    /// rather than waited on. Adjustable, because where that line falls is a
-    /// matter of how fast someone drives their pointer.
+    /// enough that the Dock can be crossed on the way somewhere else, short
+    /// enough that a cursor which stopped is answered. Adjustable: that line
+    /// falls differently for every pointer speed.
     static let defaultOpenDelayMilliseconds = 200
-    /// The floor is the shortest wait that still holds two promises. The window
-    /// list is read `prefetchLead` before the panel, so a shorter wait would
-    /// read it the moment the cursor landed and charge a Dock crossed on the way
-    /// somewhere else for every icon it passed. And a switch costs its own delay
-    /// plus the reading it does inline, which has to stay under the shortest
-    /// opening, or handing an open panel on would come out slower than opening
-    /// one from nothing.
+    /// The floor keeps two properties: the window list is read `prefetchLead`
+    /// earlier, so a shorter wait would read it the moment the cursor lands;
+    /// and `switchDelay` plus its inline reading stays under it, so a switch is
+    /// never slower than an open.
     static let openDelayMillisecondsRange: ClosedRange<Int> = 200 ... 900
 
     static func sanitizedOpenDelay(milliseconds: Int) -> Int {
@@ -113,17 +109,14 @@ enum DockPreviewSupport {
         TimeInterval(sanitizedOpenDelay(milliseconds: milliseconds)) / 1000
     }
 
-    /// Handing an already open panel to the app under the cursor: shorter than
-    /// opening one, because the panel is on screen and only has to re-point.
-    /// Never longer than the shortest open delay on offer, so switching cannot
-    /// come out slower than opening at any setting.
+    /// Handing an already open panel to the app under the cursor: the panel is
+    /// on screen and only has to re-point. Kept under the shortest open delay
+    /// on offer, so a switch is never slower than an open.
     static let switchDelay: TimeInterval = 0.1
 
-    /// How far ahead of the panel the window list is read. Enough for an
-    /// ordinary list, so the panel opens on one already in hand rather than
-    /// stopping to read it, and no further ahead than that, so what it opens on
-    /// is still true. Half the shortest wait, which leaves the other half as the
-    /// stillness a cursor has to show before the reading is worth making.
+    /// How far ahead of the panel the window list is read: far enough that an
+    /// ordinary list is in hand when the panel opens, no further, so what it
+    /// opens on is still true. Half the shortest wait.
     static let prefetchLead: TimeInterval = 0.1
 
     static func prefetchDelay(openDelay: TimeInterval) -> TimeInterval {

--- a/Sources/Vorssaint/UI/Settings/SettingsView.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsView.swift
@@ -840,6 +840,7 @@ struct SwitcherSettings: View {
     @AppStorage(DefaultsKey.switcherShowShortcutHints) private var switcherShowShortcutHints = true
     @AppStorage(DefaultsKey.dockPreviewEnabled) private var dockPreviewEnabled = false
     @AppStorage(DefaultsKey.dockPreviewBackgroundOpacity) private var dockPreviewBackgroundOpacity = 1.0
+    @AppStorage(DefaultsKey.dockPreviewOpenDelay) private var dockPreviewOpenDelay = DockPreviewSupport.defaultOpenDelayMilliseconds
     @AppStorage(DefaultsKey.dockClickMinimize) private var dockClickMinimize = false
     @AppStorage(DefaultsKey.dockClickHide) private var dockClickHide = false
     @AppStorage(DefaultsKey.dockClickCycleWindows) private var dockClickCycleWindows = false
@@ -950,6 +951,22 @@ struct SwitcherSettings: View {
                             .font(.caption)
                             .foregroundStyle(dockPreviewWarning ? .orange : .secondary)
                         if dockPreviewEnabled {
+                            HStack {
+                                Text(l10n.s.dockPreviewOpenDelay)
+                                Spacer()
+                                TextField("", value: dockPreviewOpenDelayBinding,
+                                          formatter: Self.dockPreviewOpenDelayFormatter)
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(width: 64)
+                                Stepper("", value: dockPreviewOpenDelayBinding,
+                                        in: DockPreviewSupport.openDelayMillisecondsRange,
+                                        step: 50)
+                                    .labelsHidden()
+                                Text(verbatim: "ms")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .fixedSize(horizontal: false, vertical: true)
+                            SettingsCaptionText(l10n.s.dockPreviewOpenDelayCaption)
                             HStack {
                                 Text(l10n.s.dockPreviewBackgroundOpacity)
                                 Slider(value: dockPreviewBackgroundOpacityBinding,
@@ -1064,6 +1081,24 @@ struct SwitcherSettings: View {
     private var dockPreviewBackgroundOpacityPercent: Int {
         Int((DockPreviewSupport.sanitizedBackgroundOpacity(dockPreviewBackgroundOpacity) * 100).rounded())
     }
+
+    private var dockPreviewOpenDelayBinding: Binding<Int> {
+        Binding(
+            get: { DockPreviewSupport.sanitizedOpenDelay(milliseconds: dockPreviewOpenDelay) },
+            set: { dockPreviewOpenDelay = DockPreviewSupport.sanitizedOpenDelay(milliseconds: $0) }
+        )
+    }
+
+    /// Bounded here as well as in the binding: the field rejects an out-of-range
+    /// number as it is typed rather than silently snapping it afterwards.
+    private static let dockPreviewOpenDelayFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .none
+        formatter.minimum = NSNumber(value: DockPreviewSupport.openDelayMillisecondsRange.lowerBound)
+        formatter.maximum = NSNumber(value: DockPreviewSupport.openDelayMillisecondsRange.upperBound)
+        formatter.usesGroupingSeparator = false
+        return formatter
+    }()
 }
 
 // MARK: - About

--- a/Sources/Vorssaint/UI/Switcher/DockPreviewPanelView.swift
+++ b/Sources/Vorssaint/UI/Switcher/DockPreviewPanelView.swift
@@ -329,11 +329,19 @@ private struct DockPreviewCard: View {
                         .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
                         .padding(4)
                 } else if let icon = window.appIcon {
+                    // Drawn as a watermark, not as content. Every card in a
+                    // panel belongs to the app whose Dock icon opened it, and
+                    // that icon is already in the header, so this says nothing
+                    // new — it only fills the space until a capture lands. At
+                    // full strength the capture replacing it reads as a jump;
+                    // at this weight it reads as the space filling in, and it
+                    // costs no transition, so nothing takes longer.
                     Image(nsImage: icon)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: DockPreviewSupport.cardFallbackIconSize,
                                height: DockPreviewSupport.cardFallbackIconSize)
+                        .opacity(0.35)
                 }
 
                 if hasStatusBadges {

--- a/Sources/Vorssaint/UI/Switcher/DockPreviewPanelView.swift
+++ b/Sources/Vorssaint/UI/Switcher/DockPreviewPanelView.swift
@@ -332,7 +332,8 @@ private struct DockPreviewCard: View {
                     Image(nsImage: icon)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(width: 52, height: 52)
+                        .frame(width: DockPreviewSupport.cardFallbackIconSize,
+                               height: DockPreviewSupport.cardFallbackIconSize)
                 }
 
                 if hasStatusBadges {
@@ -348,7 +349,7 @@ private struct DockPreviewCard: View {
 
                 previewControlBar
             }
-            .frame(width: DockPreviewSupport.cardWidth - DockPreviewSupport.cardPadding * 2,
+            .frame(width: DockPreviewSupport.cardThumbnailWidth,
                    height: DockPreviewSupport.cardThumbnailHeight)
 
             Text(window.displayTitle)
@@ -357,7 +358,7 @@ private struct DockPreviewCard: View {
                 .truncationMode(.middle)
                 .foregroundStyle(.primary)
                 .frame(height: DockPreviewSupport.cardTitleHeight)
-                .frame(maxWidth: DockPreviewSupport.cardWidth - DockPreviewSupport.cardPadding * 2 - 4)
+                .frame(maxWidth: DockPreviewSupport.cardThumbnailWidth - 4)
         }
         .padding(DockPreviewSupport.cardPadding)
         .frame(width: DockPreviewSupport.cardWidth, height: DockPreviewSupport.cardHeight)

--- a/Sources/Vorssaint/UI/Switcher/DockPreviewPanelView.swift
+++ b/Sources/Vorssaint/UI/Switcher/DockPreviewPanelView.swift
@@ -83,7 +83,9 @@ private struct DockPreviewPanelContent: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            panelHeader
+            if DockPreviewSupport.showsPanelHeader(itemCount: windows.count, isPinned: isPinned) {
+                panelHeader
+            }
             ScrollViewReader { proxy in
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: DockPreviewSupport.cardSpacing) {
@@ -93,6 +95,7 @@ private struct DockPreviewPanelContent: View {
                                 preview: window.previewWindowID.flatMap { previews[$0] },
                                 isSelected: selectedWindowID == window.windowID,
                                 isPanelPinned: isPinned,
+                                onTogglePinned: onTogglePinned,
                                 onCommit: {
                                     onCommit(window)
                                 },
@@ -143,8 +146,9 @@ private struct DockPreviewPanelContent: View {
                 }
             }
         }
-        .frame(height: DockPreviewSupport.panelSize(itemCount: 1,
-                                                    screenVisibleFrame: CGRect(x: 0, y: 0, width: 500, height: 500)).height)
+        .frame(height: DockPreviewSupport.panelSize(itemCount: windows.count,
+                                                    screenVisibleFrame: CGRect(x: 0, y: 0, width: 500, height: 500),
+                                                    isPinned: isPinned).height)
         .background(HUDBackdrop(cornerRadius: 18,
                                 opacity: DockPreviewSupport.sanitizedBackgroundOpacity(backgroundOpacity)))
         .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
@@ -160,28 +164,33 @@ private struct DockPreviewPanelContent: View {
         HStack(spacing: 7) {
             dragTitleArea
             windowNavigationButtons
-            Button {
-                onTogglePinned()
-            } label: {
-                Image(systemName: isPinned ? "pin.slash.fill" : "pin.fill")
-                    .font(.system(size: 12, weight: .semibold))
-                    .frame(width: 22, height: 20)
+            // Both belong to the pinned panel alone. A hovered panel is
+            // dismissed by moving off it, and pinning one is a named item in
+            // any card's menu.
+            if isPinned {
+                Button {
+                    onTogglePinned()
+                } label: {
+                    Image(systemName: "pin.slash.fill")
+                        .font(.system(size: 12, weight: .semibold))
+                        .frame(width: 22, height: 20)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(Color.accentColor)
+                .help(l10n.s.dockPreviewUnpinPanel)
+                .accessibilityLabel(l10n.s.dockPreviewUnpinPanel)
+                Button {
+                    onClosePanel()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .bold))
+                        .frame(width: 20, height: 20)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(Color.secondary)
+                .help(l10n.s.dockPreviewClosePanel)
+                .accessibilityLabel(l10n.s.dockPreviewClosePanel)
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(isPinned ? Color.accentColor : Color.secondary)
-            .help(isPinned ? l10n.s.dockPreviewUnpinPanel : l10n.s.dockPreviewPinPanel)
-            .accessibilityLabel(isPinned ? l10n.s.dockPreviewUnpinPanel : l10n.s.dockPreviewPinPanel)
-            Button {
-                onClosePanel()
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 11, weight: .bold))
-                    .frame(width: 20, height: 20)
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(Color.secondary)
-            .help(l10n.s.dockPreviewClosePanel)
-            .accessibilityLabel(l10n.s.dockPreviewClosePanel)
         }
         .focusEffectDisabled()
         .padding(.horizontal, DockPreviewSupport.panelPadding)
@@ -196,15 +205,20 @@ private struct DockPreviewPanelContent: View {
             }
 
             HStack(spacing: 7) {
-                if let icon = windows.first?.appIcon {
-                    Image(nsImage: icon)
-                        .resizable()
-                        .frame(width: 16, height: 16)
+                // A hovered panel sits above the Dock icon the pointer is
+                // resting on. A pinned panel outlives that pointer and has to
+                // name itself.
+                if isPinned {
+                    if let icon = windows.first?.appIcon {
+                        Image(nsImage: icon)
+                            .resizable()
+                            .frame(width: 16, height: 16)
+                    }
+                    Text(currentAppName ?? "")
+                        .font(.system(size: 12, weight: .semibold))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
                 }
-                Text(currentAppName ?? "")
-                    .font(.system(size: 12, weight: .semibold))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
                 if let positionText = DockPreviewSupport.windowPositionText(
                     selectedWindowID: selectedWindowID,
                     windowIDs: windows.compactMap(\.windowID)
@@ -298,6 +312,7 @@ private struct DockPreviewCard: View {
     let preview: CGImage?
     let isSelected: Bool
     let isPanelPinned: Bool
+    let onTogglePinned: () -> Void
     let onCommit: () -> Void
     let onClose: () -> Void
     let onToggleMinimized: () -> Void
@@ -309,7 +324,7 @@ private struct DockPreviewCard: View {
     @State private var suppressNextCommit = false
 
     private var showsPreviewControls: Bool {
-        isHovering || isSelected || isPanelPinned
+        DockPreviewSupport.showsCardControls(isHovering: isHovering, isSelected: isSelected)
     }
 
     private var hasStatusBadges: Bool {
@@ -327,7 +342,7 @@ private struct DockPreviewCard: View {
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
-                        .padding(4)
+                        .padding(DockPreviewSupport.cardThumbnailInset)
                 } else if let icon = window.appIcon {
                     // Drawn as a watermark, not as content. Every card in a
                     // panel belongs to the app whose Dock icon opened it, and
@@ -355,18 +370,11 @@ private struct DockPreviewCard: View {
                     }
                 }
 
-                previewControlBar
             }
             .frame(width: DockPreviewSupport.cardThumbnailWidth,
                    height: DockPreviewSupport.cardThumbnailHeight)
 
-            Text(window.displayTitle)
-                .font(.system(size: 12, weight: .semibold))
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .foregroundStyle(.primary)
-                .frame(height: DockPreviewSupport.cardTitleHeight)
-                .frame(maxWidth: DockPreviewSupport.cardThumbnailWidth - 4)
+            titleBand
         }
         .padding(DockPreviewSupport.cardPadding)
         .frame(width: DockPreviewSupport.cardWidth, height: DockPreviewSupport.cardHeight)
@@ -409,6 +417,14 @@ private struct DockPreviewCard: View {
                       systemImage: window.isMinimized ? "plus.rectangle" : "minus.rectangle")
             }
         }
+        Divider()
+        Button {
+            onTogglePinned()
+        } label: {
+            Label(isPanelPinned ? l10n.s.dockPreviewUnpinPanel : l10n.s.dockPreviewPinPanel,
+                  systemImage: isPanelPinned ? "pin.slash" : "pin")
+        }
+        Divider()
         Button(role: .destructive) {
             onClose()
         } label: {
@@ -416,47 +432,23 @@ private struct DockPreviewCard: View {
         }
     }
 
-    /// Window controls only. The title used to live here too, which put the same
-    /// string on screen twice — once floating over the thumbnail, once in the
-    /// band below it. The band keeps it, because a title that is only there
-    /// while the pointer is on the card cannot tell six windows of one app
-    /// apart, which is the whole job of this panel.
-    private var previewControlBar: some View {
-        VStack {
-            HStack(spacing: 6) {
-                Spacer(minLength: 0)
-                if isPanelPinned, isSelected {
-                    Text(l10n.s.dockPreviewPinned)
-                        .font(.system(size: 9, weight: .semibold))
-                        .foregroundStyle(Color.white.opacity(0.70))
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 1)
-                        .background(Capsule().fill(Color.white.opacity(0.12)))
-                }
-                closeButton
-                minimizeButton
-            }
-            .padding(.leading, 7)
-            .padding(.trailing, 5)
-            .padding(.vertical, 5)
-            .fixedSize(horizontal: true, vertical: false)
-            .frame(height: 28)
-            .background(
-                Capsule(style: .continuous)
-                    .fill(Color.black.opacity(0.44))
-                    .overlay(
-                        Capsule(style: .continuous)
-                            .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
-                    )
-            )
-            .shadow(color: Color.black.opacity(0.18), radius: 6, y: 2)
-            .padding(.trailing, 7)
-            .padding(.top, 7)
-            .frame(maxWidth: .infinity, alignment: .trailing)
-            .opacity(showsPreviewControls ? 1 : 0)
-            .allowsHitTesting(showsPreviewControls)
-            Spacer()
+    /// The title and the two window controls, side by side under the picture.
+    /// The controls used to float over the thumbnail in a capsule a third of
+    /// its height. The room they take here is held whether or not they are
+    /// drawn, so the title does not shift as the pointer arrives.
+    private var titleBand: some View {
+        HStack(spacing: 4) {
+            Text(window.displayTitle)
+                .font(.system(size: 12, weight: .semibold))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .foregroundStyle(.primary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            closeButton
+            minimizeButton
         }
+        .frame(width: DockPreviewSupport.cardThumbnailWidth,
+               height: DockPreviewSupport.cardTitleHeight)
     }
 
     @ViewBuilder
@@ -493,11 +485,11 @@ private struct DockPreviewCard: View {
             }
         } label: {
             Image(systemName: "xmark.circle.fill")
-                .font(.system(size: 18, weight: .medium))
+                .font(.system(size: 13, weight: .medium))
                 .symbolRenderingMode(.palette)
                 .foregroundStyle(Color.white.opacity(isCloseHovering ? 0.95 : 0.72),
                                  Color(red: 1.0, green: 0.38, blue: 0.33).opacity(isCloseHovering ? 1 : 0.92))
-                .frame(width: 24, height: 24)
+                .frame(width: 16, height: 16)
                 .contentShape(Circle())
         }
         .buttonStyle(.plain)
@@ -517,11 +509,11 @@ private struct DockPreviewCard: View {
             }
         } label: {
             Image(systemName: window.isMinimized ? "plus.circle.fill" : "minus.circle.fill")
-                .font(.system(size: 18, weight: .medium))
+                .font(.system(size: 13, weight: .medium))
                 .symbolRenderingMode(.palette)
                 .foregroundStyle(Color.white.opacity(isMinimizeHovering ? 0.95 : 0.72),
                                  Color.black.opacity(isMinimizeHovering ? 0.58 : 0.46))
-                .frame(width: 24, height: 24)
+                .frame(width: 16, height: 16)
                 .contentShape(Circle())
         }
         .buttonStyle(.plain)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -2141,17 +2141,34 @@ struct MetricsTests {
         expect(!DockPreviewSupport.canDragToPlace(hasWindowID: false, isOnScreen: false,
                                                   isMinimized: false, isFullscreen: false),
                "an entry without a window has nothing to move")
-        // The thumbnail is derived from the card, so a constant changed on its
-        // own must not silently eat into it or leave the card short.
-        expectClose(Double(DockPreviewSupport.cardThumbnailHeight
-                            + DockPreviewSupport.cardPadding * 2
-                            + DockPreviewSupport.cardTitleSpacing
-                            + DockPreviewSupport.cardTitleHeight),
-                    Double(DockPreviewSupport.cardHeight),
-                    "a Dock Preview card's chrome and thumbnail add up to the card")
-        expect(DockPreviewSupport.cardThumbnailHeight
-                > DockPreviewSupport.cardHeight * 0.7,
-               "the thumbnail keeps most of the Dock Preview card")
+        // The preview size setting sizes the thumbnail, not the writing around
+        // it. Both halves of that are checked across every size on offer: the
+        // picture tracks the setting exactly, and the chrome does not move at
+        // all — a title band that scaled with the card once left a 12pt line
+        // adrift in 31pt of nothing at the largest setting.
+        let previewScales = Defaults.allowedPreviewSizes.map { PreviewSizing.scale(for: $0) }
+        expect(previewScales.count == 4 && previewScales.contains(1.0),
+               "every preview size on offer has a scale, including the unscaled one")
+        expect(previewScales.allSatisfy { scale in
+                   let thumbnail = DockPreviewSupport.cardThumbnailSize(scale: scale)
+                   let base = DockPreviewSupport.cardThumbnailSize(scale: 1)
+                   return abs(thumbnail.width - base.width * scale) < 0.0001
+                       && abs(thumbnail.height - base.height * scale) < 0.0001
+               },
+               "a Dock Preview thumbnail is exactly the chosen preview size")
+        expect(previewScales.allSatisfy { scale in
+                   let card = DockPreviewSupport.cardSize(scale: scale)
+                   let thumbnail = DockPreviewSupport.cardThumbnailSize(scale: scale)
+                   return card.height - thumbnail.height - 13 * scale >= DockPreviewSupport.cardTitleHeight
+               },
+               "a card keeps a full title band at every preview size, never a scaled-down one")
+        expect(DockPreviewSupport.cardTitleHeight >= 16,
+               "the title band holds one line of 12pt semibold with its descenders")
+        expect(previewScales.allSatisfy {
+                   DockPreviewSupport.cardFallbackIconSize(scale: $0)
+                       < DockPreviewSupport.cardThumbnailSize(scale: $0).height
+               },
+               "the stand-in app icon stays inside the thumbnail it stands in for at every size")
 
         // The card used to draw the app icon on every thumbnail and the window
         // title both over the thumbnail and under it. In a panel every card

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -2162,8 +2162,21 @@ struct MetricsTests {
                    return card.height - thumbnail.height - 13 * scale >= DockPreviewSupport.cardTitleHeight
                },
                "a card keeps a full title band at every preview size, never a scaled-down one")
-        expect(DockPreviewSupport.cardTitleHeight >= 16,
-               "the title band holds one line of 12pt semibold with its descenders")
+        expect(DockPreviewSupport.cardTitleHeight >= 20,
+               "the title band holds one line of 12pt semibold beside two 16pt controls")
+        // The well is cut to the shape of the screen the capture came from, so
+        // a full-height window fills it instead of sitting between two bars.
+        expect(previewScales.allSatisfy { scale in
+                   let picture = DockPreviewSupport.cardPictureSize(scale: scale)
+                   return abs(picture.width / picture.height - 1.6) < 0.001
+               },
+               "the picture inside a thumbnail is 16:10 at every preview size")
+        expect(previewScales.allSatisfy { scale in
+                   let picture = DockPreviewSupport.cardPictureSize(scale: scale)
+                   let thumbnail = DockPreviewSupport.cardThumbnailSize(scale: scale)
+                   return picture.width < thumbnail.width && picture.height < thumbnail.height
+               },
+               "the picture keeps its inset inside the thumbnail well at every size")
         expect(previewScales.allSatisfy {
                    DockPreviewSupport.cardFallbackIconSize(scale: $0)
                        < DockPreviewSupport.cardThumbnailSize(scale: $0).height
@@ -2178,6 +2191,29 @@ struct MetricsTests {
             encoding: .utf8)) ?? ""
         expect(dockPreviewCardSource.components(separatedBy: "Text(window.displayTitle)").count - 1 == 1,
                "a Dock Preview card names its window once")
+        // Nothing is drawn on top of the picture any more. The close and
+        // minimize buttons sat in a 28pt capsule in its top-right corner --
+        // over a third of its height -- and the pinned badge sat beside them.
+        let dockPreviewCardCode = dockPreviewCardSource
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(!dockPreviewCardCode.contains("previewControlBar"),
+               "no control bar floats over a Dock Preview thumbnail")
+        let titleBandBody = dockPreviewCardCode
+            .components(separatedBy: "private var titleBand: some View {").last ?? ""
+        let bandDeclaration = titleBandBody.components(separatedBy: "private var").first ?? ""
+        expect(bandDeclaration.contains("closeButton") && bandDeclaration.contains("minimizeButton"),
+               "both window controls sit in the title band, beside the name")
+        expect(!DockPreviewSupport.showsCardControls(isHovering: false, isSelected: false),
+               "a card with no pointer on it and no selection draws no window controls")
+        expect(DockPreviewSupport.showsCardControls(isHovering: true, isSelected: false),
+               "the pointer summons a card's window controls")
+        let contextMenuBody = dockPreviewCardCode
+            .components(separatedBy: "private var cardContextMenu: some View {").last ?? ""
+        expect((contextMenuBody.components(separatedBy: "private var").first ?? "")
+                   .contains("dockPreviewPinPanel"),
+               "pinning is offered by name in the card menu, not by a bare pushpin")
         expect(dockPreviewCardSource.components(separatedBy: "window.appIcon").count - 1 == 1,
                "a Dock Preview card only falls back to the app icon when it has no thumbnail")
         expect(dockPreviewCardSource.contains("window.isOnHiddenSpace"),
@@ -6688,14 +6724,29 @@ struct MetricsTests {
         expect(DockPreviewSupport.dockProximityBand(tileSize: 200)
                > DockPreviewSupport.dockProximityBand(tileSize: 64),
                "Dock proximity band grows with the Dock tile size")
-        let onePreviewSize = DockPreviewSupport.panelSize(itemCount: 1, screenVisibleFrame: screen)
-        let twoPreviewSize = DockPreviewSupport.panelSize(itemCount: 2, screenVisibleFrame: screen)
+        let onePreviewSize = DockPreviewSupport.panelSize(itemCount: 1, screenVisibleFrame: screen,
+                                                          isPinned: false)
+        let twoPreviewSize = DockPreviewSupport.panelSize(itemCount: 2, screenVisibleFrame: screen,
+                                                          isPinned: false)
         expect(twoPreviewSize.width > onePreviewSize.width,
                "Dock Preview panel size shrinks when a card is removed")
+        // The header carries the window counter and the steppers that move
+        // between windows, so one window leaves it with nothing to say. It used
+        // to name the app instead, back at a pointer resting on that app's Dock
+        // icon. A pinned panel keeps it: there it is the drag handle, and the
+        // only way to unpin or close.
+        expect(!DockPreviewSupport.showsPanelHeader(itemCount: 1, isPinned: false),
+               "a hovered panel showing one window draws no header")
+        expect(DockPreviewSupport.showsPanelHeader(itemCount: 2, isPinned: false),
+               "a second window gives the header a counter and steppers to hold")
+        expect(DockPreviewSupport.showsPanelHeader(itemCount: 1, isPinned: true),
+               "a pinned panel keeps its header at any window count")
         expect(onePreviewSize.height == DockPreviewSupport.cardHeight
-               + DockPreviewSupport.panelPadding * 2
-               + DockPreviewSupport.panelHeaderHeight,
-               "Dock Preview panel reserves room for the pinned header")
+               + DockPreviewSupport.panelPadding * 2,
+               "a headerless panel is the card and the padding, nothing more")
+        expect(DockPreviewSupport.panelSize(itemCount: 1, screenVisibleFrame: screen, isPinned: true).height
+               == onePreviewSize.height + DockPreviewSupport.panelHeaderHeight,
+               "the header is the whole difference a pinned panel makes to the height")
         expect(DockPreviewSupport.windowPositionText(selectedWindowID: nil, windowIDs: [11]) == nil,
                "Dock Preview hides the window counter for a single window")
         expect(DockPreviewSupport.windowPositionText(selectedWindowID: nil, windowIDs: [11, 22, 33]) == "3",

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -2191,6 +2191,48 @@ struct MetricsTests {
                && DockPreviewSupport.sanitizedBackgroundOpacity(.nan) == 1.0
                && DockPreviewSupport.sanitizedBackgroundOpacity(.infinity) == 1.0,
                "a broken stored Dock Preview opacity falls back to solid")
+        expect(registeredDefaults[DefaultsKey.dockPreviewOpenDelay] as? Int
+               == DockPreviewSupport.defaultOpenDelayMilliseconds,
+               "a clean install waits the default before opening a Dock Preview")
+        expect(DockPreviewSupport.openDelayMillisecondsRange
+               .contains(DockPreviewSupport.defaultOpenDelayMilliseconds),
+               "the default Dock Preview delay is one the field accepts")
+        expect(DockPreviewSupport.sanitizedOpenDelay(milliseconds: 350) == 350,
+               "a typed Dock Preview delay inside the range is kept")
+        expect(DockPreviewSupport.sanitizedOpenDelay(milliseconds: -1)
+               == DockPreviewSupport.openDelayMillisecondsRange.lowerBound
+               && DockPreviewSupport.sanitizedOpenDelay(milliseconds: 9_000)
+               == DockPreviewSupport.openDelayMillisecondsRange.upperBound,
+               "a Dock Preview delay outside the range is clamped to it")
+        expect(DockPreviewSupport.sanitizedOpenDelay(milliseconds: 0)
+               >= DockPreviewSupport.openDelayMillisecondsRange.lowerBound,
+               "an unset or zeroed Dock Preview delay cannot disarm the wait entirely")
+        expectClose(DockPreviewSupport.openDelay(milliseconds: 250), 0.25,
+                    "the stored milliseconds drive the timer in seconds")
+        let openDelays = DockPreviewSupport.openDelayMillisecondsRange
+            .map { DockPreviewSupport.openDelay(milliseconds: $0) }
+        expect(openDelays.allSatisfy { DockPreviewSupport.switchDelay <= $0 },
+               "no chosen delay makes switching slower than opening")
+        expect(openDelays.allSatisfy { DockPreviewSupport.prefetchDelay(openDelay: $0) <= $0 },
+               "the window list is never read after the panel it is read for has opened")
+        expect(openDelays.allSatisfy {
+                   $0 - DockPreviewSupport.prefetchDelay(openDelay: $0)
+                       <= DockPreviewSupport.prefetchLead + 0.0001
+               },
+               "the window list is never read further ahead than the lead, so what opens is still true")
+        expectClose(DockPreviewSupport.prefetchDelay(
+                        openDelay: DockPreviewSupport.openDelay(
+                            milliseconds: DockPreviewSupport.defaultOpenDelayMilliseconds)),
+                    0.1,
+                    "at the default the window list is read halfway through the wait")
+        expect(openDelays.allSatisfy {
+                   DockPreviewSupport.prefetchDelay(openDelay: $0) >= DockPreviewSupport.prefetchLead
+               },
+               "no setting reads the window list before the cursor has held still")
+        expect(DockPreviewSupport.switchDelay + 0.06
+               < DockPreviewSupport.openDelay(
+                   milliseconds: DockPreviewSupport.openDelayMillisecondsRange.lowerBound),
+               "a switch, reading its window list inline, still lands before the shortest fresh open")
         expect(registeredDefaults[DefaultsKey.autoCheckUpdates] as? Bool == true,
                "update checks are on for clean installs")
         expect(registeredDefaults[DefaultsKey.updateShowcaseIntroVersion] as? String == "",
@@ -8672,6 +8714,12 @@ struct MetricsTests {
             expect(!strings.dockPreviewBackgroundOpacityCaption.isEmpty
                    && !strings.dockPreviewBackgroundOpacityCaption.contains("—"),
                    "\(prefix) Dock Preview background caption is present without em dash")
+            expect(!strings.dockPreviewOpenDelay.isEmpty
+                   && !strings.dockPreviewOpenDelay.contains("—"),
+                   "\(prefix) Dock Preview open delay title is present without em dash")
+            expect(!strings.dockPreviewOpenDelayCaption.isEmpty
+                   && !strings.dockPreviewOpenDelayCaption.contains("—"),
+                   "\(prefix) Dock Preview open delay caption is present without em dash")
             expect(!strings.switcherShortcutHintApps.isEmpty, "\(prefix) App Switcher app shortcut hint is present")
             expect(!strings.switcherShortcutHintWindows.isEmpty, "\(prefix) App Switcher window shortcut hint is present")
             expect(!strings.networkApps.isEmpty, "\(prefix) network app usage title is present")


### PR DESCRIPTION
**Depends on #745**, which itself sits on #744. Only the last commit here is new.

Tested against the shipped `v3.3.3-beta.1` build: hovering a Dock icon with one
window open gives a panel 200x186, of which the picture of the window is
141x88 — a third of it. The rest is a header naming the app whose Dock icon the
pointer is resting on, a title band, and a control capsule sitting on top of the
one thing the panel exists to show.

Measured against DockDoor 1.39.5 at its defaults, whose card *is* the picture at
300x187.5 and carries its title and window buttons as overlays: our picture is a
fifth of the area of theirs. #720 moved in the wrong direction here — it raised
the thumbnail from 64% to 78% of the card by shrinking the card from 204x152 to
176x134, so the picture came out 2% smaller than before.

## What changed

**The thumbnail is cut to 16:10 and grows to 248x158.** That is the shape of the
screen the capture came from, so a full-height window fills the well instead of
sitting between two bars. The picture inside goes 141x88 -> 240x150, near three
times the area. The card follows at 264x199, and a 1440pt-wide screen shows four
cards instead of six.

**The close and minimize buttons move into the title band.** They used to float
over the thumbnail in a capsule 28pt tall and 62pt wide — a third of the
picture's height, in its top-right corner. The band grows 17pt -> 20pt to hold
them beside the title, and their room is reserved whether or not they are drawn,
so the title does not shift as the pointer arrives. Nothing is drawn over the
picture now except the status badges along its bottom edge.

**A panel showing one window drops its header.** The header carries the window
counter and the steppers between windows, so one window leaves it with nothing to
say — it named the app instead, back at a pointer resting on that app's Dock
icon. A pinned panel keeps the header at any count: there it is also the window's
drag handle and the only way to unpin or close.

**Pinning becomes a named menu item.** It was a bare pushpin in that header,
beside a close button that a hovered panel does not need — moving off the panel
already dismisses it. Both now belong to the pinned panel alone, and the card's
context menu offers Pin panel / Unpin panel in words. DockDoor reaches its own
pinning the same way, from a context menu.

**A pinned panel no longer counts as permanent hover.** It held both window
controls open on every card it showed, along with a Pinned badge beside them, for
as long as it stayed up. The pointer summons the controls now, on a pinned panel
as on a hovered one, and the badge is gone — the header already says the panel is
pinned.

## Not changed

Preview sizing still scales off `PreviewSizing.scale`, and the picture's inset
now scales with the well so 16:10 survives all four sizes. Hover, tap, context
menu, drag-to-place, the status badges and the spoken label behave as before. The
App Switcher's own card is untouched. No new strings, so nothing to translate in
the 13 language files.

## Alternatives considered

**Let the card be the picture and put the title over it, as DockDoor does.** That
is denser still — the band and its 25pt would go — and it is the option #720
rejected on purpose. A title over the picture either covers content or needs a
scrim that does; a title in its own band is how a user picks one of six windows
without sweeping the pointer across all of them.

**Keep the header and only trim its contents.** The single-window case would
still pay 28pt for an empty row.

## Tests

`TESTS OK (8068 checks)`, `./build.sh`, `SELFTEST OK`. The new checks cover the
header rule, the control rule, the 16:10 picture at every preview size, and two
source-shape guards on the card; both guards were verified red by putting the
control capsule back over the thumbnail.
