### PR TITLE
fix(quick-tools): keep the copy confirmation on screen for long text

### DIFF
--- a/Sources/Vorssaint/Services/QuickTools/QuickToolHUD.swift
+++ b/Sources/Vorssaint/Services/QuickTools/QuickToolHUD.swift
@@ -12,6 +12,11 @@ enum QuickToolHUD {
     private static var scrollingPanel: ScrollingCapturePanel?
     private static var scrollingModel: ScrollingCaptureHUDModel?
     private static var dismissWork: DispatchWorkItem?
+    /// How wide a message is allowed to get, on either of this file's two
+    /// message panels. A confirmation is read at a
+    /// glance, so anything past this is a preview rather than the whole value;
+    /// a short one still sizes to itself and is not padded out to this width.
+    fileprivate static let messageWidthLimit: CGFloat = 360
     /// Bumped by every show(). A dismiss whose fade-out was overtaken by a
     /// newer show() must not order the panel out from its completion handler.
     private static var generation = 0
@@ -51,6 +56,19 @@ enum QuickToolHUD {
             }
             Text(message)
                 .font(.system(size: 12, weight: .semibold))
+                // What was copied can be a whole paragraph, and the panel is
+                // laid out at whatever the text asks for. Unbounded, one long
+                // line measures wider than the screen and the panel, centred on
+                // that width, hangs off both edges with nothing readable left.
+                //
+                // Truncating at the tail rather than the middle so that the
+                // ellipsis is always drawn: a value whose first paragraph ends
+                // on the second line is cut at a line break, not inside one,
+                // and middle truncation leaves no mark at all there — the
+                // preview then reads as the whole of what was copied.
+                .lineLimit(2)
+                .truncationMode(.tail)
+                .frame(maxWidth: messageWidthLimit, alignment: .leading)
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 9)
@@ -272,6 +290,11 @@ private struct ScrollingCaptureHUDView: View {
                 Text(model.message)
                     .font(.system(size: 12, weight: .semibold))
                     .lineLimit(2)
+                    // Same panel geometry as the confirmation above, so the
+                    // same bound: this one is laid out from fittingSize and
+                    // centred on it too.
+                    .truncationMode(.tail)
+                    .frame(maxWidth: QuickToolHUD.messageWidthLimit, alignment: .leading)
                 Text("\(model.height) px")
                     .font(.system(size: 10, weight: .medium, design: .rounded))
                     .foregroundStyle(.secondary)


### PR DESCRIPTION
## The problem

Both message panels in `QuickToolHUD` are laid out from `fittingSize` and then centred on the width that came back:

```swift
let size = host.view.fittingSize
panel.setFrame(NSRect(x: frame.midX - size.width / 2, ...
```

Neither message is bounded. The confirmation's message is usually whatever was just copied, so a copied paragraph — or one long line of one — measures far wider than the display and the panel hangs off both edges with nothing readable left.

Measured with `NSHostingController.fittingSize` against this exact view hierarchy, on a 2560pt screen:

| message | now | with this change |
|---|---|---|
| `#3A7BD5` | 110 × 37pt | 110 × 37pt |
| one long line of cleaned text | **5199 × 37pt** | 414 × 37pt |
| a multi-paragraph transcript | 354 × 198pt | 414 × 48pt |

`show(icon:message:)` has **68 call sites**. I went through the strings behind them: all are short and fixed except `CommandBarCatalog.swift:1549`, which formats `urlCleanerRemovedFormat` with `names.joined(separator: ", ")` and has no upper bound on its length. That one is the realistic overflow in shipped code; a copied answer from the command bar is the other.

`showScrollingCapture(message:)` sits on the same panel geometry and was unbounded too. Its one caller passes a fixed localized string today, so it is not reachable with arbitrary text, but it is the same defect one function down and is bounded here as well.

## The change

Both messages are capped at two lines and 360pt.

A short message still sizes to itself rather than being padded out to the cap — as the table shows, a picked colour measures exactly what it did before. That matters when almost all of the 68 callers pass something short.

**Truncation is at the tail, not the middle.** With middle truncation, a value whose first paragraph happens to end on the second line is cut at a line break rather than inside one, so no ellipsis is drawn anywhere and the preview reads as the entire copied value:

| middle | tail |
|---|---|
| `…transcript, / which runs on for a while before it ends.` | `…transcript, / which runs on for a while before it ends.…` |

Rendered both offscreen to compare.

The clipboard is unaffected either way — `copyAnswer` writes the full value to the pasteboard and the HUD only previews it.

## Testing

`./build.sh` clean, `--selftest` passes, `./build.sh --test` passes. Sizes measured directly against the same view hierarchy the HUD builds, and the panels rendered to images to confirm the wrapping and the ellipsis.
