### PR TITLE
fix(cleaning-mode): widen the Esc unlock window and let modifiers reset it

### DIFF
--- a/Sources/Vorssaint/Services/CleaningMode/CleaningModeManager.swift
+++ b/Sources/Vorssaint/Services/CleaningMode/CleaningModeManager.swift
@@ -45,9 +45,10 @@ final class CleaningModeManager: ObservableObject {
     /// pressing Escape slower than once per two seconds could never unlock
     /// (progress restarted at 1 on every press). The window's one remaining job
     /// is rejecting five isolated Esc-only contacts spread across a long wipe:
-    /// other keys reset the count and auto-repeat never counts, but a cloth can
-    /// strike Escape alone. Widening to 6s weakens that guard on purpose —
-    /// a gesture a deliberate user cannot complete protects nothing.
+    /// every other key resets the count — modifiers included, they reach the
+    /// counter as flags-changed events — and auto-repeat never counts, but a
+    /// cloth can strike Escape alone. Widening to 6s weakens that guard on
+    /// purpose — a gesture a deliberate user cannot complete protects nothing.
     private lazy var unlock = CleaningUnlockCounter(requiredKeyCode: Self.escapeKeyCode,
                                                     threshold: unlockThreshold,
                                                     pressWindow: 6.0)
@@ -158,6 +159,15 @@ final class CleaningModeManager: ObservableObject {
             let code = event.getIntegerValueField(.keyboardEventKeycode)
             let isRepeat = event.getIntegerValueField(.keyboardEventAutorepeat) != 0
             registerUnlockKeyDown(code: code, isRepeat: isRepeat)
+        } else if type == .flagsChanged {
+            // Shift, control, option, command, fn and caps lock arrive here rather
+            // than as key-downs, and they are the keys nearest Escape — a cloth
+            // resting on them must reset the count like any other key. Both the
+            // press and the release report the same key code and neither is
+            // Escape, so each one resets and the pair is idempotent. Modifiers
+            // never auto-repeat.
+            registerUnlockKeyDown(code: event.getIntegerValueField(.keyboardEventKeycode),
+                                  isRepeat: false)
         } else if type == Self.systemDefinedEventType,
                   let systemKey = systemKeyEvent(from: event),
                   systemKey.isKeyDown {

--- a/Sources/Vorssaint/Services/CleaningMode/CleaningModeManager.swift
+++ b/Sources/Vorssaint/Services/CleaningMode/CleaningModeManager.swift
@@ -41,9 +41,16 @@ final class CleaningModeManager: ObservableObject {
     private var screenObserver: NSObjectProtocol?
 
     /// The unlock-gesture state machine (pure, unit-tested separately).
+    /// The 6s press window forgives hesitant, deliberate presses — at 2s a user
+    /// pressing Escape slower than once per two seconds could never unlock
+    /// (progress restarted at 1 on every press). The window's one remaining job
+    /// is rejecting five isolated Esc-only contacts spread across a long wipe:
+    /// other keys reset the count and auto-repeat never counts, but a cloth can
+    /// strike Escape alone. Widening to 6s weakens that guard on purpose —
+    /// a gesture a deliberate user cannot complete protects nothing.
     private lazy var unlock = CleaningUnlockCounter(requiredKeyCode: Self.escapeKeyCode,
                                                     threshold: unlockThreshold,
-                                                    pressWindow: 2.0)
+                                                    pressWindow: 6.0)
 
     private init() {}
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -10674,6 +10674,20 @@ struct MetricsTests {
         let afterReset2 = cleared.registerKeyDown(code: escapeKeyCode, time: 0.4, isRepeat: false)
         expect(!afterReset2 && cleared.progress == 1, "after reset Escape starts fresh at 1")
 
+        // The counters above build their own windows, so nothing else here
+        // fails if the shipped constant regresses. Pin it at the source: the
+        // 2s window made the gesture impossible for anyone pressing Escape
+        // slower than once per two seconds (#697).
+        let cleaningSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/CleaningMode/CleaningModeManager.swift",
+            encoding: .utf8)) ?? ""
+        let cleaningCode = cleaningSource
+            .components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(!cleaningCode.isEmpty && cleaningCode.contains("pressWindow: 6.0"),
+               "the shipped unlock counter keeps the forgiving 6s press window")
+
         func systemKeyData(keyCode: Int, state: Int, repeatFlag: Bool = false) -> Int {
             Int((UInt32(keyCode) << 16) | (UInt32(state) << 8) | (repeatFlag ? 1 : 0))
         }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -10674,6 +10674,24 @@ struct MetricsTests {
         let afterReset2 = cleared.registerKeyDown(code: escapeKeyCode, time: 0.4, isRepeat: false)
         expect(!afterReset2 && cleared.progress == 1, "after reset Escape starts fresh at 1")
 
+        // Modifiers are the keys nearest Escape, so a cloth reaches them first.
+        // They arrive as flags-changed events, which the tap feeds here too, and
+        // one physical press reports twice — once down, once up. Both are resets.
+        var smeared = CleaningUnlockCounter(requiredKeyCode: escapeKeyCode, threshold: 5, pressWindow: 6.0)
+        let leftShiftKeyCode: Int64 = 56
+        var smearedUnlock = false
+        for t in [0.0, 0.5, 1.0, 1.5] {
+            if smeared.registerKeyDown(code: escapeKeyCode, time: t, isRepeat: false) { smearedUnlock = true }
+        }
+        expect(smeared.progress == 4, "four Escapes stop one short of the threshold")
+        _ = smeared.registerKeyDown(code: leftShiftKeyCode, time: 2.0, isRepeat: false)
+        expect(smeared.progress == 0, "a modifier going down clears the Escape count")
+        _ = smeared.registerKeyDown(code: leftShiftKeyCode, time: 2.1, isRepeat: false)
+        expect(smeared.progress == 0, "the modifier's release resets again, idempotently")
+        if smeared.registerKeyDown(code: escapeKeyCode, time: 2.5, isRepeat: false) { smearedUnlock = true }
+        expect(!smearedUnlock && smeared.progress == 1,
+               "four Escapes with a modifier in between never unlock; the next Escape starts at 1")
+
         // The counters above build their own windows, so nothing else here
         // fails if the shipped constant regresses. Pin it at the source: the
         // 2s window made the gesture impossible for anyone pressing Escape
@@ -10687,6 +10705,39 @@ struct MetricsTests {
             .joined(separator: "\n")
         expect(!cleaningCode.isEmpty && cleaningCode.contains("pressWindow: 6.0"),
                "the shipped unlock counter keeps the forgiving 6s press window")
+
+        // The counter above cannot see how events reach it, and the real HID
+        // gesture is not reproducible headlessly. Pin the two properties of the
+        // tap's handler the counter depends on: modifiers reach it (they arrive
+        // as .flagsChanged, never as key-downs, and are the keys nearest
+        // Escape), and every event is still swallowed — the handler's only way
+        // out is `return nil`, or a wipe types into the frontmost app.
+        let cleaningLines = cleaningSource.components(separatedBy: "\n")
+        let handlerStart = cleaningLines.firstIndex { $0.contains("private func handle(type:") }
+        let handlerEnd = handlerStart.flatMap { start in
+            cleaningLines[(start + 1)...].firstIndex { $0.hasPrefix("    private func ") }
+        } ?? cleaningLines.count
+        var modifiersReachCounter = false
+        var leakedEvents: [String] = []
+        for (index, line) in cleaningLines[(handlerStart ?? handlerEnd)..<handlerEnd].enumerated()
+        where !line.trimmingCharacters(in: .whitespaces).hasPrefix("//") {
+            let number = (handlerStart ?? 0) + index + 1
+            if line.contains("type == .flagsChanged") {
+                // Read to the end of that branch: the call has to be inside it.
+                var cursor = (handlerStart ?? 0) + index + 1
+                while cursor < handlerEnd, !cleaningLines[cursor].trimmingCharacters(in: .whitespaces).hasPrefix("}") {
+                    if cleaningLines[cursor].contains("registerUnlockKeyDown(") { modifiersReachCounter = true }
+                    cursor += 1
+                }
+            }
+            if line.contains("return"), !line.contains("return nil") {
+                leakedEvents.append("CleaningModeManager.swift:\(number)")
+            }
+        }
+        expect(modifiersReachCounter,
+               "flags-changed events feed the unlock counter, so modifiers reset the Escape count")
+        expect(handlerStart != nil && leakedEvents.isEmpty,
+               "the cleaning tap swallows every event it sees: \(leakedEvents)")
 
         func systemKeyData(keyCode: Int, state: Int, repeatFlag: Bool = false) -> Int {
             Int((UInt32(keyCode) << 16) | (UInt32(state) << 8) | (repeatFlag ? 1 : 0))


### PR DESCRIPTION
Candidate fix for the second symptom of #697 (Cleaning Mode not unlocking after five Esc presses). The first symptom was fixed by #814; PathGao noted this half had no PR yet. Candidate, not confirmed: the harness proves this failure mode exists, but the reporter's diagnostic question in #697 was never answered, so #697 should stay open until a reporter confirms on a build with this in.

## What was wrong

The five Esc presses only count when each lands within 2 s of the previous one (`CleaningUnlockCounter`, `pressWindow: 2.0`). A user pressing Esc deliberately but slower than once per two seconds restarts the count at 1 on every press — the overlay dots stay pinned at one filled dot and the gesture can never complete. Demonstrated with a runtime harness against the real `CleaningUnlockCounter` fed by a listen-only tap with the same mask: synthetic HID Esc presses 150 ms apart unlock (progress 1→5); the same presses 2.5 s apart never unlock on current main; they unlock with a wider window.

(Ruled out: session-level Esc remappers stealing the key — SuperKey's tap is `.cgSessionEventTap`, downstream of our `.cghidEventTap` head-insert, so it cannot intercept first. If a reporter uses Karabiner-style synthesized Esc that never reaches the HID tap, that is a separate cause this PR cannot address.)

## The change

Two commits, and the second is what makes the first safe.

**1. `pressWindow` 2.0 → 6.0.** A gesture a deliberate user cannot complete protects nothing, so the window is widened to a speed a person actually presses at. The doc comment now says exactly that. The shipped constant is pinned by a source-shape assertion beside the counter tests, since the test binary does not compile `CleaningModeManager.swift` and the counter cases construct their own windows.

**2. Modifiers now reach the counter.** The window's one narrow job is rejecting five isolated Esc-only contacts spread across a long wipe: any other key resets the count, and auto-repeat never counts. That was not actually true when this PR was opened. Shift, control, option, command, fn and caps lock arrive as `.flagsChanged` events, and while `.flagsChanged` was already in the tap's mask (`CleaningModeManager.swift:105`), the handler swallowed them without ever showing them to the counter — so the keys a cloth is most likely to land on while it is near Escape were precisely the ones that did *not* reset the count. At a 2 s window that gap was mostly academic; at 6 s it is the thing that would let a wipe accumulate five presses and unlock itself. They now take the same reset path as any other non-Escape key. No modifier key code is 53 (they run 54–63), so the new call can only reach the reset branch, and `isRepeat: false` is passed literally because CG does not define that field for `.flagsChanged`.

Merging only the first commit would ship the widened window without the guard that pays for it. That is why they are one PR.

## Verification

- Harness on this machine: 2.5 s-spaced presses fail to unlock at 2 s window, unlock at 6 s; fast presses unchanged.
- `./build.sh` — 0 warnings. `./build.sh --test` — 8804 checks, **1 failure**: `the dispatch pool starvation this check needs was actually reached`. That is the known machine-dependent check #1014 exists to skip: red on this 15-core M5 Pro, green on CI's smaller runners. It came up identically on two other unrelated branches gated in the same sitting, so it is environmental and not from this change — I am reporting it rather than writing `TESTS OK`. `./build/Vorssaint --selftest` — `SELFTEST OK`. The run includes the `pressWindow` source-shape pin (red if 2.0 returns) and the two anchored scans over the handler and the counter.
- Rebased onto current `main`.

**Still unverified on both sides:** the live HID gesture for the modifier path — nothing here synthesises a real `.flagsChanged` through a tap. The `fn` caveat stands rather than being resolved.

Refs #697
