### PR TITLE
fix(clipboard): fold Chromium promised-flavor re-declares into the original clipboard image entry

### DIFF
--- a/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
+++ b/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
@@ -43,6 +43,10 @@ final class ClipboardHistoryService: ObservableObject {
 
     private var timer: Timer?
     private var lastChangeCount = 0
+    /// Signature of the most recent image capture, kept briefly so a source
+    /// app re-declaring the pasteboard while resolving a promised flavor is
+    /// folded into the entry it already produced (see ClipboardImageRedeclare).
+    private var lastImageSignature: ClipboardImageRedeclare.Signature?
     /// The poll reads the pasteboard off the main thread: while a password
     /// prompt is up the pasteboard server can take seconds to answer, and a
     /// blocked main thread stalls every event tap with it, so typing freezes
@@ -637,6 +641,16 @@ final class ClipboardHistoryService: ObservableObject {
 
     private func promoteImage(_ image: (data: Data, width: Int, height: Int)) {
         let hash = Self.sha256Hex(image.data)
+        let thumbnail = ClipboardImageRedeclare.thumbnail(of: image.data)
+        defer {
+            lastImageSignature = thumbnail.map {
+                ClipboardImageRedeclare.Signature(width: image.width,
+                                                  height: image.height,
+                                                  thumbnail: $0,
+                                                  capturedAt: Date(),
+                                                  entryID: entries.first { $0.kind == .image }?.id ?? UUID())
+            }
+        }
         if let existing = entries.first(where: { $0.kind == .image && $0.imageHash == hash }) {
             entries.removeAll { $0.id == existing.id }
             insertPromoted(ClipboardHistoryEntry(id: existing.id,
@@ -646,6 +660,27 @@ final class ClipboardHistoryService: ObservableObject {
                                                  kind: .image,
                                                  imageFile: existing.imageFile,
                                                  imageHash: hash,
+                                                 imageWidth: existing.imageWidth,
+                                                 imageHeight: existing.imageHeight))
+        } else if let thumbnail,
+                  let redeclaredID = ClipboardImageRedeclare.redeclaredEntryID(
+                      previous: lastImageSignature,
+                      width: image.width,
+                      height: image.height,
+                      thumbnail: thumbnail),
+                  let existing = entries.first(where: { $0.id == redeclaredID }) {
+            // The source app re-posted the same picture while resolving a
+            // promised flavor (Chromium image copies do this seconds after the
+            // copy, re-encoded to sRGB). Refresh the entry it already has
+            // instead of recording a twin.
+            entries.removeAll { $0.id == existing.id }
+            insertPromoted(ClipboardHistoryEntry(id: existing.id,
+                                                 text: "",
+                                                 copiedAt: Date(),
+                                                 pinnedAt: existing.pinnedAt,
+                                                 kind: .image,
+                                                 imageFile: existing.imageFile,
+                                                 imageHash: existing.imageHash,
                                                  imageWidth: existing.imageWidth,
                                                  imageHeight: existing.imageHeight))
         } else {

--- a/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
+++ b/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
@@ -641,16 +641,15 @@ final class ClipboardHistoryService: ObservableObject {
 
     private func promoteImage(_ image: (data: Data, width: Int, height: Int)) {
         let hash = Self.sha256Hex(image.data)
-        let thumbnail = ClipboardImageRedeclare.thumbnail(of: image.data)
-        defer {
-            lastImageSignature = thumbnail.map {
-                ClipboardImageRedeclare.Signature(width: image.width,
-                                                  height: image.height,
-                                                  thumbnail: $0,
-                                                  capturedAt: Date(),
-                                                  entryID: entries.first { $0.kind == .image }?.id ?? UUID())
-            }
-        }
+        var thumbnail: [UInt8]?
+        // The id of the entry this capture was recorded into. Threaded from
+        // each insertion site instead of re-searching `entries` afterwards:
+        // the array is pinned-first, so a lookup like
+        // `entries.first { $0.kind == .image }` binds to a PINNED image when
+        // one exists and the next re-declare would fold into (and refresh)
+        // the wrong entry, silently dropping a real copy.
+        var recordedID: UUID?
+
         if let existing = entries.first(where: { $0.kind == .image && $0.imageHash == hash }) {
             entries.removeAll { $0.id == existing.id }
             insertPromoted(ClipboardHistoryEntry(id: existing.id,
@@ -662,35 +661,59 @@ final class ClipboardHistoryService: ObservableObject {
                                                  imageHash: hash,
                                                  imageWidth: existing.imageWidth,
                                                  imageHeight: existing.imageHeight))
-        } else if let thumbnail,
-                  let redeclaredID = ClipboardImageRedeclare.redeclaredEntryID(
-                      previous: lastImageSignature,
-                      width: image.width,
-                      height: image.height,
-                      thumbnail: thumbnail),
-                  let existing = entries.first(where: { $0.id == redeclaredID }) {
-            // The source app re-posted the same picture while resolving a
-            // promised flavor (Chromium image copies do this seconds after the
-            // copy, re-encoded to sRGB). Refresh the entry it already has
-            // instead of recording a twin.
-            entries.removeAll { $0.id == existing.id }
-            insertPromoted(ClipboardHistoryEntry(id: existing.id,
-                                                 text: "",
-                                                 copiedAt: Date(),
-                                                 pinnedAt: existing.pinnedAt,
-                                                 kind: .image,
-                                                 imageFile: existing.imageFile,
-                                                 imageHash: existing.imageHash,
-                                                 imageWidth: existing.imageWidth,
-                                                 imageHeight: existing.imageHeight))
+            recordedID = existing.id
         } else {
-            guard let name = ClipboardImageStore.store(image.data) else { return }
-            insertPromoted(ClipboardHistoryEntry(text: "",
-                                                 kind: .image,
-                                                 imageFile: name,
-                                                 imageHash: hash,
-                                                 imageWidth: image.width,
-                                                 imageHeight: image.height))
+            thumbnail = ClipboardImageRedeclare.thumbnail(of: image.data)
+            if let thumbnail,
+               let redeclaredID = ClipboardImageRedeclare.redeclaredEntryID(
+                   previous: lastImageSignature,
+                   width: image.width,
+                   height: image.height,
+                   thumbnail: thumbnail),
+               let existing = entries.first(where: { $0.id == redeclaredID }) {
+                // The source app re-posted the same picture while resolving a
+                // promised flavor (Chromium image copies do this seconds after
+                // the copy, re-encoded to sRGB). Refresh the entry it already
+                // has instead of recording a twin.
+                entries.removeAll { $0.id == existing.id }
+                insertPromoted(ClipboardHistoryEntry(id: existing.id,
+                                                     text: "",
+                                                     copiedAt: Date(),
+                                                     pinnedAt: existing.pinnedAt,
+                                                     kind: .image,
+                                                     imageFile: existing.imageFile,
+                                                     imageHash: existing.imageHash,
+                                                     imageWidth: existing.imageWidth,
+                                                     imageHeight: existing.imageHeight))
+                recordedID = existing.id
+            } else if let name = ClipboardImageStore.store(image.data) {
+                let entry = ClipboardHistoryEntry(text: "",
+                                                  kind: .image,
+                                                  imageFile: name,
+                                                  imageHash: hash,
+                                                  imageWidth: image.width,
+                                                  imageHeight: image.height)
+                insertPromoted(entry)
+                recordedID = entry.id
+            }
+        }
+
+        guard let recordedID else {
+            // Nothing was recorded (image store failure). A signature must
+            // not survive pointing at a stale id, or the next capture inside
+            // the window would fold into an entry this capture never touched.
+            lastImageSignature = nil
+            return
+        }
+        if thumbnail == nil {
+            thumbnail = ClipboardImageRedeclare.thumbnail(of: image.data)
+        }
+        lastImageSignature = thumbnail.map {
+            ClipboardImageRedeclare.Signature(width: image.width,
+                                              height: image.height,
+                                              thumbnail: $0,
+                                              capturedAt: Date(),
+                                              entryID: recordedID)
         }
         normalizeEntryOrder()
         trimToLimit()

--- a/Sources/Vorssaint/Services/Clipboard/ClipboardImageRedeclareSupport.swift
+++ b/Sources/Vorssaint/Services/Clipboard/ClipboardImageRedeclareSupport.swift
@@ -60,8 +60,18 @@ enum ClipboardImageRedeclare {
     }
 
     static func thumbnail(of data: Data) -> [UInt8]? {
-        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
-              let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        // Ask ImageIO for a decode bounded at the comparison size instead of
+        // decoding the full bitmap: this runs on the main queue for every
+        // image copy, and a full decode of a 6K screenshot there is real,
+        // visible latency. ImageIO subsamples during decode, so the cost
+        // scales with the thumbnail, not the source.
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: thumbnailSide,
+            kCGImageSourceShouldCacheImmediately: true,
+        ]
+        guard let image = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary)
         else { return nil }
         return thumbnail(of: image)
     }

--- a/Sources/Vorssaint/Services/Clipboard/ClipboardImageRedeclareSupport.swift
+++ b/Sources/Vorssaint/Services/Clipboard/ClipboardImageRedeclareSupport.swift
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import CoreGraphics
+import Foundation
+import ImageIO
+
+/// Detects the second capture produced when a source app re-declares the
+/// pasteboard while resolving a promised image flavor. Chromium browsers post
+/// image copies with lazy flavors; the history capture's immediate read makes
+/// the browser render the promised PNG, and posting that render bumps the
+/// change count again seconds after the copy. The picture is the same, but it
+/// arrives from a different encoder — often converted from the page's Display
+/// P3 profile to sRGB — so byte hashes never match and the history records a
+/// twin. Compared here on a small colorspace-normalized thumbnail instead,
+/// which absorbs the rounding that color conversion introduces while still
+/// telling genuinely different images apart.
+enum ClipboardImageRedeclare {
+    /// A re-declare lands within a couple of seconds of the copy; anything
+    /// later is treated as a deliberate new copy.
+    static let window: TimeInterval = 3
+    static let thumbnailSide = 16
+    /// Mean absolute channel difference at or below this reads as the same
+    /// picture. Color-managed re-encodes land near zero once downsampled;
+    /// different images of the same size land far above it.
+    static let tolerance: Double = 3
+
+    struct Signature {
+        let width: Int
+        let height: Int
+        let thumbnail: [UInt8]
+        let capturedAt: Date
+        let entryID: UUID
+    }
+
+    /// The entry the new image re-declares, or nil when it is a genuine new
+    /// copy: same pixel size, inside the window, and matching thumbnails.
+    static func redeclaredEntryID(previous: Signature?,
+                                  width: Int,
+                                  height: Int,
+                                  thumbnail: [UInt8],
+                                  at date: Date = Date()) -> UUID? {
+        guard let previous,
+              previous.width == width,
+              previous.height == height,
+              date.timeIntervalSince(previous.capturedAt) >= 0,
+              date.timeIntervalSince(previous.capturedAt) <= window,
+              matches(previous.thumbnail, thumbnail)
+        else { return nil }
+        return previous.entryID
+    }
+
+    static func matches(_ a: [UInt8], _ b: [UInt8]) -> Bool {
+        guard a.count == b.count, !a.isEmpty else { return false }
+        var total = 0
+        for index in a.indices {
+            total += abs(Int(a[index]) - Int(b[index]))
+        }
+        return Double(total) / Double(a.count) <= tolerance
+    }
+
+    static func thumbnail(of data: Data) -> [UInt8]? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+        else { return nil }
+        return thumbnail(of: image)
+    }
+
+    /// Draws into a fixed sRGB RGBA8 canvas so images tagged with different
+    /// profiles are compared in one colorspace.
+    static func thumbnail(of image: CGImage) -> [UInt8]? {
+        let side = thumbnailSide
+        let bytesPerRow = side * 4
+        var buffer = [UInt8](repeating: 0, count: side * bytesPerRow)
+        guard let space = CGColorSpace(name: CGColorSpace.sRGB) else { return nil }
+        let drawn = buffer.withUnsafeMutableBytes { raw -> Bool in
+            guard let context = CGContext(data: raw.baseAddress,
+                                          width: side,
+                                          height: side,
+                                          bitsPerComponent: 8,
+                                          bytesPerRow: bytesPerRow,
+                                          space: space,
+                                          bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+            else { return false }
+            context.interpolationQuality = .high
+            context.draw(image, in: CGRect(x: 0, y: 0, width: side, height: side))
+            return true
+        }
+        return drawn ? buffer : nil
+    }
+}

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -169,6 +169,117 @@ struct MetricsTests {
         expect(ClipboardHistorySearch.rankedIndexes(candidates: clipboardCandidates,
                                                     matching: "cleanup token") == [1],
                "clipboard search matches pinned entries with reordered query terms")
+
+        // MARK: Clipboard image re-declare detection
+
+        func solidThumbnail(_ value: UInt8) -> [UInt8] {
+            [UInt8](repeating: value,
+                    count: ClipboardImageRedeclare.thumbnailSide
+                        * ClipboardImageRedeclare.thumbnailSide * 4)
+        }
+        let redeclareID = UUID()
+        let baseSignature = ClipboardImageRedeclare.Signature(width: 300,
+                                                              height: 200,
+                                                              thumbnail: solidThumbnail(120),
+                                                              capturedAt: Date(),
+                                                              entryID: redeclareID)
+        expect(ClipboardImageRedeclare.redeclaredEntryID(previous: baseSignature,
+                                                         width: 300,
+                                                         height: 200,
+                                                         thumbnail: solidThumbnail(122)) == redeclareID,
+               "re-declare match: same size, near-identical pixels inside the window")
+        expect(ClipboardImageRedeclare.redeclaredEntryID(previous: baseSignature,
+                                                         width: 300,
+                                                         height: 200,
+                                                         thumbnail: solidThumbnail(140)) == nil,
+               "different pixels are a new copy, not a re-declare")
+        expect(ClipboardImageRedeclare.redeclaredEntryID(previous: baseSignature,
+                                                         width: 200,
+                                                         height: 300,
+                                                         thumbnail: solidThumbnail(120)) == nil,
+               "different pixel size is a new copy")
+        expect(ClipboardImageRedeclare.redeclaredEntryID(previous: nil,
+                                                         width: 300,
+                                                         height: 200,
+                                                         thumbnail: solidThumbnail(120)) == nil,
+               "no prior capture means no re-declare")
+        let staleSignature = ClipboardImageRedeclare.Signature(
+            width: 300,
+            height: 200,
+            thumbnail: solidThumbnail(120),
+            capturedAt: Date().addingTimeInterval(-ClipboardImageRedeclare.window - 1),
+            entryID: redeclareID)
+        expect(ClipboardImageRedeclare.redeclaredEntryID(previous: staleSignature,
+                                                         width: 300,
+                                                         height: 200,
+                                                         thumbnail: solidThumbnail(120)) == nil,
+               "a matching image after the window is a deliberate re-copy")
+        expect(!ClipboardImageRedeclare.matches(solidThumbnail(120), []),
+               "empty thumbnails never match")
+        // Same picture through two encoders/colorspaces must land inside the
+        // tolerance: render one bitmap, tag it P3 vs sRGB, and compare.
+        let redeclareSide = ClipboardImageRedeclare.thumbnailSide
+        var gradient = [UInt8](repeating: 0, count: redeclareSide * redeclareSide * 4)
+        for y in 0..<redeclareSide {
+            for x in 0..<redeclareSide {
+                let offset = (y * redeclareSide + x) * 4
+                gradient[offset] = UInt8((x * 255) / (redeclareSide - 1))
+                gradient[offset + 1] = UInt8((y * 255) / (redeclareSide - 1))
+                gradient[offset + 2] = 96
+                gradient[offset + 3] = 255
+            }
+        }
+        func gradientImage(space name: CFString) -> CGImage? {
+            gradient.withUnsafeMutableBytes { raw -> CGImage? in
+                guard let space = CGColorSpace(name: name),
+                      let context = CGContext(data: raw.baseAddress,
+                                              width: redeclareSide,
+                                              height: redeclareSide,
+                                              bitsPerComponent: 8,
+                                              bytesPerRow: redeclareSide * 4,
+                                              space: space,
+                                              bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+                else { return nil }
+                return context.makeImage()
+            }
+        }
+        // A real re-declare is a color-managed CONVERSION: the pixel values
+        // change to keep the picture looking the same. Simulate it by
+        // normalizing a P3-tagged render to sRGB (what the detector's own
+        // thumbnail pass does) and re-wrapping that result as an sRGB image —
+        // the two must compare as the same picture. Same bytes merely
+        // re-TAGGED with a different profile are genuinely different colors
+        // and must NOT match.
+        if let p3 = gradientImage(space: CGColorSpace.displayP3),
+           let p3Thumb = ClipboardImageRedeclare.thumbnail(of: p3) {
+            var converted = p3Thumb
+            let convertedImage = converted.withUnsafeMutableBytes { raw -> CGImage? in
+                guard let space = CGColorSpace(name: CGColorSpace.sRGB),
+                      let context = CGContext(data: raw.baseAddress,
+                                              width: redeclareSide,
+                                              height: redeclareSide,
+                                              bitsPerComponent: 8,
+                                              bytesPerRow: redeclareSide * 4,
+                                              space: space,
+                                              bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+                else { return nil }
+                return context.makeImage()
+            }
+            if let convertedImage,
+               let srgbThumb = ClipboardImageRedeclare.thumbnail(of: convertedImage) {
+                expect(ClipboardImageRedeclare.matches(p3Thumb, srgbThumb),
+                       "a color-managed P3→sRGB re-encode compares as the same image")
+            } else {
+                expect(false, "converted sRGB image can be produced")
+            }
+            if let retagged = gradientImage(space: CGColorSpace.sRGB),
+               let retaggedThumb = ClipboardImageRedeclare.thumbnail(of: retagged) {
+                expect(!ClipboardImageRedeclare.matches(p3Thumb, retaggedThumb),
+                       "same bytes re-tagged with a different profile are different colors")
+            }
+        } else {
+            expect(false, "colorspace-normalized thumbnails can be produced")
+        }
         expect(ClipboardHistorySearch.rankedIndexes(candidates: clipboardCandidates,
                                                     matching: "missing") == [],
                "clipboard search returns no results for unmatched terms")

--- a/build.sh
+++ b/build.sh
@@ -222,6 +222,7 @@ if (( TEST )); then
         Sources/Vorssaint/Core/DiskImageInstallerStrings.swift \
         Sources/Vorssaint/Services/DiskImageInstaller/DiskImageInstallerSupport.swift \
         Sources/Vorssaint/Services/Clipboard/ClipboardHistorySupport.swift \
+        Sources/Vorssaint/Services/Clipboard/ClipboardImageRedeclareSupport.swift \
         Sources/Vorssaint/Services/Clipboard/ClipboardAutoClearSupport.swift \
         Sources/Vorssaint/Services/AutoQuit/AutoQuitSupport.swift \
         Sources/Vorssaint/Services/Shelf/ShelfSupport.swift \


### PR DESCRIPTION
Refs #873.

Chromium browsers post image copies with promised (lazy) flavors. The history capture's immediate read resolves the promise, and Chromium re-declares the pasteboard with its own PNG render seconds after the copy — re-encoded to sRGB, so the byte hash never matches the first capture and `promoteImage` records the same picture twice (full instrumentation in the issue).

### What this does

- New `ClipboardImageRedeclare` helper: keeps a 16×16 sRGB-normalized thumbnail signature of the most recent image capture.
- In `promoteImage`, when the byte-hash dedupe misses, a new image with the **same pixel size**, arriving **within 3 seconds**, whose **normalized thumbnail matches** (mean absolute channel delta ≤ 3) is treated as the source app re-posting the same picture: the existing entry is refreshed (same file, same id) instead of a twin being inserted.
- Genuine new copies are untouched: different pixels, different dimensions, no prior capture, or anything after the window all fall through to the existing insert path.

### Why thumbnail comparison

The re-declared render is a color-managed conversion, so bytes and even exact pixel values differ. Measured on a real Brave copy pair (P3 original vs Chromium sRGB re-render): mean channel delta **~0.5** after normalizing both to sRGB. Measured on the counter-case (same bytes merely re-tagged with a different profile — genuinely different colors): **~8.5**. The tolerance of 3 sits between them with margin on both sides.

### Tests

Added to `MetricsTests` (runs in `./build.sh --test`, 8302 checks green):
- re-declare match inside the window / different pixels / different size / no prior / stale window / empty thumbnails
- a color-managed P3→sRGB re-encode of one picture compares equal; same bytes re-tagged P3 vs sRGB compare different

Verified live on a MacBook Pro (macOS 26): with this build, driven Brave image copies that previously produced two entries produce one.

