### PR TITLE
docs: stop counting the locales in three places

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Every user facing string lives in `Core/Localization.swift` as a field of the
 it, and the compiler is the completeness check, so a translation can never
 silently fall out of sync.
 
-Vorssaint ships thirteen locales today: English (US), Português (Brasil),
+Vorssaint ships these locales today: English (US), Português (Brasil),
 Türkçe, Русский, Español, Deutsch, Français, Italiano, 日本語, 한국어, 简体中文,
 繁體中文（台灣） and 繁體中文（香港）. The non-base translations live in
 `Core/Localizations/`. To add a language, add a case to `AppLanguage`, provide

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ First setup offers three one click bundles, Essentials, Windows, and Battery and
   <img src="docs/assets/readme/features-hub.png" width="720" alt="The Features hub in Settings, installing and uninstalling whole features">
 </p>
 
-The rest bends the same way: panel sections reorder and hide, the compact layout trades sections for tabs, settings export to a file and import on a new Mac, the app can stay light or dark apart from the Mac, and the whole app speaks thirteen languages.
+The rest bends the same way: panel sections reorder and hide, the compact layout trades sections for tabs, settings export to a file and import on a new Mac, the app can stay light or dark apart from the Mac, and the whole app speaks more than a dozen languages.
 
 ## Everything it does
 

--- a/docs/AI-CONTRIBUTIONS.md
+++ b/docs/AI-CONTRIBUTIONS.md
@@ -112,8 +112,8 @@ path, a network management protocol for a narrow audience: all declined.
 Narrow on its own is fine, and the app is full of things only some people ever
 switch on. Narrow **and** needing a new subsystem is what fails. The ratio to
 weigh is the permanent surface a feature adds — a service, a permission,
-settings, strings in thirteen languages — against how many people will ever
-turn it on.
+settings, strings in every locale — against how many people will ever turn
+it on.
 
 The ruled-out section of the enhancement summary linked above is the record of
 these four being applied, with the reasoning attached to each. It is worth


### PR DESCRIPTION
Three files stated the locale count, and the count is the only part of any of
them that goes stale.

`CONTRIBUTING.md:79` names every locale in the same sentence, so "thirteen" is
a second answer to what the list beside it has already given; it becomes
"these locales today". `README.md:69` becomes "more than a dozen languages",
which stays true as languages are added. `docs/AI-CONTRIBUTIONS.md:115` weighs
"strings in thirteen languages" as part of the permanent surface a feature
adds — a present-tense claim about today's app, so it becomes "strings in
every locale".

Not hypothetical: the README sentence read "eight languages" for a while after
the count had moved, and #413 had to come along and fix it. #821 is adding
Vietnamese now, which would make all three wrong again the day it lands.

## Not changed

`docs/AI-CONTRIBUTIONS.md` keeps "thirteen" at `:150`, `:153` and `:327`. Those
are one past measurement of one overflowing Settings page, written in past
tense, and the number carries arithmetic with the sentence around it: eight
languages overflowed, five did not, and eight plus five has to be thirteen.
Vietnamese landing does not make them wrong — the measurement covered the
locales that existed when it was taken. Rewriting them would falsify the
record rather than protect it.

That leaves no file stating a number, which is the intended end state.
`CONTRIBUTING.md` still answers "how many" by listing them, and that list is
the thing that changes when a language is added, so it cannot disagree with
itself. The alternative — keep one hardcoded count as the single source and
point the other two at it — puts the stale sentence back, just in one place
instead of three.

## Verification

Documentation only. `git grep -nEi 'thirteen|[0-9]+ languages|[0-9]+ locales'
-- '*.md'` returns the three `AI-CONTRIBUTIONS.md` history lines above and
nothing else.

The first revision of this description claimed that command returned nothing.
It did not: `docs/AI-CONTRIBUTIONS.md` landed in #919 after this branch was
cut, so the grep was run against a tree that did not contain it. The branch is
rebased onto `a175fce` and the claim is now measured against the file. Gap
named in #837.
