### PR TITLE
fix(capture): keep the editor window from resizing below its minimum

### DIFF
--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift
@@ -980,8 +980,16 @@ final class ScreenshotEditorController: NSObject, NSWindowDelegate {
     }
 
     func show() {
+        let screen = NSScreen.pointerVisibleFrame
+        let minimumSize = ScreenshotSupport.editorMinimumContentSize(visibleSize: screen.size)
+        // The hosting view rewrites the window's size limits on its first
+        // layout pass, so a contentMinSize set on the window is silently
+        // lost. Declare the minimum on the hosted view and track just that:
+        // the hosting controller then maintains contentMinSize itself.
         let content = ScreenshotEditorView(model: model, controller: self)
+            .frame(minWidth: minimumSize.width, minHeight: minimumSize.height)
         let host = NSHostingController(rootView: content)
+        host.sizingOptions = [.minSize]
         let window = NSWindow(contentViewController: host)
         // One continuous surface: the canvas fills the window and the
         // controls float over it, so the editor reads as a single object.
@@ -1000,13 +1008,10 @@ final class ScreenshotEditorController: NSObject, NSWindowDelegate {
         // Chrome must equal the view's designed margins exactly (rail 64 +
         // sides, action band above, style band below), so a fresh window
         // opens with zero leftover stage around the capture.
-        let screen = NSScreen.pointerVisibleFrame
         let contentSize = ScreenshotSupport.editorContentSize(
             imagePointSize: model.pointSize,
             visibleSize: screen.size)
-        let minimumSize = ScreenshotSupport.editorMinimumContentSize(visibleSize: screen.size)
         window.setContentSize(contentSize)
-        window.contentMinSize = minimumSize
         window.center()
 
         self.window = window


### PR DESCRIPTION
Refs #775.

**Scope narrowed since the last review — please re-read, this is no longer the three-window PR you approved the shape of.** Two of the three windows were fixed on `main` this morning, by the maintainer, in a different shape:

- `0135ce8 fix(scratchpad)` adds `panel.minSize = 280x220` plus a `windowWillResize` clamp, and keeps `contentMinSize`.
- `4c91d32 fix(settings)` adds `host.view` width/height Auto Layout constraints, `window.minSize`, a `windowWillResize` clamp and a validity check on the persisted size, and keeps `contentMinSize`.

Both land the minimum this PR was landing, so this PR's scratchpad and Settings commits are dropped rather than re-litigated. What is left is the one window nobody else has touched: `ScreenshotEditorController.swift` still carries a bare `window.contentMinSize = minimumSize` at `:1009` and nothing else, and no commit on `main` has touched that file since `890dd0b`.

## What was wrong

`NSHostingController` rewrites the window's size limits from what it tracks on its first layout pass, so a `contentMinSize` assigned after `NSWindow(contentViewController:)` is silently dropped. The screenshot editor could then be edge-dragged down to a **761x142** strip.

## The change

Declare the computed minimum on the hosted view with `.frame(minWidth:minHeight:)` and track exactly that with `host.sizingOptions = [.minSize]`. The hosting controller then maintains `contentMinSize` itself. Only `.minSize` is tracked — the other options let SwiftUI content drive the window's size — and the dead `contentMinSize` assignment is removed. The declared minimum still comes from `ScreenshotSupport.editorMinimumContentSize(visibleSize:)` — but under `[.minSize]` that is a floor rather than the whole story; see the note under Environment.

## Consequence worth recording

The minimum is now enforced against Accessibility resizes too, and Vorssaint resizes its own windows through AX: `WindowLayoutService.swift:277-279` targets the app's own key window when it is `.resizable` and not an `NSPanel`, which includes the screenshot editor. So a half or a quarter on a narrow display leaves the editor overhanging the target rect instead of shrinking under its minimum. `WindowLayoutSupport.swift:428-442` accepts an edge-anchored window with over 0.45 overlap and no failure feedback fires, so this reads as fine rather than broken — and stopping at the minimum is what the minimum is for. Not drag-tested; reasoning is from those two files. (Credit to @PathGao, who found this and asked for it to be written down here.)

## Environment

MacBook Pro (Mac17,9, Apple M5 Pro), macOS 26.6.2 (25G83), built-in Liquid Retina XDR, 3024x1964 native / 1512x982 points.

This matters more than usual: `ScreenshotSupport.swift:790-794` computes the editor minimum from the visible frame, so the 980x712 below is the top of the clamp on this display and a narrower screen lands somewhere else.

And a second thing decides that number. Under `[.minSize]` the hosting controller reports the **larger** of the declared frame and the content's own intrinsic minimum. The tool rail is `.fixedSize(horizontal: true, vertical: false)` (`ScreenshotEditorView.swift:51`) so it never compresses, which puts the intrinsic width at 761pt. On this display 980 > 761, so the declared value governs and the drag stops at exactly 980x712. Below a roughly 761pt-wide visible frame the relationship inverts and the effective minimum would exceed the display — the case `ScreenshotSupport.swift:792` and the 700x500 expectation at `MetricsTests.swift:13921-13924` exist to protect. No Mac ships a display that narrow. (Measured by @PathGao in review.)

## Verification

- Interactive drag test, run 2026-08-24 against a dev build on this Mac, **not re-run against today's `main`**: unmodified, a scripted edge drag collapsed the editor to **761x142**; with this change the identical drag, plus a second harder one, stopped at exactly **980x712**. The editor hunk itself is unchanged since that run, and no commit has touched `ScreenshotEditorController.swift` since `890dd0b`, so the result should still hold — but I am dating it rather than implying a fresh run.
- `./build.sh` — 0 warnings. `./build.sh --test` — 8797 checks, **1 failure**: `the dispatch pool starvation this check needs was actually reached`. That is the known machine-dependent check #1014 exists to skip: red on this 15-core M5 Pro, green on CI's smaller runners. It came up identically on two other unrelated branches gated in the same sitting, so it is environmental and not from this change — I am reporting it rather than writing `TESTS OK`. `./build/Vorssaint --selftest` — `SELFTEST OK`.

