### PR TITLE
Let repeated Shift+Tab keep stepping backwards in the switcher

### DIFF
--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -126,6 +126,12 @@ final class AppSwitcher: ObservableObject {
     private var sessionShortcut: GlobalShortcut?
     private var sessionScope: SwitcherSessionScope = .allApps
     private var shiftBackNavigationHeld = false
+    /// Pressing Shift mid-session already steps back once, so the Tab landing
+    /// in that same physical chord must not step again — but later Tabs during
+    /// the same Shift hold must keep walking the list (issue #784). The chord
+    /// is recognized by time: anything after this deadline is a deliberate
+    /// separate press.
+    private var shiftBackChordDeadline: TimeInterval = 0
 
     /// Windows already asked to close, still listed until they are really
     /// gone. Releasing the shortcut skips them, so they are never raised on
@@ -614,7 +620,7 @@ final class AppSwitcher: ObservableObject {
         let shortcut = sessionShortcut ?? appsShortcut
         switch keyCode {
         case _ where keyCode == shortcut.keyCode && shortcut.matches(event: event, allowingExtraShift: true):
-            if shortcut.shiftIsNavigationModifier, flags.contains(.maskShift), shiftBackNavigationHeld {
+            if shortcut.shiftIsNavigationModifier, flags.contains(.maskShift), consumesShiftBackChordTab() {
                 break
             }
             let delta = shortcut.shiftIsNavigationModifier && flags.contains(.maskShift) ? -1 : 1
@@ -629,7 +635,7 @@ final class AppSwitcher: ObservableObject {
                                     tolerating: shortcut.modifiers):
             // A window-scoped session keeps its list when the Apps shortcut is
             // pressed with overlapping modifiers instead of expanding to all apps.
-            if appsShortcut.shiftIsNavigationModifier, flags.contains(.maskShift), shiftBackNavigationHeld {
+            if appsShortcut.shiftIsNavigationModifier, flags.contains(.maskShift), consumesShiftBackChordTab() {
                 break
             }
             let delta = appsShortcut.shiftIsNavigationModifier && flags.contains(.maskShift) ? -1 : 1
@@ -862,6 +868,16 @@ final class AppSwitcher: ObservableObject {
                                                                   isShiftHeld: shiftHeld)
         else { return false }
         advanceSelection(by: -1)
+        shiftBackChordDeadline = ProcessInfo.processInfo.systemUptime
+            + SwitcherSupport.shiftBackChordWindow
+        return true
+    }
+
+    /// True exactly once for the Tab that belongs to the Shift press that just
+    /// stepped back; consuming it keeps a Shift+Tab chord at one step.
+    private func consumesShiftBackChordTab() -> Bool {
+        guard ProcessInfo.processInfo.systemUptime < shiftBackChordDeadline else { return false }
+        shiftBackChordDeadline = 0
         return true
     }
 
@@ -1269,6 +1285,7 @@ final class AppSwitcher: ObservableObject {
         sessionShortcut = nil
         sessionScope = .allApps
         shiftBackNavigationHeld = false
+        shiftBackChordDeadline = 0
         closingItemIDs = []
         commitPendingForClose = false
     }

--- a/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
+++ b/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
@@ -796,6 +796,11 @@ enum SwitcherSupport {
         return min(itemCount - 1, first + min(visible, itemCount) - 1)
     }
 
+    /// A Tab this close behind a Shift-press step is the same physical chord
+    /// and must not step again; later Tabs during the Shift hold keep walking
+    /// the list (issue #784).
+    static let shiftBackChordWindow: TimeInterval = 0.35
+
     static func selectedPreviewPlacement(appCount rawAppCount: Int,
                                          selectedAppIndex rawSelectedAppIndex: Int,
                                          selectedWindowIndex _: Int,


### PR DESCRIPTION
Ref #784.

## What was wrong

Before: with the switcher open and Cmd+Shift held, only the first Tab press stepped backwards; every following Tab press was swallowed until Shift was released and pressed again.

The keyDown handler bailed out of both app-navigation branches whenever Shift was held **and** `shiftBackNavigationHeld` was set. That flag is the latch `handleShiftBackNavigation` uses to detect the Shift *press transition* on `flagsChanged` (pressing Shift alone steps back once — the 3.1.6 'move backward with Shift' feature), and it stays true for as long as Shift is physically held — so after the first backward step, every Cmd+Shift+Tab keyDown hit the early exit.

## Why the guard existed — and why plain removal is wrong

The guard shipped with the Shift-back feature itself (3.1.6), and it does one legitimate job: when the user presses **Shift+Tab as one chord** mid-session, the Shift press lands first (`flagsChanged` steps back once) and Tab's keyDown arrives milliseconds later — without any guard, one physical chord would step back **twice**. The bug is that the latch swallowed every later Tab too, not that swallowing is wrong.

## The change

After: Shift alone steps back once; Shift+Tab pressed as a chord steps back once; holding Cmd+Shift and tapping Tab keeps walking backwards, mirroring how Cmd+Tab walks forwards.

The blanket latch check is replaced by a one-shot chord window: when the Shift-press transition steps back, a deadline of `SwitcherSupport.shiftBackChordWindow` (0.35 s) is armed, and only a Tab arriving inside that window is consumed — once. Later Tabs during the same Shift hold navigate normally. A session opened with Cmd+Shift+Tab pre-latches `shiftBackNavigationHeld` without arming the window, so the first Tab after a reversed open already navigates. The deadline is cleared on consumption and at session teardown. Autorepeat and wrap behavior (#187) are unchanged, and `shouldNavigateBackwardOnShiftPress` (with its existing tests) still gates the transition step.

## Verification

`./build.sh` finishes with no warnings and `./build/Vorssaint --selftest` prints `SELFTEST OK`. Scenario walk against the event order macOS delivers (flagsChanged precedes the keyDown carrying the flag):

- open with Cmd+Tab, press Shift → one step back (transition), tap Tab ×3 within the hold → first Tab inside the chord window is consumed, the next two step — the chord counts once and repeats work
- open with Cmd+Shift+Tab, keep both held, tap Tab ×3 → three steps back (the issue's repro)
- Shift+Tab chord pressed mid-session → exactly one step (no double-step regression)
- release Shift, press again → steps again (transition re-arms)
