### PR TITLE
Edit the copied file itself, not Finder's icon preview

### DIFF
--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotService.swift
@@ -3,6 +3,7 @@
 
 import AppKit
 import ImageIO
+import UniformTypeIdentifiers
 
 /// The screenshot tool: freeze-first area, window and full screen capture
 /// with an annotation editor, pinned floating captures and direct clipboard
@@ -482,7 +483,7 @@ final class ScreenshotService: ObservableObject {
     private static func clipboardCapture(
         from pasteboard: NSPasteboard
     ) -> ScreenshotSelectionController.Capture? {
-        guard let image = NSImage(pasteboard: pasteboard),
+        guard let image = clipboardImage(from: pasteboard),
               image.size.width > 0, image.size.height > 0
         else { return nil }
         var rect = CGRect(origin: .zero, size: image.size)
@@ -496,6 +497,22 @@ final class ScreenshotService: ObservableObject {
         return ScreenshotSelectionController.Capture(image: cgImage,
                                                      scale: scale,
                                                      anchorRect: .zero)
+    }
+
+    /// Copying a file in Finder leaves both its URL and a small icon preview on
+    /// the pasteboard, so the file on disk wins whenever it is a readable image.
+    private static func clipboardImage(from pasteboard: NSPasteboard) -> NSImage? {
+        let options: [NSPasteboard.ReadingOptionKey: Any] = [
+            .urlReadingFileURLsOnly: true,
+            .urlReadingContentsConformToTypes: [UTType.image.identifier]
+        ]
+        if let url = (pasteboard.readObjects(forClasses: [NSURL.self],
+                                             options: options) as? [NSURL])?.first as URL?,
+           let image = NSImage(contentsOf: url),
+           image.size.width > 0, image.size.height > 0 {
+            return image
+        }
+        return NSImage(pasteboard: pasteboard)
     }
 
     func editorDidClose(_ editor: ScreenshotEditorController) {


### PR DESCRIPTION
Fixes #774.

## What was wrong

Before: copying an image file in Finder and invoking the "Edit clipboard image" shortcut opened the file's small Finder icon in the editor instead of the actual image.

When Finder copies a file it puts both `public.file-url` and an icon/thumbnail image representation on the pasteboard. `clipboardCapture(from:)` in `ScreenshotService` built the capture straight from `NSImage(pasteboard:)`, which prefers the image types — so the editor got the icon, not the file's pixels. This is the only entry point for the clipboard-edit path (`openClipboardImage()` is its sole caller); `ShelfService` already checks file URLs first and was never affected.

## The change

After: the editor opens the copied file at full resolution.

`clipboardCapture(from:)` now asks the pasteboard for file URLs whose contents conform to `UTType.image` (AppKit's own `.urlReadingContentsConformToTypes` filter — no hand-rolled extension list) and loads the file from disk when one is present, falling back to `NSImage(pasteboard:)` otherwise. A copied .zip, .txt or folder never matches the filter, and an unreadable or corrupt file falls back to the old behavior rather than failing. The read runs off the main thread inside the existing `GeneralPasteboardAccess` async block, so no UI stall.

## Verification

`./build.sh` finishes with no warnings and `./build/Vorssaint --selftest` prints `SELFTEST OK`. Manual check: Cmd+C an image file in Finder → "Edit clipboard image" → the editor opens the file's real pixels; copying pixel data (e.g. a screenshot region) behaves as before.