### PR TITLE
Show real video-frame thumbnails on the shelf

### DIFF
--- a/Sources/Vorssaint/Services/ImageThumbnailer.swift
+++ b/Sources/Vorssaint/Services/ImageThumbnailer.swift
@@ -8,10 +8,25 @@ enum ImageThumbnailer {
     static let defaultPointSize: CGFloat = 20
 
     static func thumbnail(for url: URL, pointSize: CGFloat = defaultPointSize) -> NSImage? {
+        thumbnail(for: url, pointSize: pointSize, scale: backingScale)
+    }
+
+    /// The same decode, off the main thread. Decoding is synchronous work
+    /// that scales with the source file, so a caller with many files to get
+    /// through (the shelf restoring a saved list) would otherwise hold the
+    /// main thread for the sum of all of them. NSScreen is main-thread-only,
+    /// so the scale is read there and the decode runs off the main actor,
+    /// the same split VideoThumbnailer uses.
+    static func thumbnail(for url: URL, pointSize: CGFloat = defaultPointSize) async -> NSImage? {
+        let scale = await MainActor.run { backingScale }
+        return thumbnail(for: url, pointSize: pointSize, scale: scale)
+    }
+
+    private static func thumbnail(for url: URL, pointSize: CGFloat, scale: CGFloat) -> NSImage? {
         let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
         guard let source = CGImageSourceCreateWithURL(url as CFURL, sourceOptions) else { return nil }
 
-        let maxPixelSize = pixelSize(for: pointSize)
+        let maxPixelSize = pixelSize(for: pointSize, scale: scale)
         let options = [
             kCGImageSourceCreateThumbnailFromImageAlways: true,
             kCGImageSourceCreateThumbnailWithTransform: true,
@@ -20,7 +35,6 @@ enum ImageThumbnailer {
         ] as CFDictionary
 
         guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options) else { return nil }
-        let scale = backingScale
         let size = NSSize(width: CGFloat(cgImage.width) / scale,
                           height: CGFloat(cgImage.height) / scale)
         return NSImage(cgImage: cgImage, size: size)
@@ -74,11 +88,11 @@ enum ImageThumbnailer {
         return pixels * pixels * 4
     }
 
-    private static var backingScale: CGFloat {
+    static var backingScale: CGFloat {
         max(1, NSScreen.main?.backingScaleFactor ?? 2)
     }
 
-    private static func pixelSize(for pointSize: CGFloat) -> Int {
-        max(16, Int((pointSize * backingScale).rounded(.up)))
+    private static func pixelSize(for pointSize: CGFloat, scale: CGFloat = backingScale) -> Int {
+        max(16, Int((pointSize * scale).rounded(.up)))
     }
 }

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -31,17 +31,24 @@ final class ShelfService: ObservableObject {
         let title: String
         let icon: NSImage
         let isImage: Bool
+        /// True once `icon` is a real decoded frame of the item's own
+        /// content (an image thumbnail or a patched-in video frame), as
+        /// opposed to a generic fallback icon. Purely a tile-sizing signal
+        /// for ShelfTilesView: unlike `isImage`, it does not gate any
+        /// decoding or kind-classification behavior.
+        let hasContentThumbnail: Bool
         /// Finds a file payload again after a move or rename; nil for
         /// non-file payloads and for files whose bookmark could not be made.
         let bookmark: Data?
 
         init(id: UUID = UUID(), payload: Payload, title: String, icon: NSImage,
-             isImage: Bool, bookmark: Data? = nil) {
+             isImage: Bool, hasContentThumbnail: Bool = false, bookmark: Data? = nil) {
             self.id = id
             self.payload = payload
             self.title = title
             self.icon = icon
             self.isImage = isImage
+            self.hasContentThumbnail = hasContentThumbnail
             self.bookmark = bookmark
         }
 
@@ -53,7 +60,9 @@ final class ShelfService: ObservableObject {
         /// healed URL/title after a moved or renamed file's bookmark
         /// resolves - an id-only comparison would call that unchanged.
         func hasSameContent(as other: Item) -> Bool {
-            guard id == other.id, title == other.title, isImage == other.isImage else { return false }
+            guard id == other.id, title == other.title, isImage == other.isImage,
+                  hasContentThumbnail == other.hasContentThumbnail,
+                  icon === other.icon else { return false }
             switch (payload, other.payload) {
             case let (.file(lhs), .file(rhs)): return lhs == rhs
             case let (.text(lhs), .text(rhs)): return lhs == rhs
@@ -96,6 +105,7 @@ final class ShelfService: ObservableObject {
 
     @Published private(set) var items: [Item] = [] {
         didSet {
+            contentRevision &+= 1
             scheduleRefit()
             schedulePersist()
             // Emptying the shelf (removing or dragging out the last item) always
@@ -115,6 +125,14 @@ final class ShelfService: ObservableObject {
     /// into view. Not persisted: it means "just now", and a relaunch has no
     /// just now.
     @Published private var lastAddedID: UUID?
+    /// Counts every mutation of `items`, including one that swaps an item for
+    /// a same-id replacement. `Item.==` is id-only by design, so a SwiftUI
+    /// view taking `[Item]` alone compares equal after such a swap and its
+    /// `updateNSView` is never called: an async-patched video thumbnail would
+    /// sit in `items` and never reach the screen. Feeding this to the tiles
+    /// gives them a value that always differs, so the redraw is decided by
+    /// `rebuildTiles`' own content check rather than by id equality.
+    @Published private(set) var contentRevision = 0
     /// Counts adds so the tiles can tell a genuine arrival from a redraw.
     /// The resolved reveal target is not enough on its own: it changes when a
     /// pile is expanded, and it repeats when two files land in the same pile.
@@ -1196,6 +1214,7 @@ final class ShelfService: ObservableObject {
         return Item(id: item.id, payload: .file(resolved),
                     title: resolved.lastPathComponent,
                     icon: item.icon, isImage: item.isImage,
+                    hasContentThumbnail: item.hasContentThumbnail,
                     bookmark: (try? resolved.bookmarkData()) ?? bookmark)
     }
 
@@ -1211,10 +1230,16 @@ final class ShelfService: ObservableObject {
                 if case let .batch(children) = items[index].payload {
                     var mutable = children
                     if replace(in: &mutable) {
+                        // Mirrors batchItem's own icon derivation (first
+                        // child's icon) so a pile whose first child just
+                        // patched in a video thumbnail shows it too, instead
+                        // of keeping the icon from when the batch was built.
+                        // Title is intentionally left untouched here.
                         items[index] = Item(id: items[index].id, payload: .batch(mutable),
                                             title: items[index].title,
-                                            icon: items[index].icon,
-                                            isImage: items[index].isImage)
+                                            icon: mutable.first?.icon ?? symbol("doc.on.doc"),
+                                            isImage: items[index].isImage,
+                                            hasContentThumbnail: mutable.first?.hasContentThumbnail ?? false)
                         return true
                     }
                 }
@@ -1367,42 +1392,110 @@ final class ShelfService: ObservableObject {
         }
     }
 
+    /// `ImageThumbnailer.defaultPointSize` (20pt) is sized for a small
+    /// generic icon elsewhere in the app; a shelf tile's own content-
+    /// thumbnail well is bigger (64x50pt, see ShelfTilesView's iconWell),
+    /// so a real image or video frame decoded at the smaller default looks
+    /// visibly soft once stretched to fill it. Matches the well's own
+    /// declared width for a bit of headroom over its 56pt inset content area.
+    private static let contentThumbnailPointSize: CGFloat = 64
+
     private func addFileBatch(_ urls: [URL]) -> Bool {
         let children = urls.map { fileItem(for: $0) }
         return append(batchItem(children: children))
     }
 
+    private enum ContentThumbnailKind {
+        case image
+        case video
+    }
+
+    /// `deferImageThumbnail` moves an image's decode off the main thread, at
+    /// the cost of the tile wearing its fallback icon for a moment. A single
+    /// interactive drop keeps the inline decode, which is one file's worth of
+    /// work and shows the real thumbnail immediately; restore, which can
+    /// rebuild a whole saved shelf at once, defers instead of holding launch
+    /// for the sum of every image on it.
     private func fileItem(for url: URL, id: UUID = UUID(), title: String? = nil,
-                          bookmark: Data? = nil) -> Item {
+                          bookmark: Data? = nil, deferImageThumbnail: Bool = false) -> Item {
         let imageExtensions: Set<String> = ["png", "jpg", "jpeg", "gif", "heic", "heif", "tiff", "bmp", "webp"]
+        let videoExtensions: Set<String> = ["mp4", "mov", "m4v", "avi", "mkv", "webm", "wmv", "mpg", "mpeg", "3gp"]
         let isImage = imageExtensions.contains(url.pathExtension.lowercased())
+        let isVideo = videoExtensions.contains(url.pathExtension.lowercased())
         let fallbackIcon = NSWorkspace.shared.icon(forFile: url.path)
-        let icon = (isImage ? ImageThumbnailer.thumbnail(for: url) : nil)
+        let inlineThumbnail = isImage && !deferImageThumbnail
+            ? ImageThumbnailer.thumbnail(for: url, pointSize: Self.contentThumbnailPointSize)
+            : nil
+        let icon = inlineThumbnail
             ?? ImageThumbnailer.thumbnail(for: fallbackIcon)
             ?? fallbackIcon
         // Made once when the item is shelved (or upgrading a legacy entry),
         // so a later move or rename of the file cannot orphan the tile.
-        return Item(id: id, payload: .file(url), title: title ?? url.lastPathComponent,
-                    icon: icon, isImage: isImage,
-                    bookmark: bookmark ?? (try? url.bookmarkData()))
+        // The flag tracks the icon actually in hand, so an unreadable image
+        // (or one still decoding) is not sized as though it had a thumbnail.
+        let item = Item(id: id, payload: .file(url), title: title ?? url.lastPathComponent,
+                        icon: icon, isImage: isImage, hasContentThumbnail: inlineThumbnail != nil,
+                        bookmark: bookmark ?? (try? url.bookmarkData()))
+        if isImage, deferImageThumbnail {
+            patchContentThumbnail(for: url, id: id, kind: .image)
+        } else if isVideo {
+            patchContentThumbnail(for: url, id: id, kind: .video)
+        }
+        return item
+    }
+
+    /// Decodes a real thumbnail off the main thread and swaps it in when it
+    /// lands. The item is already shelved wearing its fallback icon, so
+    /// nothing waits on the decode.
+    private func patchContentThumbnail(for url: URL, id: UUID, kind: ContentThumbnailKind) {
+        Task { @MainActor [weak self] in
+            let size = Self.contentThumbnailPointSize
+            let decoded: NSImage?
+            switch kind {
+            case .image: decoded = await ImageThumbnailer.thumbnail(for: url, pointSize: size)
+            case .video: decoded = await VideoThumbnailer.thumbnail(for: url, pointSize: size)
+            }
+            guard let decoded, let self else { return }
+            func patch(_ current: Item) {
+                self.replaceItem(Item(id: current.id, payload: current.payload,
+                                      title: current.title, icon: decoded,
+                                      isImage: current.isImage, hasContentThumbnail: true,
+                                      bookmark: current.bookmark))
+            }
+            if let current = self.item(withID: id) {
+                patch(current)
+                return
+            }
+            // In a mixed-provider batch (see acceptMixedBatch), a slower
+            // sibling provider can delay this item's append past the point
+            // where the decode already finished. Give the batch one run-loop
+            // turn to catch up before giving up on the thumbnail, rather
+            // than silently discarding it.
+            try? await Task.sleep(for: .milliseconds(50))
+            guard let current = self.item(withID: id) else { return }
+            patch(current)
+        }
     }
 
     private func imageItem(for image: NSImage) -> Item? {
-        let icon = ImageThumbnailer.thumbnail(for: image) ?? symbol("photo")
+        let icon = ImageThumbnailer.thumbnail(for: image, pointSize: Self.contentThumbnailPointSize)
+            ?? symbol("photo")
         if let png = autoreleasepool(invoking: { () -> Data? in
             guard let tiff = image.tiffRepresentation,
                   let rep = NSBitmapImageRep(data: tiff) else { return nil }
             return rep.representation(using: .png, properties: [:])
         }), let url = storePayloadData(png, fileExtension: "png") {
-            return Item(payload: .file(url), title: L10n.shared.s.shelfItemImage, icon: icon, isImage: true)
+            return Item(payload: .file(url), title: L10n.shared.s.shelfItemImage, icon: icon,
+                       isImage: true, hasContentThumbnail: true)
         }
         return nil
     }
 
     private func gifItem(for data: Data) -> Item? {
         guard let url = storePayloadData(data, fileExtension: "gif") else { return nil }
-        let icon = ImageThumbnailer.thumbnail(for: url) ?? symbol("photo")
-        return Item(payload: .file(url), title: "GIF", icon: icon, isImage: true)
+        let icon = ImageThumbnailer.thumbnail(for: url, pointSize: Self.contentThumbnailPointSize)
+            ?? symbol("photo")
+        return Item(payload: .file(url), title: "GIF", icon: icon, isImage: true, hasContentThumbnail: true)
     }
 
     /// Writes a pasted payload where it can outlive this run; only if the
@@ -1463,7 +1556,12 @@ final class ShelfService: ObservableObject {
         let total = children.reduce(0) { $0 + $1.leafCount }
         let title = children.first.map { "\($0.title) +\(max(0, total - 1))" } ?? ""
         let icon = children.first?.icon ?? symbol("doc.on.doc")
-        return Item(id: id, payload: .batch(children), title: title, icon: icon, isImage: false)
+        // The pile wears its first child's icon, so it has to inherit that
+        // child's thumbnail flag too: the flag drives the tile's image inset,
+        // and a real thumbnail shown at the generic-icon inset is visibly
+        // undersized.
+        return Item(id: id, payload: .batch(children), title: title, icon: icon, isImage: false,
+                    hasContentThumbnail: children.first?.hasContentThumbnail ?? false)
     }
 
     private func items(from pasteboard: NSPasteboard) -> [Item] {
@@ -1908,7 +2006,8 @@ final class ShelfService: ObservableObject {
             guard let path = persisted.path else { return nil }
             return fileItem(for: URL(fileURLWithPath: path), id: persisted.id,
                             title: persisted.title.isEmpty ? nil : persisted.title,
-                            bookmark: persisted.bookmark)
+                            bookmark: persisted.bookmark,
+                            deferImageThumbnail: true)
         case .text:
             guard let text = persisted.text else { return nil }
             let firstLine = text.split(whereSeparator: \.isNewline).first.map(String.init) ?? text

--- a/Sources/Vorssaint/Services/VideoThumbnailer.swift
+++ b/Sources/Vorssaint/Services/VideoThumbnailer.swift
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AVFoundation
+import AppKit
+
+enum VideoThumbnailer {
+    /// A real decoded frame from a video file, sized and scaled the same way
+    /// ImageThumbnailer sizes image frames. Grabs a frame slightly into the
+    /// video rather than at time zero: an arbitrary user video's raw first
+    /// frame is often black or a title card, unlike this app's own screen
+    /// recordings (see RecentCaptureService, which uses .zero because it
+    /// controls what's at the start of the file).
+    static func thumbnail(for url: URL, pointSize: CGFloat = ImageThumbnailer.defaultPointSize) async -> NSImage? {
+        let asset = AVURLAsset(url: url)
+        guard let duration = try? await asset.load(.duration),
+              duration.isValid, duration.seconds > 0 else {
+            return await frame(from: asset, at: .zero, pointSize: pointSize)
+        }
+        let offsetSeconds = min(1.0, duration.seconds * 0.1)
+        let time = CMTime(seconds: offsetSeconds, preferredTimescale: 600)
+        return await frame(from: asset, at: time, pointSize: pointSize)
+    }
+
+    private static func frame(from asset: AVURLAsset, at time: CMTime, pointSize: CGFloat) async -> NSImage? {
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        // NSScreen is AppKit UI API and must only be read on the main thread;
+        // this function runs off the main actor when awaited from a
+        // nonisolated context, so the read is hopped back explicitly rather
+        // than done inline here.
+        let scale = await MainActor.run { ImageThumbnailer.backingScale }
+        let maxPixels = pointSize * scale
+        generator.maximumSize = CGSize(width: maxPixels, height: maxPixels)
+        // Both default to infinite, which lets the generator snap to the
+        // nearest keyframe instead of `time`, often back to frame zero for a
+        // typical keyframe interval; zero tolerance is what makes the offset
+        // above actually avoid a black or title-card first frame.
+        generator.requestedTimeToleranceBefore = .zero
+        generator.requestedTimeToleranceAfter = .zero
+        guard let cgImage = try? await generator.image(at: time).image else { return nil }
+        let size = NSSize(width: CGFloat(cgImage.width) / scale, height: CGFloat(cgImage.height) / scale)
+        return NSImage(cgImage: cgImage, size: size)
+    }
+}

--- a/Sources/Vorssaint/UI/Shelf/ShelfTilesView.swift
+++ b/Sources/Vorssaint/UI/Shelf/ShelfTilesView.swift
@@ -88,6 +88,9 @@ class ShelfPanelMoveView: NSView {
 /// shelf once the drop is accepted somewhere.
 struct ShelfTilesView: NSViewRepresentable {
     var items: [ShelfService.Item]
+    /// Only here to make this view compare unequal after an in-place item
+    /// swap; see ShelfService.contentRevision. Never read.
+    var contentRevision: Int
     var selection: Set<UUID>
     var expandedBatches: Set<UUID>
     var revealID: UUID?
@@ -317,8 +320,9 @@ final class ShelfTileView: NSView, NSDraggingSource {
         iconWell.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.06).cgColor
         addSubview(iconWell)
 
-        let imageView = NSImageView(frame: iconWell.bounds.insetBy(dx: item.isImage ? 4 : 13,
-                                                                   dy: item.isImage ? 4 : 8))
+        let hasThumbnail = item.isImage || item.hasContentThumbnail
+        let imageView = NSImageView(frame: iconWell.bounds.insetBy(dx: hasThumbnail ? 4 : 13,
+                                                                   dy: hasThumbnail ? 4 : 8))
         imageView.image = item.icon
         imageView.imageScaling = .scaleProportionallyUpOrDown
         imageView.autoresizingMask = [.width, .height]

--- a/Sources/Vorssaint/UI/Shelf/ShelfView.swift
+++ b/Sources/Vorssaint/UI/Shelf/ShelfView.swift
@@ -214,6 +214,7 @@ struct ShelfView: View {
             emptyState
         } else {
             ShelfTilesView(items: shelf.visibleItems,
+                           contentRevision: shelf.contentRevision,
                            selection: shelf.selection,
                            expandedBatches: shelf.expandedBatches,
                            revealID: shelf.revealTargetID,


### PR DESCRIPTION
## Summary

- video files dropped onto the shelf now show a real decoded video frame instead of macOS's generic file-type icon, matching Finder/QuickLook
- generation is async via `AVAssetImageGenerator`, grabbing a frame slightly into the video rather than at time zero, so an arbitrary video's black/title-card first frame is never what shows
- the shelf item is shelved immediately with today's fallback icon; the real frame patches in once ready through the shelf's existing "build now, patch in later" mechanism (`replaceItem`, already used to heal moved/renamed files)
- `ShelfService.Item` compares by id alone, so a same-id icon swap leaves a SwiftUI view taking `[Item]` comparing equal and its `updateNSView` is never called. The tiles now also take a revision counter that changes on every `items` mutation, which lets the content check `rebuildTiles` already does decide the redraw
- every shelf content thumbnail now decodes at one size sized for the tile's own well, so a dropped image, a dropped video frame, a pasted image and a pasted GIF are all equally sharp. They previously decoded at the 20pt small-icon default and were upscaled into a 112x84px area
- app-launch restore decodes image thumbnails off the main thread rather than inline, so rebuilding a saved shelf no longer holds launch for the sum of every image on it. An interactive drop keeps the inline decode, where it is one file's work and shows the thumbnail immediately

## Behavior before

A video file on the shelf showed the OS's generic file-type icon, resized, with no indication of its actual content.

## Behavior after

A video file shows a real decoded frame from partway into the clip. A corrupt or unsupported video keeps the generic icon with no crash. A batch drop of several videos, including inside a collapsed pile, updates independently as each finishes.

## Testing

- `swift build`: passed, no errors
- `./build.sh --test`: `TESTS OK (8498 checks)`
- `./build.sh`: passed without warnings
- `./build/Vorssaint --selftest`: `SELFTEST OK`
- `./build.sh --dev --install` plus manual testing in the running app: individual videos each patching in their own frame; a batch forming a collapsed pile whose first item is a video, where the pile tile picks up that frame at the content-thumbnail inset; a pasted image and a pasted GIF; and relaunching with videos and images already shelved so they come back through the restore path.

Thumbnail sizing was checked against the tile rather than by eye. The shelf's content well is 56x42pt, so 112x84px at 2x; the old 20pt default decoded to 40x30px and was upscaled into it, the tile size decodes to 128x96px.

Decode cost was measured before deciding not to bound the fan-out: 200 concurrent 1080p exact-frame extractions finish in 2.8s off the main thread with a 65MB peak footprint, and 200 image thumbnails in 147ms with no cooperative-pool starvation.

Checked on Apple Silicon, a single Retina display and English, against a `--dev --install` build rather than a release one. Not tried on Intel, on a non-Retina or multi-display setup, or in another app language.
