### PR TITLE
chore(tests): sweep the preference files a run leaves behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ Vorssaint 3.3.3-beta.1 introduces the opt-in beta release channel and in-app fee
   already in front. Thanks to @PathGao.
 - The recording editor now trims reliably from the beginning of a video when
   dragging the left handle. Thanks to @lmilojevicc.
+
+- A test run no longer leaves a preference file behind in `~/Library/Preferences`
+  for every defaults suite it uses.
 - Screen recorder, Copy text from screen and Color picker can each take a shortcut
   of their own again, opening screen capture already on that mode. Their Settings
   rows no longer record a combination that does nothing. Thanks to @wiidede and

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -6674,8 +6674,8 @@ struct MetricsTests {
         expect(Defaults.registeredDefaults[DefaultsKey.includeBetaUpdates] as? Bool == false,
                "includeBetaUpdates defaults to false in registeredDefaults")
 
-        let testDefaults = UserDefaults(suiteName: "VorssaintTests.BetaActivation")!
-        testDefaults.removePersistentDomain(forName: "VorssaintTests.BetaActivation")
+        let testDefaults = UserDefaults(suiteName: "com.vorssaint.tests.betaActivation")!
+        testDefaults.removePersistentDomain(forName: "com.vorssaint.tests.betaActivation")
         Defaults.activateBetaChannelIfRunningBeta(in: testDefaults, version: "3.3.3-beta.1")
         expect(testDefaults.bool(forKey: DefaultsKey.includeBetaUpdates) == true,
                "beta channel is activated automatically on a beta build")
@@ -6685,13 +6685,13 @@ struct MetricsTests {
                "manual opt-out on a beta build is preserved across launches")
 
         // Stable version does not activate beta channel
-        let stableDefaults = UserDefaults(suiteName: "VorssaintTests.StableActivation")!
-        stableDefaults.removePersistentDomain(forName: "VorssaintTests.StableActivation")
+        let stableDefaults = UserDefaults(suiteName: "com.vorssaint.tests.stableActivation")!
+        stableDefaults.removePersistentDomain(forName: "com.vorssaint.tests.stableActivation")
         Defaults.activateBetaChannelIfRunningBeta(in: stableDefaults, version: "3.3.3")
         expect(stableDefaults.object(forKey: DefaultsKey.includeBetaUpdates) == nil,
                "stable release does not touch beta channel default")
-        stableDefaults.removePersistentDomain(forName: "VorssaintTests.StableActivation")
-        testDefaults.removePersistentDomain(forName: "VorssaintTests.BetaActivation")
+        stableDefaults.removePersistentDomain(forName: "com.vorssaint.tests.stableActivation")
+        testDefaults.removePersistentDomain(forName: "com.vorssaint.tests.betaActivation")
 
         // Localization completeness & formatting
         for language in AppLanguage.allCases {
@@ -16089,6 +16089,43 @@ struct MetricsTests {
         try? FileManager.default.removeItem(at: privateRoot)
 
         // MARK: Result
+
+        // MARK: Every defaults suite stays inside a namespace build.sh sweeps
+        // A UserDefaults suite leaves an empty plist in ~/Library/Preferences
+        // even after `removePersistentDomain`, and cfprefsd writes that file
+        // back out around the time this process exits, so the run cannot delete
+        // it itself. `build.sh --test` clears them afterwards, by name prefix.
+        // A suite named outside those prefixes survives every run instead.
+        let testSource = (try? String(contentsOfFile: "Tests/MetricsTests.swift",
+                                      encoding: .utf8)) ?? ""
+        expect(!testSource.isEmpty, "the test file reads back for its own source checks")
+        // The prefixes are read out of the sweep itself, so the check and the
+        // thing it guards cannot drift apart.
+        let buildScript = (try? String(contentsOfFile: "build.sh", encoding: .utf8)) ?? ""
+        let sweepBody = buildScript.components(separatedBy: "discard_test_preferences() {")
+            .dropFirst().first?.components(separatedBy: "\n}").first ?? ""
+        let sweptNamespaces = sweepBody.components(separatedBy: "\"")
+            .enumerated().filter { $0.offset % 2 == 1 }.map(\.element)
+            .filter { $0.hasSuffix(".") }
+        expect(!sweptNamespaces.isEmpty, "the swept namespaces read back out of build.sh")
+        // Split so this needle is not itself a match in the text it scans.
+        let suiteCall = "UserDefaults(suiteName" + ": "
+        let suiteArguments = testSource.components(separatedBy: suiteCall)
+            .dropFirst()
+            .map { String($0.prefix { $0 != ")" && $0 != "," && !$0.isNewline }) }
+        expect(!suiteArguments.isEmpty, "the namespace check finds the suites it guards")
+        for argument in Set(suiteArguments) {
+            let name: String?
+            if argument.hasPrefix("\"") {
+                name = String(argument.dropFirst().prefix { $0 != "\"" })
+            } else {
+                name = testSource.components(separatedBy: "let \(argument) = \"")
+                    .dropFirst().first
+                    .map { String($0.prefix { $0 != "\"" }) }
+            }
+            expect(name.map { value in sweptNamespaces.contains { value.hasPrefix($0) } } == true,
+                   "defaults suite \(argument) is named inside a namespace build.sh sweeps")
+        }
 
         if failures.isEmpty {
             print("TESTS OK (\(checks) checks)")

--- a/build.sh
+++ b/build.sh
@@ -141,6 +141,31 @@ if [[ "$SDK" == "$PINNED_SDK" ]]; then
     SDK_COMPAT_FLAGS=(-Xfrontend -interface-compiler-version -Xfrontend 6.3.2)
 fi
 
+# The defaults migrations under test need a real UserDefaults suite, and every
+# suite leaves an empty plist in ~/Library/Preferences. The tests already clear
+# the domains, but cfprefsd writes the emptied file back out around the time the
+# process that owned it exits, so only a caller that outlives the run can remove
+# them. `MetricsTests` keeps every suite name inside these two namespaces (a
+# check in the test file holds it to that), which is what makes this sweep
+# complete rather than a list to keep in step by hand.
+discard_test_preferences() {
+    local preferences="$HOME/Library/Preferences" name
+    for name in "vorss.tests." "com.vorssaint.tests."; do
+        find "$preferences" -maxdepth 1 -name "$name*.plist" -delete 2>/dev/null || true
+    done
+    # The harness has no bundle identifier, so `UserDefaults.standard` writes
+    # a file named after the executable.
+    rm -f "$preferences/metrics-tests.plist"
+    local survivors
+    survivors=$(find "$preferences" -maxdepth 1 \
+        \( -name "vorss.tests.*.plist" -o -name "com.vorssaint.tests.*.plist" \
+           -o -name "metrics-tests.plist" \) 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$survivors" != "0" ]]; then
+        echo "✗ the test run left $survivors preference file(s) in $preferences" >&2
+        return 1
+    fi
+}
+
 # --test: compile and run the standalone unit tests (pure helpers only: metrics,
 # Homebrew parsing, defaults, localization contracts; no app, no UI, no IOKit),
 # then exit. Fast and deterministic; no XCTest needed.
@@ -299,8 +324,11 @@ if (( TEST )); then
         Sources/Vorssaint/Services/ManagedDownloads/WhatsAppDownloadSupport.swift \
         Tests/MetricsTests.swift \
         -o build/metrics-tests
-    ./build/metrics-tests
-    exit $?
+    # `set -e` would end the script on a failing run before the sweep below.
+    test_status=0
+    ./build/metrics-tests || test_status=$?
+    discard_test_preferences || test_status=1
+    exit $test_status
 fi
 
 echo "▸ Compiling ($BUILD_CONFIGURATION) against $(basename "$SDK")…"


### PR DESCRIPTION
Reopens #751, rebuilt on today's `main`.

## What was wrong

A test run wrote a preference file into `~/Library/Preferences` for every defaults suite it used, and nothing removed them. They piled up unnoticed.

## What changed

`build.sh` sweeps the two test namespaces (`vorss.tests.` and `com.vorssaint.tests.`) plus the harness's own `metrics-tests.plist` after each run, and fails the run if any survive. A test reads the swept prefixes back out of `build.sh` and checks every defaults suite the tests open is named inside one of them, so the sweep and the suites cannot drift apart.

## Why the branch was rebuilt

The original branch was cut at `814b94a`. Since then `main` gained two suites named `VorssaintTests.BetaActivation` and `VorssaintTests.StableActivation`, which fall outside both swept namespaces — so the guard this PR adds went red the moment it met current `main`, and the two files were being left behind for real (there was one sitting in `~/Library/Preferences` on my machine).

They are named `com.vorssaint.tests.betaActivation` / `.stableActivation` now, inside the swept namespace. That is the only difference from the closed branch besides the rebase.

Tests: `TESTS OK (8225 checks)`.
