### PR TITLE
chore: add a pull request template and extend the issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,10 +1,31 @@
 name: "🐛 Bug Report"
 description: Report a bug or unexpected behavior in Vorssaint
-title: "[Bug]: "
 labels:
   - bug
 
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Fill in what you can. A partial report is still useful.
+
+        **One problem per issue.** A second problem added to an existing thread
+        tends to get lost while the first one is being discussed.
+
+        [Reporting a useful bug](https://github.com/vorssaintapp/vorssaint-utils/blob/main/docs/TROUBLESHOOTING.md#reporting-a-useful-bug)
+        lists what a report needs to be actionable.
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before you file
+      description: The [troubleshooting guide](https://github.com/vorssaintapp/vorssaint-utils/blob/main/docs/TROUBLESHOOTING.md) covers both of these.
+      options:
+        - label: "If the feature does nothing at all, I checked that Vorssaint is listed and switched on for the permission it needs in System Settings, Privacy and Security, and toggled it off and back on."
+          required: true
+        - label: "It still happens on the latest version."
+          required: true
+
   - type: textarea
     id: description
     attributes:
@@ -23,6 +44,24 @@ body:
         1. Open Vorssaint
         2. Click on '...'
         3. See error
+    validations:
+      required: true
+
+  - type: dropdown
+    id: feature_area
+    attributes:
+      label: Feature Area
+      description: The same groups you see in Settings.
+      options:
+        - Windows and Dock
+        - Mouse and keyboard
+        - Clipboard and files
+        - Sound
+        - Energy and display
+        - Tools
+        - System monitor
+        - Menu bar
+        - Other
     validations:
       required: true
 
@@ -54,7 +93,23 @@ body:
       required: true
 
   - type: input
+    id: language
+    attributes:
+      label: Language
+      description: The language Vorssaint is running in, and your macOS language if it differs. Several bugs so far were invisible in English, so this narrows things down fast.
+      placeholder: "简体中文 · macOS in 简体中文"
+    validations:
+      required: true
+
+  - type: input
+    id: hardware
+    attributes:
+      label: Mac and displays
+      description: Skip only if the bug touches neither windows nor hardware. The Mac model decides the sensors, fans and brightness range; the display and Spaces layout decides almost every window bug.
+      placeholder: "MacBook Pro 14 (M3 Pro) · built-in + one 4K external, scaled, two Spaces"
+
+  - type: input
     id: installation_method
     attributes:
       label: Installation Method
-      placeholder: Homebrew, DMG, GitHub Release, etc.
+      placeholder: Homebrew, DMG, GitHub Release, built from source

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,9 @@
 blank_issues_enabled: true
 
 contact_links:
+  - name: Troubleshooting Guide
+    about: The usual fixes for permissions, Gatekeeper and a feature that stopped responding.
+    url: https://github.com/vorssaintapp/vorssaint-utils/blob/main/docs/TROUBLESHOOTING.md
   - name: Security Vulnerability
     about: Please report security vulnerabilities privately.
     url: https://github.com/vorssaintapp/vorssaint-utils/security/advisories/new

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,10 +1,19 @@
 name: "✨ Feature Request"
 description: Suggest a new feature or improvement for Vorssaint
-title: "[Feature]: "
 labels:
   - enhancement
 
 body:
+  - type: markdown
+    attributes:
+      value: |
+        **Someone may have asked already.** [Enhancement Summary](https://github.com/vorssaintapp/vorssaint-utils/issues/838)
+        indexes every open request, sorted into what already shipped, what is
+        worth doing, and what has been ruled out and why.
+
+        A comment and a 👍 on the existing request carries further than a
+        second issue for the same thing, since the votes stay in one place.
+
   - type: textarea
     id: problem
     attributes:
@@ -40,6 +49,13 @@ body:
         - Other
     validations:
       required: true
+
+  - type: input
+    id: existing_apps
+    attributes:
+      label: Does another app already do this?
+      description: "A name or a screenshot is the most useful thing you can add. A request pointing at something concrete gets answered against that thing rather than against a guess at what you meant. [Related Apps](https://github.com/vorssaintapp/vorssaint-utils/issues/880) already tracks the apps people cite most often and where Vorssaint stands on each — worth a look before and after you write this, and say which behaviour of it you mean rather than only the name."
+      placeholder: "Rectangle, Raycast, macOS itself..."
 
   - type: textarea
     id: mockups

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,9 +14,13 @@ What changes, and for a fix, what was wrong.
 
 If this adds or changes a feature, say why it belongs in Vorssaint. Direction
 is the most common reason a pull request is turned down here, and it is far
-cheaper to settle in an issue before the code exists. Intel support and
-hardcoded integrations with particular third-party apps have both been
-declined before.
+cheaper to settle in an issue before the code exists. Say what the feature is
+built on and whether that will still be here, what it drags in at runtime and
+who carries that when it breaks, what it exposes the project to, and how much
+permanent surface it adds against how many people will ever switch it on.
+Intel support, hardcoded integrations with particular third-party apps, a
+plugin system and video downloading have all been declined on those grounds;
+CONTRIBUTING works them through with the cases.
 
 ## Verification
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+<!--
+Nothing here is required, and a one-line fix needs only the first section.
+The shortest description ever merged here was five lines.
+
+Size is what decides how long this waits. The median merged pull request is
++110 lines and lands within a day. Nothing under +200 lines is stuck right
+now; half of everything over +1000 lines is. Splitting a large change is
+worth more than describing it well.
+-->
+
+## Summary
+
+What changes, and for a fix, what was wrong.
+
+If this adds or changes a feature, say why it belongs in Vorssaint. Direction
+is the most common reason a pull request is turned down here, and it is far
+cheaper to settle in an issue before the code exists. Intel support and
+hardcoded integrations with particular third-party apps have both been
+declined before.
+
+## Verification
+
+Where you ran it, in as much detail as you have, and **what you could not
+test**. The Mac model, the macOS version and build, the display and Spaces
+layout, whether it was a release build or one of your own — any of those can
+be the whole difference. Every pull request is run locally before it is
+merged, on one maintainer's hardware, so the gap between your machine and
+that one is the useful part; changes have passed review and then failed on a
+different Mac.
+
+```sh
+./build.sh                     # must finish without warnings
+./build/Vorssaint --selftest
+./build.sh --test
+```
+
+New user-facing text has to compile in every supported language; a missing
+translation is a failed build, not a missing string.
+
+## Anything else
+
+`Refs #123` for a related issue, rather than `Closes` — the reporter confirms
+the fix. If the issue carries more than one report and this covers only one,
+say which, here and on the issue when this merges. `Depends on #123` if it
+has to land after another branch.


### PR DESCRIPTION
Adds `.github/PULL_REQUEST_TEMPLATE.md`, which this repository does not have,
and fills three gaps in the issue forms.

Both forms drop their `[Bug]: ` / `[Feature]: ` title prefix. The forms already
apply `bug` and `enhancement`, so the prefix answered the same question a
second time and cost the reporter the front of every title.

The bug form gains **Feature Area**, which the feature form has had all along,
so half the reports currently arrive unrouted; **Language**, which is a setting
of its own here and independent of the system locale; **Mac and displays**,
optional, since the model decides which sensors and brightness range exist and
the Spaces layout decides most window behaviour; and a two-item pre-flight
naming steps that already exist in the troubleshooting guide. The feature form
gains a prior-art question and points at #838 up front and #880 beside that
question. `config.yml` gets the troubleshooting guide as a second contact link.

The pull request template is three sections and about thirty visible lines. It
asks only for what a reviewer cannot get by running the branch themselves: why
the change belongs in the app, which Mac and macOS it was run on, and what the
author could not test. The first of those names the four grounds a feature is
actually judged on here — what it is built on, what it drags in at runtime,
what it exposes the project to, and how much permanent surface it adds for how
few people — since a template asking "why does this belong" without saying
against what collects a sentence of restatement.

## Verification

Both forms parse and render as issue forms; the template is plain markdown. No
code changed.

Not verified: how the pre-flight reads to a first-time reporter. That only
shows up in the reports that arrive afterwards.
