### PR TITLE
fix(homebrew): skip disabled packages when upgrading everything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented here. The format follows
 - Monitor alerts can now warn you when the battery stays above a temperature you choose. Under Monitor alerts, off by default. Thanks to @ywu73.
 
 ### Fixed
+- Upgrading Homebrew packages no longer fails outright when one of the outdated packages has been disabled by Homebrew: the disabled package is skipped, with a note in the log, and everything else still updates.
 - The screen capture loupe now rings the pixel under the pointer instead of drawing a crosshair across it, and that pixel sits in the middle of the loupe, so the Color picker shows the color it is about to copy. Thanks to @I-Have-No-Idea-What-Im-Doing-Right-Now and @PathGao.
 
 ## [3.3.3-beta.2] - 2026-08-22

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
@@ -42,6 +42,8 @@ final class HomebrewManager: ObservableObject {
     private var popularityLoads: Set<HomebrewPackageKind> = []
     private var activeProcess: Process?
     private var cancelRequested = false
+    private var pendingUpgradeRetries: [HomebrewCommand] = []
+    private var upgradeRetryNote = ""
     private var installedCaskRecords: [HomebrewCaskRecord] = []
     private var installedCaskRecordsFetchedAt: Date?
     private var ownershipLoads: [String: [(HomebrewPackage?) -> Void]] = [:]
@@ -362,6 +364,8 @@ final class HomebrewManager: ObservableObject {
         terminalFallbackCommand = nil
         errorMessage = nil
         clearUntrustedTap()
+        pendingUpgradeRetries = []
+        upgradeRetryNote = ""
         cancelRequested = false
         completedOperationCleanup?.cancel()
         completedOperationCleanup = nil
@@ -376,6 +380,11 @@ final class HomebrewManager: ObservableObject {
                 self.activeProcess = nil
                 self.operation = nil
                 if status == 0 {
+                    if action == .upgradeAll, !self.pendingUpgradeRetries.isEmpty {
+                        self.continueUpgradeRetry(self.pendingUpgradeRetries,
+                                                  note: self.upgradeRetryNote)
+                        return
+                    }
                     self.markOperationComplete(result: .succeeded,
                                                phase: .refreshing,
                                                activity: nil)
@@ -409,8 +418,10 @@ final class HomebrewManager: ObservableObject {
                               from: command,
                               outdated: Array(self.outdatedPackagesByID.values)) {
                     // A disabled package can never be upgraded, so skip it.
-                    self.perform(action, package: package, command: retry)
-                    self.appendLog("Skipping \(disabled): disabled in Homebrew.\n\n")
+                    self.continueUpgradeRetry(
+                        retry + self.pendingUpgradeRetries,
+                        note: self.upgradeRetryNote
+                            + "Skipping \(disabled): disabled in Homebrew.\n")
                 } else {
                     let message = HomebrewProgressParser.visibleError(from: output)
                     self.errorMessage = message.isEmpty ? output.trimmingCharacters(in: .whitespacesAndNewlines) : message
@@ -421,6 +432,18 @@ final class HomebrewManager: ObservableObject {
                 self.cancelRequested = false
             }
         }
+    }
+
+    /// Runs the next command of a retried upgrade-all. The queue and note are
+    /// restored after `perform` resets them, and the note plus the command
+    /// being run are appended after it clears the log, so every leg's log
+    /// says what was skipped and exactly what the retry covers.
+    private func continueUpgradeRetry(_ commands: [HomebrewCommand], note: String) {
+        guard let first = commands.first else { return }
+        perform(.upgradeAll, package: nil, command: first)
+        pendingUpgradeRetries = Array(commands.dropFirst())
+        upgradeRetryNote = note
+        appendLog(note + "$ " + HomebrewCommandBuilder.shellCommand(first) + "\n\n")
     }
 
     private func finishOwnershipLoad(path: String, package: HomebrewPackage?) {

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
@@ -402,6 +402,15 @@ final class HomebrewManager: ObservableObject {
                     self.markOperationComplete(result: .failed,
                                                phase: self.operationStatus?.phase ?? .finalizing,
                                                activity: nil)
+                } else if action == .upgradeAll,
+                          let disabled = HomebrewCommandBuilder.disabledPackageName(fromOutput: output),
+                          let retry = HomebrewCommandBuilder.upgradeExcluding(
+                              [disabled],
+                              from: command,
+                              outdated: Array(self.outdatedPackagesByID.values)) {
+                    // A disabled package can never be upgraded, so skip it.
+                    self.perform(action, package: package, command: retry)
+                    self.appendLog("Skipping \(disabled): disabled in Homebrew.\n\n")
                 } else {
                     let message = HomebrewProgressParser.visibleError(from: output)
                     self.errorMessage = message.isEmpty ? output.trimmingCharacters(in: .whitespacesAndNewlines) : message

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
@@ -310,6 +310,39 @@ enum HomebrewCommandBuilder {
         HomebrewCommand(executable: brewPath, arguments: ["trust", "--tap", tap])
     }
 
+    /// Homebrew aborts a whole `upgrade` run when any package in it has been
+    /// disabled ("Error: six has been disabled because …"). The name is
+    /// extracted so the upgrade can be retried without that package.
+    static func disabledPackageName(fromOutput output: String) -> String? {
+        guard let range = output.range(of: #"Error: ([A-Za-z0-9._+@/-]+) has been disabled"#,
+                                       options: .regularExpression) else { return nil }
+        let name = String(output[range])
+            .replacingOccurrences(of: "Error: ", with: "")
+            .replacingOccurrences(of: " has been disabled", with: "")
+        return isValidToken(name) ? name : nil
+    }
+
+    /// The failed upgrade rebuilt without the given packages: explicit tokens
+    /// lose the excluded names, a bare `upgrade` expands to the outdated list
+    /// minus them. nil when the retry would repeat the same command or
+    /// nothing is left to upgrade.
+    static func upgradeExcluding(_ excluded: Set<String>,
+                                 from command: HomebrewCommand,
+                                 outdated: [HomebrewPackageUpdate]) -> HomebrewCommand? {
+        guard command.arguments.first == "upgrade" else { return nil }
+        let rest = command.arguments.dropFirst()
+        let flags = rest.filter { $0.hasPrefix("-") }
+        var tokens = rest.filter { !$0.hasPrefix("-") }
+        if tokens.isEmpty {
+            tokens = outdated.filter { !$0.isPinned }.map(\.name).sorted()
+        }
+        guard tokens.contains(where: excluded.contains) else { return nil }
+        tokens.removeAll { excluded.contains($0) || !isValidToken($0) }
+        guard !tokens.isEmpty else { return nil }
+        return HomebrewCommand(executable: command.executable,
+                               arguments: ["upgrade"] + flags + tokens)
+    }
+
     static func needsTerminalFallback(output: String) -> Bool {
         let lower = output.lowercased()
         return lower.contains("sudo:")

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
@@ -322,25 +322,40 @@ enum HomebrewCommandBuilder {
         return isValidToken(name) ? name : nil
     }
 
-    /// The failed upgrade rebuilt without the given packages: explicit tokens
-    /// lose the excluded names, a bare `upgrade` expands to the outdated list
-    /// minus them. nil when the retry would repeat the same command or
-    /// nothing is left to upgrade.
+    /// The failed upgrade rebuilt without the given packages, as the commands
+    /// to run in order. Explicit tokens just lose the excluded names, keeping
+    /// their flags. A bare `upgrade` cannot exclude anything, so it splits by
+    /// kind: an explicit `--formula` upgrade from the outdated list minus
+    /// excluded and pinned names, then a bare `--cask` upgrade — a plain name
+    /// shared by a formula and a cask would resolve as the formula, so cask
+    /// coverage stays brew's own instead of a list of names. nil when the
+    /// retry would repeat the failed command or nothing is left to upgrade.
     static func upgradeExcluding(_ excluded: Set<String>,
                                  from command: HomebrewCommand,
-                                 outdated: [HomebrewPackageUpdate]) -> HomebrewCommand? {
+                                 outdated: [HomebrewPackageUpdate]) -> [HomebrewCommand]? {
         guard command.arguments.first == "upgrade" else { return nil }
         let rest = command.arguments.dropFirst()
         let flags = rest.filter { $0.hasPrefix("-") }
         var tokens = rest.filter { !$0.hasPrefix("-") }
-        if tokens.isEmpty {
-            tokens = outdated.filter { !$0.isPinned }.map(\.name).sorted()
+        guard tokens.isEmpty else {
+            guard tokens.contains(where: excluded.contains) else { return nil }
+            tokens.removeAll { excluded.contains($0) || !isValidToken($0) }
+            guard !tokens.isEmpty else { return nil }
+            return [HomebrewCommand(executable: command.executable,
+                                    arguments: ["upgrade"] + flags + tokens)]
         }
-        guard tokens.contains(where: excluded.contains) else { return nil }
-        tokens.removeAll { excluded.contains($0) || !isValidToken($0) }
-        guard !tokens.isEmpty else { return nil }
-        return HomebrewCommand(executable: command.executable,
-                               arguments: ["upgrade"] + flags + tokens)
+        guard flags.isEmpty else { return nil }
+        let formulae = outdated
+            .filter { $0.kind == .formula && !$0.isPinned && !excluded.contains($0.name) }
+            .map(\.name).filter(isValidToken).sorted()
+        var commands: [HomebrewCommand] = []
+        if !formulae.isEmpty {
+            commands.append(HomebrewCommand(executable: command.executable,
+                                            arguments: ["upgrade", "--formula"] + formulae))
+        }
+        commands.append(HomebrewCommand(executable: command.executable,
+                                        arguments: ["upgrade", "--cask"]))
+        return commands
     }
 
     static func needsTerminalFallback(output: String) -> Bool {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9132,6 +9132,44 @@ struct MetricsTests {
         expect(!HomebrewCommandBuilder.isValidToken("bad token"), "spaced Homebrew token is invalid")
 
         let brewPath = "/opt/homebrew/bin/brew"
+        expect(HomebrewCommandBuilder.disabledPackageName(fromOutput:
+            "Error: six has been disabled because it does not meet homebrew/core's requirements for Python library formulae! It was disabled on 2025-10-16.")
+            == "six",
+               "disabled package name is extracted from Homebrew's refusal")
+        expect(HomebrewCommandBuilder.disabledPackageName(fromOutput: "Error: no such formula") == nil,
+               "other Homebrew errors extract no disabled package")
+        let sixOutdated = HomebrewPackageUpdate(kind: .formula, name: "six",
+                                                installedVersions: ["1.16.0_3"],
+                                                currentVersion: "1.17.0", isPinned: false)
+        let jqOutdated = HomebrewPackageUpdate(kind: .formula, name: "jq",
+                                               installedVersions: ["1.7"],
+                                               currentVersion: "1.8", isPinned: false)
+        let pinnedOutdated = HomebrewPackageUpdate(kind: .formula, name: "node",
+                                                   installedVersions: ["22.0"],
+                                                   currentVersion: "24.0", isPinned: true)
+        expect(HomebrewCommandBuilder.upgradeExcluding(
+                ["six"],
+                from: HomebrewCommand(executable: brewPath, arguments: ["upgrade"]),
+                outdated: [sixOutdated, jqOutdated, pinnedOutdated])?.arguments
+               == ["upgrade", "jq"],
+               "bare upgrade retries with the outdated list minus disabled and pinned packages")
+        expect(HomebrewCommandBuilder.upgradeExcluding(
+                ["six"],
+                from: HomebrewCommand(executable: brewPath, arguments: ["upgrade", "--cask", "six", "jq"]),
+                outdated: [])?.arguments
+               == ["upgrade", "--cask", "jq"],
+               "explicit upgrade keeps its flags and drops only the disabled package")
+        expect(HomebrewCommandBuilder.upgradeExcluding(
+                ["six"],
+                from: HomebrewCommand(executable: brewPath, arguments: ["upgrade", "six"]),
+                outdated: [sixOutdated]) == nil,
+               "an upgrade with nothing left after the disabled package is not retried")
+        expect(HomebrewCommandBuilder.upgradeExcluding(
+                ["six"],
+                from: HomebrewCommand(executable: brewPath, arguments: ["upgrade", "jq"]),
+                outdated: [jqOutdated]) == nil,
+               "an upgrade that never named the disabled package is not retried again")
+
         let cask = HomebrewPackage(kind: .cask, name: "sample-tool",
                                    displayName: "Sample Tool", desc: nil,
                                    installedVersion: nil, stableVersion: nil, homepage: nil)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9147,17 +9147,27 @@ struct MetricsTests {
         let pinnedOutdated = HomebrewPackageUpdate(kind: .formula, name: "node",
                                                    installedVersions: ["22.0"],
                                                    currentVersion: "24.0", isPinned: true)
+        let dockerOutdated = HomebrewPackageUpdate(kind: .cask, name: "docker",
+                                                   installedVersions: ["4.30"],
+                                                   currentVersion: "4.31", isPinned: false)
         expect(HomebrewCommandBuilder.upgradeExcluding(
                 ["six"],
                 from: HomebrewCommand(executable: brewPath, arguments: ["upgrade"]),
-                outdated: [sixOutdated, jqOutdated, pinnedOutdated])?.arguments
-               == ["upgrade", "jq"],
-               "bare upgrade retries with the outdated list minus disabled and pinned packages")
+                outdated: [sixOutdated, jqOutdated, pinnedOutdated, dockerOutdated])?
+                .map(\.arguments)
+               == [["upgrade", "--formula", "jq"], ["upgrade", "--cask"]],
+               "bare upgrade retries per kind: outdated formulae minus disabled and pinned by name, casks left to brew so a name shared with a formula cannot misresolve")
+        expect(HomebrewCommandBuilder.upgradeExcluding(
+                ["six"],
+                from: HomebrewCommand(executable: brewPath, arguments: ["upgrade"]),
+                outdated: [sixOutdated])?.map(\.arguments)
+               == [["upgrade", "--cask"]],
+               "a bare upgrade with no formula left still retries the cask half")
         expect(HomebrewCommandBuilder.upgradeExcluding(
                 ["six"],
                 from: HomebrewCommand(executable: brewPath, arguments: ["upgrade", "--cask", "six", "jq"]),
-                outdated: [])?.arguments
-               == ["upgrade", "--cask", "jq"],
+                outdated: [])?.map(\.arguments)
+               == [["upgrade", "--cask", "jq"]],
                "explicit upgrade keeps its flags and drops only the disabled package")
         expect(HomebrewCommandBuilder.upgradeExcluding(
                 ["six"],
@@ -9169,6 +9179,11 @@ struct MetricsTests {
                 from: HomebrewCommand(executable: brewPath, arguments: ["upgrade", "jq"]),
                 outdated: [jqOutdated]) == nil,
                "an upgrade that never named the disabled package is not retried again")
+        expect(HomebrewCommandBuilder.upgradeExcluding(
+                ["six"],
+                from: HomebrewCommand(executable: brewPath, arguments: ["upgrade", "--cask"]),
+                outdated: [sixOutdated, dockerOutdated]) == nil,
+               "a failing retried cask half is never expanded again, so retries always end")
 
         let cask = HomebrewPackage(kind: .cask, name: "sample-tool",
                                    displayName: "Sample Tool", desc: nil,


### PR DESCRIPTION
**Before.** When any outdated package has been disabled by Homebrew, `brew upgrade` refuses the entire run (`Error: six has been disabled because it does not meet homebrew/core's requirements for Python library formulae!`), so Upgrade all in the Homebrew panel fails outright and none of the other packages get their update.

**After.** The app recognizes the refusal, notes `Skipping six: disabled in Homebrew.` in the operation log, and retries the upgrade with the remaining packages, so everything that can update still does. The mechanics mirror the existing untrusted-tap handling: `disabledPackageName(fromOutput:)` extracts the token-validated name, and `upgradeExcluding(_:from:outdated:)` rebuilds the failed command without it as the commands to run in order — an explicit token list just loses the name (flags preserved), while a bare `upgrade` splits by kind: an explicit `--formula` upgrade built from the known outdated formulae minus disabled and pinned names, then a bare `upgrade --cask`. Casks are deliberately never named, because `brew upgrade <name>` resolves a name shared by a formula and a cask as the formula — leaving the cask half bare keeps its coverage brew's own decision instead of a snapshot's. The log notes the skip and echoes the exact retry command each leg runs, so a narrowed run is visible. The rebuild returns nil whenever a retry would repeat the failed command or nothing is left: an explicit retry strictly shrinks and a failing bare `--cask` leg is never expanded again, so the chain always terminates; anything unrecognized falls through to the existing failure path unchanged. Upgrading a single disabled package directly still shows Homebrew's own error, which already says what to do.

Seven unit checks cover the parser and the rebuild rules (per-kind split, cask half kept when no formula remains, flags kept, pinned excluded, all three nil cases).

Verified on macOS 26.5.2 (25F84), Apple Silicon, self-built dev bundle, app in English: `./build.sh` finishes without warnings, `--selftest` passes, and `./build.sh --test` passes 8506 checks. The fix was exercised against the real condition — an installed `six` 1.16.0_3 with the formula disabled upstream: before the change Upgrade all failed with the error above, after it the run skips `six` and upgrades the rest. Not verified on a real machine: several disabled packages in one run (the retry loop resolves them one per pass; unit-tested only) and a disabled cask rather than formula.