### PR TITLE
ci(issues): move a fix from merged to released without anyone remembering to

### DIFF
--- a/.github/workflows/issue-fix-status.yml
+++ b/.github/workflows/issue-fix-status.yml
@@ -3,14 +3,20 @@ name: Issue fix status
 # Two mechanical steps, no judgement in either.
 #
 #   a merged pull request that references an issue  ->  the issue gets
-#   `fixed on main`, with the merge commit recorded in the bot's comment
+#   `fixed (pending release)`, with the merge commit recorded in the bot's
+#   comment
 #
 #   a stable release that contains that commit      ->  the label becomes
-#   `v<version> reporter check` and the reporter is asked to confirm
+#   `v<version> please confirm` and the reporter is asked to check it
 #
 # Neither step decides that anything is fixed. A human decided that when they
 # merged. The label only says where the change is, and `git tag --contains`
 # answers the second one, so a changelog entry is never the evidence.
+#
+# Both labels and both comments are addressed to the person who filed the
+# report, and most of them are not developers. Nothing in what they read says
+# `main`, a commit, or a merge: the change is in the development build, and it
+# is not on their Mac until a release says it is.
 
 on:
   pull_request_target:
@@ -60,28 +66,30 @@ jobs:
               })
               if (issue.pull_request) continue
               if (issue.state !== 'open') continue
-              if (issue.labels.some(l => (l.name || l) === 'fixed on main')) continue
+              if (issue.labels.some(l => (l.name || l) === 'fixed (pending release)')) continue
 
               await github.rest.issues.addLabels({
-                ...context.repo, issue_number: number, labels: ['fixed on main'],
+                ...context.repo, issue_number: number, labels: ['fixed (pending release)'],
               })
               await github.rest.issues.createComment({
                 ...context.repo, issue_number: number,
                 body: [
-                  `#${pr.number} referenced this issue and has been merged, so the change is on \`main\`.`,
+                  `A fix for this went into the development version of the app in #${pr.number}, and it`,
+                  `is queued to go out in an upcoming release.`,
                   ``,
-                  `Nothing here says the report is fixed — that is what the next step asks you. When a`,
-                  `release contains this commit you will get a note on this issue with the version to`,
-                  `install, and two weeks to say whether it holds up on your Mac.`,
+                  `**Nothing has changed on your Mac yet**, and this is not us saying your report is`,
+                  `fixed — that part is up to you. When a release goes out carrying this fix you will get`,
+                  `a note on this issue with the version to install, and two weeks to say whether it`,
+                  `worked for you.`,
                   ``,
                   `**If it fixes part of what you reported and not the rest, please say which part** when`,
-                  `that note arrives. A pull request often answers one report inside an issue that carries`,
-                  `several, and the remaining ones are invisible to us unless you name them.`,
+                  `that note arrives. One fix often answers one thing in a report that mentions several,`,
+                  `and the rest are invisible to us unless you name them.`,
                   ``,
                   `<!-- vorssaint-fix-status sha=${sha} pr=${pr.number} -->`,
                 ].join('\n'),
               })
-              core.info(`#${number}: labelled fixed on main (${sha})`)
+              core.info(`#${number}: labelled fixed (pending release) (${sha})`)
             }
 
   reporter-check:
@@ -125,18 +133,18 @@ jobs:
             }
 
             const version = tag.replace(/^v/, '')
-            const label = `v${version} reporter check`
+            const label = `v${version} please confirm`
             try {
               await github.rest.issues.createLabel({
                 ...context.repo, name: label, color: '1F8B8B',
-                description: `Fix is in the ${version} release; reporter has two weeks to confirm on that build`,
+                description: `The fix is out in ${version}; whoever reported it has two weeks to say whether that build fixed it`,
               })
             } catch (e) {
               if (e.status !== 422) throw e   // 422 = already there
             }
 
             const issues = await github.paginate(github.rest.issues.listForRepo, {
-              ...context.repo, state: 'open', labels: 'fixed on main', per_page: 100,
+              ...context.repo, state: 'open', labels: 'fixed (pending release)', per_page: 100,
             })
 
             for (const issue of issues) {
@@ -152,7 +160,7 @@ jobs:
                 }
               }
               if (shas.length === 0) {
-                core.warning(`#${issue.number}: labelled fixed on main with no recorded commit, left alone`)
+                core.warning(`#${issue.number}: labelled fixed (pending release) with no recorded commit, left alone`)
                 continue
               }
 
@@ -176,20 +184,20 @@ jobs:
                 ...context.repo, issue_number: issue.number, labels: [label],
               })
               await github.rest.issues.removeLabel({
-                ...context.repo, issue_number: issue.number, name: 'fixed on main',
+                ...context.repo, issue_number: issue.number, name: 'fixed (pending release)',
               }).catch(e => { if (e.status !== 404) throw e })
 
               await github.rest.issues.createComment({
                 ...context.repo, issue_number: issue.number,
                 body: [
-                  `The change for this issue is in **${version}**, out now.`,
+                  `The fix for this is out now, in **${version}**.`,
                   ``,
-                  `@${issue.user.login}, could you install it and say whether it holds up on your Mac?`,
-                  `Reading the code is not the same as your setup, which is the one that found this.`,
+                  `@${issue.user.login}, could you update to that version and say whether it fixed things`,
+                  `on your Mac? We cannot tell from here — yours is the setup that found this.`,
                   ``,
                   `Please say **how much of it is fixed**, not only whether it is. If part of what you`,
-                  `reported still happens, or a related case appeared, say so here and the issue goes back`,
-                  `for another look — this is not a last call.`,
+                  `reported still happens, or something related turned up, say so here and the issue goes`,
+                  `back for another look — this is not a last call.`,
                   ``,
                   `If nothing arrives in two weeks the issue will be closed as it stands, and a comment`,
                   `reopens it at any point after that.`,

--- a/.github/workflows/issue-fix-status.yml
+++ b/.github/workflows/issue-fix-status.yml
@@ -1,0 +1,199 @@
+name: Issue fix status
+
+# Two mechanical steps, no judgement in either.
+#
+#   a merged pull request that references an issue  ->  the issue gets
+#   `fixed on main`, with the merge commit recorded in the bot's comment
+#
+#   a stable release that contains that commit      ->  the label becomes
+#   `v<version> reporter check` and the reporter is asked to confirm
+#
+# Neither step decides that anything is fixed. A human decided that when they
+# merged. The label only says where the change is, and `git tag --contains`
+# answers the second one, so a changelog entry is never the evidence.
+
+on:
+  pull_request_target:
+    types: [closed]
+  workflow_run:
+    # Not `release: published`. The release is created by `gh release create`
+    # with the built-in token, and an event raised by that token does not start
+    # another workflow, so a `release` trigger here would never fire once.
+    workflows: [Release]
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: issue-fix-status-${{ github.event.pull_request.number || github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  fixed-on-main:
+    name: Label the issues a merged PR referenced
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # No checkout. This job runs with write access in the base repository
+      # context, so it must never execute anything from the pull request.
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const pr = context.payload.pull_request
+            const sha = pr.merge_commit_sha
+            const body = pr.body || ''
+
+            // Every form people actually use here. `Closes`/`Fixes` already
+            // closed the issue on merge, and closed issues are skipped below,
+            // so matching them costs nothing and catches the rest.
+            const refs = new Set()
+            const pattern = /(?:refs?|references?|related to|fixes|fixed|closes?|resolves?)\s*:?\s*#(\d+)/gi
+            for (const m of body.matchAll(pattern)) refs.add(Number(m[1]))
+            if (refs.size === 0) return
+
+            for (const number of refs) {
+              const { data: issue } = await github.rest.issues.get({
+                ...context.repo, issue_number: number,
+              })
+              if (issue.pull_request) continue
+              if (issue.state !== 'open') continue
+              if (issue.labels.some(l => (l.name || l) === 'fixed on main')) continue
+
+              await github.rest.issues.addLabels({
+                ...context.repo, issue_number: number, labels: ['fixed on main'],
+              })
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: number,
+                body: [
+                  `#${pr.number} referenced this issue and has been merged, so the change is on \`main\`.`,
+                  ``,
+                  `Nothing here says the report is fixed — that is what the next step asks you. When a`,
+                  `release contains this commit you will get a note on this issue with the version to`,
+                  `install, and two weeks to say whether it holds up on your Mac.`,
+                  ``,
+                  `**If it fixes part of what you reported and not the rest, please say which part** when`,
+                  `that note arrives. A pull request often answers one report inside an issue that carries`,
+                  `several, and the remaining ones are invisible to us unless you name them.`,
+                  ``,
+                  `<!-- vorssaint-fix-status sha=${sha} pr=${pr.number} -->`,
+                ].join('\n'),
+              })
+              core.info(`#${number}: labelled fixed on main (${sha})`)
+            }
+
+  reporter-check:
+    name: Ask the reporters a stable release reached
+    if: >-
+      github.event_name == 'workflow_run'
+      && github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { execFileSync } = require('child_process')
+
+            // A tag-triggered run carries the tag in head_branch.
+            const tag = context.payload.workflow_run.head_branch || ''
+            if (!/^v\d+\.\d+\.\d+$/.test(tag)) {
+              core.info(`${tag || '(no tag)'} is not a stable version tag, nothing to do`)
+              return
+            }
+
+            // Asking anyone to confirm on a build that is not downloadable is a
+            // wasted trip, so the release has to exist and be the real thing.
+            let release
+            try {
+              release = (await github.rest.repos.getReleaseByTag({ ...context.repo, tag })).data
+            } catch (e) {
+              if (e.status === 404) { core.info(`No release published for ${tag}`); return }
+              throw e
+            }
+            if (release.draft || release.prerelease) {
+              core.info(`${tag} is a draft or pre-release, nothing to do`)
+              return
+            }
+
+            const version = tag.replace(/^v/, '')
+            const label = `v${version} reporter check`
+            try {
+              await github.rest.issues.createLabel({
+                ...context.repo, name: label, color: '1F8B8B',
+                description: `Fix is in the ${version} release; reporter has two weeks to confirm on that build`,
+              })
+            } catch (e) {
+              if (e.status !== 422) throw e   // 422 = already there
+            }
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              ...context.repo, state: 'open', labels: 'fixed on main', per_page: 100,
+            })
+
+            for (const issue of issues) {
+              if (issue.pull_request) continue
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                ...context.repo, issue_number: issue.number, per_page: 100,
+              })
+              const shas = []
+              for (const c of comments) {
+                for (const m of (c.body || '').matchAll(/<!--\s*vorssaint-fix-status sha=([0-9a-f]{7,40})/g)) {
+                  shas.push(m[1])
+                }
+              }
+              if (shas.length === 0) {
+                core.warning(`#${issue.number}: labelled fixed on main with no recorded commit, left alone`)
+                continue
+              }
+
+              // The label moves only when the release really carries the fix.
+              // Reading the changelog instead of the history is how issues get
+              // closed against a version that never shipped the change.
+              const contained = shas.filter(sha => {
+                try {
+                  const tags = execFileSync('git', ['tag', '--contains', sha], { encoding: 'utf8' })
+                  return tags.split('\n').includes(tag)
+                } catch {
+                  return false
+                }
+              })
+              if (contained.length === 0) {
+                core.info(`#${issue.number}: fix is not in ${tag} yet, left alone`)
+                continue
+              }
+
+              await github.rest.issues.addLabels({
+                ...context.repo, issue_number: issue.number, labels: [label],
+              })
+              await github.rest.issues.removeLabel({
+                ...context.repo, issue_number: issue.number, name: 'fixed on main',
+              }).catch(e => { if (e.status !== 404) throw e })
+
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: issue.number,
+                body: [
+                  `The change for this issue is in **${version}**, out now.`,
+                  ``,
+                  `@${issue.user.login}, could you install it and say whether it holds up on your Mac?`,
+                  `Reading the code is not the same as your setup, which is the one that found this.`,
+                  ``,
+                  `Please say **how much of it is fixed**, not only whether it is. If part of what you`,
+                  `reported still happens, or a related case appeared, say so here and the issue goes back`,
+                  `for another look — this is not a last call.`,
+                  ``,
+                  `If nothing arrives in two weeks the issue will be closed as it stands, and a comment`,
+                  `reopens it at any point after that.`,
+                ].join('\n'),
+              })
+              core.info(`#${issue.number}: moved to ${label}`)
+            }


### PR DESCRIPTION
Two jobs in one workflow.

**`fixed-on-main`** — fires on a merged pull request. Reads `Refs #123` and the
other reference verbs out of the description, labels those issues `fixed
(pending release)`, and records the merge commit in its own comment. It says
where the change is, not that anything is fixed.

**`reporter-check`** — fires after the Release workflow finishes a stable tag.
For each `fixed (pending release)` issue whose recorded commit `git
tag --contains` puts in that tag, it swaps the label to `v<version> please
confirm` and asks the reporter to update to that build and say how much of
their report it fixed.

So the first half moves an issue from *merged* to *waiting for a release*, and
the second from *released* to *in your hands*. Neither decides anything: a
human decided at merge time, and git answers the version question.

Both labels and both comments are read by the person who filed the report, and
most of them do not work on software. Nothing they see says `main`, a commit or
a merge: the change is in the development build, and it is not on their Mac
until a release says it is.

## What you are approving

- **`issues: write`**, declared in this file and scoped to it. The rest of CI
  keeps `contents: read`.
- The labelling job takes **no checkout**. It runs in the base repository
  context under `pull_request_target`, so it must never execute anything that
  arrived with the pull request, and it does not.
- **`release.yml` is untouched.** A step at the end of the release job would
  have been the obvious alternative, but that file carries the signing secrets
  and the protected environment.
- Not `on: release: published`. The release is created by `gh release create`
  with the built-in token, and an event raised by that token does not start
  another workflow run, so that trigger would never fire. Hence `workflow_run`,
  plus an API check that a non-draft, non-prerelease release exists for the tag
  before anyone is written to.
- The two weeks are stated in the comment and enforced nowhere. The expiry
  sweep stays manual, because closing an issue is a decision and this makes
  none.

If the labelling job misbehaves, the blast radius is one label and one comment,
both reversible. Neither trigger can fire from a fork, so the first real
exercise is the first merge after this lands.

