### PR TITLE
feat(settings): add user applications install option

### DIFF
--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -99,6 +99,7 @@ enum DefaultsKey {
     static let finderRenameEnabled = "finderRenameEnabled"
     static let finderRenameShortcut = "finderRenameShortcut"
     static let finderPasteImageAsFile = "finderPasteImageAsFile"
+    static let diskImageInstallerUseUserApplications = "diskImageInstallerUseUserApplications"
     static let autoQuitEnabled = "autoQuitEnabled"
     static let autoQuitExceptions = "autoQuitExceptions"  // [bundle id] kept running
     static let shelfEnabled = "shelfEnabled"
@@ -1103,6 +1104,7 @@ enum Defaults {
         DefaultsKey.pastePlainShortcut: GlobalShortcut.pastePlainDefault.storageValue,
         DefaultsKey.finderRenameEnabled: false,
         DefaultsKey.finderRenameShortcut: GlobalShortcut.finderRenameDefault.storageValue,
+        DefaultsKey.diskImageInstallerUseUserApplications: false,
         DefaultsKey.colorPickerShortcutEnabled: false,
         DefaultsKey.colorPickerShortcut: GlobalShortcut.colorPickerDefault.storageValue,
         DefaultsKey.colorPickerFormat: "hex",

--- a/Sources/Vorssaint/Core/DiskImageInstallerStrings.swift
+++ b/Sources/Vorssaint/Core/DiskImageInstallerStrings.swift
@@ -6,6 +6,7 @@ import Foundation
 struct DiskImageInstallerStrings {
     let title: String
     let hubDescription: String
+    let useUserApplications: String
     let promptTitle: String
     let promptBodyFormat: String
     let installButton: String
@@ -43,6 +44,7 @@ extension DiskImageInstallerStrings {
     static let enUS = DiskImageInstallerStrings(
         title: "Disk image installer",
         hubDescription: "Install the single app inside a disk image and clean up the download",
+        useUserApplications: "Install apps in ~/Applications",
         promptTitle: "Install this app?",
         promptBodyFormat: "%@ will be copied to Applications. The disk image is then ejected and its download moved to Trash.",
         installButton: "Install",
@@ -59,6 +61,7 @@ extension DiskImageInstallerStrings {
     static let ptBR = DiskImageInstallerStrings(
         title: "Instalador de imagens de disco",
         hubDescription: "Instale o único app de uma imagem de disco e limpe o download",
+        useUserApplications: "Instalar apps em ~/Applications",
         promptTitle: "Instalar este app?",
         promptBodyFormat: "%@ será copiado para Aplicativos. Depois, a imagem de disco será ejetada e o download irá para o Lixo.",
         installButton: "Instalar",
@@ -75,6 +78,7 @@ extension DiskImageInstallerStrings {
     static let tr = DiskImageInstallerStrings(
         title: "Disk görüntüsü yükleyicisi",
         hubDescription: "Disk görüntüsündeki tek uygulamayı yükle ve indirilen dosyayı temizle",
+        useUserApplications: "Uygulamaları ~/Applications klasörüne yükle",
         promptTitle: "Bu uygulama yüklensin mi?",
         promptBodyFormat: "%@ Uygulamalar'a kopyalanacak. Ardından disk görüntüsü çıkarılacak ve indirilen dosya Çöp Sepeti'ne taşınacak.",
         installButton: "Yükle",
@@ -91,6 +95,7 @@ extension DiskImageInstallerStrings {
     static let ru = DiskImageInstallerStrings(
         title: "Установка из образа диска",
         hubDescription: "Установите единственное приложение из образа диска и удалите загрузку",
+        useUserApplications: "Устанавливать приложения в ~/Applications",
         promptTitle: "Установить это приложение?",
         promptBodyFormat: "%@ будет скопировано в папку «Программы». Затем образ диска будет извлечён, а загрузка перемещена в Корзину.",
         installButton: "Установить",
@@ -107,6 +112,7 @@ extension DiskImageInstallerStrings {
     static let es = DiskImageInstallerStrings(
         title: "Instalador de imágenes de disco",
         hubDescription: "Instala la única app de una imagen de disco y limpia la descarga",
+        useUserApplications: "Instalar apps en ~/Applications",
         promptTitle: "¿Instalar esta app?",
         promptBodyFormat: "%@ se copiará en Aplicaciones. Después, se expulsará la imagen de disco y la descarga irá a la Papelera.",
         installButton: "Instalar",
@@ -123,6 +129,7 @@ extension DiskImageInstallerStrings {
     static let de = DiskImageInstallerStrings(
         title: "Disk-Image-Installer",
         hubDescription: "Installiere die einzige App in einem Disk-Image und räume den Download auf",
+        useUserApplications: "Apps in ~/Applications installieren",
         promptTitle: "Diese App installieren?",
         promptBodyFormat: "%@ wird in Programme kopiert. Danach wird das Disk-Image ausgeworfen und der Download in den Papierkorb gelegt.",
         installButton: "Installieren",
@@ -139,6 +146,7 @@ extension DiskImageInstallerStrings {
     static let fr = DiskImageInstallerStrings(
         title: "Installation depuis une image disque",
         hubDescription: "Installez l'unique app d'une image disque et nettoyez le téléchargement",
+        useUserApplications: "Installer les apps dans ~/Applications",
         promptTitle: "Installer cette app ?",
         promptBodyFormat: "%@ sera copiée dans Applications. L'image disque sera ensuite éjectée et le téléchargement placé dans la Corbeille.",
         installButton: "Installer",
@@ -155,6 +163,7 @@ extension DiskImageInstallerStrings {
     static let it = DiskImageInstallerStrings(
         title: "Installazione da immagine disco",
         hubDescription: "Installa l'unica app di un'immagine disco e ripulisci il download",
+        useUserApplications: "Installa le app in ~/Applications",
         promptTitle: "Installare questa app?",
         promptBodyFormat: "%@ verrà copiata in Applicazioni. Poi l'immagine disco verrà espulsa e il download spostato nel Cestino.",
         installButton: "Installa",
@@ -171,6 +180,7 @@ extension DiskImageInstallerStrings {
     static let ja = DiskImageInstallerStrings(
         title: "ディスクイメージからインストール",
         hubDescription: "ディスクイメージ内の1つのアプリをインストールし、ダウンロードを片付けます",
+        useUserApplications: "アプリを ~/Applications にインストール",
         promptTitle: "このアプリをインストールしますか？",
         promptBodyFormat: "%@をアプリケーションにコピーします。その後、ディスクイメージを取り出し、ダウンロードをゴミ箱に移動します。",
         installButton: "インストール",
@@ -187,6 +197,7 @@ extension DiskImageInstallerStrings {
     static let ko = DiskImageInstallerStrings(
         title: "디스크 이미지 설치",
         hubDescription: "디스크 이미지 안의 단일 앱을 설치하고 다운로드를 정리합니다",
+        useUserApplications: "앱을 ~/Applications에 설치",
         promptTitle: "이 앱을 설치할까요?",
         promptBodyFormat: "%@을(를) 응용 프로그램에 복사합니다. 그런 다음 디스크 이미지를 추출하고 다운로드를 휴지통으로 이동합니다.",
         installButton: "설치",
@@ -203,6 +214,7 @@ extension DiskImageInstallerStrings {
     static let zhHans = DiskImageInstallerStrings(
         title: "磁盘映像安装器",
         hubDescription: "安装磁盘映像中的唯一应用，并清理下载文件",
+        useUserApplications: "将 App 安装到 ~/Applications",
         promptTitle: "安装此应用？",
         promptBodyFormat: "%@ 将复制到“应用程序”。随后会推出磁盘映像，并将下载文件移到废纸篓。",
         installButton: "安装",
@@ -219,6 +231,7 @@ extension DiskImageInstallerStrings {
     static let zhTW = DiskImageInstallerStrings(
         title: "磁碟映像檔安裝器",
         hubDescription: "安裝磁碟映像檔中的單一 App，並清理下載檔案",
+        useUserApplications: "將 App 安裝到 ~/Applications",
         promptTitle: "要安裝此 App 嗎？",
         promptBodyFormat: "%@ 將複製到「應用程式」。接著會退出磁碟映像檔，並將下載檔案移到垃圾桶。",
         installButton: "安裝",
@@ -235,6 +248,7 @@ extension DiskImageInstallerStrings {
     static let zhHK = DiskImageInstallerStrings(
         title: "磁碟映像檔安裝器",
         hubDescription: "安裝磁碟映像檔中的單一 App，並清理下載檔案",
+        useUserApplications: "將 App 安裝到 ~/Applications",
         promptTitle: "要安裝此 App 嗎？",
         promptBodyFormat: "%@ 將複製到「應用程式」。之後會退出磁碟映像檔，並將下載檔案移到垃圾桶。",
         installButton: "安裝",

--- a/Sources/Vorssaint/Services/DiskImageInstaller/DiskImageInstallerService.swift
+++ b/Sources/Vorssaint/Services/DiskImageInstaller/DiskImageInstallerService.swift
@@ -118,12 +118,21 @@ final class DiskImageInstallerService {
             else { return false }
             return Self.validBundle(at: url)
         }
+        let useUserApplications = UserDefaults.standard.bool(
+            forKey: DefaultsKey.diskImageInstallerUseUserApplications)
+        let applicationsDomain = DiskImageInstallerSupport.applicationsDomain(
+            useUserApplications: useUserApplications)
         guard apps.count == 1, let appURL = apps.first,
+              let applicationsURL = try? fm.url(for: .applicationDirectory,
+                                                in: applicationsDomain,
+                                                appropriateFor: nil,
+                                                create: true),
               let destinationURL = DiskImageInstallerSupport.destinationURL(
                 for: appURL,
-                applicationsURL: URL(fileURLWithPath: "/Applications", isDirectory: true)),
-              !fm.fileExists(atPath: destinationURL.path)
+                applicationsURL: applicationsURL)
         else { return nil }
+        guard Self.collisionURLs(for: appURL, fileManager: fm)
+            .allSatisfy({ !fm.fileExists(atPath: $0.path) }) else { return nil }
 
         let preferredName = Bundle(url: appURL)?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
         return Candidate(mountURL: mountURL,
@@ -169,7 +178,8 @@ final class DiskImageInstallerService {
 
     private func install(_ candidate: Candidate) -> InstallOutcome {
         let fm = FileManager.default
-        guard !fm.fileExists(atPath: candidate.destinationURL.path) else {
+        guard Self.collisionURLs(for: candidate.appURL, fileManager: fm)
+            .allSatisfy({ !fm.fileExists(atPath: $0.path) }) else {
             return .failed(.alreadyInstalled)
         }
 
@@ -198,7 +208,8 @@ final class DiskImageInstallerService {
         }
 
         do {
-            guard !fm.fileExists(atPath: candidate.destinationURL.path) else {
+            guard Self.collisionURLs(for: candidate.appURL, fileManager: fm)
+                .allSatisfy({ !fm.fileExists(atPath: $0.path) }) else {
                 return .failed(.alreadyInstalled)
             }
             try fm.moveItem(at: stagedApp, to: candidate.destinationURL)
@@ -221,6 +232,20 @@ final class DiskImageInstallerService {
         } catch {
             return .installedKeepingDownload
         }
+    }
+
+    private static func collisionURLs(for appURL: URL,
+                                      fileManager fm: FileManager) -> [URL] {
+        let domains: [FileManager.SearchPathDomainMask] = [.localDomainMask, .userDomainMask]
+        let applicationsURLs: [URL] = domains.compactMap { domain -> URL? in
+            guard let applicationsURL = try? fm.url(for: .applicationDirectory,
+                                                    in: domain,
+                                                    appropriateFor: nil,
+                                                    create: false) else { return nil }
+            return applicationsURL
+        }
+        return DiskImageInstallerSupport.destinationURLs(for: appURL,
+                                                         applicationsURLs: applicationsURLs)
     }
 
     private func present(outcome: InstallOutcome, candidate: Candidate) {

--- a/Sources/Vorssaint/Services/DiskImageInstaller/DiskImageInstallerService.swift
+++ b/Sources/Vorssaint/Services/DiskImageInstaller/DiskImageInstallerService.swift
@@ -18,7 +18,6 @@ final class DiskImageInstallerService {
         let appURL: URL
         let imageURL: URL
         let imageIdentity: FileIdentity
-        let destinationURL: URL
         let displayName: String
     }
 
@@ -33,6 +32,11 @@ final class DiskImageInstallerService {
         case installedKeepingMount
         case installedKeepingDownload
         case failed(InstallFailure)
+    }
+
+    private struct InstallResult {
+        let outcome: InstallOutcome
+        let destinationURL: URL?
     }
 
     private struct CommandResult {
@@ -120,26 +124,18 @@ final class DiskImageInstallerService {
         }
         let useUserApplications = UserDefaults.standard.bool(
             forKey: DefaultsKey.diskImageInstallerUseUserApplications)
-        let applicationsDomain = DiskImageInstallerSupport.applicationsDomain(
-            useUserApplications: useUserApplications)
         guard apps.count == 1, let appURL = apps.first,
-              let applicationsURL = try? fm.url(for: .applicationDirectory,
-                                                in: applicationsDomain,
-                                                appropriateFor: nil,
-                                                create: true),
-              let destinationURL = DiskImageInstallerSupport.destinationURL(
-                for: appURL,
-                applicationsURL: applicationsURL)
+              let collisionURLs = Self.collisionURLs(for: appURL,
+                                                      useUserApplications: useUserApplications,
+                                                      fileManager: fm),
+              collisionURLs.allSatisfy({ !fm.fileExists(atPath: $0.path) })
         else { return nil }
-        guard Self.collisionURLs(for: appURL, fileManager: fm)
-            .allSatisfy({ !fm.fileExists(atPath: $0.path) }) else { return nil }
 
         let preferredName = Bundle(url: appURL)?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
         return Candidate(mountURL: mountURL,
                          appURL: appURL,
                          imageURL: imageURL,
                          imageIdentity: imageIdentity,
-                         destinationURL: destinationURL,
                          displayName: DiskImageInstallerSupport.displayName(preferred: preferredName,
                                                                             appURL: appURL))
     }
@@ -163,9 +159,10 @@ final class DiskImageInstallerService {
         }
 
         workQueue.async { [weak self] in
-            let outcome = self?.install(candidate) ?? .failed(.copy)
+            let result = self?.install(candidate)
+                ?? InstallResult(outcome: .failed(.copy), destinationURL: nil)
             DispatchQueue.main.async { [weak self] in
-                self?.present(outcome: outcome, candidate: candidate)
+                self?.present(result: result, candidate: candidate)
                 self?.finishCurrentCandidate()
             }
         }
@@ -176,21 +173,39 @@ final class DiskImageInstallerService {
         presentNextCandidate()
     }
 
-    private func install(_ candidate: Candidate) -> InstallOutcome {
+    private func install(_ candidate: Candidate) -> InstallResult {
         let fm = FileManager.default
-        guard Self.collisionURLs(for: candidate.appURL, fileManager: fm)
-            .allSatisfy({ !fm.fileExists(atPath: $0.path) }) else {
-            return .failed(.alreadyInstalled)
+        let useUserApplications = UserDefaults.standard.bool(
+            forKey: DefaultsKey.diskImageInstallerUseUserApplications)
+        let applicationsDomain = DiskImageInstallerSupport.applicationsDomain(
+            useUserApplications: useUserApplications)
+        guard let applicationsURL = try? fm.url(for: .applicationDirectory,
+                                                in: applicationsDomain,
+                                                appropriateFor: nil,
+                                                create: true),
+              let destinationURL = DiskImageInstallerSupport.destinationURL(
+                for: candidate.appURL,
+                applicationsURL: applicationsURL),
+              let collisionURLs = Self.collisionURLs(for: candidate.appURL,
+                                                      useUserApplications: useUserApplications,
+                                                      fileManager: fm),
+              collisionURLs.contains(destinationURL)
+        else {
+            return InstallResult(outcome: .failed(.copy), destinationURL: nil)
+        }
+        guard collisionURLs.allSatisfy({ !fm.fileExists(atPath: $0.path) }) else {
+            return InstallResult(outcome: .failed(.alreadyInstalled),
+                                 destinationURL: destinationURL)
         }
 
         let stagingDirectory: URL
         do {
             stagingDirectory = try fm.url(for: .itemReplacementDirectory,
                                           in: .userDomainMask,
-                                          appropriateFor: candidate.destinationURL.deletingLastPathComponent(),
+                                          appropriateFor: destinationURL.deletingLastPathComponent(),
                                           create: true)
         } catch {
-            return .failed(.copy)
+            return InstallResult(outcome: .failed(.copy), destinationURL: destinationURL)
         }
         defer { try? fm.removeItem(at: stagingDirectory) }
 
@@ -201,58 +216,72 @@ final class DiskImageInstallerService {
             candidate.appURL.path, stagedApp.path,
         ])
         guard copy.status == 0, Self.validBundle(at: stagedApp) else {
-            return .failed(.copy)
+            return InstallResult(outcome: .failed(.copy), destinationURL: destinationURL)
         }
         guard Self.gatekeeperAccepts(stagedApp) else {
-            return .failed(.verification)
+            return InstallResult(outcome: .failed(.verification), destinationURL: destinationURL)
         }
 
         do {
-            guard Self.collisionURLs(for: candidate.appURL, fileManager: fm)
-                .allSatisfy({ !fm.fileExists(atPath: $0.path) }) else {
-                return .failed(.alreadyInstalled)
+            guard let finalCollisionURLs = Self.collisionURLs(
+                for: candidate.appURL,
+                useUserApplications: useUserApplications,
+                fileManager: fm),
+                finalCollisionURLs.contains(destinationURL)
+            else {
+                return InstallResult(outcome: .failed(.copy), destinationURL: destinationURL)
             }
-            try fm.moveItem(at: stagedApp, to: candidate.destinationURL)
+            guard finalCollisionURLs.allSatisfy({ !fm.fileExists(atPath: $0.path) }) else {
+                return InstallResult(outcome: .failed(.alreadyInstalled),
+                                     destinationURL: destinationURL)
+            }
+            try fm.moveItem(at: stagedApp, to: destinationURL)
         } catch {
-            return .failed(.copy)
+            return InstallResult(outcome: .failed(.copy), destinationURL: destinationURL)
         }
 
         do {
             try NSWorkspace.shared.unmountAndEjectDevice(at: candidate.mountURL)
         } catch {
-            return .installedKeepingMount
+            return InstallResult(outcome: .installedKeepingMount, destinationURL: destinationURL)
         }
 
         guard Self.fileIdentity(at: candidate.imageURL) == candidate.imageIdentity else {
-            return .installedKeepingDownload
+            return InstallResult(outcome: .installedKeepingDownload,
+                                 destinationURL: destinationURL)
         }
         do {
             try fm.trashItem(at: candidate.imageURL, resultingItemURL: nil)
-            return .installed
+            return InstallResult(outcome: .installed, destinationURL: destinationURL)
         } catch {
-            return .installedKeepingDownload
+            return InstallResult(outcome: .installedKeepingDownload,
+                                 destinationURL: destinationURL)
         }
     }
 
     private static func collisionURLs(for appURL: URL,
-                                      fileManager fm: FileManager) -> [URL] {
-        let domains: [FileManager.SearchPathDomainMask] = [.localDomainMask, .userDomainMask]
-        let applicationsURLs: [URL] = domains.compactMap { domain -> URL? in
+                                      useUserApplications: Bool,
+                                      fileManager fm: FileManager) -> [URL]? {
+        let domains = DiskImageInstallerSupport.collisionDomains(
+            useUserApplications: useUserApplications)
+        var applicationsURLs: [URL] = []
+        for domain in domains {
             guard let applicationsURL = try? fm.url(for: .applicationDirectory,
                                                     in: domain,
                                                     appropriateFor: nil,
                                                     create: false) else { return nil }
-            return applicationsURL
+            applicationsURLs.append(applicationsURL)
         }
         return DiskImageInstallerSupport.destinationURLs(for: appURL,
                                                          applicationsURLs: applicationsURLs)
     }
 
-    private func present(outcome: InstallOutcome, candidate: Candidate) {
+    private func present(result: InstallResult, candidate: Candidate) {
         let strings = FeatureStrings.diskImageInstaller(L10n.shared.language)
         let alert = NSAlert()
-        alert.icon = NSWorkspace.shared.icon(forFile: candidate.destinationURL.path)
-        switch outcome {
+        alert.icon = NSWorkspace.shared.icon(forFile: result.destinationURL?.path
+                                              ?? candidate.appURL.path)
+        switch result.outcome {
         case .installed:
             alert.messageText = strings.installedTitle
             alert.informativeText = String(format: strings.installedBodyFormat, candidate.displayName)

--- a/Sources/Vorssaint/Services/DiskImageInstaller/DiskImageInstallerSupport.swift
+++ b/Sources/Vorssaint/Services/DiskImageInstaller/DiskImageInstallerSupport.swift
@@ -34,8 +34,18 @@ enum DiskImageInstallerSupport {
         useUserApplications ? .userDomainMask : .localDomainMask
     }
 
-    static func destinationURLs(for appURL: URL, applicationsURLs: [URL]) -> [URL] {
-        applicationsURLs.compactMap { destinationURL(for: appURL, applicationsURL: $0) }
+    static func collisionDomains(
+        useUserApplications: Bool
+    ) -> [FileManager.SearchPathDomainMask] {
+        useUserApplications ? [.localDomainMask, .userDomainMask] : [.localDomainMask]
+    }
+
+    static func destinationURLs(for appURL: URL, applicationsURLs: [URL]) -> [URL]? {
+        guard !applicationsURLs.isEmpty else { return nil }
+        let destinations = applicationsURLs.compactMap {
+            destinationURL(for: appURL, applicationsURL: $0)
+        }
+        return destinations.count == applicationsURLs.count ? destinations : nil
     }
 
     static func destinationURL(for appURL: URL, applicationsURL: URL) -> URL? {

--- a/Sources/Vorssaint/Services/DiskImageInstaller/DiskImageInstallerSupport.swift
+++ b/Sources/Vorssaint/Services/DiskImageInstaller/DiskImageInstallerSupport.swift
@@ -30,6 +30,14 @@ enum DiskImageInstallerSupport {
         return url
     }
 
+    static func applicationsDomain(useUserApplications: Bool) -> FileManager.SearchPathDomainMask {
+        useUserApplications ? .userDomainMask : .localDomainMask
+    }
+
+    static func destinationURLs(for appURL: URL, applicationsURLs: [URL]) -> [URL] {
+        applicationsURLs.compactMap { destinationURL(for: appURL, applicationsURL: $0) }
+    }
+
     static func destinationURL(for appURL: URL, applicationsURL: URL) -> URL? {
         let name = appURL.lastPathComponent
         guard appURL.pathExtension.caseInsensitiveCompare("app") == .orderedSame,

--- a/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
@@ -241,7 +241,20 @@ private struct FeatureHubRow: View {
         }
     }
 
+    @ViewBuilder
     var body: some View {
+        if installed, feature == .diskImageInstaller {
+            VStack(alignment: .leading, spacing: 8) {
+                primaryRow
+                DiskImageInstallerDestinationToggle()
+                    .padding(.leading, 40)
+            }
+        } else {
+            primaryRow
+        }
+    }
+
+    private var primaryRow: some View {
         HStack(spacing: 10) {
             if installed, feature.hasNavigableSettingsDestination {
                 Button {
@@ -345,6 +358,19 @@ private struct FeatureHubRow: View {
             }
             working = false
         }
+    }
+}
+
+private struct DiskImageInstallerDestinationToggle: View {
+    @ObservedObject private var l10n = L10n.shared
+    @AppStorage(DefaultsKey.diskImageInstallerUseUserApplications)
+    private var useUserApplications = false
+
+    var body: some View {
+        Toggle(FeatureStrings.diskImageInstaller(l10n.language).useUserApplications,
+               isOn: $useUserApplications)
+            .font(.caption)
+            .controlSize(.small)
     }
 }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -10190,7 +10190,7 @@ struct MetricsTests {
         for language in AppLanguage.allCases {
             let strings = FeatureStrings.diskImageInstaller(language)
             let values = Mirror(reflecting: strings).children.compactMap { $0.value as? String }
-            expect(values.count == 13 && values.allSatisfy { !$0.isEmpty },
+            expect(values.count == 14 && values.allSatisfy { !$0.isEmpty },
                    "disk image installer has every localized field for \(language.rawValue)")
             expect(values.allSatisfy { !$0.contains("—") },
                    "disk image installer text uses human punctuation for \(language.rawValue)")
@@ -10234,6 +10234,27 @@ struct MetricsTests {
             applicationsURL: URL(fileURLWithPath: "/Applications", isDirectory: true))?.path
             == "/Applications/Example.app",
             "a top-level app gets one fixed Applications destination")
+        expect(DiskImageInstallerSupport.destinationURL(
+            for: URL(fileURLWithPath: "/Volumes/Installer/Example.app"),
+            applicationsURL: URL(fileURLWithPath: "/Users/test/Applications",
+                                 isDirectory: true))?.path
+            == "/Users/test/Applications/Example.app",
+            "the installer support accepts the current user's Applications directory")
+        expect(DiskImageInstallerSupport.applicationsDomain(useUserApplications: false)
+                == .localDomainMask
+                && DiskImageInstallerSupport.applicationsDomain(useUserApplications: true)
+                == .userDomainMask,
+               "the disk image setting selects the system or user application domain")
+        let installerDestinations = DiskImageInstallerSupport.destinationURLs(
+            for: URL(fileURLWithPath: "/Volumes/Installer/Example.app"),
+            applicationsURLs: [
+                URL(fileURLWithPath: "/Applications", isDirectory: true),
+                URL(fileURLWithPath: "/Users/test/Applications", isDirectory: true),
+            ])
+        expect(installerDestinations.map(\.path) == [
+            "/Applications/Example.app",
+            "/Users/test/Applications/Example.app",
+        ], "the already-installed guard covers both application directories")
         expect(DiskImageInstallerSupport.destinationURL(
             for: URL(fileURLWithPath: "/Volumes/Installer/.Hidden.app"),
             applicationsURL: URL(fileURLWithPath: "/Applications", isDirectory: true)) == nil,
@@ -14326,6 +14347,10 @@ struct MetricsTests {
         expect(Defaults.registeredDefaults[DefaultsKey.finderPasteImageAsFile] as? Bool == false
                 && backupKeys.contains(DefaultsKey.finderPasteImageAsFile),
                "pasting copied images as files is opt-in and travels with settings backup")
+        expect(Defaults.registeredDefaults[
+            DefaultsKey.diskImageInstallerUseUserApplications] as? Bool == false
+                && backupKeys.contains(DefaultsKey.diskImageInstallerUseUserApplications),
+               "installing disk-image apps for the current user is opt-in and travels with settings backup")
         expect(Defaults.registeredDefaults[DefaultsKey.finderCutPasteShowHUD] as? Bool == true
                 && backupKeys.contains(DefaultsKey.finderCutPasteShowHUD),
                "the Finder cut and paste floating panel default is on and travels with settings backup")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -10245,16 +10245,25 @@ struct MetricsTests {
                 && DiskImageInstallerSupport.applicationsDomain(useUserApplications: true)
                 == .userDomainMask,
                "the disk image setting selects the system or user application domain")
+        expect(DiskImageInstallerSupport.collisionDomains(useUserApplications: false)
+                == [.localDomainMask]
+                && DiskImageInstallerSupport.collisionDomains(useUserApplications: true)
+                == [.localDomainMask, .userDomainMask],
+               "only the opt-in installer checks both application domains for collisions")
         let installerDestinations = DiskImageInstallerSupport.destinationURLs(
             for: URL(fileURLWithPath: "/Volumes/Installer/Example.app"),
             applicationsURLs: [
                 URL(fileURLWithPath: "/Applications", isDirectory: true),
                 URL(fileURLWithPath: "/Users/test/Applications", isDirectory: true),
             ])
-        expect(installerDestinations.map(\.path) == [
+        expect(installerDestinations?.map(\.path) == [
             "/Applications/Example.app",
             "/Users/test/Applications/Example.app",
         ], "the already-installed guard covers both application directories")
+        expect(DiskImageInstallerSupport.destinationURLs(
+            for: URL(fileURLWithPath: "/Volumes/Installer/Example.app"),
+            applicationsURLs: []) == nil,
+            "missing application-domain resolutions fail closed")
         expect(DiskImageInstallerSupport.destinationURL(
             for: URL(fileURLWithPath: "/Volumes/Installer/.Hidden.app"),
             applicationsURL: URL(fileURLWithPath: "/Applications", isDirectory: true)) == nil,


### PR DESCRIPTION
## Summary

Adds an optional, remembered choice in the disk image install prompt to install apps into the Applications folder inside the current user’s home folder.

- Installation into `/Applications` remains the default.
- The home-folder choice appears alongside the existing Trash download and Show app choices, with no additional control in Features settings.
- The prompt updates when the destination choice changes, and completion messages identify the folder used.
- Show app reveals the actual installed copy in Finder.
- Mount inspection does not create the home Applications folder. Installation creates it only after the user confirms.
- Default collision checks remain scoped to `/Applications`; the home-folder option checks both destinations. Required directory-resolution failures prevent installation.

The change extends the existing installer and remembered-choice mechanism. It adds no runtime dependency or background process. New user-facing text is included in all 13 supported languages.

## Verification

Tested on an Apple silicon MacBook Air using the locally built app and the English app language.

Automated verification:

- `./build.sh --test` — `TESTS OK (52978 checks)`
- `./build.sh` — completed without compiler warnings
- `./build/Vorssaint --selftest` — `SELFTEST OK`
- `git diff --check` — clean
- Regression coverage checks destination selection, collision scope, unavailable directory results, and missing-folder detection without creating directories.

Manual verification using the official Rectangle disk image:

- Installed into `/Applications` with the home-folder option off.
- Installed into `~/Applications` with the option on.
- Confirmed that prompt and completion wording identify the selected destination.
- Confirmed that Finder selects the copy installed at that destination.
- Confirmed that the home-folder choice remains selected after quitting and reopening the app.
- Confirmed that cancellation leaves the app uninstalled.
- Temporarily renamed the existing home Applications folder and verified that the prompt still appears with the remembered home-folder option on.
- Confirmed that cancellation leaves the folder absent, while installation creates it and reveals the installed app.
- Removed the test installation and restored the original folder afterward.

The source DMG was retained during these tests. I did not visually inspect every translation or test on Intel hardware or a separate macOS user account.

## Anything else

Refs #798