### PR TITLE
feat(always-on-top): add Always On Top window pin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,11 +81,10 @@ A few conventions to keep in mind.
 
 ## Strings and translations
 
-Shared chrome strings live in `Core/Localization.swift` as fields of the
-`Strings` struct. Feature-specific copy lives in a `*Strings.swift` file under
-`Core/` and is exposed through `FeatureStrings`. Adding a field forces **every**
-supported language to provide it, and the compiler is the completeness check,
-so a translation can never silently fall out of sync.
+Every user facing string lives in `Core/Localization.swift` as a field of the
+`Strings` struct. Adding a field forces **every** supported language to provide
+it, and the compiler is the completeness check, so a translation can never
+silently fall out of sync.
 
 Vorssaint ships these locales today: English (US), Português (Brasil),
 Türkçe, Русский, Español, Deutsch, Français, Italiano, 日本語, 한국어, 简体中文,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,10 +81,11 @@ A few conventions to keep in mind.
 
 ## Strings and translations
 
-Every user facing string lives in `Core/Localization.swift` as a field of the
-`Strings` struct. Adding a field forces **every** supported language to provide
-it, and the compiler is the completeness check, so a translation can never
-silently fall out of sync.
+Shared chrome strings live in `Core/Localization.swift` as fields of the
+`Strings` struct. Feature-specific copy lives in a `*Strings.swift` file under
+`Core/` and is exposed through `FeatureStrings`. Adding a field forces **every**
+supported language to provide it, and the compiler is the completeness check,
+so a translation can never silently fall out of sync.
 
 Vorssaint ships these locales today: English (US), Português (Brasil),
 Türkçe, Русский, Español, Deutsch, Français, Italiano, 日本語, 한국어, 简体中文,

--- a/Sources/Vorssaint/App/AppDelegate.swift
+++ b/Sources/Vorssaint/App/AppDelegate.swift
@@ -232,6 +232,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         URLCleanerService.shared.stop()
         FocusFollowsMouseService.shared.stop()
         WindowMaximizer.shared.stop()
+        AlwaysOnTopService.shared.stop()
         WindowLayoutService.shared.suspend()
         KeyboardDebounceService.shared.suspend()
         TextSnippetService.shared.suspend()

--- a/Sources/Vorssaint/App/FeatureRuntime.swift
+++ b/Sources/Vorssaint/App/FeatureRuntime.swift
@@ -165,6 +165,7 @@ final class FeatureRuntime: ObservableObject {
             WindowLayoutService.shared.syncWithPreferences()
         },
         .autoQuit: { AutoQuitService.shared.syncWithPreferences() },
+        .alwaysOnTop: { AlwaysOnTopService.shared.syncWithPreferences() },
         .scrollInverter: { ScrollInverter.shared.syncWithPreferences() },
         .focusFollowsMouse: { FocusFollowsMouseService.shared.syncWithPreferences() },
         .smoothScroll: { SmoothScrollService.shared.syncWithPreferences() },

--- a/Sources/Vorssaint/Core/AlwaysOnTopStrings.swift
+++ b/Sources/Vorssaint/Core/AlwaysOnTopStrings.swift
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+struct AlwaysOnTopFeatureStrings {
+    let title: String
+    let hubDescription: String
+    let enable: String
+    let enableCaption: String
+    let activeNow: String
+    let shortcut: String
+    let showBorder: String
+    let borderColor: String
+    let borderThickness: String
+    let playSound: String
+    let excludeTitle: String
+    let excludeEmpty: String
+    let addApp: String
+    let excludeCaption: String
+    let pinningUnavailable: String
+    let permissionRequired: String
+}
+
+extension FeatureStrings {
+    static func alwaysOnTop(_ language: AppLanguage) -> AlwaysOnTopFeatureStrings {
+        switch language {
+        case .enUS: return .enUS
+        case .ptBR: return .ptBR
+        case .tr: return .tr
+        case .ru: return .ru
+        case .es: return .es
+        case .de: return .de
+        case .fr: return .fr
+        case .it: return .it
+        case .ja: return .ja
+        case .ko: return .ko
+        case .zhHans: return .zhHans
+        case .zhTW: return .zhTW
+        case .zhHK: return .zhHK
+        }
+    }
+}
+
+extension AlwaysOnTopFeatureStrings {
+    static let enUS = AlwaysOnTopFeatureStrings(
+        title: "Always On Top",
+        hubDescription: "Pin the frontmost window above other windows",
+        enable: "Enable Always On Top",
+        enableCaption: "Press the shortcut to pin or unpin the frontmost window.",
+        activeNow: "Pinning is on",
+        shortcut: "Pin window",
+        showBorder: "Show border around pinned windows",
+        borderColor: "Border color",
+        borderThickness: "Border thickness",
+        playSound: "Play a sound when pinning",
+        excludeTitle: "Excluded apps",
+        excludeEmpty: "No apps excluded",
+        addApp: "Add App",
+        excludeCaption: "The shortcut does nothing when one of these apps is frontmost.",
+        pinningUnavailable: "This Mac cannot pin other apps' windows. The shortcut will do nothing.",
+        permissionRequired: "Accessibility is required to find the frontmost window."
+    )
+
+    static let ptBR = AlwaysOnTopFeatureStrings(
+        title: "Sempre no topo",
+        hubDescription: "Fixa a janela da frente acima das outras",
+        enable: "Ativar Sempre no topo",
+        enableCaption: "Pressione o atalho para fixar ou desafixar a janela da frente.",
+        activeNow: "A fixação está ligada",
+        shortcut: "Fixar janela",
+        showBorder: "Mostrar borda nas janelas fixadas",
+        borderColor: "Cor da borda",
+        borderThickness: "Espessura da borda",
+        playSound: "Tocar um som ao fixar",
+        excludeTitle: "Apps excluídos",
+        excludeEmpty: "Nenhum app excluído",
+        addApp: "Adicionar App",
+        excludeCaption: "O atalho não faz nada quando um destes apps está na frente.",
+        pinningUnavailable: "Este Mac não consegue fixar janelas de outros apps. O atalho não fará nada.",
+        permissionRequired: "A Acessibilidade é necessária para encontrar a janela da frente."
+    )
+
+    static let tr = AlwaysOnTopFeatureStrings(
+        title: "Her Zaman Üstte",
+        hubDescription: "Öndeki pencereyi diğer pencerelerin üstünde tut",
+        enable: "Her Zaman Üstte’yi aç",
+        enableCaption: "Öndeki pencereyi sabitlemek veya kaldırmak için kısayola basın.",
+        activeNow: "Sabitleme açık",
+        shortcut: "Pencereyi sabitle",
+        showBorder: "Sabitlenen pencerelerin çevresinde kenarlık göster",
+        borderColor: "Kenarlık rengi",
+        borderThickness: "Kenarlık kalınlığı",
+        playSound: "Sabitlerken bir ses çal",
+        excludeTitle: "Hariç tutulan uygulamalar",
+        excludeEmpty: "Hariç tutulan uygulama yok",
+        addApp: "Uygulama Ekle",
+        excludeCaption: "Bu uygulamalardan biri öndeyken kısayol hiçbir şey yapmaz.",
+        pinningUnavailable: "Bu Mac diğer uygulamaların pencerelerini sabitleyemez. Kısayol hiçbir şey yapmaz.",
+        permissionRequired: "Öndeki pencereyi bulmak için Erişilebilirlik gerekir."
+    )
+
+    static let ru = AlwaysOnTopFeatureStrings(
+        title: "Поверх всех окон",
+        hubDescription: "Закрепляет переднее окно над остальными",
+        enable: "Включить «Поверх всех окон»",
+        enableCaption: "Нажмите сочетание клавиш, чтобы закрепить или открепить переднее окно.",
+        activeNow: "Закрепление включено",
+        shortcut: "Закрепить окно",
+        showBorder: "Показывать рамку вокруг закреплённых окон",
+        borderColor: "Цвет рамки",
+        borderThickness: "Толщина рамки",
+        playSound: "Звук при закреплении",
+        excludeTitle: "Исключённые приложения",
+        excludeEmpty: "Нет исключённых приложений",
+        addApp: "Добавить приложение",
+        excludeCaption: "Сочетание ничего не делает, когда одно из этих приложений на переднем плане.",
+        pinningUnavailable: "Этот Mac не может закреплять окна других приложений. Сочетание ничего не сделает.",
+        permissionRequired: "Для поиска переднего окна нужна Универсальный доступ."
+    )
+
+    static let es = AlwaysOnTopFeatureStrings(
+        title: "Siempre visible",
+        hubDescription: "Fija la ventana delantera por encima de las demás",
+        enable: "Activar Siempre visible",
+        enableCaption: "Pulsa el atajo para fijar o desfijar la ventana delantera.",
+        activeNow: "La fijación está activa",
+        shortcut: "Fijar ventana",
+        showBorder: "Mostrar borde alrededor de las ventanas fijadas",
+        borderColor: "Color del borde",
+        borderThickness: "Grosor del borde",
+        playSound: "Reproducir un sonido al fijar",
+        excludeTitle: "Apps excluidas",
+        excludeEmpty: "Ninguna app excluida",
+        addApp: "Añadir App",
+        excludeCaption: "El atajo no hace nada cuando una de estas apps está al frente.",
+        pinningUnavailable: "Este Mac no puede fijar ventanas de otras apps. El atajo no hará nada.",
+        permissionRequired: "Se necesita Accesibilidad para encontrar la ventana delantera."
+    )
+
+    static let de = AlwaysOnTopFeatureStrings(
+        title: "Immer im Vordergrund",
+        hubDescription: "Hält das vorderste Fenster über den anderen",
+        enable: "Immer im Vordergrund aktivieren",
+        enableCaption: "Drücke das Tastenkürzel, um das vorderste Fenster anzuheften oder zu lösen.",
+        activeNow: "Anheften ist an",
+        shortcut: "Fenster anheften",
+        showBorder: "Rahmen um angeheftete Fenster zeigen",
+        borderColor: "Rahmenfarbe",
+        borderThickness: "Rahmenstärke",
+        playSound: "Beim Anheften einen Ton abspielen",
+        excludeTitle: "Ausgeschlossene Apps",
+        excludeEmpty: "Keine Apps ausgeschlossen",
+        addApp: "App hinzufügen",
+        excludeCaption: "Das Tastenkürzel tut nichts, wenn eine dieser Apps im Vordergrund ist.",
+        pinningUnavailable: "Dieser Mac kann Fenster anderer Apps nicht anheften. Das Tastenkürzel tut nichts.",
+        permissionRequired: "Bedienungshilfen sind nötig, um das vorderste Fenster zu finden."
+    )
+
+    static let fr = AlwaysOnTopFeatureStrings(
+        title: "Toujours au premier plan",
+        hubDescription: "Épingle la fenêtre au premier plan au-dessus des autres",
+        enable: "Activer Toujours au premier plan",
+        enableCaption: "Appuyez sur le raccourci pour épingler ou détacher la fenêtre au premier plan.",
+        activeNow: "L’épinglage est activé",
+        shortcut: "Épingler la fenêtre",
+        showBorder: "Afficher une bordure autour des fenêtres épinglées",
+        borderColor: "Couleur de la bordure",
+        borderThickness: "Épaisseur de la bordure",
+        playSound: "Jouer un son lors de l’épinglage",
+        excludeTitle: "Apps exclues",
+        excludeEmpty: "Aucune app exclue",
+        addApp: "Ajouter une app",
+        excludeCaption: "Le raccourci ne fait rien lorsqu’une de ces apps est au premier plan.",
+        pinningUnavailable: "Ce Mac ne peut pas épingler les fenêtres des autres apps. Le raccourci ne fera rien.",
+        permissionRequired: "L’accessibilité est requise pour trouver la fenêtre au premier plan."
+    )
+
+    static let it = AlwaysOnTopFeatureStrings(
+        title: "Sempre in primo piano",
+        hubDescription: "Fissa la finestra in primo piano sopra le altre",
+        enable: "Attiva Sempre in primo piano",
+        enableCaption: "Premi la scorciatoia per fissare o sbloccare la finestra in primo piano.",
+        activeNow: "Il fissaggio è attivo",
+        shortcut: "Fissa finestra",
+        showBorder: "Mostra un bordo intorno alle finestre fissate",
+        borderColor: "Colore del bordo",
+        borderThickness: "Spessore del bordo",
+        playSound: "Riproduci un suono quando fissi",
+        excludeTitle: "App escluse",
+        excludeEmpty: "Nessuna app esclusa",
+        addApp: "Aggiungi App",
+        excludeCaption: "La scorciatoia non fa nulla quando una di queste app è in primo piano.",
+        pinningUnavailable: "Questo Mac non può fissare le finestre di altre app. La scorciatoia non farà nulla.",
+        permissionRequired: "Accessibilità è necessaria per trovare la finestra in primo piano."
+    )
+
+    static let ja = AlwaysOnTopFeatureStrings(
+        title: "常に最前面",
+        hubDescription: "最前面のウインドウを他のウインドウの上に固定します",
+        enable: "常に最前面を有効にする",
+        enableCaption: "ショートカットで最前面のウインドウを固定または解除します。",
+        activeNow: "固定はオンです",
+        shortcut: "ウインドウを固定",
+        showBorder: "固定したウインドウの周りに枠を表示",
+        borderColor: "枠の色",
+        borderThickness: "枠の太さ",
+        playSound: "固定するときに音を鳴らす",
+        excludeTitle: "除外するアプリ",
+        excludeEmpty: "除外するアプリはありません",
+        addApp: "アプリを追加",
+        excludeCaption: "これらのアプリが最前面のときはショートカットは何もしません。",
+        pinningUnavailable: "この Mac は他のアプリのウインドウを固定できません。ショートカットは何もしません。",
+        permissionRequired: "最前面のウインドウを見つけるにはアクセシビリティが必要です。"
+    )
+
+    static let ko = AlwaysOnTopFeatureStrings(
+        title: "항상 위",
+        hubDescription: "맨 앞 윈도우를 다른 윈도우 위에 고정합니다",
+        enable: "항상 위 켜기",
+        enableCaption: "단축키로 맨 앞 윈도우를 고정하거나 해제합니다.",
+        activeNow: "고정이 켜져 있습니다",
+        shortcut: "윈도우 고정",
+        showBorder: "고정된 윈도우 주위에 테두리 표시",
+        borderColor: "테두리 색",
+        borderThickness: "테두리 두께",
+        playSound: "고정할 때 소리 재생",
+        excludeTitle: "제외된 앱",
+        excludeEmpty: "제외된 앱이 없습니다",
+        addApp: "앱 추가",
+        excludeCaption: "이 앱 중 하나가 맨 앞에 있으면 단축키는 아무 것도 하지 않습니다.",
+        pinningUnavailable: "이 Mac은 다른 앱의 윈도우를 고정할 수 없습니다. 단축키는 아무 것도 하지 않습니다.",
+        permissionRequired: "맨 앞 윈도우를 찾으려면 손쉬운 사용이 필요합니다."
+    )
+
+    static let zhHans = AlwaysOnTopFeatureStrings(
+        title: "始终置顶",
+        hubDescription: "将最前面的窗口固定在其他窗口之上",
+        enable: "启用始终置顶",
+        enableCaption: "按快捷键固定或取消固定最前面的窗口。",
+        activeNow: "置顶已开启",
+        shortcut: "固定窗口",
+        showBorder: "在已固定窗口周围显示边框",
+        borderColor: "边框颜色",
+        borderThickness: "边框粗细",
+        playSound: "固定时播放声音",
+        excludeTitle: "排除的 App",
+        excludeEmpty: "没有排除的 App",
+        addApp: "添加 App",
+        excludeCaption: "这些 App 在最前面时，快捷键不会执行任何操作。",
+        pinningUnavailable: "这台 Mac 无法固定其他 App 的窗口。快捷键不会执行任何操作。",
+        permissionRequired: "需要辅助功能才能找到最前面的窗口。"
+    )
+
+    static let zhTW = AlwaysOnTopFeatureStrings(
+        title: "永遠置頂",
+        hubDescription: "將最前面的視窗固定在其他視窗之上",
+        enable: "啟用永遠置頂",
+        enableCaption: "按快捷鍵固定或取消固定最前面的視窗。",
+        activeNow: "置頂已開啟",
+        shortcut: "固定視窗",
+        showBorder: "在已固定視窗周圍顯示邊框",
+        borderColor: "邊框顏色",
+        borderThickness: "邊框粗細",
+        playSound: "固定時播放聲音",
+        excludeTitle: "排除的 App",
+        excludeEmpty: "沒有排除的 App",
+        addApp: "加入 App",
+        excludeCaption: "這些 App 在最前面時，快捷鍵不會執行任何操作。",
+        pinningUnavailable: "這台 Mac 無法固定其他 App 的視窗。快捷鍵不會執行任何操作。",
+        permissionRequired: "需要輔助使用才能找到最前面的視窗。"
+    )
+
+    static let zhHK = AlwaysOnTopFeatureStrings(
+        title: "永遠置頂",
+        hubDescription: "將最前面的視窗固定在其他視窗之上",
+        enable: "啟用永遠置頂",
+        enableCaption: "按快捷鍵固定或取消固定最前面的視窗。",
+        activeNow: "置頂已開啟",
+        shortcut: "固定視窗",
+        showBorder: "在已固定視窗周圍顯示邊框",
+        borderColor: "邊框顏色",
+        borderThickness: "邊框粗細",
+        playSound: "固定時播放聲音",
+        excludeTitle: "排除的 App",
+        excludeEmpty: "沒有排除的 App",
+        addApp: "加入 App",
+        excludeCaption: "這些 App 在最前面時，快捷鍵不會執行任何操作。",
+        pinningUnavailable: "這部 Mac 無法固定其他 App 的視窗。快捷鍵不會執行任何操作。",
+        permissionRequired: "需要輔助使用才能找到最前面的視窗。"
+    )
+}

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -109,6 +109,13 @@ enum DefaultsKey {
     static let finderPasteImageAsFile = "finderPasteImageAsFile"
     static let autoQuitEnabled = "autoQuitEnabled"
     static let autoQuitExceptions = "autoQuitExceptions"  // [bundle id] kept running
+    static let alwaysOnTopEnabled = "alwaysOnTopEnabled"
+    static let alwaysOnTopShortcut = "alwaysOnTopShortcut"
+    static let alwaysOnTopShowBorder = "alwaysOnTopShowBorder"
+    static let alwaysOnTopBorderColor = "alwaysOnTopBorderColor"
+    static let alwaysOnTopBorderThickness = "alwaysOnTopBorderThickness"
+    static let alwaysOnTopPlaySound = "alwaysOnTopPlaySound"
+    static let alwaysOnTopExcludedApps = "alwaysOnTopExcludedApps"
     static let shelfEnabled = "shelfEnabled"
     static let shelfShortcutEnabled = "shelfShortcutEnabled"
     static let shelfShortcut = "shelfShortcut"            // GlobalShortcut storage value
@@ -1140,6 +1147,13 @@ enum Defaults {
         DefaultsKey.screenOCRShortcutEnabled: false,
         DefaultsKey.screenOCRShortcut: GlobalShortcut.screenOCRDefault.storageValue,
         DefaultsKey.screenOCRRemoveLineBreaks: false,
+        DefaultsKey.alwaysOnTopEnabled: false,
+        DefaultsKey.alwaysOnTopShortcut: GlobalShortcut.alwaysOnTopDefault.storageValue,
+        DefaultsKey.alwaysOnTopShowBorder: true,
+        DefaultsKey.alwaysOnTopBorderColor: "#00ADEF",
+        DefaultsKey.alwaysOnTopBorderThickness: 4,
+        DefaultsKey.alwaysOnTopPlaySound: true,
+        DefaultsKey.alwaysOnTopExcludedApps: [String](),
         DefaultsKey.screenOCRDetectQRCodes: true,
         DefaultsKey.micMuteShortcutEnabled: false,
         DefaultsKey.micMuteShortcut: GlobalShortcut.micMuteDefault.storageValue,

--- a/Sources/Vorssaint/Core/FeatureCatalog.swift
+++ b/Sources/Vorssaint/Core/FeatureCatalog.swift
@@ -14,7 +14,7 @@ import Foundation
 /// keys are never touched.
 enum AppFeature: String, CaseIterable {
     // Windows and Dock
-    case switcher, dockPreview, dockClick, windowMaximizer, windowLayout, autoQuit
+    case switcher, dockPreview, dockClick, windowMaximizer, windowLayout, autoQuit, alwaysOnTop
     // Mouse and keyboard
     case scrollInverter, focusFollowsMouse, smoothScroll, mouseNavigation, mouseButtonShortcuts, middleClick,
          keyboardDebounce, textSnippets, superKey
@@ -86,7 +86,7 @@ extension AppFeature {
 
     var group: FeatureGroup {
         switch self {
-        case .switcher, .dockPreview, .dockClick, .windowMaximizer, .windowLayout, .autoQuit:
+        case .switcher, .dockPreview, .dockClick, .windowMaximizer, .windowLayout, .autoQuit, .alwaysOnTop:
             return .windowsDock
         case .scrollInverter, .focusFollowsMouse, .smoothScroll, .mouseNavigation, .mouseButtonShortcuts, .middleClick,
              .keyboardDebounce, .textSnippets, .superKey:
@@ -116,6 +116,7 @@ extension AppFeature {
         case .windowMaximizer: return "arrow.up.left.and.arrow.down.right"
         case .windowLayout: return "rectangle.3.group"
         case .autoQuit: return "xmark.rectangle"
+        case .alwaysOnTop: return "pin.fill"
         case .scrollInverter: return "arrow.up.arrow.down"
         case .focusFollowsMouse: return "cursorarrow.and.square.on.square.dashed"
         case .smoothScroll: return "cursorarrow.motionlines"
@@ -193,6 +194,7 @@ extension AppFeature {
                                  DefaultsKey.dockClickCycleWindows]
         case .windowMaximizer: return [DefaultsKey.windowMaximizeEnabled]
         case .autoQuit: return [DefaultsKey.autoQuitEnabled]
+        case .alwaysOnTop: return [DefaultsKey.alwaysOnTopEnabled]
         case .scrollInverter: return [DefaultsKey.scrollInverterEnabled,
                                       DefaultsKey.scrollInverterHorizontalEnabled]
         case .focusFollowsMouse: return [DefaultsKey.focusFollowsMouseEnabled]
@@ -235,7 +237,7 @@ extension AppFeature {
         switch self {
         case .scrollInverter, .focusFollowsMouse, .smoothScroll, .mouseNavigation, .mouseButtonShortcuts, .middleClick,
              .keyboardDebounce, .textSnippets, .superKey, .dockClick, .windowMaximizer, .windowLayout,
-             .autoQuit, .cleaningMode, .pastePlain, .radialMenu,
+             .autoQuit, .alwaysOnTop, .cleaningMode, .pastePlain, .radialMenu,
              // The bar reads other apps' menus and windows and types at the
              // caret, all of it through Accessibility.
              .commandBar:
@@ -293,8 +295,8 @@ extension AppFeature {
     static var availabilityDefaults: [String: Any] {
         Dictionary(uniqueKeysWithValues: allCases.map {
             ($0.availabilityKey,
-             $0 != .focusFollowsMouse && $0 != .fanControl && $0 != .diskImageInstaller
-                && $0 != .killProcess)
+              $0 != .focusFollowsMouse && $0 != .fanControl && $0 != .diskImageInstaller
+                 && $0 != .killProcess && $0 != .alwaysOnTop)
         })
     }
 

--- a/Sources/Vorssaint/Core/FeaturePresets.swift
+++ b/Sources/Vorssaint/Core/FeaturePresets.swift
@@ -117,7 +117,7 @@ extension AppFeature {
              .musicBlock, .bluetoothSleep, .keepAwake, .brightness, .quickLauncher, .quickToggles, .colorPicker,
              .screenOCR, .cleaningMode, .mediaTools, .cleaner, .uninstaller, .homebrew, .screenshot,
              .cameraPreview, .scratchpad, .commandBar, .screenRecorder, .fanControl,
-             .diskImageInstaller, .killProcess:
+             .diskImageInstaller, .killProcess, .alwaysOnTop:
             return .idle
         case .appUpdates:
             // The list is on demand; only a background schedule keeps a timer.

--- a/Sources/Vorssaint/Core/GlobalShortcut.swift
+++ b/Sources/Vorssaint/Core/GlobalShortcut.swift
@@ -173,6 +173,8 @@ struct GlobalShortcut: Equatable, Hashable {
                                                    modifiers: [.control, .option, .command])
     static let screenOCRDefault = GlobalShortcut(keyCode: Int64(kVK_ANSI_T),
                                                  modifiers: [.control, .option, .command])
+    static let alwaysOnTopDefault = GlobalShortcut(keyCode: Int64(kVK_ANSI_T),
+                                                   modifiers: [.control, .option, .shift])
     static let micMuteDefault = GlobalShortcut(keyCode: Int64(kVK_ANSI_M),
                                                modifiers: [.control, .option, .command])
     // W for webcam, on the same free control-option-command layer.
@@ -581,6 +583,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
     case finderRename
     case colorPicker
     case screenOCR
+    case alwaysOnTop
     case micMute
     case quickLauncher
     case screenshot
@@ -608,6 +611,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .finderRename: return DefaultsKey.finderRenameShortcut
         case .colorPicker: return DefaultsKey.colorPickerShortcut
         case .screenOCR: return DefaultsKey.screenOCRShortcut
+        case .alwaysOnTop: return DefaultsKey.alwaysOnTopShortcut
         case .micMute: return DefaultsKey.micMuteShortcut
         case .quickLauncher: return DefaultsKey.quickLauncherShortcut
         case .screenshot: return DefaultsKey.screenshotShortcut
@@ -635,6 +639,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .finderRename: return .finderRenameDefault
         case .colorPicker: return .colorPickerDefault
         case .screenOCR: return .screenOCRDefault
+        case .alwaysOnTop: return .alwaysOnTopDefault
         case .micMute: return .micMuteDefault
         case .quickLauncher: return .quickLauncherDefault
         case .screenshot: return .screenshotDefault
@@ -666,6 +671,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .finderRename: return FeatureStrings.finderRename(L10n.shared.language).hubTitle
         case .colorPicker: return strings.colorPickerName
         case .screenOCR: return strings.ocrName
+        case .alwaysOnTop: return FeatureStrings.alwaysOnTop(L10n.shared.language).title
         case .micMute: return strings.micMuteName
         case .quickLauncher: return strings.launcherName
         case .screenshot:
@@ -714,6 +720,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .finderRename: return [DefaultsKey.finderRenameEnabled]
         case .colorPicker: return [DefaultsKey.colorPickerShortcutEnabled]
         case .screenOCR: return [DefaultsKey.screenOCRShortcutEnabled]
+        case .alwaysOnTop: return [DefaultsKey.alwaysOnTopEnabled]
         case .micMute: return [DefaultsKey.micMuteShortcutEnabled]
         case .quickLauncher: return [DefaultsKey.quickLauncherShortcutEnabled]
         case .screenshot: return [DefaultsKey.screenshotShortcutEnabled]
@@ -743,6 +750,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .finderRename: return .finderRename
         case .colorPicker: return .colorPicker
         case .screenOCR: return .screenOCR
+        case .alwaysOnTop: return .alwaysOnTop
         case .micMute: return .micMute
         case .quickLauncher: return .quickLauncher
         case .screenshot, .screenshotFullScreen, .screenshotLastCapture, .screenshotClipboard:

--- a/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopBorder.swift
+++ b/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopBorder.swift
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import CoreGraphics
+
+final class AlwaysOnTopBorder {
+    func show(windowID: CGWindowID, colorHex: String, thickness: CGFloat) {}
+    func hide() {}
+    func updateFrame() {}
+    func setMinimized(_ minimized: Bool) {}
+}

--- a/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopBorder.swift
+++ b/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopBorder.swift
@@ -5,8 +5,119 @@ import AppKit
 import CoreGraphics
 
 final class AlwaysOnTopBorder {
-    func show(windowID: CGWindowID, colorHex: String, thickness: CGFloat) {}
-    func hide() {}
-    func updateFrame() {}
-    func setMinimized(_ minimized: Bool) {}
+    private var panel: NSPanel?
+    private var stroke: AlwaysOnTopBorderView?
+    private var windowID: CGWindowID?
+    private var timer: Timer?
+    private var minimized = false
+
+    func show(windowID: CGWindowID, colorHex: String, thickness: CGFloat) {
+        self.windowID = windowID
+        minimized = false
+        let rgb = MenuBarUsageBarSupport.rgb(for: colorHex, fallback: "#00ADEF")
+        let color = NSColor(srgbRed: rgb.red, green: rgb.green, blue: rgb.blue, alpha: 1)
+        let line = max(1, thickness)
+
+        if panel == nil {
+            let panel = NSPanel(contentRect: .zero,
+                                styleMask: [.borderless, .nonactivatingPanel],
+                                backing: .buffered,
+                                defer: false)
+            panel.isOpaque = false
+            panel.backgroundColor = .clear
+            panel.hasShadow = false
+            panel.hidesOnDeactivate = false
+            panel.isFloatingPanel = true
+            panel.ignoresMouseEvents = true
+            panel.level = .floating
+            panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+            let stroke = AlwaysOnTopBorderView(frame: .zero)
+            panel.contentView = stroke
+            self.panel = panel
+            self.stroke = stroke
+        }
+        stroke?.color = color
+        stroke?.thickness = line
+        stroke?.needsDisplay = true
+        startTimer()
+        updateFrame()
+        if !minimized {
+            panel?.orderFrontRegardless()
+        }
+    }
+
+    func hide() {
+        timer?.invalidate()
+        timer = nil
+        panel?.orderOut(nil)
+        panel = nil
+        stroke = nil
+        windowID = nil
+        minimized = false
+    }
+
+    func updateFrame() {
+        guard !minimized, let windowID, let quartz = quartzBounds(windowID) else { return }
+        let frame = appKitFrame(fromQuartz: quartz)
+        panel?.setFrame(frame, display: true)
+        stroke?.needsDisplay = true
+    }
+
+    func setMinimized(_ minimized: Bool) {
+        self.minimized = minimized
+        if minimized {
+            panel?.orderOut(nil)
+        } else {
+            updateFrame()
+            panel?.orderFrontRegardless()
+        }
+    }
+
+    private func startTimer() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.15, repeats: true) { [weak self] _ in
+            self?.updateFrame()
+        }
+        if let timer {
+            RunLoop.main.add(timer, forMode: .common)
+        }
+    }
+
+    private func quartzBounds(_ windowID: CGWindowID) -> CGRect? {
+        guard let info = CGWindowListCopyWindowInfo([.optionIncludingWindow], windowID) as? [[String: Any]],
+              let dict = info.first?[kCGWindowBounds as String] as? [String: CGFloat]
+        else { return nil }
+        let bounds = CGRect(x: dict["X"] ?? 0, y: dict["Y"] ?? 0,
+                            width: dict["Width"] ?? 0, height: dict["Height"] ?? 0)
+        return bounds.width > 1 && bounds.height > 1 ? bounds : nil
+    }
+
+    private func appKitFrame(fromQuartz rect: CGRect) -> CGRect {
+        CGRect(x: rect.minX,
+               y: menuBarScreenTopY - rect.maxY,
+               width: rect.width,
+               height: rect.height)
+    }
+
+    private var menuBarScreenTopY: CGFloat {
+        let menuBarScreen = NSScreen.screens.first {
+            abs($0.frame.minX) < 0.5 && abs($0.frame.minY) < 0.5
+        }
+        return (menuBarScreen ?? NSScreen.main ?? NSScreen.screens.first)?.frame.maxY ?? 0
+    }
+}
+
+private final class AlwaysOnTopBorderView: NSView {
+    var color = NSColor.systemCyan
+    var thickness: CGFloat = 4
+
+    override var isOpaque: Bool { false }
+
+    override func draw(_ dirtyRect: NSRect) {
+        let inset = thickness / 2
+        let path = NSBezierPath(rect: bounds.insetBy(dx: inset, dy: inset))
+        path.lineWidth = thickness
+        color.setStroke()
+        path.stroke()
+    }
 }

--- a/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopPinning.swift
+++ b/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopPinning.swift
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import Darwin
+
+protocol AlwaysOnTopLevelClient {
+    var isAvailable: Bool { get }
+    func level(of windowID: CGWindowID) -> Int32?
+    func setLevel(_ level: Int32, on windowID: CGWindowID) -> Bool
+}
+
+struct AlwaysOnTopPinning {
+    static let floatingLevel = Int32(NSWindow.Level.floating.rawValue)
+    let client: AlwaysOnTopLevelClient
+
+    func pin(_ windowID: CGWindowID) -> Int32? {
+        guard client.isAvailable, let original = client.level(of: windowID) else { return nil }
+        guard client.setLevel(Self.floatingLevel, on: windowID) else { return nil }
+        return original
+    }
+
+    func unpin(_ windowID: CGWindowID, originalLevel: Int32) -> Bool {
+        guard client.isAvailable else { return false }
+        return client.setLevel(originalLevel, on: windowID)
+    }
+}
+
+final class AlwaysOnTopStubClient: AlwaysOnTopLevelClient {
+    var isAvailable: Bool
+    var levels: [CGWindowID: Int32] = [:]
+    var setShouldFail: Set<CGWindowID> = []
+
+    init(isAvailable: Bool = true) {
+        self.isAvailable = isAvailable
+    }
+
+    func level(of windowID: CGWindowID) -> Int32? {
+        guard isAvailable else { return nil }
+        return levels[windowID]
+    }
+
+    func setLevel(_ level: Int32, on windowID: CGWindowID) -> Bool {
+        guard isAvailable, !setShouldFail.contains(windowID) else { return false }
+        levels[windowID] = level
+        return true
+    }
+}
+
+enum AlwaysOnTopSkyLightClient {
+    static let shared: AlwaysOnTopLevelClient = Live()
+
+    private struct Live: AlwaysOnTopLevelClient {
+        private typealias SetLevelFn = @convention(c) (UInt32, UInt32, Int32) -> Int32
+        private typealias GetLevelFn = @convention(c) (UInt32, UInt32, UnsafeMutablePointer<Int32>) -> Int32
+        private typealias ConnectionFn = @convention(c) () -> UInt32
+
+        private let connection: UInt32
+        private let getLevel: GetLevelFn?
+        private let setLevelFn: SetLevelFn?
+
+        var isAvailable: Bool { getLevel != nil && setLevelFn != nil }
+
+        init() {
+            func symbol(_ name: String) -> UnsafeMutableRawPointer? {
+                dlsym(UnsafeMutableRawPointer(bitPattern: -2), name)
+            }
+
+            let connectionSymbol = symbol("SLSMainConnectionID") ?? symbol("CGSMainConnectionID")
+            if let connectionSymbol {
+                connection = unsafeBitCast(connectionSymbol, to: ConnectionFn.self)()
+            } else {
+                connection = 0
+            }
+
+            if let set = symbol("SLSSetWindowLevel") ?? symbol("CGSSetWindowLevel") {
+                setLevelFn = unsafeBitCast(set, to: SetLevelFn.self)
+            } else {
+                setLevelFn = nil
+            }
+
+            if let get = symbol("SLSGetWindowLevel") ?? symbol("CGSGetWindowLevel") {
+                getLevel = unsafeBitCast(get, to: GetLevelFn.self)
+            } else {
+                getLevel = nil
+            }
+        }
+
+        func level(of windowID: CGWindowID) -> Int32? {
+            guard let getLevel else { return nil }
+            var value: Int32 = 0
+            let status = getLevel(connection, windowID, &value)
+            return status == 0 ? value : nil
+        }
+
+        func setLevel(_ level: Int32, on windowID: CGWindowID) -> Bool {
+            guard let setLevelFn else { return false }
+            return setLevelFn(connection, windowID, level) == 0
+        }
+    }
+}

--- a/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopService.swift
+++ b/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopService.swift
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import ApplicationServices
+import Carbon.HIToolbox
+import Combine
+import CoreGraphics
+
+final class AlwaysOnTopService: ObservableObject {
+    static let shared = AlwaysOnTopService()
+
+    @Published private(set) var isRunning = false
+
+    var pinningAvailable: Bool { pinning.client.isAvailable }
+
+    private let pinning = AlwaysOnTopPinning(client: AlwaysOnTopSkyLightClient.shared)
+    private var map = AlwaysOnTopPinMap()
+    private var borders: [CGWindowID: AlwaysOnTopBorder] = [:]
+    private var observers: [pid_t: AXObserver] = [:]
+    private var watchedWindows: [CGWindowID: AXUIElement] = [:]
+
+    private var hotKeyRef: EventHotKeyRef?
+    private var eventHandler: EventHandlerRef?
+    private var registeredShortcut: GlobalShortcut?
+    private var terminateObserver: NSObjectProtocol?
+    private var defaultsObserver: NSObjectProtocol?
+
+    private init() {}
+
+    func syncWithPreferences() {
+        let wanted = AppFeature.alwaysOnTop.isAvailable
+            && UserDefaults.standard.bool(forKey: DefaultsKey.alwaysOnTopEnabled)
+        if wanted, Permissions.shared.accessibility {
+            start()
+        } else {
+            stop()
+        }
+    }
+
+    func toggleFrontmost() {
+        guard isRunning else { return }
+        guard let pid = frontmostPID() else { return }
+        guard let windowID = WindowActivator.focusedWindowID(for: pid) else { return }
+        let bundleID = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier
+        let exceptions = UserDefaults.standard.stringArray(forKey: DefaultsKey.alwaysOnTopExcludedApps) ?? []
+        if AlwaysOnTopSupport.isExcluded(bundleIdentifier: bundleID, exceptions: exceptions) { return }
+        if map.contains(windowID) {
+            unpin(windowID)
+            return
+        }
+        guard let original = pinning.pin(windowID) else { return }
+        map.pin(AlwaysOnTopPin(windowID: windowID, originalLevel: original, pid: pid))
+        if let element = focusedAXWindow(pid: pid) {
+            watch(windowID: windowID, pid: pid, element: element)
+        }
+        if UserDefaults.standard.bool(forKey: DefaultsKey.alwaysOnTopShowBorder) {
+            let border = AlwaysOnTopBorder()
+            let color = UserDefaults.standard.string(forKey: DefaultsKey.alwaysOnTopBorderColor) ?? "#00ADEF"
+            let thickness = UserDefaults.standard.object(forKey: DefaultsKey.alwaysOnTopBorderThickness) as? Double ?? 4
+            border.show(windowID: windowID, colorHex: color, thickness: CGFloat(thickness))
+            borders[windowID] = border
+        }
+        if UserDefaults.standard.bool(forKey: DefaultsKey.alwaysOnTopPlaySound) {
+            (NSSound(named: "Tink") ?? NSSound(named: "Funk"))?.play()
+        }
+    }
+
+    func unpinAll() {
+        for pin in map.unpinAll() {
+            _ = pinning.unpin(pin.windowID, originalLevel: pin.originalLevel)
+            dropBorder(pin.windowID)
+            unwatch(windowID: pin.windowID, pid: pin.pid)
+        }
+    }
+
+    func handleAX(element: AXUIElement, notification: String) {
+        let windowID = AXWindowResolver.windowID(for: element)
+        if notification == (kAXUIElementDestroyedNotification as String) {
+            if let windowID { unpin(windowID) }
+            return
+        }
+        guard let windowID else { return }
+        if notification == (kAXWindowMiniaturizedNotification as String) {
+            borders[windowID]?.setMinimized(true)
+        } else if notification == (kAXWindowDeminiaturizedNotification as String) {
+            borders[windowID]?.setMinimized(false)
+            borders[windowID]?.updateFrame()
+        }
+    }
+
+    private func start() {
+        registerHotkey()
+        if terminateObserver == nil {
+            terminateObserver = NSWorkspace.shared.notificationCenter.addObserver(
+                forName: NSWorkspace.didTerminateApplicationNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] note in
+                guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { return }
+                self?.handleAppTerminated(app.processIdentifier)
+            }
+        }
+        if defaultsObserver == nil {
+            defaultsObserver = NotificationCenter.default.addObserver(
+                forName: UserDefaults.didChangeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.unpinExcluded()
+            }
+        }
+        isRunning = true
+    }
+
+    private func stop() {
+        unpinAll()
+        unregisterHotkey()
+        if let terminateObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(terminateObserver)
+            self.terminateObserver = nil
+        }
+        if let defaultsObserver {
+            NotificationCenter.default.removeObserver(defaultsObserver)
+            self.defaultsObserver = nil
+        }
+        isRunning = false
+    }
+
+    private func unpin(_ windowID: CGWindowID) {
+        guard let pin = map.unpin(windowID) else { return }
+        _ = pinning.unpin(windowID, originalLevel: pin.originalLevel)
+        dropBorder(windowID)
+        unwatch(windowID: windowID, pid: pin.pid)
+    }
+
+    private func dropBorder(_ windowID: CGWindowID) {
+        borders[windowID]?.hide()
+        borders[windowID] = nil
+    }
+
+    private func handleAppTerminated(_ pid: pid_t) {
+        for pin in map.remove(pid: pid) {
+            _ = pinning.unpin(pin.windowID, originalLevel: pin.originalLevel)
+            dropBorder(pin.windowID)
+            unwatch(windowID: pin.windowID, pid: pid)
+        }
+    }
+
+    private func unpinExcluded() {
+        let exceptions = UserDefaults.standard.stringArray(forKey: DefaultsKey.alwaysOnTopExcludedApps) ?? []
+        let gone = AlwaysOnTopSupport.windowIDsToUnpinAfterExclude(
+            pins: Array(map.pins.values),
+            exceptions: exceptions,
+            bundleIDForPID: { pid in
+                NSRunningApplication(processIdentifier: pid)?.bundleIdentifier
+            }
+        )
+        for windowID in gone { unpin(windowID) }
+    }
+
+    private func frontmostPID() -> pid_t? {
+        let ownBundleID = Bundle.main.bundleIdentifier
+        let ownPID = ProcessInfo.processInfo.processIdentifier
+        let ownKeyWindow = NSApp.keyWindow
+        let hasFocusedResizableOwnWindow = NSApp.isActive
+            && ownKeyWindow?.styleMask.contains(.resizable) == true
+            && !(ownKeyWindow is NSPanel)
+        let pid = hasFocusedResizableOwnWindow
+            ? ownPID
+            : NSWorkspace.shared.frontmostApplication?.processIdentifier
+        guard let pid else { return nil }
+        if hasFocusedResizableOwnWindow, pid == ownPID { return pid }
+        guard let app = NSRunningApplication(processIdentifier: pid),
+              app.activationPolicy == .regular,
+              !app.isHidden,
+              app.bundleIdentifier != ownBundleID
+        else { return nil }
+        return pid
+    }
+
+    private func focusedAXWindow(pid: pid_t) -> AXUIElement? {
+        let app = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(app, 0.35)
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(app, kAXFocusedWindowAttribute as CFString, &value) == .success,
+              let value,
+              CFGetTypeID(value) == AXUIElementGetTypeID()
+        else { return nil }
+        return (value as! AXUIElement)
+    }
+
+    private func watch(windowID: CGWindowID, pid: pid_t, element: AXUIElement) {
+        if observers[pid] == nil {
+            var observerRef: AXObserver?
+            guard AXObserverCreate(pid, alwaysOnTopAXCallback, &observerRef) == .success,
+                  let observer = observerRef else { return }
+            CFRunLoopAddSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(observer), .commonModes)
+            observers[pid] = observer
+        }
+        guard let observer = observers[pid] else { return }
+        let refcon = Unmanaged.passUnretained(self).toOpaque()
+        for name in [kAXUIElementDestroyedNotification,
+                     kAXWindowMiniaturizedNotification,
+                     kAXWindowDeminiaturizedNotification] {
+            AXObserverAddNotification(observer, element, name as CFString, refcon)
+        }
+        watchedWindows[windowID] = element
+    }
+
+    private func unwatch(windowID: CGWindowID, pid: pid_t) {
+        if let observer = observers[pid], let element = watchedWindows[windowID] {
+            for name in [kAXUIElementDestroyedNotification,
+                         kAXWindowMiniaturizedNotification,
+                         kAXWindowDeminiaturizedNotification] {
+                AXObserverRemoveNotification(observer, element, name as CFString)
+            }
+        }
+        watchedWindows[windowID] = nil
+        if map.pins(for: pid).isEmpty, let observer = observers.removeValue(forKey: pid) {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(observer), .commonModes)
+        }
+    }
+
+    private func registerHotkey() {
+        let shortcut = GlobalShortcut.saved(for: DefaultsKey.alwaysOnTopShortcut,
+                                            fallback: .alwaysOnTopDefault)
+        if hotKeyRef != nil, registeredShortcut == shortcut { return }
+        unregisterHotkey()
+        if eventHandler == nil {
+            var spec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
+                                     eventKind: UInt32(kEventHotKeyPressed))
+            InstallEventHandler(GetEventDispatcherTarget(), { _, event, userData -> OSStatus in
+                guard let userData else { return OSStatus(eventNotHandledErr) }
+                var hotKeyID = EventHotKeyID()
+                if let event {
+                    GetEventParameter(event, EventParamName(kEventParamDirectObject),
+                                      EventParamType(typeEventHotKeyID), nil,
+                                      MemoryLayout<EventHotKeyID>.size, nil, &hotKeyID)
+                }
+                guard hotKeyID.signature == 0x5655_4154, hotKeyID.id == 1
+                else { return OSStatus(eventNotHandledErr) }
+                let service = Unmanaged<AlwaysOnTopService>.fromOpaque(userData).takeUnretainedValue()
+                DispatchQueue.main.async { service.toggleFrontmost() }
+                return noErr
+            }, 1, &spec, Unmanaged.passUnretained(self).toOpaque(), &eventHandler)
+        }
+        let hotKeyID = EventHotKeyID(signature: 0x5655_4154, id: 1) // 'VUAT'
+        var ref: EventHotKeyRef?
+        let status = RegisterEventHotKey(shortcut.carbonKeyCode,
+                                         shortcut.carbonModifiers,
+                                         hotKeyID,
+                                         GetEventDispatcherTarget(),
+                                         0,
+                                         &ref)
+        if status == noErr, let ref {
+            hotKeyRef = ref
+            registeredShortcut = shortcut
+        } else {
+            hotKeyRef = nil
+            registeredShortcut = nil
+        }
+    }
+
+    private func unregisterHotkey() {
+        if let ref = hotKeyRef {
+            UnregisterEventHotKey(ref)
+            hotKeyRef = nil
+        }
+        registeredShortcut = nil
+    }
+}
+
+private func alwaysOnTopAXCallback(_ observer: AXObserver,
+                                  _ element: AXUIElement,
+                                  _ notification: CFString,
+                                  _ refcon: UnsafeMutableRawPointer?) {
+    guard let refcon else { return }
+    let service = Unmanaged<AlwaysOnTopService>.fromOpaque(refcon).takeUnretainedValue()
+    DispatchQueue.main.async {
+        service.handleAX(element: element, notification: notification as String)
+    }
+}

--- a/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopService.swift
+++ b/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopService.swift
@@ -147,7 +147,7 @@ final class AlwaysOnTopService: ObservableObject {
         }
     }
 
-    private func unpinExcluded() {
+    func unpinExcluded() {
         let exceptions = UserDefaults.standard.stringArray(forKey: DefaultsKey.alwaysOnTopExcludedApps) ?? []
         let gone = AlwaysOnTopSupport.windowIDsToUnpinAfterExclude(
             pins: Array(map.pins.values),

--- a/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopService.swift
+++ b/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopService.swift
@@ -11,11 +11,12 @@ final class AlwaysOnTopService: ObservableObject {
     static let shared = AlwaysOnTopService()
 
     @Published private(set) var isRunning = false
+    @Published private(set) var exceptions: [String] = []
 
     var pinningAvailable: Bool { pinning.client.isAvailable }
 
     private let pinning = AlwaysOnTopPinning(client: AlwaysOnTopSkyLightClient.shared)
-    private var map = AlwaysOnTopPinMap()
+    private var pinnedWindows = AlwaysOnTopPinMap()
     private var borders: [CGWindowID: AlwaysOnTopBorder] = [:]
     private var observers: [pid_t: AXObserver] = [:]
     private var watchedWindows: [CGWindowID: AXUIElement] = [:]
@@ -26,7 +27,9 @@ final class AlwaysOnTopService: ObservableObject {
     private var terminateObserver: NSObjectProtocol?
     private var defaultsObserver: NSObjectProtocol?
 
-    private init() {}
+    private init() {
+        reloadExceptions()
+    }
 
     func syncWithPreferences() {
         let wanted = AppFeature.alwaysOnTop.isAvailable
@@ -40,26 +43,22 @@ final class AlwaysOnTopService: ObservableObject {
 
     func toggleFrontmost() {
         guard isRunning else { return }
-        guard let pid = frontmostPID() else { return }
-        guard let windowID = WindowActivator.focusedWindowID(for: pid) else { return }
-        let bundleID = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier
-        let exceptions = UserDefaults.standard.stringArray(forKey: DefaultsKey.alwaysOnTopExcludedApps) ?? []
+        guard let target = resolveFrontmostWindow() else { return }
+        let bundleID = NSRunningApplication(processIdentifier: target.pid)?.bundleIdentifier
         if AlwaysOnTopSupport.isExcluded(bundleIdentifier: bundleID, exceptions: exceptions) { return }
-        if map.contains(windowID) {
-            unpin(windowID)
+        if pinnedWindows.contains(target.windowID) {
+            unpin(target.windowID)
             return
         }
-        guard let original = pinning.pin(windowID) else { return }
-        map.pin(AlwaysOnTopPin(windowID: windowID, originalLevel: original, pid: pid))
-        if let element = focusedAXWindow(pid: pid) {
-            watch(windowID: windowID, pid: pid, element: element)
-        }
+        guard let original = pinning.pin(target.windowID) else { return }
+        pinnedWindows.pin(AlwaysOnTopPin(windowID: target.windowID, originalLevel: original, pid: target.pid))
+        watch(windowID: target.windowID, pid: target.pid, element: target.element)
         if UserDefaults.standard.bool(forKey: DefaultsKey.alwaysOnTopShowBorder) {
             let border = AlwaysOnTopBorder()
             let color = UserDefaults.standard.string(forKey: DefaultsKey.alwaysOnTopBorderColor) ?? "#00ADEF"
             let thickness = UserDefaults.standard.object(forKey: DefaultsKey.alwaysOnTopBorderThickness) as? Double ?? 4
-            border.show(windowID: windowID, colorHex: color, thickness: CGFloat(thickness))
-            borders[windowID] = border
+            border.show(windowID: target.windowID, colorHex: color, thickness: CGFloat(thickness))
+            borders[target.windowID] = border
         }
         if UserDefaults.standard.bool(forKey: DefaultsKey.alwaysOnTopPlaySound) {
             (NSSound(named: "Tink") ?? NSSound(named: "Funk"))?.play()
@@ -67,11 +66,34 @@ final class AlwaysOnTopService: ObservableObject {
     }
 
     func unpinAll() {
-        for pin in map.unpinAll() {
-            _ = pinning.unpin(pin.windowID, originalLevel: pin.originalLevel)
-            dropBorder(pin.windowID)
-            unwatch(windowID: pin.windowID, pid: pin.pid)
+        for pin in pinnedWindows.unpinAll() {
+            release(pin)
         }
+    }
+
+    func stop() {
+        unpinAll()
+        unregisterHotkey()
+        if let terminateObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(terminateObserver)
+            self.terminateObserver = nil
+        }
+        if let defaultsObserver {
+            NotificationCenter.default.removeObserver(defaultsObserver)
+            self.defaultsObserver = nil
+        }
+        isRunning = false
+    }
+
+    func addException(_ bundleID: String) {
+        let bundleID = bundleID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !bundleID.isEmpty, !exceptions.contains(bundleID) else { return }
+        persistExceptions(exceptions + [bundleID])
+        unpinExcluded()
+    }
+
+    func removeException(_ bundleID: String) {
+        persistExceptions(exceptions.filter { $0 != bundleID })
     }
 
     func handleAX(element: AXUIElement, notification: String) {
@@ -110,28 +132,19 @@ final class AlwaysOnTopService: ObservableObject {
                 self?.unpinExcluded()
             }
         }
+        reloadExceptions()
         isRunning = true
     }
 
-    private func stop() {
-        unpinAll()
-        unregisterHotkey()
-        if let terminateObserver {
-            NSWorkspace.shared.notificationCenter.removeObserver(terminateObserver)
-            self.terminateObserver = nil
-        }
-        if let defaultsObserver {
-            NotificationCenter.default.removeObserver(defaultsObserver)
-            self.defaultsObserver = nil
-        }
-        isRunning = false
+    private func unpin(_ windowID: CGWindowID) {
+        guard let pin = pinnedWindows.unpin(windowID) else { return }
+        release(pin)
     }
 
-    private func unpin(_ windowID: CGWindowID) {
-        guard let pin = map.unpin(windowID) else { return }
-        _ = pinning.unpin(windowID, originalLevel: pin.originalLevel)
-        dropBorder(windowID)
-        unwatch(windowID: windowID, pid: pin.pid)
+    private func release(_ pin: AlwaysOnTopPin) {
+        _ = pinning.unpin(pin.windowID, originalLevel: pin.originalLevel)
+        dropBorder(pin.windowID)
+        unwatch(windowID: pin.windowID, pid: pin.pid)
     }
 
     private func dropBorder(_ windowID: CGWindowID) {
@@ -140,17 +153,15 @@ final class AlwaysOnTopService: ObservableObject {
     }
 
     private func handleAppTerminated(_ pid: pid_t) {
-        for pin in map.remove(pid: pid) {
-            _ = pinning.unpin(pin.windowID, originalLevel: pin.originalLevel)
-            dropBorder(pin.windowID)
-            unwatch(windowID: pin.windowID, pid: pid)
+        for pin in pinnedWindows.remove(pid: pid) {
+            release(pin)
         }
     }
 
     func unpinExcluded() {
-        let exceptions = UserDefaults.standard.stringArray(forKey: DefaultsKey.alwaysOnTopExcludedApps) ?? []
+        reloadExceptions()
         let gone = AlwaysOnTopSupport.windowIDsToUnpinAfterExclude(
-            pins: Array(map.pins.values),
+            pins: Array(pinnedWindows.pins.values),
             exceptions: exceptions,
             bundleIDForPID: { pid in
                 NSRunningApplication(processIdentifier: pid)?.bundleIdentifier
@@ -179,15 +190,51 @@ final class AlwaysOnTopService: ObservableObject {
         return pid
     }
 
-    private func focusedAXWindow(pid: pid_t) -> AXUIElement? {
+    private func resolveFrontmostWindow() -> (windowID: CGWindowID, element: AXUIElement, pid: pid_t)? {
+        guard let pid = frontmostPID() else { return nil }
         let app = AXUIElementCreateApplication(pid)
         AXUIElementSetMessagingTimeout(app, 0.35)
+        let focused = axWindow(app, kAXFocusedWindowAttribute)
+        let main = axWindow(app, kAXMainWindowAttribute)
+        let first = firstAXWindow(app)
+        let focusedID = focused.flatMap { AXWindowResolver.windowID(for: $0) }
+        let mainID = main.flatMap { AXWindowResolver.windowID(for: $0) }
+        let firstID = first.flatMap { AXWindowResolver.windowID(for: $0) }
+        guard let windowID = AlwaysOnTopSupport.preferredWindowID(focused: focusedID,
+                                                                  main: mainID,
+                                                                  first: firstID)
+        else { return nil }
+        let element = (focusedID == windowID ? focused : nil)
+            ?? (mainID == windowID ? main : nil)
+            ?? first
+        guard let element else { return nil }
+        return (windowID, element, pid)
+    }
+
+    private func axWindow(_ app: AXUIElement, _ attribute: String) -> AXUIElement? {
         var value: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(app, kAXFocusedWindowAttribute as CFString, &value) == .success,
+        guard AXUIElementCopyAttributeValue(app, attribute as CFString, &value) == .success,
               let value,
               CFGetTypeID(value) == AXUIElementGetTypeID()
         else { return nil }
         return (value as! AXUIElement)
+    }
+
+    private func firstAXWindow(_ app: AXUIElement) -> AXUIElement? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(app, kAXWindowsAttribute as CFString, &value) == .success,
+              let windows = value as? [AXUIElement]
+        else { return nil }
+        return windows.first
+    }
+
+    private func reloadExceptions() {
+        exceptions = UserDefaults.standard.stringArray(forKey: DefaultsKey.alwaysOnTopExcludedApps) ?? []
+    }
+
+    private func persistExceptions(_ next: [String]) {
+        exceptions = next
+        UserDefaults.standard.set(next, forKey: DefaultsKey.alwaysOnTopExcludedApps)
     }
 
     private func watch(windowID: CGWindowID, pid: pid_t, element: AXUIElement) {
@@ -217,7 +264,7 @@ final class AlwaysOnTopService: ObservableObject {
             }
         }
         watchedWindows[windowID] = nil
-        if map.pins(for: pid).isEmpty, let observer = observers.removeValue(forKey: pid) {
+        if pinnedWindows.pins(for: pid).isEmpty, let observer = observers.removeValue(forKey: pid) {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(observer), .commonModes)
         }
     }

--- a/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopSupport.swift
+++ b/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopSupport.swift
@@ -62,4 +62,10 @@ enum AlwaysOnTopSupport {
                 ? pin.windowID : nil
         }
     }
+
+    static func preferredWindowID(focused: CGWindowID?,
+                                  main: CGWindowID?,
+                                  first: CGWindowID?) -> CGWindowID? {
+        focused ?? main ?? first
+    }
 }

--- a/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopSupport.swift
+++ b/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopSupport.swift
@@ -51,4 +51,15 @@ enum AlwaysOnTopSupport {
                                    bundleURL: nil,
                                    exceptions: exceptions)
     }
+
+    static func windowIDsToUnpinAfterExclude(
+        pins: [AlwaysOnTopPin],
+        exceptions: [String],
+        bundleIDForPID: (pid_t) -> String?
+    ) -> [CGWindowID] {
+        pins.compactMap { pin in
+            isExcluded(bundleIdentifier: bundleIDForPID(pin.pid), exceptions: exceptions)
+                ? pin.windowID : nil
+        }
+    }
 }

--- a/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopSupport.swift
+++ b/Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopSupport.swift
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import CoreGraphics
+import Foundation
+
+struct AlwaysOnTopPin: Equatable {
+    let windowID: CGWindowID
+    let originalLevel: Int32
+    let pid: pid_t
+}
+
+struct AlwaysOnTopPinMap {
+    private(set) var pins: [CGWindowID: AlwaysOnTopPin] = [:]
+
+    var isEmpty: Bool { pins.isEmpty }
+
+    func contains(_ windowID: CGWindowID) -> Bool {
+        pins[windowID] != nil
+    }
+
+    mutating func pin(_ pin: AlwaysOnTopPin) {
+        pins[pin.windowID] = pin
+    }
+
+    @discardableResult
+    mutating func unpin(_ windowID: CGWindowID) -> AlwaysOnTopPin? {
+        pins.removeValue(forKey: windowID)
+    }
+
+    mutating func unpinAll() -> [AlwaysOnTopPin] {
+        let all = Array(pins.values)
+        pins.removeAll()
+        return all
+    }
+
+    mutating func remove(pid: pid_t) -> [AlwaysOnTopPin] {
+        let gone = pins.values.filter { $0.pid == pid }
+        for pin in gone { pins.removeValue(forKey: pin.windowID) }
+        return gone
+    }
+
+    func pins(for pid: pid_t) -> [AlwaysOnTopPin] {
+        pins.values.filter { $0.pid == pid }
+    }
+}
+
+enum AlwaysOnTopSupport {
+    static func isExcluded(bundleIdentifier: String?, exceptions: [String]) -> Bool {
+        AutoQuitSupport.isExcepted(bundleIdentifier: bundleIdentifier,
+                                   bundleURL: nil,
+                                   exceptions: exceptions)
+    }
+}

--- a/Sources/Vorssaint/UI/Settings/AlwaysOnTopSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/AlwaysOnTopSettings.swift
@@ -67,19 +67,19 @@ struct AlwaysOnTopSettings: View {
             }
 
             Section(strings.excludeTitle) {
-                if sortedExceptions.isEmpty {
+                if service.exceptions.isEmpty {
                     Text(strings.excludeEmpty)
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 } else {
-                    ForEach(sortedExceptions, id: \.self) { bundleID in
+                    ForEach(service.exceptions, id: \.self) { bundleID in
                         HStack(spacing: 9) {
                             Image(nsImage: InstalledApps.icon(for: bundleID))
                                 .resizable().frame(width: 20, height: 20)
                             Text(InstalledApps.name(for: bundleID))
                             Spacer()
                             Button {
-                                removeException(bundleID)
+                                service.removeException(bundleID)
                             } label: {
                                 Image(systemName: "minus.circle.fill")
                                     .foregroundStyle(.secondary)
@@ -122,16 +122,6 @@ struct AlwaysOnTopSettings: View {
         }
     }
 
-    private var exceptions: [String] {
-        UserDefaults.standard.stringArray(forKey: DefaultsKey.alwaysOnTopExcludedApps) ?? []
-    }
-
-    private var sortedExceptions: [String] {
-        exceptions.sorted {
-            InstalledApps.name(for: $0).localizedCaseInsensitiveCompare(InstalledApps.name(for: $1)) == .orderedAscending
-        }
-    }
-
     private var colorBinding: Binding<Color> {
         Binding {
             let rgb = MenuBarUsageBarSupport.rgb(for: borderColor, fallback: "#00ADEF")
@@ -145,28 +135,15 @@ struct AlwaysOnTopSettings: View {
     }
 
     private var appPickerSheet: some View {
-        let excluded = Set(exceptions)
+        let excluded = Set(service.exceptions)
         return AppPickerView {
             showingAppPicker = false
         } onSelect: { url in
             showingAppPicker = false
             guard let bundleID = Bundle(url: url)?.bundleIdentifier else { return }
-            addException(bundleID)
+            service.addException(bundleID)
         } loadApps: {
             InstalledApps.installedBundleApplications(excluding: excluded)
         }
-    }
-
-    private func addException(_ bundleID: String) {
-        var next = exceptions
-        guard !next.contains(bundleID) else { return }
-        next.append(bundleID)
-        UserDefaults.standard.set(next, forKey: DefaultsKey.alwaysOnTopExcludedApps)
-        AlwaysOnTopService.shared.unpinExcluded()
-    }
-
-    private func removeException(_ bundleID: String) {
-        UserDefaults.standard.set(exceptions.filter { $0 != bundleID },
-                                  forKey: DefaultsKey.alwaysOnTopExcludedApps)
     }
 }

--- a/Sources/Vorssaint/UI/Settings/AlwaysOnTopSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/AlwaysOnTopSettings.swift
@@ -1,12 +1,172 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Vorssaint
 
+import AppKit
 import SwiftUI
 
 struct AlwaysOnTopSettings: View {
+    @ObservedObject private var l10n = L10n.shared
+    @ObservedObject private var permissions = Permissions.shared
+    @ObservedObject private var service = AlwaysOnTopService.shared
+    @AppStorage(DefaultsKey.alwaysOnTopEnabled) private var enabled = false
+    @AppStorage(DefaultsKey.alwaysOnTopShowBorder) private var showBorder = true
+    @AppStorage(DefaultsKey.alwaysOnTopBorderColor) private var borderColor = "#00ADEF"
+    @AppStorage(DefaultsKey.alwaysOnTopBorderThickness) private var borderThickness = 4.0
+    @AppStorage(DefaultsKey.alwaysOnTopPlaySound) private var playSound = true
+    @State private var showingAppPicker = false
+
+    private var strings: AlwaysOnTopFeatureStrings {
+        FeatureStrings.alwaysOnTop(l10n.language)
+    }
+
     var body: some View {
         Form {
-            Text(FeatureStrings.alwaysOnTop(L10n.shared.language).title)
+            Section {
+                Toggle(strings.enable, isOn: $enabled)
+                    .onChange(of: enabled) { _, _ in
+                        AlwaysOnTopService.shared.syncWithPreferences()
+                    }
+                Text(strings.enableCaption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if enabled, service.isRunning {
+                    Label(strings.activeNow, systemImage: "checkmark.circle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                }
+            }
+
+            Section {
+                ShortcutPreferenceRow(
+                    role: .alwaysOnTop,
+                    isEnabled: enabled,
+                    label: strings.shortcut,
+                    onChange: {
+                        AlwaysOnTopService.shared.syncWithPreferences()
+                    }
+                )
+                .disabled(!enabled)
+            }
+
+            Section {
+                Toggle(strings.showBorder, isOn: $showBorder)
+                    .disabled(!enabled)
+                if showBorder {
+                    ColorPicker(strings.borderColor, selection: colorBinding, supportsOpacity: false)
+                        .disabled(!enabled)
+                    Stepper(value: $borderThickness, in: 1...12, step: 1) {
+                        Text("\(strings.borderThickness): \(Int(borderThickness))")
+                    }
+                    .disabled(!enabled)
+                }
+            }
+
+            Section {
+                Toggle(strings.playSound, isOn: $playSound)
+                    .disabled(!enabled)
+            }
+
+            Section(strings.excludeTitle) {
+                if sortedExceptions.isEmpty {
+                    Text(strings.excludeEmpty)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(sortedExceptions, id: \.self) { bundleID in
+                        HStack(spacing: 9) {
+                            Image(nsImage: InstalledApps.icon(for: bundleID))
+                                .resizable().frame(width: 20, height: 20)
+                            Text(InstalledApps.name(for: bundleID))
+                            Spacer()
+                            Button {
+                                removeException(bundleID)
+                            } label: {
+                                Image(systemName: "minus.circle.fill")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .disabled(!enabled)
+                }
+
+                Button {
+                    showingAppPicker = true
+                } label: {
+                    Label(strings.addApp, systemImage: "plus")
+                }
+                .disabled(!enabled)
+
+                Text(strings.excludeCaption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if enabled, !service.pinningAvailable {
+                Section {
+                    Text(strings.pinningUnavailable)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if enabled, !permissions.accessibility {
+                Section(strings.permissionRequired) {
+                    PermissionRow(kind: .accessibility)
+                }
+            }
         }
+        .formStyle(.grouped)
+        .sheet(isPresented: $showingAppPicker) {
+            appPickerSheet
+        }
+    }
+
+    private var exceptions: [String] {
+        UserDefaults.standard.stringArray(forKey: DefaultsKey.alwaysOnTopExcludedApps) ?? []
+    }
+
+    private var sortedExceptions: [String] {
+        exceptions.sorted {
+            InstalledApps.name(for: $0).localizedCaseInsensitiveCompare(InstalledApps.name(for: $1)) == .orderedAscending
+        }
+    }
+
+    private var colorBinding: Binding<Color> {
+        Binding {
+            let rgb = MenuBarUsageBarSupport.rgb(for: borderColor, fallback: "#00ADEF")
+            return Color(red: rgb.red, green: rgb.green, blue: rgb.blue)
+        } set: { color in
+            guard let converted = NSColor(color).usingColorSpace(.sRGB) else { return }
+            borderColor = MenuBarUsageBarSupport.hex(red: Double(converted.redComponent),
+                                                     green: Double(converted.greenComponent),
+                                                     blue: Double(converted.blueComponent))
+        }
+    }
+
+    private var appPickerSheet: some View {
+        let excluded = Set(exceptions)
+        return AppPickerView {
+            showingAppPicker = false
+        } onSelect: { url in
+            showingAppPicker = false
+            guard let bundleID = Bundle(url: url)?.bundleIdentifier else { return }
+            addException(bundleID)
+        } loadApps: {
+            InstalledApps.installedBundleApplications(excluding: excluded)
+        }
+    }
+
+    private func addException(_ bundleID: String) {
+        var next = exceptions
+        guard !next.contains(bundleID) else { return }
+        next.append(bundleID)
+        UserDefaults.standard.set(next, forKey: DefaultsKey.alwaysOnTopExcludedApps)
+        AlwaysOnTopService.shared.unpinExcluded()
+    }
+
+    private func removeException(_ bundleID: String) {
+        UserDefaults.standard.set(exceptions.filter { $0 != bundleID },
+                                  forKey: DefaultsKey.alwaysOnTopExcludedApps)
     }
 }

--- a/Sources/Vorssaint/UI/Settings/AlwaysOnTopSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/AlwaysOnTopSettings.swift
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import SwiftUI
+
+struct AlwaysOnTopSettings: View {
+    var body: some View {
+        Form {
+            Text(FeatureStrings.alwaysOnTop(L10n.shared.language).title)
+        }
+    }
+}

--- a/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
@@ -703,6 +703,7 @@ extension AppFeature {
         case .windowMaximizer: return s.windowMaximizeName
         case .windowLayout: return FeatureStrings.windowLayout(L10n.shared.language).title
         case .autoQuit: return s.autoQuitName
+        case .alwaysOnTop: return FeatureStrings.alwaysOnTop(L10n.shared.language).title
         case .scrollInverter: return s.invertMouseScroll
         case .focusFollowsMouse: return s.focusFollowsMouseName
         case .smoothScroll: return s.smoothScrollName
@@ -763,6 +764,7 @@ extension AppFeature {
         case .windowMaximizer: return hub.descWindowMaximizer
         case .windowLayout: return hub.descWindowLayout
         case .autoQuit: return hub.descAutoQuit
+        case .alwaysOnTop: return FeatureStrings.alwaysOnTop(L10n.shared.language).hubDescription
         case .scrollInverter: return hub.descScrollInverter
         case .focusFollowsMouse: return L10n.shared.s.focusFollowsMouseCaption
         case .smoothScroll: return hub.descSmoothScroll

--- a/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
@@ -8,7 +8,7 @@ import Foundation
 /// below and the unit tests can reason about pages without pulling UI in.
 enum SettingsPage: Hashable {
     case general, features, energy, monitor
-    case mouse, switcher, keyDebounce, superKey, cutPaste, autoQuit, cleaner, uninstaller, urlCleaner, homebrew, appUpdates, media, clipboard, windowLayout, shelf, quickTools, textSnippets, screenshot, radialMenu, commandBar, killProcess
+    case mouse, switcher, keyDebounce, superKey, cutPaste, autoQuit, alwaysOnTop, cleaner, uninstaller, urlCleaner, homebrew, appUpdates, media, clipboard, windowLayout, shelf, quickTools, textSnippets, screenshot, radialMenu, commandBar, killProcess
     case shortcuts, advanced, about, releaseNotes, support
 }
 
@@ -164,6 +164,7 @@ extension AppFeature {
             return FeatureSettingsDestination(.general, sectionAnchor: .panelConfiguration)
         case .windowLayout: return FeatureSettingsDestination(.windowLayout)
         case .autoQuit: return FeatureSettingsDestination(.autoQuit)
+        case .alwaysOnTop: return FeatureSettingsDestination(.alwaysOnTop)
 
         case .scrollInverter:
             return FeatureSettingsDestination(.mouse, sectionAnchor: .scrollDirection)
@@ -265,6 +266,7 @@ enum FeatureVisibilitySupport {
         case .switcher: return [.switcher, .dockPreview, .dockClick]
         case .windowLayout: return [.windowLayout]
         case .autoQuit: return [.autoQuit]
+        case .alwaysOnTop: return [.alwaysOnTop]
         case .clipboard: return [.clipboardHistory, .pastePlain, .finderCutPaste]
         case .cutPaste: return [.finderCutPaste, .finderRename]
         case .shelf: return [.shelf]

--- a/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
@@ -142,6 +142,10 @@ enum SettingsDirectory {
                                                  FeatureStrings.windowLayout(language).gestureResize]),
                 SettingsDirectoryItem(page: .autoQuit, title: s.autoQuitName, icon: "xmark.rectangle",
                                       keywords: [s.autoQuitEnable]),
+                SettingsDirectoryItem(page: .alwaysOnTop,
+                                      title: FeatureStrings.alwaysOnTop(language).title,
+                                      icon: "pin.fill",
+                                      keywords: [FeatureStrings.alwaysOnTop(language).enable]),
             ]),
             (categories.files, [
                 SettingsDirectoryItem(page: .clipboard, title: FeatureStrings.clipboard(language).title,

--- a/Sources/Vorssaint/UI/Settings/SettingsView.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsView.swift
@@ -358,6 +358,7 @@ struct SettingsView: View {
         case .superKey: SuperKeySettings()
         case .cutPaste: CutPasteSettings()
         case .autoQuit: AutoQuitSettings()
+        case .alwaysOnTop: AlwaysOnTopSettings()
         case .uninstaller: UninstallerView()
         case .killProcess: KillProcessView()
         case .urlCleaner: URLCleanerSettings()

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11958,6 +11958,18 @@ struct MetricsTests {
                "other bundle ids are not excluded")
         expect(!AlwaysOnTopSupport.isExcluded(bundleIdentifier: nil, exceptions: ["com.apple.Safari"]),
                "missing bundle id is not excluded")
+        let excludePins = [
+            AlwaysOnTopPin(windowID: 1, originalLevel: 0, pid: 10),
+            AlwaysOnTopPin(windowID: 2, originalLevel: 0, pid: 20),
+        ]
+        let gone = AlwaysOnTopSupport.windowIDsToUnpinAfterExclude(
+            pins: excludePins,
+            exceptions: ["com.apple.Safari"],
+            bundleIDForPID: { pid in
+                pid == 10 ? "com.apple.Safari" : "com.apple.Notes"
+            }
+        )
+        expect(gone == [1], "later excluding a pinned app unpins it")
 
         let missing = AlwaysOnTopPinning(client: AlwaysOnTopStubClient(isAvailable: false))
         expect(missing.pin(1) == nil, "missing private symbol is a no-op")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11865,11 +11865,11 @@ struct MetricsTests {
 
         // MARK: Features hub catalog
 
-        expect(AppFeature.allCases.count == 54, "feature catalog has 54 features")
+        expect(AppFeature.allCases.count == 55, "feature catalog has 55 features")
         expect(Set(AppFeature.allCases.map(\.rawValue)).count == AppFeature.allCases.count,
                "feature ids are unique")
         expect(AppFeature.allCases.map(\.rawValue) == [
-            "switcher", "dockPreview", "dockClick", "windowMaximizer", "windowLayout", "autoQuit",
+            "switcher", "dockPreview", "dockClick", "windowMaximizer", "windowLayout", "autoQuit", "alwaysOnTop",
             "scrollInverter", "focusFollowsMouse", "smoothScroll", "mouseNavigation", "mouseButtonShortcuts", "middleClick",
             "keyboardDebounce", "textSnippets", "superKey",
             "clipboardHistory", "pastePlain", "finderCutPaste", "finderRename", "shelf", "urlCleaner",
@@ -11888,14 +11888,43 @@ struct MetricsTests {
                 && (AppFeature.availabilityDefaults[AppFeature.fanControl.availabilityKey] as? Bool) == false
                 && (AppFeature.availabilityDefaults[AppFeature.diskImageInstaller.availabilityKey] as? Bool) == false
                 && (AppFeature.availabilityDefaults[AppFeature.focusFollowsMouse.availabilityKey] as? Bool) == false
-                && (AppFeature.availabilityDefaults[AppFeature.killProcess.availabilityKey] as? Bool) == false
-                && AppFeature.allCases.filter {
-                    $0 != .focusFollowsMouse && $0 != .fanControl && $0 != .diskImageInstaller
-                        && $0 != .killProcess
-                }.allSatisfy {
+                 && (AppFeature.availabilityDefaults[AppFeature.killProcess.availabilityKey] as? Bool) == false
+                 && (AppFeature.availabilityDefaults[AppFeature.alwaysOnTop.availabilityKey] as? Bool) == false
+                 && AppFeature.allCases.filter {
+                     $0 != .focusFollowsMouse && $0 != .fanControl && $0 != .diskImageInstaller
+                         && $0 != .killProcess && $0 != .alwaysOnTop
+                 }.allSatisfy {
                     (AppFeature.availabilityDefaults[$0.availabilityKey] as? Bool) == true
                 },
                "new opt-in features ship uninstalled while existing features remain available")
+        expect(AppFeature.alwaysOnTop.group == .windowsDock,
+               "always on top lives in Windows and Dock")
+        expect(AppFeature.alwaysOnTop.symbolName == "pin.fill",
+               "always on top uses pin.fill")
+        expect(AppFeature.alwaysOnTop.enabledKeys == [DefaultsKey.alwaysOnTopEnabled],
+               "always on top has its own enable key")
+        expect(AppFeature.alwaysOnTop.permissions == [.accessibility],
+               "always on top needs Accessibility")
+        expect(!FeaturePreset.windows.features.contains(.alwaysOnTop),
+               "always on top is not in the Windows preset")
+        expect(AppFeature.alwaysOnTop.energyProfile == .idle,
+               "always on top is idle (Carbon hotkey, not a keyboard tap)")
+
+        expect(GlobalShortcut.alwaysOnTopDefault
+                == GlobalShortcut(keyCode: Int64(kVK_ANSI_T), modifiers: [.control, .option, .shift]),
+               "default pin shortcut is control-option-shift-T")
+        expect(GlobalShortcut.alwaysOnTopDefault != GlobalShortcut.windowLayoutRightTwoThirdsDefault,
+               "pin shortcut must not collide with window layout control-option-T")
+        expect(GlobalShortcut.alwaysOnTopDefault != GlobalShortcut.screenOCRDefault,
+               "pin shortcut must not collide with screen OCR control-option-command-T")
+        expect(GlobalShortcutRole.alwaysOnTop.storageKey == DefaultsKey.alwaysOnTopShortcut,
+               "always on top role stores under alwaysOnTopShortcut")
+        expect(GlobalShortcutRole.alwaysOnTop.defaultShortcut == .alwaysOnTopDefault,
+               "always on top role default matches alwaysOnTopDefault")
+        expect(GlobalShortcutRole.alwaysOnTop.requiredEnableKeys == [DefaultsKey.alwaysOnTopEnabled],
+               "always on top shortcut follows the feature switch")
+        expect(GlobalShortcutRole.alwaysOnTop.feature == .alwaysOnTop,
+               "always on top role belongs to the alwaysOnTop feature")
         expect(FeatureGroup.allCases.map { AppFeature.features(in: $0).count }.reduce(0, +)
                 == AppFeature.allCases.count,
                "every feature belongs to exactly one group")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11925,8 +11925,41 @@ struct MetricsTests {
                "always on top shortcut follows the feature switch")
         expect(GlobalShortcutRole.alwaysOnTop.feature == .alwaysOnTop,
                "always on top role belongs to the alwaysOnTop feature")
+
+        // MARK: Always On Top
+
+        var map = AlwaysOnTopPinMap()
+        expect(map.isEmpty, "new pin map is empty")
+        map.pin(AlwaysOnTopPin(windowID: 10, originalLevel: 0, pid: 100))
+        map.pin(AlwaysOnTopPin(windowID: 11, originalLevel: 3, pid: 100))
+        map.pin(AlwaysOnTopPin(windowID: 12, originalLevel: 0, pid: 200))
+        expect(map.contains(10) && map.contains(11) && map.contains(12),
+               "pin map keeps several windows")
+        expect(map.pins(for: 100).map(\.windowID).sorted() == [10, 11],
+               "pin map can list one pid")
+        let removed = map.remove(pid: 100)
+        expect(removed.map(\.windowID).sorted() == [10, 11],
+               "closing an app drops that pid")
+        expect(!map.contains(10) && map.contains(12),
+               "other pids stay pinned")
+        let unpinned = map.unpin(12)
+        expect(unpinned?.originalLevel == 0 && map.isEmpty,
+               "unpin restores the recorded level and drops the entry")
+        map.pin(AlwaysOnTopPin(windowID: 13, originalLevel: 5, pid: 300))
+        let all = map.unpinAll()
+        expect(all.map(\.windowID) == [13] && map.isEmpty,
+               "unpin-all clears the map")
+
+        expect(AlwaysOnTopSupport.isExcluded(bundleIdentifier: "com.apple.Safari",
+                                             exceptions: ["com.apple.Safari"]),
+               "exact bundle id is excluded")
+        expect(!AlwaysOnTopSupport.isExcluded(bundleIdentifier: "com.apple.Safari",
+                                              exceptions: ["com.apple.Notes"]),
+               "other bundle ids are not excluded")
+        expect(!AlwaysOnTopSupport.isExcluded(bundleIdentifier: nil, exceptions: ["com.apple.Safari"]),
+               "missing bundle id is not excluded")
         expect(FeatureGroup.allCases.map { AppFeature.features(in: $0).count }.reduce(0, +)
-                == AppFeature.allCases.count,
+                 == AppFeature.allCases.count,
                "every feature belongs to exactly one group")
         expect(!FeatureGroup.allCases.contains { AppFeature.features(in: $0).isEmpty },
                "no hub group is empty")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11970,6 +11970,14 @@ struct MetricsTests {
             }
         )
         expect(gone == [1], "later excluding a pinned app unpins it")
+        expect(AlwaysOnTopSupport.preferredWindowID(focused: 1, main: 2, first: 3) == 1,
+               "focused window wins")
+        expect(AlwaysOnTopSupport.preferredWindowID(focused: nil, main: 2, first: 3) == 2,
+               "main window is the first fallback")
+        expect(AlwaysOnTopSupport.preferredWindowID(focused: nil, main: nil, first: 3) == 3,
+               "first window is the last fallback")
+        expect(AlwaysOnTopSupport.preferredWindowID(focused: nil, main: nil, first: nil) == nil,
+               "no window is a no-op")
 
         let missing = AlwaysOnTopPinning(client: AlwaysOnTopStubClient(isAvailable: false))
         expect(missing.pin(1) == nil, "missing private symbol is a no-op")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11958,6 +11958,25 @@ struct MetricsTests {
                "other bundle ids are not excluded")
         expect(!AlwaysOnTopSupport.isExcluded(bundleIdentifier: nil, exceptions: ["com.apple.Safari"]),
                "missing bundle id is not excluded")
+
+        let missing = AlwaysOnTopPinning(client: AlwaysOnTopStubClient(isAvailable: false))
+        expect(missing.pin(1) == nil, "missing private symbol is a no-op")
+
+        let stub = AlwaysOnTopStubClient()
+        stub.levels[42] = 0
+        let pinning = AlwaysOnTopPinning(client: stub)
+        let original = pinning.pin(42)
+        expect(original == 0, "pin remembers the original level")
+        expect(stub.levels[42] == AlwaysOnTopPinning.floatingLevel,
+               "pin sets the floating level")
+        expect(pinning.unpin(42, originalLevel: 0), "unpin restores")
+        expect(stub.levels[42] == 0, "unpin writes the recorded level back")
+
+        stub.setShouldFail.insert(99)
+        stub.levels[99] = 0
+        expect(pinning.pin(99) == nil, "failed pin leaves the window alone")
+        expect(stub.levels[99] == 0, "failed pin does not change the stored level")
+
         expect(FeatureGroup.allCases.map { AppFeature.features(in: $0).count }.reduce(0, +)
                  == AppFeature.allCases.count,
                "every feature belongs to exactly one group")

--- a/build.sh
+++ b/build.sh
@@ -285,6 +285,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/Clipboard/ClipboardAutoClearSupport.swift \
          Sources/Vorssaint/Services/AutoQuit/AutoQuitSupport.swift \
          Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopSupport.swift \
+         Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopPinning.swift \
          Sources/Vorssaint/Services/Shelf/ShelfSupport.swift \
         Sources/Vorssaint/Services/Finder/FinderRenameSupport.swift \
         Sources/Vorssaint/Services/Update/UpdateInstallerSupport.swift \

--- a/build.sh
+++ b/build.sh
@@ -283,8 +283,9 @@ if (( TEST )); then
         Sources/Vorssaint/Services/DiskImageInstaller/DiskImageInstallerSupport.swift \
         Sources/Vorssaint/Services/Clipboard/ClipboardHistorySupport.swift \
         Sources/Vorssaint/Services/Clipboard/ClipboardAutoClearSupport.swift \
-        Sources/Vorssaint/Services/AutoQuit/AutoQuitSupport.swift \
-        Sources/Vorssaint/Services/Shelf/ShelfSupport.swift \
+         Sources/Vorssaint/Services/AutoQuit/AutoQuitSupport.swift \
+         Sources/Vorssaint/Services/AlwaysOnTop/AlwaysOnTopSupport.swift \
+         Sources/Vorssaint/Services/Shelf/ShelfSupport.swift \
         Sources/Vorssaint/Services/Finder/FinderRenameSupport.swift \
         Sources/Vorssaint/Services/Update/UpdateInstallerSupport.swift \
         Sources/Vorssaint/Services/Update/UpdateServiceSupport.swift \

--- a/build.sh
+++ b/build.sh
@@ -262,6 +262,7 @@ if (( TEST )); then
         Sources/Vorssaint/Core/Localizations/Strings+*.swift \
         Sources/Vorssaint/Core/FeatureStrings.swift \
         Sources/Vorssaint/Core/KillProcessStrings.swift \
+        Sources/Vorssaint/Core/AlwaysOnTopStrings.swift \
         Sources/Vorssaint/Core/WhatsAppDownloadStrings.swift \
         Sources/Vorssaint/Core/WhatsAppOrganizerStrings.swift \
         Sources/Vorssaint/Core/ReleaseNotes.swift \


### PR DESCRIPTION
## Summary

Adds an opt-in Always On Top feature so a shortcut can pin the frontmost window above other windows. Same idea as PowerToys Always On Top, built for macOS.

Ref #461. Also covers #475.

## Behavior before

There was no way to pin a real window on top. Dock Preview can pin a preview card, not the window itself.

## Behavior after

- New Windows-group feature, not installed by default, not in the Windows preset.
- Needs Accessibility. Shortcut defaults to ⌃⌥⇧T and is remappable.
- Toggle pins or unpins the frontmost window. Several windows can stay pinned at once.
- Optional cyan border, optional pin sound, exclude list by exact bundle ID.
- Pins live in memory only. Feature off, uninstall, or a Vorssaint restart unpins everything.
- Best-effort private SkyLight implementation. Pinning is successful only when SLS readback confirms the requested level; cross-app pinning is currently unsupported on macOS Tahoe.

## Verification

- `./build.sh --test`: TESTS OK (8337 checks)
- Manual Safari pin on a signed Tahoe build: SLS set returns success, independent readback stays at normal level. Feature does not pin other apps' windows on macOS Tahoe.

## Notes

Keep as draft until pinning is validated on a supported older macOS and gated accordingly. Fullscreen, other topmost windows, and Screen Sharing may not stay above everything.