### PR TITLE
Show the app icon the user picked in the switcher

### DIFF
--- a/Sources/Vorssaint/Services/Switcher/SwitcherModels.swift
+++ b/Sources/Vorssaint/Services/Switcher/SwitcherModels.swift
@@ -78,8 +78,15 @@ struct SwitcherItem: Identifiable, Equatable {
         return label
     }
 
+    /// Read from the bundle on disk, the same icon Finder and the Dock draw,
+    /// so an app whose user picked one of its alternate icons shows the one
+    /// they picked. Asking the running process instead hands back one cached
+    /// NSImage for the app's whole life, and a view that already drew it never
+    /// redraws it, so the switcher stayed on the bundled icon (issue #801).
     var appIcon: NSImage? {
-        NSRunningApplication(processIdentifier: pid)?.icon
+        guard let app = NSRunningApplication(processIdentifier: pid) else { return nil }
+        guard let bundlePath = app.bundleURL?.path else { return app.icon }
+        return NSWorkspace.shared.icon(forFile: bundlePath)
     }
 
     func withMinimized(_ minimized: Bool) -> SwitcherItem {


### PR DESCRIPTION
Fixes #801.

## What was wrong

Before: an app whose user picked one of its alternate icons (e.g. ChatGPT for macOS set to the Codex icon) shows the picked icon in the Dock and Finder, but the switcher keeps drawing the default bundled icon.

Every switcher surface resolves icons through the single shared `SwitcherItem.appIcon`, which returned `NSRunningApplication(processIdentifier:)?.icon`. Measured behavior of that API (probed with throwaway bundles on this machine): it hands back **the same `NSImage` instance for the app's entire lifetime** — the object identity is stable across repeated fetches, even through fresh `NSRunningApplication` objects. `Image(nsImage:)` diffs on that identity, so a tile that has drawn an app's icon once never re-rasterizes it: the bundled icon sticks for the whole Vorssaint process even after the user switches. (`NSWorkspace.icon(forFile:)` returns a fresh instance per call, and both APIs were confirmed to pick up custom-icon changes within ~1s — which is why the old API looks correct when probed in isolation and wrong on screen.)

## The change

After: the switcher draws the same icon Finder and the Dock draw.

`appIcon` now reads `NSWorkspace.icon(forFile:)` for the running app's bundle — the definitionally Finder-agreeing icon, where alternate-icon apps persist the choice — falling back to `NSRunningApplication.icon` for bundleless processes and `nil` for dead pids, both as before. One file, +8/−1.

Deliberately **no icon cache**: a path-keyed `NSImage` cache would hand SwiftUI an identity-stable image again and reintroduce exactly this bug. Cost measured at ~83 µs per warm lookup (~5 ms for a full 30-tile re-render), off the animation path and an order of magnitude under the AX window enumeration each session already pays; if this ever profiles hot, the right shape is a per-session cache cleared at session start.

## Verification

`./build.sh` finishes with no warnings and `./build/Vorssaint --selftest` prints `SELFTEST OK`. API behavior (instance stability of `.icon`, freshness of `icon(forFile:)`, both picking up `NSWorkspace.setIcon` and in-bundle `.icns` swaps, `NSApp.applicationIconImage` being invisible cross-process) was verified with probe binaries rather than assumed. Known limit: the ChatGPT alternate-icon picker itself wasn't available to test end to end — if a Codex-icon ChatGPT is handy, the switcher should show the picked icon on the next session after this change.