### PR TITLE
Size switcher rows and panel from one shared content width

### DIFF
--- a/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
+++ b/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
@@ -168,12 +168,23 @@ struct SwitcherIconRowLayout: Equatable {
     static let simpleTitleSpacing: CGFloat = 6
     static let simpleTitleScrollPadding: CGFloat = 1
 
+    /// The widest row the panel has to hold. Panel sizing and the rows
+    /// themselves both measure against this one value, so a row can never come
+    /// out wider than the window drawing it and get clipped (issues #710, #730).
+    func contentWidth(simpleMode: Bool, windowRow: Bool) -> CGFloat {
+        let hintWidth = showsShortcutHints ? Self.hintBarWidth : 0
+        guard simpleMode else {
+            return max(appRowSurfaceWidth, previewSurfaceWidth, hintWidth)
+        }
+        return max(appRowSurfaceWidth,
+                   windowRow ? 0 : simpleTitleSurfaceWidth,
+                   hintWidth)
+    }
+
     /// App-only mode keeps the same icon row and shortcut preference, but
     /// removes the entire preview area so no blank space remains where captures were.
     var simplePanelSize: CGSize {
-        CGSize(width: max(appRowSurfaceWidth,
-                          simpleTitleSurfaceWidth,
-                          showsShortcutHints ? Self.hintBarWidth : 0) + Self.padding * 2,
+        CGSize(width: contentWidth(simpleMode: true, windowRow: false) + Self.padding * 2,
                height: Self.simpleTitleHeight + Self.simpleTitleGap
                         + Self.rowHeight + shortcutHintHeight
                         + Self.padding * 2)
@@ -182,8 +193,7 @@ struct SwitcherIconRowLayout: Equatable {
     /// A flat window row names every entry under its icon, so it needs no
     /// separate title strip above the row.
     var simpleWindowPanelSize: CGSize {
-        CGSize(width: max(appRowSurfaceWidth,
-                          showsShortcutHints ? Self.hintBarWidth : 0) + Self.padding * 2,
+        CGSize(width: contentWidth(simpleMode: true, windowRow: true) + Self.padding * 2,
                height: Self.rowHeight + shortcutHintHeight + Self.padding * 2)
     }
 

--- a/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
+++ b/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
@@ -530,14 +530,7 @@ struct SwitcherView: View {
     }
 
     private var iconRowContentWidth: CGFloat {
-        if simpleMode {
-            return max(switcher.iconRowLayout.appRowSurfaceWidth,
-                       usesWindowRow ? 0 : switcher.iconRowLayout.simpleTitleSurfaceWidth,
-                       showsShortcutHints ? SwitcherIconRowLayout.hintBarWidth : 0)
-        }
-        return max(switcher.iconRowLayout.appRowSurfaceWidth,
-                   switcher.iconRowLayout.previewSurfaceWidth,
-                   SwitcherIconRowLayout.hintBarWidth)
+        switcher.iconRowLayout.contentWidth(simpleMode: simpleMode, windowRow: usesWindowRow)
     }
 
     private var selectedPreviewPlacement: SwitcherIconRowPreviewPlacement {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -6886,6 +6886,18 @@ struct MetricsTests {
                       compactIconRowLayout.simpleTitleSurfaceWidth)
                     + SwitcherIconRowLayout.padding * 2,
                "App Switcher without shortcut hints still fits its title rail")
+        // Two apps leave the icon row narrower than the hint bar, the case that
+        // used to lay rows out against a width the panel was never sized for.
+        let twoAppLayout = SwitcherIconRowLayout.compute(appCount: 2,
+                                                         selectedWindowCount: 1,
+                                                         screenVisibleFrame: screen,
+                                                         showsShortcutHints: false)
+        expect(twoAppLayout.appRowSurfaceWidth < SwitcherIconRowLayout.hintBarWidth
+               && twoAppLayout.contentWidth(simpleMode: true, windowRow: false)
+                    == twoAppLayout.simplePanelSize.width - SwitcherIconRowLayout.padding * 2
+               && twoAppLayout.contentWidth(simpleMode: true, windowRow: true)
+                    == twoAppLayout.simpleWindowPanelSize.width - SwitcherIconRowLayout.padding * 2,
+               "App Switcher rows fit the panel with fewer apps than the hint bar is wide")
         expect(SwitcherSupport.gridColumnCount(itemCount: 10, maxColumns: 8) == 5,
                "App Switcher wrapping splits ten windows across two even rows")
         expect(SwitcherSupport.gridColumnCount(itemCount: 9, maxColumns: 8) == 5,


### PR DESCRIPTION
Hardening for #730 (see the issue for why the visible clip no longer reproduces on main).

## What was wrong

The switcher panel's window width and the width its rows are laid out against were **two separate copies of the same `max(...)` expression** — `SwitcherIconRowLayout.simplePanelSize` on the service side and `SwitcherView.iconRowContentWidth` on the UI side. They have drifted twice already:

- in 3.3.2 the UI copy included `hintBarWidth` unconditionally while the panel only added it when hints are shown, so with hints off and two apps the rows were laid out 300 pt wide inside a 272 pt window — 34 pt clipped per side, which is #730 (with three apps the icon row passes 300 pt and the clip disappears, matching the report's 'less than 3 apps');
- 68764fa fixed the visible symptom as a side effect of the #710 title clipping fix, but left the duplicated formula in place, free to drift a third time.

The 2-app arithmetic, confirmed against the issue screenshots by pixel measurement (Retina 2×): icon row surface 464 px = 232 pt, visible rail 544 px = 272 pt (a 300 pt rail clipped to the 272 pt window), icon row inset 40 px = 20 pt — exactly what a 300 pt content box centred in a 272 pt window predicts.

## The change

One source of truth: `SwitcherIconRowLayout.contentWidth(simpleMode:windowRow:)`. Panel sizing (`simplePanelSize`, `simpleWindowPanelSize`) and the rows (`iconRowContentWidth`) both measure against it, so a row can never come out wider than the window drawing it. The only behavior delta is in preview (non-simple) mode, where hint width is now excluded when hints are off — consumed there only by `shortcutHintBar`, which is not rendered when hints are off, so no visual change.

A regression test pins the two-app case: the app row narrower than the hint bar, and the content width the rows use equal to `panelWidth − 2·padding` for both the merged and the flat window row.

## Verification

`./build.sh` finishes with no warnings, `./build.sh --test` prints `TESTS OK (8216 checks)`, and `./build/Vorssaint --selftest` prints `SELFTEST OK`.