### PR TITLE
#852 switch bluetooth off while sleeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. The format follows
 ## [3.3.3-beta.2] - 2026-08-22
 
 ### Added
+- A new Bluetooth on sleep feature switches Bluetooth off while the Mac sleeps, so a closed laptop stops connecting to headphones it should leave alone. Bluetooth that was already off before sleep stays off, and only what Vorssaint switched off is put back on wake.
 - The radial menu now includes a Now Playing media action with a floating track card and direct app access. Thanks to @ruvelro.
 - The radial menu editor now includes a broader built-in SF Symbol catalog with runtime availability filtering. Thanks to @ruvelro.
 - Sound Mixer now includes an option to hide inactive applications while keeping custom volume and output selections visible. Thanks to @ruvelro.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The rest bends the same way: panel sections reorder and hide, the compact layout
 - **Keep awake.** Keep the Mac up for a timer, until you say stop or automatically with an external display or power connection, including with the lid closed, let displays sleep without stopping local work, choose the active menu bar icon and color, see the remaining time beside it, and optionally toggle it with a right click.
 - **Displays.** Adjust brightness or turn individual displays on and off. External screens use their own control channel when available and fall back to dimming the picture, while the keyboard brightness keys can follow the pointer and show the brightness percentage.
 - **Extra brightness.** Pushes the XDR panel of a MacBook Pro past its regular maximum using the display's HDR headroom.
+- **Bluetooth on sleep.** Switches Bluetooth off while the Mac sleeps, so a laptop in a bag stops stealing the headphones you are listening to elsewhere. Bluetooth you had already turned off stays off, and only what Vorssaint switched off comes back on wake.
 
 ## Install
 

--- a/Sources/Vorssaint/App/FeatureRuntime.swift
+++ b/Sources/Vorssaint/App/FeatureRuntime.swift
@@ -177,6 +177,7 @@ final class FeatureRuntime: ObservableObject {
         },
         .brightness: { BrightnessService.shared.syncWithPreferences() },
         .extraBrightness: { ExtraBrightnessService.shared.syncWithPreferences() },
+        .bluetoothSleep: { BluetoothSleepService.shared.syncWithPreferences() },
         .quickLauncher: { QuickLauncherService.shared.syncWithPreferences() },
         .colorPicker: {
             ScreenCaptureService.shared.syncWithPreferences()

--- a/Sources/Vorssaint/Core/BluetoothSleepStrings.swift
+++ b/Sources/Vorssaint/Core/BluetoothSleepStrings.swift
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+/// Strings for the Bluetooth on sleep feature. Same contract as the other
+/// FeatureStrings structs: memberwise init with labeled arguments in
+/// declaration order, one static per language, all in this file.
+struct BluetoothSleepStrings {
+    let pageTitle: String
+    let hubDescription: String
+    let enable: String
+    let enableCaption: String
+    let restoreToggle: String
+    let restoreCaption: String
+    let unsupported: String
+}
+
+extension FeatureStrings {
+    static func bluetoothSleep(_ language: AppLanguage) -> BluetoothSleepStrings {
+        switch language {
+        case .enUS: return .enUS
+        case .ptBR: return .ptBR
+        case .tr: return .tr
+        case .ru: return .ru
+        case .es: return .es
+        case .de: return .de
+        case .fr: return .fr
+        case .it: return .it
+        case .ja: return .ja
+        case .ko: return .ko
+        case .zhHans: return .zhHans
+        case .zhTW: return .zhTW
+        case .zhHK: return .zhHK
+        }
+    }
+}
+
+extension BluetoothSleepStrings {
+    static let enUS = BluetoothSleepStrings(
+        pageTitle: "Bluetooth on sleep",
+        hubDescription: "Switches Bluetooth off while the Mac sleeps, so headphones in a bag stop connecting to it.",
+        enable: "Turn Bluetooth off when the Mac sleeps",
+        enableCaption: "Bluetooth already off before sleep is left alone and stays off on wake.",
+        restoreToggle: "Turn Bluetooth back on when the Mac wakes",
+        restoreCaption: "Only when Vorssaint was the one that switched it off.",
+        unsupported: "This Mac has no Bluetooth controller."
+    )
+
+    static let ptBR = BluetoothSleepStrings(
+        pageTitle: "Bluetooth ao dormir",
+        hubDescription: "Desliga o Bluetooth enquanto o Mac dorme, para que os fones na mochila parem de se conectar.",
+        enable: "Desligar o Bluetooth quando o Mac dormir",
+        enableCaption: "O Bluetooth que já estava desligado antes do repouso não é tocado e continua desligado ao acordar.",
+        restoreToggle: "Ligar o Bluetooth de volta quando o Mac acordar",
+        restoreCaption: "Apenas quando foi o Vorssaint que o desligou.",
+        unsupported: "Este Mac não tem controlador Bluetooth."
+    )
+
+    static let tr = BluetoothSleepStrings(
+        pageTitle: "Uykuda Bluetooth",
+        hubDescription: "Mac uyurken Bluetooth'u kapatır, böylece çantadaki kulaklıklar bağlanmayı bırakır.",
+        enable: "Mac uyuduğunda Bluetooth'u kapat",
+        enableCaption: "Uykudan önce zaten kapalı olan Bluetooth'a dokunulmaz ve uyanışta kapalı kalır.",
+        restoreToggle: "Mac uyandığında Bluetooth'u yeniden aç",
+        restoreCaption: "Yalnızca kapatan Vorssaint olduğunda.",
+        unsupported: "Bu Mac'te Bluetooth denetleyicisi yok."
+    )
+
+    static let ru = BluetoothSleepStrings(
+        pageTitle: "Bluetooth при сне",
+        hubDescription: "Выключает Bluetooth на время сна Mac, чтобы наушники в сумке перестали к нему подключаться.",
+        enable: "Выключать Bluetooth, когда Mac засыпает",
+        enableCaption: "Bluetooth, уже выключенный до сна, не трогается и остаётся выключенным после пробуждения.",
+        restoreToggle: "Включать Bluetooth обратно при пробуждении Mac",
+        restoreCaption: "Только если его выключил сам Vorssaint.",
+        unsupported: "На этом Mac нет контроллера Bluetooth."
+    )
+
+    static let es = BluetoothSleepStrings(
+        pageTitle: "Bluetooth al reposo",
+        hubDescription: "Apaga el Bluetooth mientras el Mac duerme, para que los auriculares en la mochila dejen de conectarse.",
+        enable: "Apagar el Bluetooth cuando el Mac entre en reposo",
+        enableCaption: "El Bluetooth que ya estaba apagado antes del reposo no se toca y sigue apagado al despertar.",
+        restoreToggle: "Volver a encender el Bluetooth cuando el Mac despierte",
+        restoreCaption: "Solo cuando fue Vorssaint quien lo apagó.",
+        unsupported: "Este Mac no tiene controlador Bluetooth."
+    )
+
+    static let de = BluetoothSleepStrings(
+        pageTitle: "Bluetooth im Ruhezustand",
+        hubDescription: "Schaltet Bluetooth aus, während der Mac schläft, damit Kopfhörer in der Tasche sich nicht mehr verbinden.",
+        enable: "Bluetooth ausschalten, wenn der Mac in den Ruhezustand geht",
+        enableCaption: "Bereits vor dem Ruhezustand ausgeschaltetes Bluetooth bleibt unberührt und beim Aufwachen aus.",
+        restoreToggle: "Bluetooth wieder einschalten, wenn der Mac aufwacht",
+        restoreCaption: "Nur wenn Vorssaint es ausgeschaltet hat.",
+        unsupported: "Dieser Mac hat keinen Bluetooth-Controller."
+    )
+
+    static let fr = BluetoothSleepStrings(
+        pageTitle: "Bluetooth en veille",
+        hubDescription: "Coupe le Bluetooth pendant que le Mac dort, pour que les écouteurs rangés dans un sac cessent de s’y connecter.",
+        enable: "Couper le Bluetooth quand le Mac se met en veille",
+        enableCaption: "Un Bluetooth déjà coupé avant la veille n’est pas touché et reste coupé au réveil.",
+        restoreToggle: "Rallumer le Bluetooth au réveil du Mac",
+        restoreCaption: "Uniquement si c’est Vorssaint qui l’a coupé.",
+        unsupported: "Ce Mac n’a pas de contrôleur Bluetooth."
+    )
+
+    static let it = BluetoothSleepStrings(
+        pageTitle: "Bluetooth in stop",
+        hubDescription: "Spegne il Bluetooth mentre il Mac dorme, così le cuffie nello zaino smettono di collegarsi.",
+        enable: "Spegni il Bluetooth quando il Mac va in stop",
+        enableCaption: "Il Bluetooth già spento prima dello stop resta intoccato e spento alla riattivazione.",
+        restoreToggle: "Riaccendi il Bluetooth quando il Mac si riattiva",
+        restoreCaption: "Solo quando è stato Vorssaint a spegnerlo.",
+        unsupported: "Questo Mac non ha un controller Bluetooth."
+    )
+
+    static let ja = BluetoothSleepStrings(
+        pageTitle: "スリープ時のBluetooth",
+        hubDescription: "Macのスリープ中にBluetoothを切り、カバンの中のヘッドホンが勝手につながらないようにします。",
+        enable: "Macがスリープしたら Bluetooth を切る",
+        enableCaption: "スリープ前からオフだったBluetoothはそのままで、復帰後もオフのままです。",
+        restoreToggle: "Macの復帰時に Bluetooth を戻す",
+        restoreCaption: "Vorssaintが切った場合のみ戻します。",
+        unsupported: "このMacにはBluetoothコントローラがありません。"
+    )
+
+    static let ko = BluetoothSleepStrings(
+        pageTitle: "잠자기 시 Bluetooth",
+        hubDescription: "Mac이 잠자는 동안 Bluetooth를 꺼서 가방 속 헤드폰이 계속 연결되지 않도록 합니다.",
+        enable: "Mac이 잠자기에 들어가면 Bluetooth 끄기",
+        enableCaption: "잠자기 전에 이미 꺼져 있던 Bluetooth는 건드리지 않고 깨어난 뒤에도 꺼진 채로 둡니다.",
+        restoreToggle: "Mac이 깨어나면 Bluetooth 다시 켜기",
+        restoreCaption: "Vorssaint가 껐을 때만 다시 켭니다.",
+        unsupported: "이 Mac에는 Bluetooth 컨트롤러가 없습니다."
+    )
+
+    static let zhHans = BluetoothSleepStrings(
+        pageTitle: "睡眠时的蓝牙",
+        hubDescription: "Mac 睡眠期间关闭蓝牙，包里的耳机不再自动连上来。",
+        enable: "Mac 进入睡眠时关闭蓝牙",
+        enableCaption: "睡眠前就已关闭的蓝牙不会被改动，唤醒后仍保持关闭。",
+        restoreToggle: "Mac 唤醒时重新打开蓝牙",
+        restoreCaption: "仅在蓝牙是由 Vorssaint 关闭时。",
+        unsupported: "这台 Mac 没有蓝牙控制器。"
+    )
+
+    static let zhTW = BluetoothSleepStrings(
+        pageTitle: "睡眠時的藍牙",
+        hubDescription: "Mac 睡眠期間關閉藍牙，包包裡的耳機不會再自動連上來。",
+        enable: "Mac 進入睡眠時關閉藍牙",
+        enableCaption: "睡眠前就已關閉的藍牙不會被更動，喚醒後仍保持關閉。",
+        restoreToggle: "Mac 喚醒時重新開啟藍牙",
+        restoreCaption: "僅在藍牙是由 Vorssaint 關閉時。",
+        unsupported: "這台 Mac 沒有藍牙控制器。"
+    )
+
+    static let zhHK = BluetoothSleepStrings(
+        pageTitle: "睡眠時的藍牙",
+        hubDescription: "Mac 睡眠期間關閉藍牙，袋裡的耳機不會再自動連上來。",
+        enable: "Mac 進入睡眠時關閉藍牙",
+        enableCaption: "睡眠前已經關閉的藍牙不會被更動，喚醒後仍然保持關閉。",
+        restoreToggle: "Mac 喚醒時重新開啟藍牙",
+        restoreCaption: "只在藍牙是由 Vorssaint 關閉時。",
+        unsupported: "這部 Mac 沒有藍牙控制器。"
+    )
+}

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -122,6 +122,11 @@ enum DefaultsKey {
     // healthily for a while, or when it is quit properly. Found still set at
     // the next start, it means the previous one died on the way up.
     static let startupDidNotFinish = "startupDidNotFinish"
+    static let bluetoothSleepEnabled = "bluetoothSleepEnabled"
+    static let bluetoothSleepRestoreOnWake = "bluetoothSleepRestoreOnWake"
+    // Set only while Vorssaint owes a Bluetooth restore, so a Mac shut down
+    // while asleep still gets it back on the next launch.
+    static let bluetoothSleepRestorePending = "bluetoothSleepRestorePending"
     static let musicBlockEnabled = "musicBlockEnabled"
     static let musicBlockReplacementPath = "musicBlockReplacementPath"  // app bundle path ("" = none)
     static let cleanerScheduleFrequency = "cleanerScheduleFrequency"    // off | daily | weekly
@@ -824,6 +829,9 @@ enum Defaults {
         DefaultsKey.brightnessControlEnabled: false,
         DefaultsKey.brightnessKeysEnabled: false,
         DefaultsKey.brightnessOSDEnabled: false,
+        DefaultsKey.bluetoothSleepEnabled: false,
+        DefaultsKey.bluetoothSleepRestoreOnWake: true,
+        DefaultsKey.bluetoothSleepRestorePending: false,
         DefaultsKey.musicBlockEnabled: false,
         DefaultsKey.musicBlockReplacementPath: "",
         DefaultsKey.cleanerScheduleFrequency: "off",

--- a/Sources/Vorssaint/Core/FeatureCatalog.swift
+++ b/Sources/Vorssaint/Core/FeatureCatalog.swift
@@ -24,7 +24,7 @@ enum AppFeature: String, CaseIterable {
     // Sound
     case mixer, soundOutputSwitcher, micMute, musicBlock
     // Energy and display
-    case keepAwake, brightness, extraBrightness
+    case keepAwake, brightness, extraBrightness, bluetoothSleep
     // Tools
     case quickLauncher, quickToggles, colorPicker, screenOCR, cleaningMode, mediaTools,
          cleaner, uninstaller, homebrew, appUpdates, screenshot, cameraPreview, radialMenu, scratchpad,
@@ -96,7 +96,7 @@ extension AppFeature {
             return .clipboardFiles
         case .mixer, .soundOutputSwitcher, .micMute, .musicBlock:
             return .sound
-        case .keepAwake, .brightness, .extraBrightness:
+        case .keepAwake, .brightness, .extraBrightness, .bluetoothSleep:
             return .energyDisplay
         case .quickLauncher, .quickToggles, .colorPicker, .screenOCR, .cleaningMode, .mediaTools,
              .cleaner, .uninstaller, .homebrew, .appUpdates, .screenshot, .cameraPreview, .radialMenu,
@@ -139,6 +139,7 @@ extension AppFeature {
         case .keepAwake: return "moon.zzz.fill"
         case .brightness: return "display.2"
         case .extraBrightness: return "sun.max.fill"
+        case .bluetoothSleep: return "wave.3.right.circle"
         case .quickLauncher: return "wand.and.rays"
         case .quickToggles: return "togglepower"
         case .colorPicker: return "eyedropper"
@@ -211,6 +212,7 @@ extension AppFeature {
         case .musicBlock: return [DefaultsKey.musicBlockEnabled]
         case .brightness: return [DefaultsKey.brightnessControlEnabled]
         case .extraBrightness: return [DefaultsKey.extraBrightnessEnabled]
+        case .bluetoothSleep: return [DefaultsKey.bluetoothSleepEnabled]
         case .windowLayout, .diskImageInstaller, .mixer, .micMute, .keepAwake,
              .quickLauncher, .quickToggles, .colorPicker, .screenOCR, .cleaningMode, .mediaTools,
              .cleaner, .uninstaller, .homebrew, .appUpdates, .screenshot, .cameraPreview, .scratchpad,
@@ -258,7 +260,7 @@ extension AppFeature {
         case .monitorCPU, .monitorMemory, .monitorDisk, .monitorPower: return [.notifications]
         case .clipboardHistory, .shelf, .urlCleaner,
              .soundOutputSwitcher, .musicBlock,
-             .extraBrightness, .quickLauncher, .colorPicker, .micMute, .mediaTools,
+             .extraBrightness, .bluetoothSleep, .quickLauncher, .colorPicker, .micMute, .mediaTools,
              .scratchpad, .monitorGPU, .monitorNetwork, .fanControl, .killProcess:
             return []
         }

--- a/Sources/Vorssaint/Core/FeaturePresets.swift
+++ b/Sources/Vorssaint/Core/FeaturePresets.swift
@@ -111,7 +111,7 @@ extension AppFeature {
              .monitorNetwork, .monitorDisk, .monitorPower:
             return .periodic
         case .pastePlain, .mixer, .soundOutputSwitcher, .micMute,
-             .musicBlock, .keepAwake, .brightness, .quickLauncher, .quickToggles, .colorPicker,
+             .musicBlock, .bluetoothSleep, .keepAwake, .brightness, .quickLauncher, .quickToggles, .colorPicker,
              .screenOCR, .cleaningMode, .mediaTools, .cleaner, .uninstaller, .homebrew, .screenshot,
              .cameraPreview, .scratchpad, .commandBar, .screenRecorder, .fanControl,
              .diskImageInstaller, .killProcess:

--- a/Sources/Vorssaint/Core/SettingsBackupSupport.swift
+++ b/Sources/Vorssaint/Core/SettingsBackupSupport.swift
@@ -72,6 +72,8 @@ enum SettingsBackupSupport {
     /// out by construction (they are not preference keys), listed here only
     /// when they would otherwise slip in through the registered set.
     static let machineStateKeys: Set<String> = [
+        // A Bluetooth restore owed by one sleeping Mac means nothing on another.
+        DefaultsKey.bluetoothSleepRestorePending,
         DefaultsKey.micMuteActive,
         DefaultsKey.micMuteSavedVolume,
         // Levels and device ids belong to the microphones of one Mac.

--- a/Sources/Vorssaint/Services/Bluetooth/BluetoothSleepService.swift
+++ b/Sources/Vorssaint/Services/Bluetooth/BluetoothSleepService.swift
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import IOKit
+
+/// Switches Bluetooth off while the Mac sleeps, so a closed laptop in a bag
+/// stops grabbing the headphones the user is listening to elsewhere.
+///
+/// Unlike the plain sleep-and-wake toggle, the restore is honest: the state
+/// found before sleep is remembered, so Bluetooth the user had already turned
+/// off is never switched back on for them. The memory is a preference rather
+/// than a variable, so a Mac shut down while asleep still gets its Bluetooth
+/// back on the next launch instead of staying dark.
+///
+/// Nothing runs while the feature is off: no observers, no polling, no cost.
+final class BluetoothSleepService {
+    static let shared = BluetoothSleepService()
+
+    /// A Bluetooth controller is soldered in or it is not; the answer cannot
+    /// change while the Mac is running, so resolve it once.
+    static let isSupported: Bool = {
+        let service = IOServiceGetMatchingService(kIOMainPortDefault,
+                                                  IOServiceMatching("IOBluetoothHCIController"))
+        guard service != 0 else { return false }
+        IOObjectRelease(service)
+        return true
+    }()
+
+    private var observers: [NSObjectProtocol] = []
+
+    private init() {}
+
+    func syncWithPreferences() {
+        guard Self.isSupported else { return }
+        // A restore still owed here means an earlier run switched Bluetooth
+        // off and never saw the wake, because the Mac was shut down (or the
+        // app quit) while it slept. The debt is paid before anything else,
+        // and paid even when the feature has since been switched off, so
+        // nothing Vorssaint took away is ever kept.
+        restoreIfOwed()
+        if AppFeature.bluetoothSleep.isAvailable,
+           UserDefaults.standard.bool(forKey: DefaultsKey.bluetoothSleepEnabled) {
+            start()
+        } else {
+            stop()
+        }
+    }
+
+    private func start() {
+        guard observers.isEmpty else { return }
+        let center = NSWorkspace.shared.notificationCenter
+        observers = [
+            center.addObserver(forName: NSWorkspace.willSleepNotification,
+                               object: nil, queue: .main) { [weak self] _ in
+                self?.macWillSleep()
+            },
+            center.addObserver(forName: NSWorkspace.didWakeNotification,
+                               object: nil, queue: .main) { [weak self] _ in
+                self?.restoreIfOwed()
+            },
+        ]
+    }
+
+    func stop() {
+        guard !observers.isEmpty else { return }
+        let center = NSWorkspace.shared.notificationCenter
+        for observer in observers { center.removeObserver(observer) }
+        observers = []
+    }
+
+    private func macWillSleep() {
+        let defaults = UserDefaults.standard
+        let plan = BluetoothSleepSupport.sleepPlan(
+            isPoweredOn: Self.isPoweredOn,
+            restoresOnWake: defaults.bool(forKey: DefaultsKey.bluetoothSleepRestoreOnWake))
+        defaults.set(plan.owesRestore, forKey: DefaultsKey.bluetoothSleepRestorePending)
+        if plan.powersOff { Self.setPowered(false) }
+    }
+
+    private func restoreIfOwed() {
+        let defaults = UserDefaults.standard
+        let restores = BluetoothSleepSupport.restores(
+            owesRestore: defaults.bool(forKey: DefaultsKey.bluetoothSleepRestorePending),
+            isPoweredOn: Self.isPoweredOn)
+        // The debt is settled either way: Bluetooth the user switched on
+        // themselves cancels it instead of waiting for the next sleep.
+        defaults.set(false, forKey: DefaultsKey.bluetoothSleepRestorePending)
+        if restores { Self.setPowered(true) }
+    }
+
+    // MARK: Controller power
+
+    private typealias PowerGet = @convention(c) () -> Int32
+    private typealias PowerSet = @convention(c) (Int32) -> Void
+
+    /// The Bluetooth controller's power switch, the same pair the menu bar
+    /// item uses. Resolved once and guarded: without it the feature simply
+    /// does nothing rather than pretending to work.
+    private static let controllerPower: (get: PowerGet, set: PowerSet)? = {
+        let path = "/System/Library/Frameworks/IOBluetooth.framework/IOBluetooth"
+        guard let handle = dlopen(path, RTLD_LAZY),
+              let getSymbol = dlsym(handle, "IOBluetoothPreferenceGetControllerPowerState"),
+              let setSymbol = dlsym(handle, "IOBluetoothPreferenceSetControllerPowerState")
+        else { return nil }
+        return (unsafeBitCast(getSymbol, to: PowerGet.self),
+                unsafeBitCast(setSymbol, to: PowerSet.self))
+    }()
+
+    private static var isPoweredOn: Bool {
+        guard let controllerPower else { return false }
+        return controllerPower.get() != 0
+    }
+
+    private static func setPowered(_ on: Bool) {
+        controllerPower?.set(on ? 1 : 0)
+    }
+}

--- a/Sources/Vorssaint/Services/Bluetooth/BluetoothSleepSupport.swift
+++ b/Sources/Vorssaint/Services/Bluetooth/BluetoothSleepSupport.swift
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+/// The decisions behind Bluetooth on sleep, kept free of AppKit and IOKit so
+/// they can be tested directly.
+///
+/// The rule the whole feature turns on: Vorssaint only ever puts back what it
+/// took away. Bluetooth already off when the Mac went to sleep is never
+/// switched on for the user, which is the part a plain sleep-and-wake toggle
+/// gets wrong.
+enum BluetoothSleepSupport {
+    /// What to do as the Mac goes to sleep.
+    struct SleepPlan: Equatable {
+        /// Whether Bluetooth should be switched off now.
+        let powersOff: Bool
+        /// Whether a later wake owes the user a restore.
+        let owesRestore: Bool
+    }
+
+    static func sleepPlan(isPoweredOn: Bool, restoresOnWake: Bool) -> SleepPlan {
+        guard isPoweredOn else { return SleepPlan(powersOff: false, owesRestore: false) }
+        return SleepPlan(powersOff: true, owesRestore: restoresOnWake)
+    }
+
+    /// Whether waking (or a launch that finds a restore still owed, because
+    /// the Mac was shut down while asleep) should switch Bluetooth back on.
+    /// Bluetooth the user turned on themselves in the meantime is left alone.
+    static func restores(owesRestore: Bool, isPoweredOn: Bool) -> Bool {
+        owesRestore && !isPoweredOn
+    }
+}

--- a/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
@@ -627,6 +627,7 @@ extension AppFeature {
         case .keepAwake: return s.keepAwakeTitle
         case .brightness: return FeatureStrings.brightness(L10n.shared.language).pageTitle
         case .extraBrightness: return s.extraBrightnessName
+        case .bluetoothSleep: return FeatureStrings.bluetoothSleep(L10n.shared.language).pageTitle
         case .quickLauncher: return s.launcherName
         case .quickToggles: return FeatureStrings.quickToggles(L10n.shared.language).pageTitle
         case .colorPicker: return s.colorPickerName
@@ -686,6 +687,7 @@ extension AppFeature {
         case .keepAwake: return hub.descKeepAwake
         case .brightness: return FeatureStrings.brightness(L10n.shared.language).hubDescription
         case .extraBrightness: return hub.descExtraBrightness
+        case .bluetoothSleep: return FeatureStrings.bluetoothSleep(L10n.shared.language).hubDescription
         case .quickLauncher: return hub.descQuickLauncher
         case .quickToggles: return FeatureStrings.quickToggles(L10n.shared.language).hubDescription
         case .colorPicker: return hub.descColorPicker

--- a/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
@@ -21,6 +21,7 @@ enum SettingsSectionAnchor: String, CaseIterable, Hashable {
     case keepAwake
     case brightness
     case extraBrightness
+    case bluetoothSleep
     case scrollDirection
     case focusFollowsMouse
     case smoothScroll
@@ -49,7 +50,7 @@ enum SettingsSectionAnchor: String, CaseIterable, Hashable {
     var page: SettingsPage {
         switch self {
         case .panelConfiguration, .musicBlocking: return .general
-        case .keepAwake, .brightness, .extraBrightness: return .energy
+        case .keepAwake, .brightness, .extraBrightness, .bluetoothSleep: return .energy
         case .scrollDirection, .focusFollowsMouse, .smoothScroll, .mouseNavigation, .mouseButtonShortcuts,
              .middleClick:
             return .mouse
@@ -182,6 +183,8 @@ extension AppFeature {
             return FeatureSettingsDestination(.energy, sectionAnchor: .brightness)
         case .extraBrightness:
             return FeatureSettingsDestination(.energy, sectionAnchor: .extraBrightness)
+        case .bluetoothSleep:
+            return FeatureSettingsDestination(.energy, sectionAnchor: .bluetoothSleep)
 
         case .quickLauncher:
             return FeatureSettingsDestination(.quickTools, sectionAnchor: .quickLauncher)
@@ -230,7 +233,7 @@ enum FeatureVisibilitySupport {
     /// always shows (General, Shortcuts, About and friends).
     static func features(for page: SettingsPage) -> [AppFeature] {
         switch page {
-        case .energy: return [.keepAwake, .brightness, .extraBrightness]
+        case .energy: return [.keepAwake, .brightness, .extraBrightness, .bluetoothSleep]
         case .monitor: return monitorFeatures
         case .mouse: return [.scrollInverter, .focusFollowsMouse, .smoothScroll, .mouseNavigation, .mouseButtonShortcuts,
                              .middleClick]

--- a/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
@@ -48,7 +48,9 @@ enum SettingsDirectory {
                                                      .externalDisplayToggle,
                                                  FeatureStrings.keepAwakeAutomation(language).powerToggle,
                                                  FeatureStrings.keepAwakeDisplaySleep(language)
-                                                     .allowDisplaySleep]),
+                                                     .allowDisplaySleep,
+                                                 FeatureStrings.bluetoothSleep(language).pageTitle,
+                                                 FeatureStrings.bluetoothSleep(language).enable]),
                 SettingsDirectoryItem(page: .monitor, title: s.tabMonitor, icon: "chart.line.uptrend.xyaxis",
                                       keywords: [s.menuBarSpacingLabel, s.menuBarHideIconToggle,
                                                  s.monitorMemoryPressureDot,

--- a/Sources/Vorssaint/UI/Settings/SettingsView.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsView.swift
@@ -404,6 +404,8 @@ struct EnergySettings: View {
     @AppStorage(DefaultsKey.brightnessOSDEnabled) private var brightnessOSDEnabled = false
     @AppStorage(DefaultsKey.extraBrightnessEnabled) private var extraBrightnessEnabled = false
     @AppStorage(DefaultsKey.extraBrightnessLevel) private var extraBrightnessLevel = 100
+    @AppStorage(DefaultsKey.bluetoothSleepEnabled) private var bluetoothSleepEnabled = false
+    @AppStorage(DefaultsKey.bluetoothSleepRestoreOnWake) private var bluetoothSleepRestoreOnWake = true
     @AppStorage(DefaultsKey.defaultDuration) private var defaultDuration = 0
     @AppStorage(DefaultsKey.batteryLimit) private var batteryLimit = 10
     @AppStorage(DefaultsKey.keepAwakeAutoStart) private var keepAwakeAutoStart = false
@@ -560,6 +562,27 @@ struct EnergySettings: View {
                     }
                 }
                 .settingsSectionAnchor(.extraBrightness)
+            }
+            if AppFeature.bluetoothSleep.isAvailable {
+                let strings = FeatureStrings.bluetoothSleep(l10n.language)
+                Section(strings.pageTitle) {
+                    if BluetoothSleepService.isSupported {
+                        SettingsToggleWithCaption(title: strings.enable,
+                                                  caption: strings.enableCaption,
+                                                  isOn: $bluetoothSleepEnabled)
+                            .onChange(of: bluetoothSleepEnabled) { _, _ in
+                                BluetoothSleepService.shared.syncWithPreferences()
+                            }
+                        if bluetoothSleepEnabled {
+                            SettingsToggleWithCaption(title: strings.restoreToggle,
+                                                      caption: strings.restoreCaption,
+                                                      isOn: $bluetoothSleepRestoreOnWake)
+                        }
+                    } else {
+                        SettingsCaptionText(strings.unsupported)
+                    }
+                }
+                .settingsSectionAnchor(.bluetoothSleep)
             }
         }
         .formStyle(.grouped)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -2922,6 +2922,14 @@ struct MetricsTests {
                "extra brightness is opt-in")
         expect(registeredDefaults[DefaultsKey.extraBrightnessLevel] as? Int == 100,
                "extra brightness starts at full intensity once enabled")
+        expect(registeredDefaults[DefaultsKey.bluetoothSleepEnabled] as? Bool == false,
+               "switching Bluetooth off on sleep is opt-in")
+        expect(registeredDefaults[DefaultsKey.bluetoothSleepRestoreOnWake] as? Bool == true,
+               "an enabled Bluetooth sleep feature puts Bluetooth back on wake")
+        expect(registeredDefaults[DefaultsKey.bluetoothSleepRestorePending] as? Bool == false,
+               "no Bluetooth restore is owed before the first sleep")
+        expect(!SettingsBackupSupport.exportKeys().contains(DefaultsKey.bluetoothSleepRestorePending),
+               "a Bluetooth restore owed by one sleeping Mac never travels to another")
         expect(registeredDefaults[DefaultsKey.musicBlockEnabled] as? Bool == false,
                "blocking the music app from launching is opt-in")
         expect(registeredDefaults[DefaultsKey.musicBlockReplacementPath] as? String == "",
@@ -9525,7 +9533,7 @@ struct MetricsTests {
 
         // MARK: Features hub catalog
 
-        expect(AppFeature.allCases.count == 53, "feature catalog has 53 features")
+        expect(AppFeature.allCases.count == 54, "feature catalog has 54 features")
         expect(Set(AppFeature.allCases.map(\.rawValue)).count == AppFeature.allCases.count,
                "feature ids are unique")
         expect(AppFeature.allCases.map(\.rawValue) == [
@@ -9535,7 +9543,7 @@ struct MetricsTests {
             "clipboardHistory", "pastePlain", "finderCutPaste", "finderRename", "shelf", "urlCleaner",
             "diskImageInstaller",
             "mixer", "soundOutputSwitcher", "micMute", "musicBlock",
-            "keepAwake", "brightness", "extraBrightness",
+            "keepAwake", "brightness", "extraBrightness", "bluetoothSleep",
             "quickLauncher", "quickToggles", "colorPicker", "screenOCR", "cleaningMode", "mediaTools",
             "cleaner", "uninstaller", "homebrew", "appUpdates", "screenshot", "cameraPreview",
             "radialMenu", "scratchpad", "commandBar", "screenRecorder", "killProcess",
@@ -9602,6 +9610,43 @@ struct MetricsTests {
                 && AppFeature.diskImageInstaller.permissions == [.appManagement]
                 && AppFeature.diskImageInstaller.energyProfile == .idle,
                "the disk image installer is an event-driven file feature with contextual app access")
+        expect(AppFeature.bluetoothSleep.group == .energyDisplay
+                && AppFeature.bluetoothSleep.enabledKeys == [DefaultsKey.bluetoothSleepEnabled]
+                && AppFeature.bluetoothSleep.permissions.isEmpty
+                && AppFeature.bluetoothSleep.energyProfile == .idle
+                && !AppFeature.bluetoothSleep.isBeta,
+               "Bluetooth on sleep is an energy feature that costs nothing at rest")
+        expect((AppFeature.availabilityDefaults[AppFeature.bluetoothSleep.availabilityKey] as? Bool) == true,
+               "Bluetooth on sleep ships installed, switched off, so its section is findable")
+        expect(AppFeature.bluetoothSleep.settingsDestination
+                == FeatureSettingsDestination(.energy, sectionAnchor: .bluetoothSleep)
+                && AppFeature.bluetoothSleep.settingsDestination.hasValidSectionAnchor
+                && FeatureVisibilitySupport.features(for: .energy).contains(.bluetoothSleep),
+               "Bluetooth on sleep owns a section of the Energy page and can keep it alive alone")
+        expect(BluetoothSleepSupport.sleepPlan(isPoweredOn: true, restoresOnWake: true)
+                == BluetoothSleepSupport.SleepPlan(powersOff: true, owesRestore: true),
+               "Bluetooth on before sleep is switched off and owed back")
+        expect(BluetoothSleepSupport.sleepPlan(isPoweredOn: true, restoresOnWake: false)
+                == BluetoothSleepSupport.SleepPlan(powersOff: true, owesRestore: false),
+               "without the restore option, sleep switches Bluetooth off for good")
+        expect(BluetoothSleepSupport.sleepPlan(isPoweredOn: false, restoresOnWake: true)
+                == BluetoothSleepSupport.SleepPlan(powersOff: false, owesRestore: false),
+               "Bluetooth already off before sleep is left alone, so the wake never turns it on")
+        expect(BluetoothSleepSupport.restores(owesRestore: true, isPoweredOn: false),
+               "a wake that still owes a restore switches Bluetooth back on")
+        expect(!BluetoothSleepSupport.restores(owesRestore: false, isPoweredOn: false),
+               "a wake owing nothing leaves Bluetooth off")
+        expect(!BluetoothSleepSupport.restores(owesRestore: true, isPoweredOn: true),
+               "Bluetooth the user switched on first is left alone")
+
+        for language in AppLanguage.allCases {
+            let strings = FeatureStrings.bluetoothSleep(language)
+            let values = Mirror(reflecting: strings).children.compactMap { $0.value as? String }
+            expect(values.count == 7 && values.allSatisfy { !$0.isEmpty },
+                   "Bluetooth on sleep has every localized field for \(language.rawValue)")
+            expect(values.allSatisfy { !$0.contains("—") },
+                   "Bluetooth on sleep text uses human punctuation for \(language.rawValue)")
+        }
         expect((Defaults.registeredDefaults[DefaultsKey.panelShowFanControl] as? Bool) == true,
                "installing fan control reveals its panel section by default")
 
@@ -10505,8 +10550,9 @@ struct MetricsTests {
         expect(!pageVisible(.mouse, available: []),
                "the mouse page hides only with all six mouse features off")
         expect(!pageVisible(.energy, available: allFeatures.subtracting([.keepAwake, .brightness,
-                                                                         .extraBrightness])),
-               "energy hides when all three display features are off")
+                                                                         .extraBrightness,
+                                                                         .bluetoothSleep])),
+               "energy hides when all four of its features are off")
         expect(pageVisible(.energy, available: [.extraBrightness]), "XDR alone keeps the energy page")
         expect(pageVisible(.energy, available: [.brightness]),
                "brightness control alone keeps the energy page")

--- a/build.sh
+++ b/build.sh
@@ -179,6 +179,7 @@ if (( TEST )); then
         Sources/Vorssaint/Core/AppearanceStrings.swift \
         Sources/Vorssaint/Core/BatteryTimeStrings.swift \
         Sources/Vorssaint/Core/KeepAwakeStrings.swift \
+        Sources/Vorssaint/Core/BluetoothSleepStrings.swift \
         Sources/Vorssaint/Core/PermissionGuideStrings.swift \
         Sources/Vorssaint/Core/FanControlStrings.swift \
         Sources/Vorssaint/Services/FanControl/FanControlSupport.swift \
@@ -209,6 +210,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/GeneralPasteboardAccess.swift \
         Sources/Vorssaint/Services/Audio/MixerRoutingSupport.swift \
         Sources/Vorssaint/Services/Audio/MusicLaunchSupport.swift \
+        Sources/Vorssaint/Services/Bluetooth/BluetoothSleepSupport.swift \
         Sources/Vorssaint/UI/MenuPanel/MixerPercentNativeTextField.swift \
         Sources/Vorssaint/Services/Audio/BoostLimiter.swift \
         Sources/Vorssaint/Services/Audio/MixerRender.swift \


### PR DESCRIPTION
## Why

Closes #852.

A sleeping Mac keeps its Bluetooth on, so a laptop in a bag grabs the
headphones you are listening to elsewhere.

## What it does

New Bluetooth on sleep feature in the Energy group, off by default.

- Bluetooth on before sleep: switched off, back on at wake.
- Bluetooth already off before sleep: left alone, stays off at wake.

The second line is what the issue asks for. Bluesnooze powers Bluetooth on
unconditionally at launch, so a radio you deliberately turned off comes back
anyway. Here the state is read before sleep and remembered, and only what
Vorssaint switched off is ever restored.

## Notes

No new permission, no new dependency. Nothing runs while the feature is off.
Optional toggle for "switch it off and leave it off". All 13 languages.

## Checks

- [x] `./build.sh --test` passes, 8254 checks, 6 new
- [x] `./build.sh` finishes without warnings
- [x] `./build/Vorssaint --selftest` passes