### PR TITLE
feat(power): add MacBook charge protection

### DIFF
--- a/Resources/com.vorssaint.utils.charge-control.plist
+++ b/Resources/com.vorssaint.utils.charge-control.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>BundleProgram</key><string>Contents/Library/LaunchServices/com.vorssaint.utils.charge-control</string>
+<key>ExitTimeOut</key><integer>60</integer>
+<key>KeepAlive</key><dict><key>Crashed</key><true/></dict>
+<key>Label</key><string>com.vorssaint.utils.charge-control</string>
+<key>MachServices</key><dict><key>com.vorssaint.utils.charge-control</key><true/></dict>
+<key>ThrottleInterval</key><integer>5</integer>
+</dict></plist>

--- a/Sources/ChargeControlHelper/main.swift
+++ b/Sources/ChargeControlHelper/main.swift
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+import os
+
+private final class ChargeControlController {
+    private let queue = DispatchQueue(label: "com.vorssaint.charge-control.helper")
+    private var hardware = ChargeControlHardware()
+    private var mode: ChargeControlMode = .charging
+    private var lastHeartbeat = ProcessInfo.processInfo.systemUptime
+    private var owner: UUID?
+    private var watchdog: DispatchSourceTimer?
+
+    init() {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + 5, repeating: 5)
+        timer.setEventHandler { [weak self] in self?.checkHeartbeat() }
+        timer.resume()
+        watchdog = timer
+        try? hardware?.set(.charging)
+    }
+
+    func opened(_ id: UUID) { queue.async { self.owner = id; self.lastHeartbeat = ProcessInfo.processInfo.systemUptime } }
+    func closed(_ id: UUID) { queue.async { if self.owner == id { self.restore() } } }
+
+    func reply(_ reply: @escaping (Data) -> Void) {
+        queue.async { reply(ChargeControlIPC.encode(self.response())) }
+    }
+
+    func apply(_ requested: ChargeControlMode, id: UUID, reply: @escaping (Data) -> Void) {
+        queue.async {
+            guard self.owner == id else {
+                reply(ChargeControlIPC.encode(.failure(.controlFailed)))
+                return
+            }
+            guard let hardware = self.hardware else {
+                reply(ChargeControlIPC.encode(.failure(.unsupportedHardware)))
+                return
+            }
+            do {
+                try hardware.set(requested)
+                self.mode = requested
+                self.lastHeartbeat = ProcessInfo.processInfo.systemUptime
+                reply(ChargeControlIPC.encode(self.response()))
+            } catch {
+                try? hardware.set(.charging)
+                self.mode = .charging
+                reply(ChargeControlIPC.encode(.failure(.controlFailed, api: hardware.api)))
+            }
+        }
+    }
+
+    func heartbeat(id: UUID, reply: @escaping (Data) -> Void) {
+        queue.async {
+            guard self.owner == id else {
+                reply(ChargeControlIPC.encode(.failure(.controlFailed)))
+                return
+            }
+            self.lastHeartbeat = ProcessInfo.processInfo.systemUptime
+            reply(ChargeControlIPC.encode(self.response()))
+        }
+    }
+
+    private func response() -> ChargeControlResponse {
+        guard let hardware else { return .failure(.unsupportedHardware) }
+        return .success(api: hardware.api, mode: mode)
+    }
+
+    private func checkHeartbeat() {
+        if mode != .charging,
+           ProcessInfo.processInfo.systemUptime - lastHeartbeat > 25 { restore() }
+    }
+
+    private func restore() {
+        try? hardware?.set(.charging)
+        mode = .charging
+        owner = nil
+    }
+
+    func shutdown() { queue.sync { restore() } }
+}
+
+private final class ChargeControlConnection: NSObject, ChargeControlXPCProtocol {
+    let id = UUID()
+    private let controller: ChargeControlController
+    init(_ controller: ChargeControlController) { self.controller = controller; super.init(); controller.opened(id) }
+    deinit { controller.closed(id) }
+    func status(withReply reply: @escaping (Data) -> Void) { controller.reply(reply) }
+    func allowCharging(withReply reply: @escaping (Data) -> Void) { controller.apply(.charging, id: id, reply: reply) }
+    func pauseCharging(withReply reply: @escaping (Data) -> Void) { controller.apply(.paused, id: id, reply: reply) }
+    func startDischarging(withReply reply: @escaping (Data) -> Void) { controller.apply(.discharging, id: id, reply: reply) }
+    func heartbeat(withReply reply: @escaping (Data) -> Void) { controller.heartbeat(id: id, reply: reply) }
+    func restoreSystemDefault(withReply reply: @escaping (Data) -> Void) { controller.apply(.charging, id: id, reply: reply) }
+}
+
+private final class Delegate: NSObject, NSXPCListenerDelegate {
+    let controller = ChargeControlController()
+    func listener(_ listener: NSXPCListener, shouldAcceptNewConnection connection: NSXPCConnection) -> Bool {
+        let session = ChargeControlConnection(controller)
+        connection.exportedInterface = NSXPCInterface(with: ChargeControlXPCProtocol.self)
+        connection.exportedObject = session
+        connection.invalidationHandler = { [weak controller] in controller?.closed(session.id) }
+        connection.activate()
+        return true
+    }
+}
+
+if CommandLine.arguments.contains("--selftest") { exit(0) }
+guard geteuid() == 0 else { exit(EXIT_FAILURE) }
+private let delegate = Delegate()
+private let listener = NSXPCListener(machServiceName: ChargeControlIdentifiers.helperID)
+listener.setConnectionCodeSigningRequirement(ChargeControlIdentifiers.appCodeRequirement)
+listener.delegate = delegate
+listener.activate()
+signal(SIGTERM, SIG_IGN)
+signal(SIGINT, SIG_IGN)
+let termination = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .main)
+termination.setEventHandler { delegate.controller.shutdown(); exit(EXIT_SUCCESS) }
+termination.resume()
+let interruption = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+interruption.setEventHandler { delegate.controller.shutdown(); exit(EXIT_SUCCESS) }
+interruption.resume()
+RunLoop.main.run()

--- a/Sources/Vorssaint/App/FeatureRuntime.swift
+++ b/Sources/Vorssaint/App/FeatureRuntime.swift
@@ -176,6 +176,7 @@ final class FeatureRuntime: ObservableObject {
             KeepAwakeManager.shared.syncWithFeatures()
             HotkeyManager.shared.syncWithPreferences()
         },
+        .batteryChargeLimit: { ChargeControlService.shared.syncWithPreferences() },
         .brightness: { BrightnessService.shared.syncWithPreferences() },
         .extraBrightness: { ExtraBrightnessService.shared.syncWithPreferences() },
         .bluetoothSleep: { BluetoothSleepService.shared.syncWithPreferences() },

--- a/Sources/Vorssaint/Core/ChargeControlStrings.swift
+++ b/Sources/Vorssaint/Core/ChargeControlStrings.swift
@@ -71,4 +71,20 @@ struct ChargeControlStrings {
         case .controlFailed: return "Control failed; system charging restored"
         }
     }
+
+    func limitValue(_ value: Int) -> String {
+        switch L10n.shared.language {
+        case .zhHans: return "上限：\(value)%"
+        case .zhTW, .zhHK: return "上限：\(value)%"
+        default: return "Limit: \(value)%"
+        }
+    }
+
+    func batteryAccessibility(percent: Int, limit: Int) -> String {
+        switch L10n.shared.language {
+        case .zhHans: return "电池电量 \(percent)%，充电上限 \(limit)%"
+        case .zhTW, .zhHK: return "電池電量 \(percent)%，充電上限 \(limit)%"
+        default: return "Battery \(percent)%, limit \(limit)%"
+        }
+    }
 }

--- a/Sources/Vorssaint/Core/ChargeControlStrings.swift
+++ b/Sources/Vorssaint/Core/ChargeControlStrings.swift
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+struct ChargeControlStrings {
+    let title: String
+    let description: String
+    let enable: String
+    let enableCaption: String
+    let limit: String
+    let discharge: String
+    let topUp: String
+    let approveHelper: String
+    let resolveConflict: String
+    let warning: String
+
+    static func current(_ language: AppLanguage) -> Self {
+        switch language {
+        case .zhHans:
+            return Self(title: "充电保护", description: "将 MacBook 的最高充电量限制在你选择的百分比。",
+                        enable: "限制充电上限", enableCaption: "Vorssaint 运行期间生效；退出或控制失败时恢复正常充电。",
+                        limit: "充电上限", discharge: "放电", topUp: "充满",
+                        approveHelper: "允许后台充电控制",
+                        resolveConflict: "检查 macOS 电池设置",
+                        warning: "此 Beta 功能使用私有硬件接口。macOS 的优化充电或系统充电上限可能与它冲突。")
+        case .zhTW, .zhHK:
+            return Self(title: "充電保護", description: "將 MacBook 的最高充電量限制在你選擇的百分比。",
+                        enable: "限制充電上限", enableCaption: "Vorssaint 執行期間生效；結束或控制失敗時恢復正常充電。",
+                        limit: "充電上限", discharge: "放電", topUp: "充滿",
+                        approveHelper: "允許背景充電控制",
+                        resolveConflict: "檢查 macOS 電池設定",
+                        warning: "此 Beta 功能使用私有硬體介面。macOS 的最佳化充電或系統充電上限可能與它衝突。")
+        default:
+            return Self(title: "Charge Protection", description: "Limit the maximum charge of your MacBook battery.",
+                        enable: "Limit maximum charge", enableCaption: "Active while Vorssaint runs; normal charging is restored on exit or control failure.",
+                        limit: "Charge limit", discharge: "Discharge", topUp: "Top Up",
+                        approveHelper: "Allow background charge control",
+                        resolveConflict: "Check macOS Battery Settings",
+                        warning: "This beta uses private hardware interfaces. Optimized Charging or the macOS charge limit may conflict with it.")
+        }
+    }
+
+    func status(_ value: ChargeControlStatus) -> String {
+        if L10n.shared.language == .zhHans {
+            switch value {
+            case .uninstalled: return "未安装"
+            case .disabled: return "已关闭"
+            case .charging: return "正在充电"
+            case .paused: return "已暂停充电"
+            case .discharging: return "正在放电至上限"
+            case .onBattery: return "正在使用电池"
+            case .systemConflict: return "与 macOS 充电策略冲突"
+            case .approvalRequired: return "需要在系统设置中允许后台控制"
+            case .unsupportedHardware: return "硬件不支持"
+            case .helperUnavailable: return "充电控制服务不可用"
+            case .controlFailed: return "控制失败，已恢复系统充电"
+            }
+        }
+        switch value {
+        case .uninstalled: return "Not installed"
+        case .disabled: return "Off"
+        case .charging: return "Charging"
+        case .paused: return "Charging paused"
+        case .discharging: return "Discharging to limit"
+        case .onBattery: return "On battery"
+        case .systemConflict: return "System charging policy conflict"
+        case .approvalRequired: return "Allow background control in System Settings"
+        case .unsupportedHardware: return "Unsupported hardware"
+        case .helperUnavailable: return "Charge control service unavailable"
+        case .controlFailed: return "Control failed; system charging restored"
+        }
+    }
+}

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -19,6 +19,10 @@ enum DefaultsKey {
     static let updateShowcaseMediaOverride = "updateShowcaseMediaOverride"
     static let defaultDuration = "defaultDurationMinutes" // 0 = indefinite
     static let batteryLimit = "batteryLimitPercent"       // 0 = never
+    static let chargeLimitEnabled = "chargeLimitEnabled"
+    static let chargeLimitPercent = "chargeLimitPercent"
+    static let chargeLimitDischargeEnabled = "chargeLimitDischargeEnabled"
+    static let chargeControlHelperVersion = "chargeControlHelperVersion"
     static let keepAwakeAutoStart = "keepAwakeAutoStart"  // start Keep Awake when the app launches
     static let keepAwakeRightClickToggle = "keepAwakeRightClickToggle"
     static let keepAwakeAllowDisplaySleep = "keepAwakeAllowDisplaySleep"
@@ -284,6 +288,7 @@ enum DefaultsKey {
     static let monitorShowPower = "monitorShowPower"
     static let monitorShowMixer = "monitorShowMixer"
     static let panelShowFanControl = "panelShowFanControl"
+    static let panelShowChargeControl = "panelShowChargeControl"
     static let fanControlMode = "fanControlMode"
     static let fanControlCoolingLevel = "fanControlCoolingLevel"
     static let fanControlCurves = "fanControlCurves"
@@ -762,6 +767,10 @@ enum Defaults {
         DefaultsKey.clamshellPreferred: false,
         DefaultsKey.defaultDuration: 0,
         DefaultsKey.batteryLimit: 10,
+        DefaultsKey.chargeLimitEnabled: false,
+        DefaultsKey.chargeLimitPercent: ChargeLimitPolicy.defaultLimit,
+        DefaultsKey.chargeLimitDischargeEnabled: false,
+        DefaultsKey.chargeControlHelperVersion: "",
         DefaultsKey.keepAwakeAutoStart: false,
         DefaultsKey.keepAwakeRightClickToggle: false,
         DefaultsKey.keepAwakeAllowDisplaySleep: false,
@@ -999,6 +1008,7 @@ enum Defaults {
         DefaultsKey.monitorShowPower: true,
         DefaultsKey.monitorShowMixer: true,
         DefaultsKey.panelShowFanControl: true,
+        DefaultsKey.panelShowChargeControl: true,
         DefaultsKey.fanControlMode: FanControlMode.system.rawValue,
         DefaultsKey.fanControlCoolingLevel: FanControlPolicy.defaultCoolingLevel,
         DefaultsKey.fanControlCurves: FanControlConfiguration.defaultCurvesStorage,

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -21,7 +21,6 @@ enum DefaultsKey {
     static let batteryLimit = "batteryLimitPercent"       // 0 = never
     static let chargeLimitEnabled = "chargeLimitEnabled"
     static let chargeLimitPercent = "chargeLimitPercent"
-    static let chargeLimitDischargeEnabled = "chargeLimitDischargeEnabled"
     static let chargeControlHelperVersion = "chargeControlHelperVersion"
     static let keepAwakeAutoStart = "keepAwakeAutoStart"  // start Keep Awake when the app launches
     static let keepAwakeRightClickToggle = "keepAwakeRightClickToggle"
@@ -769,7 +768,6 @@ enum Defaults {
         DefaultsKey.batteryLimit: 10,
         DefaultsKey.chargeLimitEnabled: false,
         DefaultsKey.chargeLimitPercent: ChargeLimitPolicy.defaultLimit,
-        DefaultsKey.chargeLimitDischargeEnabled: false,
         DefaultsKey.chargeControlHelperVersion: "",
         DefaultsKey.keepAwakeAutoStart: false,
         DefaultsKey.keepAwakeRightClickToggle: false,

--- a/Sources/Vorssaint/Core/FeatureCatalog.swift
+++ b/Sources/Vorssaint/Core/FeatureCatalog.swift
@@ -24,7 +24,7 @@ enum AppFeature: String, CaseIterable {
     // Sound
     case mixer, soundOutputSwitcher, micMute, musicBlock
     // Energy and display
-    case keepAwake, brightness, extraBrightness, bluetoothSleep
+    case keepAwake, batteryChargeLimit, brightness, extraBrightness, bluetoothSleep
     // Tools
     case quickLauncher, quickToggles, colorPicker, screenOCR, cleaningMode, mediaTools,
          cleaner, uninstaller, homebrew, appUpdates, screenshot, cameraPreview, radialMenu, scratchpad,
@@ -96,7 +96,7 @@ extension AppFeature {
             return .clipboardFiles
         case .mixer, .soundOutputSwitcher, .micMute, .musicBlock:
             return .sound
-        case .keepAwake, .brightness, .extraBrightness, .bluetoothSleep:
+        case .keepAwake, .batteryChargeLimit, .brightness, .extraBrightness, .bluetoothSleep:
             return .energyDisplay
         case .quickLauncher, .quickToggles, .colorPicker, .screenOCR, .cleaningMode, .mediaTools,
              .cleaner, .uninstaller, .homebrew, .appUpdates, .screenshot, .cameraPreview, .radialMenu,
@@ -137,6 +137,7 @@ extension AppFeature {
         case .micMute: return "mic.slash"
         case .musicBlock: return "music.note"
         case .keepAwake: return "moon.zzz.fill"
+        case .batteryChargeLimit: return "battery.75percent"
         case .brightness: return "display.2"
         case .extraBrightness: return "sun.max.fill"
         case .bluetoothSleep: return "wave.3.right.circle"
@@ -169,7 +170,7 @@ extension AppFeature {
 
     var availabilityKey: String { DefaultsKey.featureAvailable(rawValue) }
 
-    var isBeta: Bool { self == .fanControl || self == .killProcess }
+    var isBeta: Bool { self == .fanControl || self == .killProcess || self == .batteryChargeLimit }
 
     /// Availability read straight from defaults. Existing features stay
     /// available on update; explicit beta opt-ins may start unavailable.
@@ -213,6 +214,7 @@ extension AppFeature {
         case .brightness: return [DefaultsKey.brightnessControlEnabled]
         case .extraBrightness: return [DefaultsKey.extraBrightnessEnabled]
         case .bluetoothSleep: return [DefaultsKey.bluetoothSleepEnabled]
+        case .batteryChargeLimit: return [DefaultsKey.chargeLimitEnabled]
         case .windowLayout, .diskImageInstaller, .mixer, .micMute, .keepAwake,
              .quickLauncher, .quickToggles, .colorPicker, .screenOCR, .cleaningMode, .mediaTools,
              .cleaner, .uninstaller, .homebrew, .appUpdates, .screenshot, .cameraPreview, .scratchpad,
@@ -258,7 +260,7 @@ extension AppFeature {
         case .diskImageInstaller: return [.appManagement]
         case .mixer: return [.audioCapture, .accessibility]
         case .monitorCPU, .monitorMemory, .monitorDisk, .monitorPower: return [.notifications]
-        case .clipboardHistory, .shelf, .urlCleaner,
+        case .clipboardHistory, .shelf, .urlCleaner, .batteryChargeLimit,
              .soundOutputSwitcher, .musicBlock,
              .extraBrightness, .bluetoothSleep, .quickLauncher, .colorPicker, .micMute, .mediaTools,
              .scratchpad, .monitorGPU, .monitorNetwork, .fanControl, .killProcess:
@@ -289,7 +291,7 @@ extension AppFeature {
     static var availabilityDefaults: [String: Any] {
         Dictionary(uniqueKeysWithValues: allCases.map {
             ($0.availabilityKey,
-             $0 != .focusFollowsMouse && $0 != .fanControl && $0 != .diskImageInstaller
+             $0 != .focusFollowsMouse && $0 != .fanControl && $0 != .batteryChargeLimit && $0 != .diskImageInstaller
                 && $0 != .killProcess)
         })
     }

--- a/Sources/Vorssaint/Core/FeaturePresets.swift
+++ b/Sources/Vorssaint/Core/FeaturePresets.swift
@@ -106,7 +106,7 @@ extension AppFeature {
             return RadialMenuMouseTrigger.sanitized(
                 UserDefaults.standard.string(forKey: DefaultsKey.radialMenuMouseButton)) == .off
                 ? .idle : .mouse
-        case .clipboardHistory, .urlCleaner, .extraBrightness,
+        case .clipboardHistory, .urlCleaner, .extraBrightness, .batteryChargeLimit,
              .monitorCPU, .monitorGPU, .monitorMemory,
              .monitorNetwork, .monitorDisk, .monitorPower:
             return .periodic

--- a/Sources/Vorssaint/Core/SettingsBackupSupport.swift
+++ b/Sources/Vorssaint/Core/SettingsBackupSupport.swift
@@ -119,6 +119,7 @@ enum SettingsBackupSupport {
         DefaultsKey.screenshotSharingDeveloperEndpoint,
         DefaultsKey.fanControlRecoveryNeeded,
         DefaultsKey.fanControlHelperVersion,
+        DefaultsKey.chargeControlHelperVersion,
         // DDC capability belongs to one physical monitor on one Mac port.
         DefaultsKey.brightnessDDCWriteOnlyPaths,
     ]

--- a/Sources/Vorssaint/Services/ChargeControl/ChargeControlHardware.swift
+++ b/Sources/Vorssaint/Services/ChargeControl/ChargeControlHardware.swift
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+import os
+
+/// Narrow SMC policy for charge inhibition. The caller can only request the
+/// two safe states; key names and payloads never cross the XPC boundary.
+final class ChargeControlHardware {
+    private let log = Logger(subsystem: ChargeControlIdentifiers.helperID, category: "hardware")
+    private struct Command {
+        let keys: [SMCClient.Key]
+        let allow: [[UInt8]]
+        let pause: [[UInt8]]
+    }
+
+    let api: ChargeControlAPI
+    private let smc: SMCClient
+    private let command: Command
+    private let supplementalCommand: Command?
+    private let dischargeKey: SMCClient.Key
+    private let dischargeOn: [UInt8]
+    private let dischargeOff: [UInt8]
+
+    init?() {
+        guard let smc = SMCClient() else { return nil }
+        // CHTE exists on some Apple Silicon models before Tahoe, but on those
+        // releases it is not the complete charge-control path. Selecting it by
+        // key presence alone can leave CH0B/CH0C inhibited: discharge works,
+        // while an "allow charging" command never resumes charging. Only use
+        // the Tahoe path on the OS generation that owns those semantics.
+        if ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 26,
+           let key = smc.key(named: "CHTE"), key.dataSize == 4,
+           let discharge = smc.key(named: "CHIE"), discharge.dataSize == 1 {
+            self.smc = smc
+            api = .tahoe
+            command = Command(keys: [key],
+                              allow: [[0, 0, 0, 0]],
+                              pause: [[1, 0, 0, 0]])
+            supplementalCommand = nil
+            dischargeKey = discharge
+            dischargeOn = [8]
+            dischargeOff = [0]
+            return
+        }
+        if let first = smc.key(named: "CH0B"), first.dataSize == 1,
+           let second = smc.key(named: "CH0C"), second.dataSize == 1 {
+            let discharge: (key: SMCClient.Key, on: [UInt8])?
+            if let key = smc.key(named: "CHIE"), key.dataSize == 1 {
+                // M4 machines on pre-Tahoe macOS use the legacy inhibit pair,
+                // but expose the newer discharge switch.
+                discharge = (key, [8])
+            } else if let key = smc.key(named: "CH0I"), key.dataSize == 1 {
+                discharge = (key, [1])
+            } else {
+                discharge = nil
+            }
+            guard let discharge else { return nil }
+            self.smc = smc
+            api = .legacy
+            command = Command(keys: [first, second], allow: [[0], [0]], pause: [[2], [2]])
+            if let key = smc.key(named: "CHTE"), key.dataSize == 4 {
+                supplementalCommand = Command(keys: [key],
+                                               allow: [[0, 0, 0, 0]],
+                                               pause: [[1, 0, 0, 0]])
+            } else {
+                supplementalCommand = nil
+            }
+            dischargeKey = discharge.key
+            dischargeOn = discharge.on
+            dischargeOff = [0]
+            return
+        }
+        return nil
+    }
+
+    func set(_ mode: ChargeControlMode) throws {
+        let commands: [Command]
+        if let supplementalCommand {
+            // M4 on pre-Tahoe macOS exposes both generations. Keeping both
+            // inhibit flags in sync prevents either path from retaining a
+            // stale pause after a discharge or another battery utility.
+            commands = [command, supplementalCommand]
+        } else {
+            commands = [command]
+        }
+        for attempt in 0..<3 {
+            do {
+                for item in commands {
+                    let payloads = mode == .charging ? item.allow : item.pause
+                    for (key, payload) in zip(item.keys, payloads) {
+                        try smc.writeBytes(payload, to: key)
+                    }
+                }
+                try smc.writeBytes(mode == .discharging ? dischargeOn : dischargeOff,
+                                   to: dischargeKey)
+                let commandChecks = commands.flatMap { item -> [(String, [UInt8], [UInt8]?)] in
+                    let payloads = mode == .charging ? item.allow : item.pause
+                    return zip(item.keys, payloads).map { ($0.0.name, $0.1, smc.readBytes($0.0)) }
+                }
+                let dischargeExpected = mode == .discharging ? dischargeOn : dischargeOff
+                let dischargeActual = smc.readBytes(dischargeKey)
+                if commandChecks.allSatisfy({ check in
+                    guard let actual = check.2 else { return false }
+                    if actual == check.1 { return true }
+                    // M4 reports CH0B/CH0C as 3 while forced discharge is
+                    // active: the requested pause bit (2) plus a controller-
+                    // owned discharge status bit (1). Verify that our bit is
+                    // present without rejecting the additional hardware bit.
+                    return mode == .discharging
+                        && (check.0 == "CH0B" || check.0 == "CH0C")
+                        && check.1.count == 1 && actual.count == 1
+                        && (actual[0] & check.1[0]) == check.1[0]
+                })
+                    && dischargeActual == dischargeExpected {
+                    log.notice("applied mode=\(mode.rawValue, privacy: .public) api=\(self.api.rawValue, privacy: .public)")
+                    return
+                }
+                let inhibitDetails = commandChecks.map { check in
+                    let expected = String(describing: check.1)
+                    let actual = check.2.map { String(describing: $0) } ?? "nil"
+                    return "\(check.0):\(expected)->\(actual)"
+                }.joined(separator: ",")
+                let dischargeExpectedText = String(describing: dischargeExpected)
+                let dischargeActualText = dischargeActual.map { String(describing: $0) } ?? "nil"
+                log.error("verify failed mode=\(mode.rawValue, privacy: .public) attempt=\(attempt, privacy: .public) inhibit=\(inhibitDetails, privacy: .public) discharge=\(self.dischargeKey.name, privacy: .public):\(dischargeExpectedText, privacy: .public)->\(dischargeActualText, privacy: .public)")
+            } catch where attempt == 2 {
+                log.error("write failed mode=\(mode.rawValue, privacy: .public) error=\(String(describing: error), privacy: .public)")
+                throw error
+            } catch {
+                log.error("write retry mode=\(mode.rawValue, privacy: .public) attempt=\(attempt, privacy: .public) error=\(String(describing: error), privacy: .public)")
+            }
+        }
+        throw ChargeControlErrorCode.controlFailed
+    }
+}
+
+extension ChargeControlErrorCode: Error {}

--- a/Sources/Vorssaint/Services/ChargeControl/ChargeControlService.swift
+++ b/Sources/Vorssaint/Services/ChargeControl/ChargeControlService.swift
@@ -47,9 +47,6 @@ final class ChargeControlService: ObservableObject {
     }
 
     private init() {
-        // Automatic discharge was briefly shipped during the beta. It is now
-        // an explicit, session-only action, so never carry the old preference forward.
-        UserDefaults.standard.set(false, forKey: DefaultsKey.chargeLimitDischargeEnabled)
         refreshAccessState()
         NSWorkspace.shared.notificationCenter.addObserver(
             self, selector: #selector(didWake), name: NSWorkspace.didWakeNotification, object: nil)

--- a/Sources/Vorssaint/Services/ChargeControl/ChargeControlService.swift
+++ b/Sources/Vorssaint/Services/ChargeControl/ChargeControlService.swift
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import Foundation
+import IOKit
+import IOKit.ps
+import ServiceManagement
+
+enum ChargeControlStatus: Equatable {
+    case uninstalled, disabled, charging, paused, discharging, onBattery, systemConflict, approvalRequired,
+         unsupportedHardware, helperUnavailable, controlFailed
+}
+
+final class ChargeControlService: ObservableObject {
+    enum AccessState: Equatable { case notRegistered, requiresApproval, enabled, unavailable }
+    static let shared = ChargeControlService()
+
+    @Published private(set) var status: ChargeControlStatus = .uninstalled
+    @Published private(set) var accessState: AccessState = .notRegistered
+    @Published private(set) var percent: Int?
+    @Published private(set) var isPluggedIn = false
+    @Published private(set) var api: ChargeControlAPI = .unavailable
+    @Published private(set) var isWorking = false
+    @Published private(set) var sessionAction: ChargeControlSessionAction = .normal
+
+    private var connection: NSXPCConnection?
+    private var timer: Timer?
+    private var previousMode: ChargeControlMode = .charging
+    private var tick = 0
+    private var requestInFlight = false
+    private var pendingMode: ChargeControlMode?
+    private var openedApprovalSettings = false
+    private var lastChargingCommandAt: TimeInterval?
+    private var helperUpgradeInProgress = false
+    private var registrationRetryCount = 0
+    private var registrationRetryWorkItem: DispatchWorkItem?
+
+    private static var appService: SMAppService {
+        SMAppService.daemon(plistName: ChargeControlIdentifiers.plistName)
+    }
+
+    private static var helperVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "VorssaintChargeControlHelperVersion") as? String
+            ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+            ?? AppInfo.version
+    }
+
+    private init() {
+        // Automatic discharge was briefly shipped during the beta. It is now
+        // an explicit, session-only action, so never carry the old preference forward.
+        UserDefaults.standard.set(false, forKey: DefaultsKey.chargeLimitDischargeEnabled)
+        refreshAccessState()
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self, selector: #selector(didWake), name: NSWorkspace.didWakeNotification, object: nil)
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self, selector: #selector(willSleep), name: NSWorkspace.willSleepNotification, object: nil)
+    }
+
+    deinit {
+        timer?.invalidate()
+        connection?.invalidate()
+        NSWorkspace.shared.notificationCenter.removeObserver(self)
+    }
+
+    var enabled: Bool { UserDefaults.standard.bool(forKey: DefaultsKey.chargeLimitEnabled) }
+    var limit: Int { ChargeLimitPolicy.sanitizedLimit(UserDefaults.standard.integer(forKey: DefaultsKey.chargeLimitPercent)) }
+    var canStartDischarge: Bool {
+        enabled && accessState == .enabled && isPluggedIn && (percent ?? 0) > limit
+    }
+
+    var canStartTopUp: Bool {
+        enabled && accessState == .enabled && isPluggedIn && (percent ?? 100) < 100
+    }
+
+    func startDischargeToLimit() {
+        guard canStartDischarge else { return }
+        sessionAction = .dischargeToLimit
+        ensureHelperRegistered()
+        startTimer()
+        evaluate()
+    }
+
+    func cancelDischarge() {
+        guard sessionAction == .dischargeToLimit else { return }
+        sessionAction = .normal
+        evaluate()
+    }
+
+    func startTopUp() {
+        guard canStartTopUp else { return }
+        sessionAction = .topUp
+        ensureHelperRegistered()
+        startTimer()
+        evaluate()
+    }
+
+    func cancelTopUp() {
+        guard sessionAction == .topUp else { return }
+        sessionAction = .normal
+        evaluate()
+    }
+
+    func syncWithPreferences() {
+        guard AppFeature.batteryChargeLimit.isAvailable else {
+            sessionAction = .normal
+            restoreAndStop(unregister: true)
+            status = .uninstalled
+            return
+        }
+        ensureHelperRegistered()
+        guard enabled else {
+            sessionAction = .normal
+            restoreAndStop(unregister: false)
+            status = .disabled
+            return
+        }
+        refreshAccessState()
+        guard accessState == .enabled else {
+            status = accessState == .requiresApproval ? .approvalRequired : .helperUnavailable
+            openApprovalSettingsIfNeeded()
+            return
+        }
+        startTimer()
+        evaluate()
+    }
+
+    func authorize() {
+        ensureHelperRegistered()
+        refreshAccessState()
+        openApprovalSettingsIfNeeded()
+        if accessState == .enabled { connect(restoringFirst: true); startTimer(); evaluate() }
+    }
+
+    func restoreSystemCharging() { restoreAndStop(unregister: false) }
+
+    func evaluate() {
+        guard AppFeature.batteryChargeLimit.isAvailable, enabled else { return }
+        let battery = batteryState()
+        percent = battery?.percent
+        isPluggedIn = battery?.pluggedIn ?? false
+        guard let battery else { status = .unsupportedHardware; return }
+        refreshAccessState()
+        guard accessState == .enabled else {
+            status = accessState == .requiresApproval ? .approvalRequired : .helperUnavailable
+            openApprovalSettingsIfNeeded()
+            return
+        }
+        let displayOnline = builtInDisplayIsOnline()
+        switch sessionAction {
+        case .dischargeToLimit where ChargeLimitPolicy.shouldEndDischarge(
+            percent: battery.percent, limit: limit, pluggedIn: battery.pluggedIn,
+            builtInDisplayOnline: displayOnline):
+            sessionAction = .normal
+        case .topUp where ChargeLimitPolicy.shouldEndTopUp(percent: battery.percent,
+                                                           pluggedIn: battery.pluggedIn):
+            sessionAction = .normal
+        default: break
+        }
+        var desired: ChargeControlMode
+        switch sessionAction {
+        case .dischargeToLimit: desired = .discharging
+        case .topUp: desired = .charging
+        case .normal:
+            desired = ChargeLimitPolicy.desiredMode(percent: battery.percent,
+                                                    limit: limit,
+                                                    pluggedIn: battery.pluggedIn,
+                                                    previous: previousMode)
+            if desired == .discharging, !displayOnline {
+                desired = .paused
+            }
+        }
+        if !battery.pluggedIn {
+            status = .onBattery
+        }
+        if desired == previousMode {
+            if battery.pluggedIn {
+                if desired == .charging, battery.percent < (sessionAction == .topUp ? 100 : limit),
+                   !battery.isCharging, lastChargingCommandAt == nil {
+                    send(.charging)
+                    return
+                }
+                let elapsed = lastChargingCommandAt.map {
+                    ProcessInfo.processInfo.systemUptime - $0
+                }
+                if ChargeLimitPolicy.shouldReportSystemConflict(
+                    wantsCharging: desired == .charging
+                        && battery.percent < (sessionAction == .topUp ? 100 : limit),
+                    isCharging: battery.isCharging,
+                    secondsSinceAllow: elapsed) {
+                    status = .systemConflict
+                } else {
+                    status = desired == .paused ? .paused : (desired == .discharging ? .discharging : .charging)
+                }
+            }
+            return
+        }
+        send(desired)
+    }
+
+    private func send(_ mode: ChargeControlMode) {
+        guard !requestInFlight else {
+            pendingMode = mode
+            return
+        }
+        requestInFlight = true
+        if mode == .charging {
+            lastChargingCommandAt = ProcessInfo.processInfo.systemUptime
+        } else {
+            lastChargingCommandAt = nil
+        }
+        proxy { proxy, reply in
+            switch mode {
+            case .paused: proxy.pauseCharging(withReply: reply)
+            case .discharging: proxy.startDischarging(withReply: reply)
+            case .charging: proxy.allowCharging(withReply: reply)
+            }
+        } completion: { response in
+            self.requestInFlight = false
+            defer {
+                if let pending = self.pendingMode {
+                    self.pendingMode = nil
+                    self.send(pending)
+                }
+            }
+            guard let response else { self.status = .helperUnavailable; return }
+            self.api = response.api
+            if response.succeeded {
+                self.previousMode = response.mode
+                self.status = response.mode == .paused ? .paused
+                    : (response.mode == .discharging ? .discharging : (self.isPluggedIn ? .charging : .onBattery))
+            } else {
+                self.status = response.error == .unsupportedHardware ? .unsupportedHardware : .controlFailed
+            }
+        }
+    }
+
+    private func heartbeat() {
+        proxy({ $0.heartbeat(withReply: $1) }) { response in
+            guard let response else { self.status = .helperUnavailable; return }
+            self.api = response.api
+        }
+    }
+
+    private func restoreAndStop(unregister: Bool) {
+        sessionAction = .normal
+        timer?.invalidate(); timer = nil
+        if accessState == .enabled {
+            proxy({ $0.restoreSystemDefault(withReply: $1) }) { _ in }
+        }
+        previousMode = .charging
+        connection?.invalidate(); connection = nil
+        if unregister { try? Self.appService.unregister(); refreshAccessState() }
+    }
+
+    private func startTimer() {
+        guard timer == nil else { return }
+        timer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            self.tick += 1
+            self.evaluate()
+            if self.tick.isMultiple(of: 2) { self.heartbeat() }
+        }
+    }
+
+    private func connect(restoringFirst: Bool = false) {
+        guard connection == nil else { return }
+        let connection = NSXPCConnection(machServiceName: ChargeControlIdentifiers.helperID,
+                                         options: .privileged)
+        connection.remoteObjectInterface = NSXPCInterface(with: ChargeControlXPCProtocol.self)
+        connection.setCodeSigningRequirement(ChargeControlIdentifiers.helperCodeRequirement)
+        connection.invalidationHandler = { [weak self] in DispatchQueue.main.async { self?.connection = nil } }
+        connection.resume()
+        self.connection = connection
+        if restoringFirst {
+            proxy({ $0.restoreSystemDefault(withReply: $1) }) { _ in
+                self.previousMode = .charging
+                self.lastChargingCommandAt = ProcessInfo.processInfo.systemUptime
+                self.evaluate()
+            }
+        }
+    }
+
+    private func proxy(_ operation: @escaping (ChargeControlXPCProtocol, @escaping (Data) -> Void) -> Void,
+                       completion: @escaping (ChargeControlResponse?) -> Void) {
+        connect()
+        guard let connection else { completion(nil); return }
+        let error: (Error) -> Void = { _ in DispatchQueue.main.async { completion(nil) } }
+        guard let remote = connection.remoteObjectProxyWithErrorHandler(error) as? ChargeControlXPCProtocol else {
+            completion(nil); return
+        }
+        operation(remote) { data in
+            let response = ChargeControlIPC.decode(data)
+            DispatchQueue.main.async { completion(response) }
+        }
+    }
+
+    private func refreshAccessState() {
+        switch Self.appService.status {
+        case .notRegistered: accessState = .notRegistered
+        case .requiresApproval: accessState = .requiresApproval
+        case .enabled: accessState = .enabled
+        case .notFound: accessState = .unavailable
+        @unknown default: accessState = .unavailable
+        }
+    }
+
+    private func ensureHelperRegistered() {
+        refreshAccessState()
+        let installedVersion = UserDefaults.standard.string(
+            forKey: DefaultsKey.chargeControlHelperVersion) ?? ""
+        if !helperUpgradeInProgress,
+           accessState != .notRegistered, accessState != .unavailable,
+           installedVersion != Self.helperVersion {
+            helperUpgradeInProgress = true
+            connection?.invalidate()
+            connection = nil
+            try? Self.appService.unregister()
+            UserDefaults.standard.removeObject(forKey: DefaultsKey.chargeControlHelperVersion)
+            refreshAccessState()
+            scheduleRegistrationRetry()
+            return
+        }
+        if helperUpgradeInProgress,
+           accessState != .notRegistered, accessState != .unavailable {
+            scheduleRegistrationRetry()
+            return
+        }
+        guard accessState == .notRegistered || accessState == .unavailable else { return }
+        do {
+            try Self.appService.register()
+            UserDefaults.standard.set(Self.helperVersion,
+                                      forKey: DefaultsKey.chargeControlHelperVersion)
+            helperUpgradeInProgress = false
+            registrationRetryCount = 0
+            refreshAccessState()
+        } catch {
+            refreshAccessState()
+            if helperUpgradeInProgress || registrationRetryCount < 10 {
+                scheduleRegistrationRetry()
+            } else {
+                status = .helperUnavailable
+            }
+        }
+    }
+
+    /// Service Management removes a daemon asynchronously. Registering its
+    /// replacement before the old BTM record disappears leaves launchd with a
+    /// stale lightweight code requirement and the new helper exits EX_CONFIG.
+    private func scheduleRegistrationRetry() {
+        guard registrationRetryWorkItem == nil, registrationRetryCount < 10 else {
+            if registrationRetryCount >= 10 { status = .helperUnavailable }
+            return
+        }
+        registrationRetryCount += 1
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.registrationRetryWorkItem = nil
+            self.ensureHelperRegistered()
+            if self.accessState == .enabled {
+                self.connect(restoringFirst: true)
+                self.startTimer()
+            }
+        }
+        registrationRetryWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: work)
+    }
+
+    private func openApprovalSettingsIfNeeded() {
+        guard accessState == .requiresApproval, !openedApprovalSettings else { return }
+        openedApprovalSettings = true
+        SMAppService.openSystemSettingsLoginItems()
+    }
+
+    private func batteryState() -> (percent: Int, pluggedIn: Bool, isCharging: Bool)? {
+        guard let info = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
+              let sources = IOPSCopyPowerSourcesList(info)?.takeRetainedValue() as? [CFTypeRef] else { return nil }
+        for source in sources {
+            guard let description = IOPSGetPowerSourceDescription(info, source)?.takeUnretainedValue() as? [String: Any],
+                  description[kIOPSTypeKey] as? String == kIOPSInternalBatteryType,
+                  let current = description[kIOPSCurrentCapacityKey] as? Int,
+                  let maximum = description[kIOPSMaxCapacityKey] as? Int, maximum > 0 else { continue }
+            let state = description[kIOPSPowerSourceStateKey] as? String
+            let charging = description[kIOPSIsChargingKey] as? Bool ?? false
+            return (Int((Double(current) / Double(maximum) * 100).rounded()),
+                    physicalAdapterIsPresent(fallback: state == kIOPSACPowerValue), charging)
+        }
+        return nil
+    }
+
+    /// Forced discharge intentionally makes IOPS report Battery Power and sets
+    /// ExternalConnected to false even though the cable is still attached. The
+    /// adapter descriptor remains present in AppleSmartBattery, so use it to
+    /// distinguish forced discharge from a real unplug event.
+    private func physicalAdapterIsPresent(fallback: Bool) -> Bool {
+        let service = IOServiceGetMatchingService(kIOMainPortDefault,
+                                                  IOServiceMatching("AppleSmartBattery"))
+        guard service != 0 else { return fallback }
+        defer { IOObjectRelease(service) }
+        guard let value = IORegistryEntryCreateCFProperty(
+            service, "AdapterDetails" as CFString, kCFAllocatorDefault, 0)?.takeRetainedValue(),
+              let details = value as? [String: Any] else { return fallback }
+        if let watts = details["Watts"] as? Int { return watts > 0 }
+        return !details.isEmpty
+    }
+
+    private func builtInDisplayIsOnline() -> Bool {
+        var count: UInt32 = 0
+        guard CGGetOnlineDisplayList(0, nil, &count) == .success, count > 0 else { return false }
+        var displays = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard CGGetOnlineDisplayList(count, &displays, &count) == .success else { return false }
+        return displays.prefix(Int(count)).contains { CGDisplayIsBuiltin($0) != 0 }
+    }
+
+    @objc private func didWake() { evaluate() }
+    @objc private func willSleep() {
+        if sessionAction == .dischargeToLimit || previousMode == .discharging {
+            sessionAction = .normal
+            send(.paused)
+        }
+    }
+}

--- a/Sources/Vorssaint/Services/ChargeControl/ChargeControlSupport.swift
+++ b/Sources/Vorssaint/Services/ChargeControl/ChargeControlSupport.swift
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+enum ChargeControlIdentifiers {
+    static let teamID = "3D485NHW29"
+#if VORSSAINT_DEVELOPMENT
+    static let appBundleID = "com.vorssaint.utils.dev"
+#else
+    static let appBundleID = "com.vorssaint.utils"
+#endif
+    static let helperID = "\(appBundleID).charge-control"
+    static let plistName = "\(helperID).plist"
+#if VORSSAINT_DEVELOPMENT
+    // Local developer builds may use the repository's self-signed identity or
+    // ad-hoc signing. The bundle identifiers still isolate the dev pair from
+    // production; production keeps the strict Team ID requirement below.
+    static let helperCodeRequirement = "identifier \"\(helperID)\""
+    static let appCodeRequirement = "identifier \"\(appBundleID)\""
+#else
+    static let helperCodeRequirement =
+        "anchor apple generic and certificate leaf[subject.OU] = \"\(teamID)\" and identifier \"\(helperID)\""
+    static let appCodeRequirement =
+        "anchor apple generic and certificate leaf[subject.OU] = \"\(teamID)\" and identifier \"\(appBundleID)\""
+#endif
+}
+
+enum ChargeControlAPI: String, Codable {
+    case tahoe, legacy, unavailable
+}
+
+enum ChargeControlMode: String, Codable {
+    case charging, paused, discharging
+}
+
+enum ChargeControlSessionAction: String, Equatable {
+    case normal, dischargeToLimit, topUp
+}
+
+enum ChargeControlErrorCode: String, Codable {
+    case unsupportedHardware, helperUnavailable, controlFailed
+}
+
+struct ChargeControlResponse: Codable, Equatable {
+    let succeeded: Bool
+    let api: ChargeControlAPI
+    let mode: ChargeControlMode
+    let error: ChargeControlErrorCode?
+
+    static func success(api: ChargeControlAPI, mode: ChargeControlMode) -> Self {
+        Self(succeeded: true, api: api, mode: mode, error: nil)
+    }
+
+    static func failure(_ error: ChargeControlErrorCode,
+                        api: ChargeControlAPI = .unavailable,
+                        mode: ChargeControlMode = .charging) -> Self {
+        Self(succeeded: false, api: api, mode: mode, error: error)
+    }
+}
+
+@objc protocol ChargeControlXPCProtocol {
+    func status(withReply reply: @escaping (Data) -> Void)
+    func allowCharging(withReply reply: @escaping (Data) -> Void)
+    func pauseCharging(withReply reply: @escaping (Data) -> Void)
+    func startDischarging(withReply reply: @escaping (Data) -> Void)
+    func heartbeat(withReply reply: @escaping (Data) -> Void)
+    func restoreSystemDefault(withReply reply: @escaping (Data) -> Void)
+}
+
+enum ChargeControlIPC {
+    static func encode(_ response: ChargeControlResponse) -> Data {
+        (try? JSONEncoder().encode(response))
+            ?? Data(#"{"succeeded":false,"api":"unavailable","mode":"charging","error":"controlFailed"}"#.utf8)
+    }
+
+    static func decode(_ data: Data) -> ChargeControlResponse? {
+        try? JSONDecoder().decode(ChargeControlResponse.self, from: data)
+    }
+}
+
+enum ChargeLimitPolicy {
+    static let range = 20...100
+    static let defaultLimit = 80
+
+    static func sanitizedLimit(_ value: Int) -> Int {
+        min(max(value, range.lowerBound), range.upperBound)
+    }
+
+    static func desiredMode(percent: Int, limit: Int, pluggedIn: Bool,
+                            previous: ChargeControlMode) -> ChargeControlMode {
+        let limit = sanitizedLimit(limit)
+        guard pluggedIn, limit < 100 else { return .charging }
+        if percent > limit { return .discharging }
+        if percent == limit { return .paused }
+        return .charging
+    }
+
+    static func shouldEndDischarge(percent: Int, limit: Int, pluggedIn: Bool,
+                                   builtInDisplayOnline: Bool) -> Bool {
+        !pluggedIn || !builtInDisplayOnline || percent <= sanitizedLimit(limit)
+    }
+
+    static func shouldEndTopUp(percent: Int, pluggedIn: Bool) -> Bool {
+        !pluggedIn || percent >= 100
+    }
+
+    static func shouldReportSystemConflict(wantsCharging: Bool, isCharging: Bool,
+                                           secondsSinceAllow: TimeInterval?) -> Bool {
+        guard wantsCharging, !isCharging, let secondsSinceAllow else { return false }
+        return secondsSinceAllow >= 20
+    }
+}

--- a/Sources/Vorssaint/Services/ChargeControl/ChargeControlSupport.swift
+++ b/Sources/Vorssaint/Services/ChargeControl/ChargeControlSupport.swift
@@ -82,6 +82,7 @@ enum ChargeControlIPC {
 enum ChargeLimitPolicy {
     static let range = 20...100
     static let defaultLimit = 80
+    static let hysteresis = 2
 
     static func sanitizedLimit(_ value: Int) -> Int {
         min(max(value, range.lowerBound), range.upperBound)
@@ -91,8 +92,10 @@ enum ChargeLimitPolicy {
                             previous: ChargeControlMode) -> ChargeControlMode {
         let limit = sanitizedLimit(limit)
         guard pluggedIn, limit < 100 else { return .charging }
-        if percent > limit { return .discharging }
-        if percent == limit { return .paused }
+        // Normal enforcement never force-discharges. While paused, wait for
+        // the full band before allowing charging again to avoid micro-cycles.
+        if previous == .paused, percent > limit - hysteresis { return .paused }
+        if percent >= limit { return .paused }
         return .charging
     }
 

--- a/Sources/Vorssaint/UI/MenuPanel/ChargeControlSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/ChargeControlSection.swift
@@ -90,7 +90,7 @@ struct ChargeControlSection: View {
 
     private func controls(_ strings: ChargeControlStrings) -> some View {
         HStack(spacing: 7) {
-            Text("Limit: \(limit)%")
+            Text(strings.limitValue(limit))
             .font(.system(size: 11, weight: .semibold))
             .frame(height: 27)
 
@@ -148,7 +148,8 @@ struct ChargeControlSection: View {
             }
         }
         .frame(height: 25)
-        .accessibilityLabel("Battery \(service.percent ?? 0)%, limit \(limit)%")
+        .accessibilityLabel(ChargeControlStrings.current(l10n.language)
+            .batteryAccessibility(percent: service.percent ?? 0, limit: limit))
     }
 
     private var powerFlow: some View {

--- a/Sources/Vorssaint/UI/MenuPanel/ChargeControlSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/ChargeControlSection.swift
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import SwiftUI
+
+struct ChargeControlSection: View {
+    let collapsible: Bool
+    @ObservedObject private var service = ChargeControlService.shared
+    @ObservedObject private var monitor = SystemMonitor.shared
+    @ObservedObject private var l10n = L10n.shared
+    @AppStorage(DefaultsKey.chargeLimitEnabled) private var enabled = false
+    @AppStorage(DefaultsKey.chargeLimitPercent) private var limit = ChargeLimitPolicy.defaultLimit
+    @State private var energyRows: [ProcessUsage] = []
+    @State private var energyExpanded = false
+    @State private var energyLoading = false
+    private let refreshTimer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        let strings = ChargeControlStrings.current(l10n.language)
+        PanelSection(.chargeControl, title: strings.title, collapsible: collapsible) {
+            if enabled {
+                VStack(alignment: .leading, spacing: 10) {
+                    controls(strings)
+                    if service.status == .approvalRequired || service.status == .helperUnavailable {
+                        authorizationNotice(strings)
+                    }
+                    if service.status == .systemConflict {
+                        conflictNotice(strings)
+                    }
+                    chargeBar
+                    powerFlow
+                    energyApps
+                }
+            } else {
+                Toggle(strings.enable, isOn: $enabled)
+                    .onChange(of: enabled) { _, _ in service.syncWithPreferences() }
+            }
+        }
+        .onAppear {
+            service.syncWithPreferences()
+            refreshEnergy(force: true)
+        }
+        .onReceive(refreshTimer) { _ in
+            service.evaluate()
+            refreshEnergy(force: false)
+        }
+    }
+
+    private func conflictNotice(_ strings: ChargeControlStrings) -> some View {
+        Button {
+            guard let url = URL(string: "x-apple.systempreferences:com.apple.Battery-Settings.extension") else { return }
+            NSWorkspace.shared.open(url)
+        } label: {
+            HStack(spacing: 7) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text(strings.status(.systemConflict))
+                    .font(.system(size: 10.5, weight: .medium))
+                Spacer(minLength: 4)
+                Text(strings.resolveConflict)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+            }
+            .padding(.horizontal, 9)
+            .frame(minHeight: 34)
+            .background(Color.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 9))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func authorizationNotice(_ strings: ChargeControlStrings) -> some View {
+        Button { service.authorize() } label: {
+            HStack(spacing: 7) {
+                Image(systemName: "exclamationmark.shield.fill")
+                    .foregroundStyle(.orange)
+                Text(strings.status(service.status))
+                    .font(.system(size: 10.5, weight: .medium))
+                    .lineLimit(2)
+                Spacer(minLength: 4)
+                Text(strings.approveHelper)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+            }
+            .padding(.horizontal, 9)
+            .frame(minHeight: 34)
+            .background(Color.orange.opacity(0.10), in: RoundedRectangle(cornerRadius: 9))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func controls(_ strings: ChargeControlStrings) -> some View {
+        HStack(spacing: 7) {
+            Text("Limit: \(limit)%")
+            .font(.system(size: 11, weight: .semibold))
+            .frame(height: 27)
+
+            Spacer(minLength: 0)
+            actionButton(title: strings.discharge,
+                         symbol: service.sessionAction == .dischargeToLimit ? "minus.circle.fill" : "minus.circle",
+                         active: service.sessionAction == .dischargeToLimit,
+                         enabled: service.sessionAction == .dischargeToLimit || service.canStartDischarge) {
+                service.sessionAction == .dischargeToLimit
+                    ? service.cancelDischarge() : service.startDischargeToLimit()
+            }
+            actionButton(title: strings.topUp,
+                         symbol: service.sessionAction == .topUp ? "xmark.circle.fill" : "plus.circle",
+                         active: service.sessionAction == .topUp,
+                         enabled: service.sessionAction == .topUp || service.canStartTopUp) {
+                service.sessionAction == .topUp ? service.cancelTopUp() : service.startTopUp()
+            }
+        }
+    }
+
+    private func actionButton(title: String, symbol: String, active: Bool, enabled: Bool,
+                              action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 3) {
+                Text(title).lineLimit(1)
+                Image(systemName: symbol)
+            }
+            .font(.system(size: 10.5, weight: .medium))
+            .padding(.horizontal, 6)
+            .frame(height: 27)
+            .background(active ? Color.accentColor.opacity(0.18) : Color.primary.opacity(0.06),
+                        in: RoundedRectangle(cornerRadius: 7))
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+        .opacity(enabled ? 1 : 0.45)
+    }
+
+    private var chargeBar: some View {
+        GeometryReader { geometry in
+            let percent = CGFloat(service.percent ?? 0) / 100
+            let target = CGFloat(limit) / 100
+            ZStack(alignment: .leading) {
+                Capsule().fill(Color.primary.opacity(0.12))
+                Capsule().fill(barColor).frame(width: geometry.size.width * percent)
+                Rectangle().fill(Color.primary.opacity(0.55)).frame(width: 2, height: 25)
+                    .offset(x: max(0, min(geometry.size.width - 2, geometry.size.width * target - 1)))
+                Image(systemName: barSymbol)
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(.primary)
+                    // The state belongs to the charged portion as a whole, not
+                    // its moving edge, so keep it centered in the current fill.
+                    .offset(x: max(6, min(geometry.size.width - 20,
+                                          geometry.size.width * percent / 2 - 7)))
+            }
+        }
+        .frame(height: 25)
+        .accessibilityLabel("Battery \(service.percent ?? 0)%, limit \(limit)%")
+    }
+
+    private var powerFlow: some View {
+        let power = monitor.snapshot.power
+        return HStack(spacing: 0) {
+            Image(systemName: power?.externalConnected == true ? "powerplug.fill" : "powerplug")
+                .frame(width: 48)
+            Divider()
+            VStack(spacing: 2) {
+                Text(powerValue(power))
+                    .font(.system(size: 14, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                Text(powerCaption(power))
+                    .font(.system(size: 9.5))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+            Divider()
+            Image(systemName: "laptopcomputer").frame(width: 48)
+        }
+        .frame(height: 62)
+        .background(Color.primary.opacity(0.055), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var energyApps: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Button {
+                energyExpanded.toggle()
+                if energyExpanded { refreshEnergy(force: true) }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: energyExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 8, weight: .bold))
+                    Text(l10n.s.energyAppsTitle)
+                        .font(.system(size: 10.5, weight: .semibold))
+                    Spacer()
+                    if let top = energyRows.first {
+                        Text(top.name).font(.system(size: 10.5)).foregroundStyle(.secondary).lineLimit(1)
+                    } else if energyLoading {
+                        ProgressView().controlSize(.mini)
+                    }
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            if energyExpanded {
+                if energyRows.isEmpty, !energyLoading {
+                    Text(l10n.s.energyAppsIdle).font(.system(size: 10)).foregroundStyle(.tertiary)
+                } else {
+                    ForEach(energyRows.prefix(5)) { row in
+                        ProcessUsageRow(row: row, value: String(format: "%.1f%%", row.value),
+                                        iconSize: 14, leadingPadding: 12)
+                    }
+                }
+            }
+        }
+        .padding(10)
+        .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private var barColor: Color {
+        if service.status == .approvalRequired || service.status == .helperUnavailable
+            || service.status == .controlFailed || service.status == .unsupportedHardware {
+            return .gray
+        }
+        switch service.sessionAction {
+        case .dischargeToLimit: return .orange
+        case .topUp: return .green
+        case .normal: return .accentColor
+        }
+    }
+
+    private var barSymbol: String {
+        switch service.status {
+        case .approvalRequired, .helperUnavailable, .controlFailed, .unsupportedHardware:
+            return "exclamationmark.triangle.fill"
+        default: break
+        }
+        if service.sessionAction == .dischargeToLimit || service.status == .discharging {
+            return "arrow.down"
+        }
+        switch service.status {
+        case .paused: return "pause.fill"
+        case .systemConflict: return "exclamationmark.triangle.fill"
+        // Top Up is still a charging state even before IOKit refreshes.
+        case .charging: return "bolt.fill"
+        default: return service.sessionAction == .topUp ? "bolt.fill" : "battery.50percent"
+        }
+    }
+
+    private func powerValue(_ power: PowerReading?) -> String {
+        if let value = power?.systemWatts ?? power?.adapterWatts { return MetricFormat.watts(value) }
+        if let value = power?.batteryWatts { return MetricFormat.watts(abs(value)) }
+        return "—"
+    }
+
+    private func powerCaption(_ power: PowerReading?) -> String {
+        guard let power else { return l10n.s.powerUnavailable }
+        if service.status == .systemConflict {
+            return ChargeControlStrings.current(l10n.language).status(.systemConflict)
+        }
+        if service.sessionAction == .dischargeToLimit || (power.batteryWatts ?? 0) < 0 {
+            return l10n.s.powerOnBattery
+        }
+        if power.isCharging || service.sessionAction == .topUp { return l10n.s.powerCharging }
+        return power.externalConnected ? l10n.s.powerPluggedIn : l10n.s.powerOnBattery
+    }
+
+    private func refreshEnergy(force: Bool) {
+        if !force, let cached = ProcessUsageService.shared.cachedTop(.energy, limit: 5) {
+            energyRows = cached
+            return
+        }
+        guard !energyLoading else { return }
+        energyLoading = energyRows.isEmpty
+        DispatchQueue.global(qos: .utility).async {
+            let rows = ProcessUsageService.shared.top(.energy, limit: 5)
+            DispatchQueue.main.async {
+                energyLoading = false
+                energyRows = rows
+            }
+        }
+    }
+}

--- a/Sources/Vorssaint/UI/MenuPanel/MenuPanelView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/MenuPanelView.swift
@@ -72,6 +72,7 @@ struct MenuPanelView: View {
     @AppStorage(DefaultsKey.monitorShowPower) private var showPower = true
     @AppStorage(DefaultsKey.panelShowFanControl) private var showFanControl = true
     @AppStorage(DefaultsKey.panelShowChargeControl) private var showChargeControl = true
+    @AppStorage(DefaultsKey.chargeLimitEnabled) private var chargeLimitEnabled = false
     @AppStorage(DefaultsKey.panelShowKeepAwake) private var showKeepAwake = true
     @AppStorage(DefaultsKey.panelShowBrightness) private var showBrightness = true
     @AppStorage(DefaultsKey.brightnessControlEnabled) private var brightnessEnabled = false
@@ -288,7 +289,10 @@ struct MenuPanelView: View {
     private func section(for id: PanelSectionID, collapsible: Bool = true) -> some View {
         switch id {
         case .keepAwake: KeepAwakeCard(collapsible: collapsible)
-        case .chargeControl: if showChargeControl { ChargeControlSection(collapsible: collapsible) }
+        case .chargeControl:
+            if showChargeControl, chargeLimitEnabled, PowerSampler.hasInternalBattery {
+                ChargeControlSection(collapsible: collapsible)
+            }
         case .brightness: if showBrightness { BrightnessSection(collapsible: collapsible) }
         case .mixer: if showMixer { MixerSection(collapsible: collapsible) }
         case .system: if showSystem { SystemSection(collapsible: collapsible) }
@@ -306,7 +310,8 @@ struct MenuPanelView: View {
         guard id.isAvailable else { return false }
         switch id {
         case .keepAwake: return showKeepAwake
-        case .chargeControl: return showChargeControl
+        case .chargeControl:
+            return showChargeControl && chargeLimitEnabled && PowerSampler.hasInternalBattery
         // The section only earns its navigation tab while the feature is on;
         // it is switched on in Settings, not from an empty panel screen.
         case .brightness: return showBrightness && brightnessEnabled

--- a/Sources/Vorssaint/UI/MenuPanel/MenuPanelView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/MenuPanelView.swift
@@ -71,6 +71,7 @@ struct MenuPanelView: View {
     @AppStorage(DefaultsKey.monitorShowDisk) private var showDisk = true
     @AppStorage(DefaultsKey.monitorShowPower) private var showPower = true
     @AppStorage(DefaultsKey.panelShowFanControl) private var showFanControl = true
+    @AppStorage(DefaultsKey.panelShowChargeControl) private var showChargeControl = true
     @AppStorage(DefaultsKey.panelShowKeepAwake) private var showKeepAwake = true
     @AppStorage(DefaultsKey.panelShowBrightness) private var showBrightness = true
     @AppStorage(DefaultsKey.brightnessControlEnabled) private var brightnessEnabled = false
@@ -136,6 +137,7 @@ struct MenuPanelView: View {
             return selectedMetric.monitorNeeds
         }
         switch activeSection {
+        case .chargeControl: return SystemMonitorPanelNeeds(power: true)
         case .system: return SystemMonitorPanelNeeds(system: true)
         case .network: return SystemMonitorPanelNeeds(network: true)
         case .disk: return SystemMonitorPanelNeeds(disk: true)
@@ -254,6 +256,7 @@ struct MenuPanelView: View {
     private var estimatedNavigableContentHeight: CGFloat {
         switch activeSection {
         case .keepAwake: return 250
+        case .chargeControl: return 330
         case .brightness: return 140
         case .mixer: return 250
         case .system: return 460
@@ -285,6 +288,7 @@ struct MenuPanelView: View {
     private func section(for id: PanelSectionID, collapsible: Bool = true) -> some View {
         switch id {
         case .keepAwake: KeepAwakeCard(collapsible: collapsible)
+        case .chargeControl: if showChargeControl { ChargeControlSection(collapsible: collapsible) }
         case .brightness: if showBrightness { BrightnessSection(collapsible: collapsible) }
         case .mixer: if showMixer { MixerSection(collapsible: collapsible) }
         case .system: if showSystem { SystemSection(collapsible: collapsible) }
@@ -302,6 +306,7 @@ struct MenuPanelView: View {
         guard id.isAvailable else { return false }
         switch id {
         case .keepAwake: return showKeepAwake
+        case .chargeControl: return showChargeControl
         // The section only earns its navigation tab while the feature is on;
         // it is switched on in Settings, not from an empty panel screen.
         case .brightness: return showBrightness && brightnessEnabled

--- a/Sources/Vorssaint/UI/MenuPanel/PanelLayout.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/PanelLayout.swift
@@ -10,7 +10,7 @@ protocol PanelOrderItem: RawRepresentable, CaseIterable, Hashable where RawValue
 /// stable identifiers persisted in the saved order and the collapsed set, so
 /// renaming a case would orphan a user's stored layout — keep them stable.
 enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
-    case keepAwake, brightness, mixer, system, network, disk, power, fanControl, utilities, controls,
+    case keepAwake, chargeControl, brightness, mixer, system, network, disk, power, fanControl, utilities, controls,
          toggles
 
     var id: String { rawValue }
@@ -19,6 +19,7 @@ enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
     func title(_ s: Strings) -> String {
         switch self {
         case .keepAwake: return s.keepAwakeTitle
+        case .chargeControl: return ChargeControlStrings.current(L10n.shared.language).title
         case .brightness: return FeatureStrings.brightness(L10n.shared.language).pageTitle
         case .mixer: return s.mixerSection
         case .system: return s.systemSection
@@ -35,6 +36,7 @@ enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
     var symbolName: String {
         switch self {
         case .keepAwake: return "moon.zzz.fill"
+        case .chargeControl: return "battery.75percent"
         case .brightness: return "display.2"
         case .mixer: return "slider.horizontal.3"
         case .system: return "cpu"
@@ -54,6 +56,7 @@ enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
     var visibilityKey: String {
         switch self {
         case .keepAwake: return DefaultsKey.panelShowKeepAwake
+        case .chargeControl: return DefaultsKey.panelShowChargeControl
         case .brightness: return DefaultsKey.panelShowBrightness
         case .mixer: return DefaultsKey.monitorShowMixer
         case .system: return DefaultsKey.monitorShowSystem
@@ -77,6 +80,7 @@ enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
     var featureGate: [AppFeature] {
         switch self {
         case .keepAwake: return [.keepAwake]
+        case .chargeControl: return [.batteryChargeLimit]
         case .brightness: return [.brightness]
         case .mixer: return [.mixer]
         case .system: return [.monitorCPU, .monitorGPU, .monitorMemory]

--- a/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
@@ -625,6 +625,7 @@ extension AppFeature {
         case .micMute: return s.micMuteName
         case .musicBlock: return hub.titleMusicBlock
         case .keepAwake: return s.keepAwakeTitle
+        case .batteryChargeLimit: return ChargeControlStrings.current(L10n.shared.language).title
         case .brightness: return FeatureStrings.brightness(L10n.shared.language).pageTitle
         case .extraBrightness: return s.extraBrightnessName
         case .bluetoothSleep: return FeatureStrings.bluetoothSleep(L10n.shared.language).pageTitle
@@ -685,6 +686,7 @@ extension AppFeature {
         case .micMute: return hub.descMicMute
         case .musicBlock: return hub.descMusicBlock
         case .keepAwake: return hub.descKeepAwake
+        case .batteryChargeLimit: return ChargeControlStrings.current(L10n.shared.language).description
         case .brightness: return FeatureStrings.brightness(L10n.shared.language).hubDescription
         case .extraBrightness: return hub.descExtraBrightness
         case .bluetoothSleep: return FeatureStrings.bluetoothSleep(L10n.shared.language).hubDescription

--- a/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
@@ -19,6 +19,7 @@ enum SettingsSectionAnchor: String, CaseIterable, Hashable {
     case panelConfiguration
     case musicBlocking
     case keepAwake
+    case batteryChargeLimit
     case brightness
     case extraBrightness
     case bluetoothSleep
@@ -50,7 +51,7 @@ enum SettingsSectionAnchor: String, CaseIterable, Hashable {
     var page: SettingsPage {
         switch self {
         case .panelConfiguration, .musicBlocking: return .general
-        case .keepAwake, .brightness, .extraBrightness, .bluetoothSleep: return .energy
+        case .keepAwake, .batteryChargeLimit, .brightness, .extraBrightness, .bluetoothSleep: return .energy
         case .scrollDirection, .focusFollowsMouse, .smoothScroll, .mouseNavigation, .mouseButtonShortcuts,
              .middleClick:
             return .mouse
@@ -179,6 +180,8 @@ extension AppFeature {
 
         case .keepAwake:
             return FeatureSettingsDestination(.energy, sectionAnchor: .keepAwake)
+        case .batteryChargeLimit:
+            return FeatureSettingsDestination(.energy, sectionAnchor: .batteryChargeLimit)
         case .brightness:
             return FeatureSettingsDestination(.energy, sectionAnchor: .brightness)
         case .extraBrightness:
@@ -233,7 +236,7 @@ enum FeatureVisibilitySupport {
     /// always shows (General, Shortcuts, About and friends).
     static func features(for page: SettingsPage) -> [AppFeature] {
         switch page {
-        case .energy: return [.keepAwake, .brightness, .extraBrightness, .bluetoothSleep]
+        case .energy: return [.keepAwake, .batteryChargeLimit, .brightness, .extraBrightness, .bluetoothSleep]
         case .monitor: return monitorFeatures
         case .mouse: return [.scrollInverter, .focusFollowsMouse, .smoothScroll, .mouseNavigation, .mouseButtonShortcuts,
                              .middleClick]

--- a/Sources/Vorssaint/UI/Settings/SettingsView.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsView.swift
@@ -399,6 +399,7 @@ struct EnergySettings: View {
     @ObservedObject private var permissions = Permissions.shared
     @ObservedObject private var extraBrightness = ExtraBrightnessService.shared
     @ObservedObject private var brightness = BrightnessService.shared
+    @ObservedObject private var chargeControl = ChargeControlService.shared
     @AppStorage(DefaultsKey.brightnessControlEnabled) private var brightnessEnabled = false
     @AppStorage(DefaultsKey.brightnessKeysEnabled) private var brightnessKeysEnabled = false
     @AppStorage(DefaultsKey.brightnessOSDEnabled) private var brightnessOSDEnabled = false
@@ -408,6 +409,8 @@ struct EnergySettings: View {
     @AppStorage(DefaultsKey.bluetoothSleepRestoreOnWake) private var bluetoothSleepRestoreOnWake = true
     @AppStorage(DefaultsKey.defaultDuration) private var defaultDuration = 0
     @AppStorage(DefaultsKey.batteryLimit) private var batteryLimit = 10
+    @AppStorage(DefaultsKey.chargeLimitEnabled) private var chargeLimitEnabled = false
+    @AppStorage(DefaultsKey.chargeLimitPercent) private var chargeLimitPercent = ChargeLimitPolicy.defaultLimit
     @AppStorage(DefaultsKey.keepAwakeAutoStart) private var keepAwakeAutoStart = false
     @AppStorage(DefaultsKey.keepAwakeRightClickToggle) private var keepAwakeRightClickToggle = false
     @AppStorage(DefaultsKey.keepAwakeAllowDisplaySleep) private var keepAwakeAllowDisplaySleep = false
@@ -419,6 +422,35 @@ struct EnergySettings: View {
 
     var body: some View {
         Form {
+            if AppFeature.batteryChargeLimit.isAvailable, PowerSampler.hasInternalBattery {
+                let strings = ChargeControlStrings.current(l10n.language)
+                Section(strings.title) {
+                    SettingsToggleWithCaption(title: strings.enable,
+                                              caption: strings.enableCaption,
+                                              isOn: $chargeLimitEnabled)
+                        .onChange(of: chargeLimitEnabled) { _, _ in
+                            ChargeControlService.shared.syncWithPreferences()
+                        }
+                    if chargeLimitEnabled {
+                        HStack {
+                            Text(strings.limit)
+                            Slider(value: Binding(get: { Double(chargeLimitPercent) },
+                                                  set: { chargeLimitPercent = ChargeLimitPolicy.sanitizedLimit(Int($0.rounded())) }),
+                                   in: 20...100, step: 1)
+                            Text("\(chargeLimitPercent)")
+                                .font(.system(.body, design: .monospaced))
+                                .frame(width: 32, alignment: .trailing)
+                            Text("%").foregroundStyle(.secondary)
+                        }
+                        .onChange(of: chargeLimitPercent) { _, _ in
+                            normalizeChargeLimit()
+                            ChargeControlService.shared.evaluate()
+                        }
+                        SettingsCaptionText(strings.warning)
+                    }
+                }
+                .settingsSectionAnchor(.batteryChargeLimit)
+            }
             if AppFeature.keepAwake.isAvailable {
                 Section(l10n.s.sessionSection) {
                     Picker(l10n.s.defaultDurationLabel, selection: $defaultDuration) {
@@ -589,6 +621,8 @@ struct EnergySettings: View {
         .onAppear {
             defaultDuration = Defaults.sanitizedDefaultDuration(defaultDuration)
             batteryLimit = Defaults.sanitizedBatteryLimit(batteryLimit)
+            normalizeChargeLimit()
+            chargeControl.syncWithPreferences()
             keepAwakeIconTint = Defaults.sanitizedKeepAwakeIconTint(keepAwakeIconTint).rawValue
             keepAwakeActiveIcon = Defaults.sanitizedKeepAwakeActiveIcon(keepAwakeActiveIcon).rawValue
             keepAwakeMouseJiggleInterval = Defaults.sanitizedKeepAwakeMouseJiggleInterval(keepAwakeMouseJiggleInterval)
@@ -598,6 +632,10 @@ struct EnergySettings: View {
             ExtraBrightnessService.shared.syncWithPreferences()
             BrightnessService.shared.refresh()
         }
+    }
+
+    private func normalizeChargeLimit() {
+        chargeLimitPercent = ChargeLimitPolicy.sanitizedLimit(chargeLimitPercent)
     }
 
     private func brightnessRow(_ display: BrightnessDisplay) -> some View {

--- a/Sources/Vorssaint/UI/Settings/SettingsView.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsView.swift
@@ -436,7 +436,8 @@ struct EnergySettings: View {
                             Text(strings.limit)
                             Slider(value: Binding(get: { Double(chargeLimitPercent) },
                                                   set: { chargeLimitPercent = ChargeLimitPolicy.sanitizedLimit(Int($0.rounded())) }),
-                                   in: 20...100, step: 1)
+                                   in: Double(ChargeLimitPolicy.range.lowerBound)...Double(ChargeLimitPolicy.range.upperBound),
+                                   step: 1)
                             Text("\(chargeLimitPercent)")
                                 .font(.system(.body, design: .monospaced))
                                 .frame(width: 32, alignment: .trailing)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -3670,6 +3670,53 @@ struct MetricsTests {
         expect(Defaults.sanitizedDefaultDuration(999) == 0, "invalid default duration falls back to indefinite")
         expect(Defaults.sanitizedBatteryLimit(15) == 15, "valid battery limit is preserved")
         expect(Defaults.sanitizedBatteryLimit(100) == 10, "invalid battery limit falls back to default")
+        expect(ChargeLimitPolicy.sanitizedLimit(10) == 20, "charge limit clamps low input")
+        expect(ChargeLimitPolicy.sanitizedLimit(101) == 100, "charge limit clamps high input")
+        expect(ChargeLimitPolicy.desiredMode(percent: 80, limit: 80, pluggedIn: true,
+                                             previous: .charging) == .paused,
+               "charge limit pauses at the target")
+        expect(ChargeLimitPolicy.desiredMode(percent: 79, limit: 80, pluggedIn: true,
+                                             previous: .paused) == .charging,
+               "charge limit charges whenever battery is below the target")
+        expect(ChargeLimitPolicy.desiredMode(percent: 77, limit: 80, pluggedIn: true,
+                                             previous: .paused) == .charging,
+               "charge limit keeps charging below the target")
+        expect(ChargeLimitPolicy.desiredMode(percent: 81, limit: 80, pluggedIn: true,
+                                             previous: .paused) == .discharging,
+               "charge limit automatically discharges above the target")
+        expect(ChargeLimitPolicy.desiredMode(percent: 90, limit: 100, pluggedIn: true,
+                                             previous: .paused) == .charging,
+               "one hundred percent restores normal charging")
+        expect(!ChargeLimitPolicy.shouldEndDischarge(percent: 81, limit: 80,
+                                                     pluggedIn: true, builtInDisplayOnline: true),
+               "temporary discharge continues above the limit while open and plugged in")
+        expect(ChargeLimitPolicy.shouldEndDischarge(percent: 80, limit: 80,
+                                                    pluggedIn: true, builtInDisplayOnline: true),
+               "temporary discharge ends at the limit")
+        expect(ChargeLimitPolicy.shouldEndDischarge(percent: 90, limit: 80,
+                                                    pluggedIn: false, builtInDisplayOnline: true),
+               "temporary discharge ends when unplugged")
+        expect(ChargeLimitPolicy.shouldEndDischarge(percent: 90, limit: 80,
+                                                    pluggedIn: true, builtInDisplayOnline: false),
+               "temporary discharge ends when the lid closes")
+        expect(!ChargeLimitPolicy.shouldEndTopUp(percent: 99, pluggedIn: true),
+               "top up continues below full charge")
+        expect(ChargeLimitPolicy.shouldEndTopUp(percent: 100, pluggedIn: true),
+               "top up ends at full charge")
+        expect(ChargeLimitPolicy.shouldEndTopUp(percent: 90, pluggedIn: false),
+               "top up ends when unplugged")
+        expect(!ChargeLimitPolicy.shouldReportSystemConflict(wantsCharging: true,
+                                                             isCharging: false,
+                                                             secondsSinceAllow: 5),
+               "charging state gets a grace period after enabling")
+        expect(ChargeLimitPolicy.shouldReportSystemConflict(wantsCharging: true,
+                                                            isCharging: false,
+                                                            secondsSinceAllow: 20),
+               "charging conflict appears after the hardware grace period")
+        expect(!ChargeLimitPolicy.shouldReportSystemConflict(wantsCharging: true,
+                                                             isCharging: true,
+                                                             secondsSinceAllow: 30),
+               "real charging clears the system conflict")
         expect(Defaults.sanitizedClipboardHistoryLimit(1_000) == 1_000,
                "larger clipboard history limits are preserved")
         expect(Defaults.sanitizedClipboardHistoryLimit(999) == 50,
@@ -10070,7 +10117,7 @@ struct MetricsTests {
 
         // MARK: Features hub catalog
 
-        expect(AppFeature.allCases.count == 54, "feature catalog has 54 features")
+        expect(AppFeature.allCases.count == 55, "feature catalog has 55 features")
         expect(Set(AppFeature.allCases.map(\.rawValue)).count == AppFeature.allCases.count,
                "feature ids are unique")
         expect(AppFeature.allCases.map(\.rawValue) == [
@@ -10080,7 +10127,7 @@ struct MetricsTests {
             "clipboardHistory", "pastePlain", "finderCutPaste", "finderRename", "shelf", "urlCleaner",
             "diskImageInstaller",
             "mixer", "soundOutputSwitcher", "micMute", "musicBlock",
-            "keepAwake", "brightness", "extraBrightness", "bluetoothSleep",
+            "keepAwake", "batteryChargeLimit", "brightness", "extraBrightness", "bluetoothSleep",
             "quickLauncher", "quickToggles", "colorPicker", "screenOCR", "cleaningMode", "mediaTools",
             "cleaner", "uninstaller", "homebrew", "appUpdates", "screenshot", "cameraPreview",
             "radialMenu", "scratchpad", "commandBar", "screenRecorder", "killProcess",
@@ -10094,8 +10141,9 @@ struct MetricsTests {
                 && (AppFeature.availabilityDefaults[AppFeature.diskImageInstaller.availabilityKey] as? Bool) == false
                 && (AppFeature.availabilityDefaults[AppFeature.focusFollowsMouse.availabilityKey] as? Bool) == false
                 && (AppFeature.availabilityDefaults[AppFeature.killProcess.availabilityKey] as? Bool) == false
+                && (AppFeature.availabilityDefaults[AppFeature.batteryChargeLimit.availabilityKey] as? Bool) == false
                 && AppFeature.allCases.filter {
-                    $0 != .focusFollowsMouse && $0 != .fanControl && $0 != .diskImageInstaller
+                    $0 != .focusFollowsMouse && $0 != .fanControl && $0 != .batteryChargeLimit && $0 != .diskImageInstaller
                         && $0 != .killProcess
                 }.allSatisfy {
                     (AppFeature.availabilityDefaults[$0.availabilityKey] as? Bool) == true
@@ -11109,10 +11157,10 @@ struct MetricsTests {
                "one remaining mouse feature keeps the mouse page")
         expect(!pageVisible(.mouse, available: []),
                "the mouse page hides only with all six mouse features off")
-        expect(!pageVisible(.energy, available: allFeatures.subtracting([.keepAwake, .brightness,
+        expect(!pageVisible(.energy, available: allFeatures.subtracting([.keepAwake, .batteryChargeLimit, .brightness,
                                                                          .extraBrightness,
                                                                          .bluetoothSleep])),
-               "energy hides when all four of its features are off")
+               "energy hides when all five of its features are off")
         expect(pageVisible(.energy, available: [.extraBrightness]), "XDR alone keeps the energy page")
         expect(pageVisible(.energy, available: [.brightness]),
                "brightness control alone keeps the energy page")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -3676,14 +3676,20 @@ struct MetricsTests {
                                              previous: .charging) == .paused,
                "charge limit pauses at the target")
         expect(ChargeLimitPolicy.desiredMode(percent: 79, limit: 80, pluggedIn: true,
+                                             previous: .paused) == .paused,
+               "charge limit stays paused inside the hysteresis band")
+        expect(ChargeLimitPolicy.desiredMode(percent: 78, limit: 80, pluggedIn: true,
                                              previous: .paused) == .charging,
-               "charge limit charges whenever battery is below the target")
+               "charge limit resumes charging at the lower hysteresis boundary")
         expect(ChargeLimitPolicy.desiredMode(percent: 77, limit: 80, pluggedIn: true,
                                              previous: .paused) == .charging,
                "charge limit keeps charging below the target")
         expect(ChargeLimitPolicy.desiredMode(percent: 81, limit: 80, pluggedIn: true,
-                                             previous: .paused) == .discharging,
-               "charge limit automatically discharges above the target")
+                                             previous: .paused) == .paused,
+               "normal limit enforcement never starts forced discharge")
+        expect(ChargeLimitPolicy.desiredMode(percent: 81, limit: 80, pluggedIn: true,
+                                             previous: .charging) == .paused,
+               "charge limit pauses charging above the target")
         expect(ChargeLimitPolicy.desiredMode(percent: 90, limit: 100, pluggedIn: true,
                                              previous: .paused) == .charging,
                "one hundred percent restores normal charging")

--- a/build.sh
+++ b/build.sh
@@ -39,6 +39,7 @@ else
     BUILD_CONFIGURATION="release"
 fi
 FAN_HELPER_ID="$APP_BUNDLE_ID.fan-control"
+CHARGE_HELPER_ID="$APP_BUNDLE_ID.charge-control"
 TARGET="arm64-apple-macosx14.0"
 ENTITLEMENTS="Resources/Vorssaint.entitlements"
 LEGACY_IDENTITY="Vorssaint Utils Signing"
@@ -91,6 +92,7 @@ write_swift_output_file_map() {
 finalize_installed_bundle_after_child() {
     local bundle="$1"
     local helper="$bundle/Contents/Library/LaunchServices/$FAN_HELPER_ID"
+    local charge_helper="$bundle/Contents/Library/LaunchServices/$CHARGE_HELPER_ID"
     local devid
     devid="$(developer_id_identity)"
 
@@ -99,18 +101,25 @@ finalize_installed_bundle_after_child() {
     if [[ -n "$devid" ]]; then
         [[ -f "$helper" ]] && codesign_with_timestamp_retry --force --strip-disallowed-xattrs \
             --options runtime --timestamp --identifier "$FAN_HELPER_ID" --sign "$devid" "$helper"
+        [[ -f "$charge_helper" ]] && codesign_with_timestamp_retry --force --strip-disallowed-xattrs \
+            --options runtime --timestamp --identifier "$CHARGE_HELPER_ID" --sign "$devid" "$charge_helper"
         codesign_with_timestamp_retry --force --strip-disallowed-xattrs --options runtime --timestamp \
             --entitlements "$ENTITLEMENTS" --sign "$devid" "$bundle"
     elif security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"; then
         [[ -f "$helper" ]] && /usr/bin/codesign --force --strip-disallowed-xattrs \
             --identifier "$FAN_HELPER_ID" --sign "$LEGACY_IDENTITY" "$helper"
+        [[ -f "$charge_helper" ]] && /usr/bin/codesign --force --strip-disallowed-xattrs \
+            --identifier "$CHARGE_HELPER_ID" --sign "$LEGACY_IDENTITY" "$charge_helper"
         /usr/bin/codesign --force --strip-disallowed-xattrs --sign "$LEGACY_IDENTITY" "$bundle"
     else
         [[ -f "$helper" ]] && /usr/bin/codesign --force --strip-disallowed-xattrs \
             --identifier "$FAN_HELPER_ID" --sign - "$helper"
+        [[ -f "$charge_helper" ]] && /usr/bin/codesign --force --strip-disallowed-xattrs \
+            --identifier "$CHARGE_HELPER_ID" --sign - "$charge_helper"
         /usr/bin/codesign --force --strip-disallowed-xattrs --sign - "$bundle"
     fi
     [[ -f "$helper" ]] && /usr/bin/codesign --verify --strict "$helper"
+    [[ -f "$charge_helper" ]] && /usr/bin/codesign --verify --strict "$charge_helper"
     /usr/bin/codesign --verify --deep --strict "$bundle"
     echo "✓ Signature ready: $bundle"
 }
@@ -307,6 +316,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/KeepAwakeAutomationSupport.swift \
         Sources/Vorssaint/Services/SudoersSupport.swift \
         Sources/Vorssaint/Services/Metrics/BatteryTimeSupport.swift \
+        Sources/Vorssaint/Services/ChargeControl/ChargeControlSupport.swift \
         Sources/Vorssaint/Services/BoundedProcessRunner.swift \
         Sources/Vorssaint/Services/ShellSupport.swift \
         Sources/Vorssaint/Services/Metrics/NetworkProcessSupport.swift \
@@ -368,6 +378,17 @@ swiftc -O -target "$TARGET" -sdk "$SDK" "${SDK_COMPAT_FLAGS[@]}" "${BUILD_VARIAN
     -o "build/$FAN_HELPER_ID"
 "build/$FAN_HELPER_ID" --selftest
 
+echo "▸ Compiling protected charge helper…"
+swiftc -O -target "$TARGET" -sdk "$SDK" "${SDK_COMPAT_FLAGS[@]}" "${BUILD_VARIANT_FLAGS[@]}" \
+    Sources/Vorssaint/Services/ChargeControl/ChargeControlSupport.swift \
+    Sources/Vorssaint/Services/ChargeControl/ChargeControlHardware.swift \
+    Sources/Vorssaint/Services/SystemMonitor/SMCClient.swift \
+    Sources/Vorssaint/Services/FanControl/FanControlSupport.swift \
+    Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift \
+    Sources/ChargeControlHelper/main.swift \
+    -o "build/$CHARGE_HELPER_ID"
+"build/$CHARGE_HELPER_ID" --selftest
+
 echo "▸ Generating app icon…"
 swift Tools/MakeIcon.swift build/AppIcon.iconset
 xattr -c -r build/AppIcon.iconset build/AppIcon.icns build/MenuBarIcon.png build/MenuBarIcon@2x.png build/BrandMark.png 2>/dev/null || true
@@ -408,8 +429,11 @@ mkdir -p "$STAGE/Contents/MacOS" "$STAGE/Contents/Resources" \
     "$STAGE/Contents/Library/LaunchDaemons" "$STAGE/Contents/Library/LaunchServices"
 cp "build/$EXECUTABLE" "$STAGE/Contents/MacOS/$EXECUTABLE"
 cp "build/$FAN_HELPER_ID" "$STAGE/Contents/Library/LaunchServices/$FAN_HELPER_ID"
+cp "build/$CHARGE_HELPER_ID" "$STAGE/Contents/Library/LaunchServices/$CHARGE_HELPER_ID"
 cp Resources/com.vorssaint.utils.fan-control.plist \
     "$STAGE/Contents/Library/LaunchDaemons/$FAN_HELPER_ID.plist"
+cp Resources/com.vorssaint.utils.charge-control.plist \
+    "$STAGE/Contents/Library/LaunchDaemons/$CHARGE_HELPER_ID.plist"
 cp Resources/Info.plist "$STAGE/Contents/Info.plist"
 cp CHANGELOG.md "$STAGE/Contents/Resources/CHANGELOG.md"
 for lproj in Resources/*.lproj(N); do
@@ -427,6 +451,11 @@ if (( DEV )); then
     /usr/libexec/PlistBuddy -c "Set :BundleProgram Contents/Library/LaunchServices/$FAN_HELPER_ID" "$FAN_PLIST"
     /usr/libexec/PlistBuddy -c "Delete :MachServices:com.vorssaint.utils.fan-control" "$FAN_PLIST"
     /usr/libexec/PlistBuddy -c "Add :MachServices:$FAN_HELPER_ID bool true" "$FAN_PLIST"
+    CHARGE_PLIST="$STAGE/Contents/Library/LaunchDaemons/$CHARGE_HELPER_ID.plist"
+    /usr/libexec/PlistBuddy -c "Set :Label $CHARGE_HELPER_ID" "$CHARGE_PLIST"
+    /usr/libexec/PlistBuddy -c "Set :BundleProgram Contents/Library/LaunchServices/$CHARGE_HELPER_ID" "$CHARGE_PLIST"
+    /usr/libexec/PlistBuddy -c "Delete :MachServices:com.vorssaint.utils.charge-control" "$CHARGE_PLIST"
+    /usr/libexec/PlistBuddy -c "Add :MachServices:$CHARGE_HELPER_ID bool true" "$CHARGE_PLIST"
     # Stamp the source commit + build time so the running dev app shows (in About)
     # exactly which code it was compiled from. Lets you verify it matches HEAD before
     # testing, instead of unknowingly running a stale build. Dev-only; never shipped.
@@ -444,6 +473,16 @@ FAN_HELPER_VERSION="$(
         | /usr/bin/awk '{print $1}'
 )"
 /usr/libexec/PlistBuddy -c "Add :VorssaintFanControlHelperVersion string '$FAN_HELPER_VERSION'" \
+    "$STAGE/Contents/Info.plist"
+CHARGE_HELPER_VERSION="$(
+    export LC_ALL=C
+    /usr/bin/shasum -a 256 \
+        "$STAGE/Contents/Library/LaunchServices/$CHARGE_HELPER_ID" \
+        "$STAGE/Contents/Library/LaunchDaemons/$CHARGE_HELPER_ID.plist" \
+        | /usr/bin/awk '{print $1}' | /usr/bin/shasum -a 256 \
+        | /usr/bin/awk '{print $1}'
+)"
+/usr/libexec/PlistBuddy -c "Add :VorssaintChargeControlHelperVersion string '$CHARGE_HELPER_VERSION'" \
     "$STAGE/Contents/Info.plist"
 printf 'APPL????' > "$STAGE/Contents/PkgInfo"
 cp build/AppIcon.icns "$STAGE/Contents/Resources/AppIcon.icns"
@@ -497,10 +536,23 @@ codesign_fan_helper() {
     fi
 }
 
+codesign_charge_helper() {
+    local target="$1"
+    if [[ -n "$DEVID" ]]; then
+        codesign_with_timestamp_retry --force --strip-disallowed-xattrs --options runtime --timestamp \
+            --identifier "$CHARGE_HELPER_ID" --sign "$DEVID" "$target"
+    elif security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"; then
+        codesign --force --strip-disallowed-xattrs --identifier "$CHARGE_HELPER_ID" --sign "$LEGACY_IDENTITY" "$target"
+    else
+        codesign --force --strip-disallowed-xattrs --identifier "$CHARGE_HELPER_ID" --sign - "$target"
+    fi
+}
+
 sign_bundle() {
     local bundle="$1"
     local executable="$bundle/Contents/MacOS/$EXECUTABLE"
     local helper="$bundle/Contents/Library/LaunchServices/$FAN_HELPER_ID"
+    local charge_helper="$bundle/Contents/Library/LaunchServices/$CHARGE_HELPER_ID"
 
     if [[ -n "$DEVID" ]]; then
         echo "  signing with Developer ID (hardened runtime): $DEVID"
@@ -510,6 +562,7 @@ sign_bundle() {
         echo "  signing ad-hoc (no identity installed — run Tools/setup-signing.sh)"
     fi
     [[ -f "$helper" ]] && codesign_fan_helper "$helper"
+    [[ -f "$charge_helper" ]] && codesign_charge_helper "$charge_helper"
     codesign_app "$bundle"
 
     # If local filesystem metadata invalidates the first signature, sign once
@@ -518,10 +571,12 @@ sign_bundle() {
         echo "  re-signing after filesystem metadata settled"
         xattr -c -r "$bundle" 2>/dev/null || true
         [[ -f "$helper" ]] && codesign_fan_helper "$helper"
+        [[ -f "$charge_helper" ]] && codesign_charge_helper "$charge_helper"
         codesign_app "$bundle"
     fi
     [[ -f "$executable" ]] && codesign --verify --strict "$executable"
     [[ -f "$helper" ]] && codesign --verify --strict "$helper"
+    [[ -f "$charge_helper" ]] && codesign --verify --strict "$charge_helper"
     codesign --verify --deep --strict "$bundle"
 }
 


### PR DESCRIPTION
<img width="2560" height="1439" alt="power" src="https://github.com/user-attachments/assets/dfc2676b-219b-41c2-96a4-4c2bad88c8e8" />

Add a separately managed privileged helper for charge limiting, forced discharge, and session-only top-up controls. Include M4-compatible SMC probing, heartbeat recovery, menu panel controls, settings integration, localization, packaging, and policy tests.

<!--
Nothing here is required, and a one-line fix needs only the first section.
The shortest description ever merged here was five lines.

Size is what decides how long this waits. The median merged pull request is
+110 lines and lands within a day. Nothing under +200 lines is stuck right
now; half of everything over +1000 lines is. Splitting a large change is
worth more than describing it well.
-->

## Summary

This pull request adds an opt-in Beta feature called **Charge Protection** for MacBook batteries.

Charge Protection allows users to:

- Set a maximum charge level between 20% and 100%.
- Automatically allow charging while the battery is below the selected limit.
- Pause charging when the battery reaches the limit.
- Discharge the battery down to the selected limit while the Mac remains connected to power.
- Temporarily override the limit and charge to 100% with **Top Up**.
- View the current battery level, charge-limit marker, charging state, live power information, and applications using significant energy from the menu panel.

The normal limit policy uses a 2% hysteresis to avoid repeatedly switching between charging and paused states near the selected limit. Temporary Discharge and Top Up operations are mutually exclusive and are cancelled when their completion or safety conditions are reached.

The settings page intentionally remains small. It contains only the feature enable switch, the charge-limit control, and an explanation of the Beta/private-hardware-interface limitations. Helper installation is handled when the feature is installed from the Features screen, so users are not asked to install it a second time from Settings or the menu panel.

## Verification

### Hardware used

Testing was performed on:

- **Mac:** MacBook Air with Apple M4
- **Model identifier:** `Mac16,13`
- **macOS:** macOS 15.2
- **Build:** `24C2101`
- **Power adapter:** 65 W adapter
- **Application build:** Locally built Developer configuration with locally signed application and helpers
- **Application location:** `/Applications/Vorssaint (Developer).app`
- **Display layout:** Built-in display only
- **Spaces/layout:** Normal desktop use; no dedicated multi-display or multi-Space test matrix was performed

The Charge Control helper was confirmed to be registered with `launchd`, running as root, and reachable through its authenticated XPC connection.

### Hardware behavior verified

The following cases were exercised on the M4 MacBook Air:

- At 81% with a 90% limit, charging was allowed.
- Charging resumed with a reported positive battery current of approximately 2366 mA.
- At 81% with a 77% limit, forced discharge started while the adapter remained physically connected.
- At 99% with a 100% limit, charging was permitted again after the macOS power-management delay.
- At 99% with a 90% limit, forced discharge remained stable instead of oscillating between charging and discharging.
- Changing the limit caused the policy to be recalculated.
- The menu panel displayed charging, paused, and discharging states.
- Temporary Discharge and Top Up controls were connected to the session state.
- The helper installation was handled by the Features flow rather than asking for a second installation in Settings.
- The application could be opened from `/Applications` with its installed helper.
- macOS Optimized Battery Charging was disabled during the main hardware-control checks.
- An existing AlDente helper was present on the test machine but was not running.

During testing, AppleSmartBattery was found to report Battery Power and `ExternalConnected = false` while forced discharge was active, even though the cable was still connected. Physical adapter presence is therefore additionally derived from `AdapterDetails`; this prevents policy evaluation from cancelling and restarting forced discharge every five seconds.

The M4 hardware also reads `CH0B`/`CH0C` back as `3` during forced discharge rather than exactly matching the written pause value. Verification now checks the requested charge-inhibit bit while still rejecting an incompatible readback.

### Commands

```sh
./build.sh                     # must finish without warnings
./build/Vorssaint --selftest
./build.sh --test
```

