### PR TITLE
fix(media): scroll the media page in Settings

### DIFF
--- a/Sources/Vorssaint/UI/Media/MediaWorkspaceView.swift
+++ b/Sources/Vorssaint/UI/Media/MediaWorkspaceView.swift
@@ -152,15 +152,14 @@ struct MediaWorkspaceView: View {
         VStack(alignment: .leading, spacing: compact ? 10 : 14) {
             header
             toolPicker
-            if compact {
-                ScrollView {
-                    content
-                        .padding(.trailing, 1)
-                }
-                .frame(maxHeight: 430)
-            } else {
+            // The settings detail slot clips its page to the window height,
+            // so without a scroll view the action row is unreachable. Only
+            // the popover needs a cap.
+            ScrollView {
                 content
+                    .padding(.trailing, 1)
             }
+            .frame(maxHeight: compact ? 430 : CGFloat.infinity)
         }
         .onChange(of: currentImageOptions) { oldOptions, newOptions in
             guard selectedTool == .imageCompressor else { return }


### PR DESCRIPTION
## Summary

The Media page does not scroll in Settings, so its action button and status
line can sit below the window's bottom edge with no way to reach them. The
settings detail slot sizes each page to the window height and clips what does
not fit, and this page was the only one reachable from the sidebar with no
scrolling container of its own: every other page is a `Form`, a `List`, or
already has a `ScrollView`.

At the window's 528pt minimum height the image tool overflows the viewport
whether or not "More options" is expanded, so the button below it is
unreachable in both states. The other three tools fit at that height and were
unaffected: with the viewport ending at y=737, the last element sits at y=630
for video, y=641 for GIF and y=493 for text, against y=787 for images.

The popover already scrolled, since `MediaWorkspaceView` wrapped its content
in a `ScrollView` only when `compact` was true. This gives both hosts the
same `ScrollView` and lets `compact` decide only the height cap: 430pt in the
popover, unbounded in Settings, where the window supplies the bound. The view
the popover renders is unchanged.

`ReleaseNotesSettings` uses the same shape already, a fixed header above a
`ScrollView`.

## Verification

```sh
swift build                    # Build complete! (17.54s)
./build.sh --test              # TESTS OK (8541 checks)
./build.sh                     # ✓ Bundle ready, no warnings
./build/Vorssaint --selftest   # SELFTEST OK
```

Ran a `--dev --install` build and checked the Media page in Settings with the
window at its 528pt minimum, both by eye and by reading element geometry. The
viewport spans y=314..737.

| state | scrolled to top | scrolled to bottom |
|---|---|---|
| More options collapsed | last element y=787 | y=714, inside the viewport |
| More options expanded | last element y=1039 | y=714, inside the viewport |

So the action row is below the clip in both states and reachable by scrolling
in both. Content stays pinned to the top (first element y=324 against a
viewport top of 314) rather than stretching or centering, a short page (text
extractor, 7 elements) still fits with no scroll bar shown, and the window
does not resize when switching between Media, Kill process and Features.

The menu bar popover was checked by eye and is unchanged, which matches the
code: at `compact == true` the view emitted is the same `ScrollView` with the
same 430pt cap as before.

Checked on Apple Silicon, a single Retina display, in English. Not tried on a
non-Retina or multi-display setup, or in another app language.

## Anything else

The Settings page now carries a `ScrollView` even when its content fits. No
scroll bar appears in that case and the content stays top-aligned, which is
what the short-page check above was for, but it is a container that was not
there before.

No open issue covers this, so there is nothing to reference.
