### PR TITLE
fix(monitor): stop stranded subprocess waits from starving the dispatch pool and freezing the app

### DIFF
--- a/Sources/Vorssaint/Services/BoundedProcessRunner.swift
+++ b/Sources/Vorssaint/Services/BoundedProcessRunner.swift
@@ -59,18 +59,22 @@ enum BoundedProcessRunner {
             }
         }
 
+        // waitUntilExit parked on a global-pool thread has been observed never
+        // returning even after the child was dead and reaped (#971). Every lost
+        // wakeup stranded one pool worker, and frequent spawners (the nettop
+        // fallback runs ~1800 times an hour) starved the 64-thread soft limit
+        // within hours. The termination handler is delivered on Foundation's
+        // own reaper queue, so a lost exit event can cost at most this call's
+        // timeout — never a thread.
+        let finished = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in finished.signal() }
+
         do {
             try process.run()
         } catch {
             reader.readabilityHandler = nil
             try? reader.close()
             return Result(status: -1, output: Data(), timedOut: false)
-        }
-
-        let finished = DispatchSemaphore(value: 0)
-        DispatchQueue.global(qos: .utility).async {
-            process.waitUntilExit()
-            finished.signal()
         }
 
         var didFinish = finished.wait(timeout: .now() + max(0, timeout)) == .success

--- a/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
@@ -29,6 +29,10 @@ enum WindowEnumerator {
     /// tree within the process thread budget while collapsing it into a few
     /// bounded AX batches.
     private static let maximumConcurrentQueries = 24
+    /// Generous against the messaging timeouts above even with every batch
+    /// pathologically slow; only a dispatch pool with no thread to give (#971)
+    /// can outlast it, and then the freeze is theirs, not ours.
+    private static let accessibilityQueryDeadline: TimeInterval = 5.0
 
     static func listWindows(groupByApp: Bool = UserDefaults.standard.bool(forKey: DefaultsKey.switcherMergeTabs),
                             preservingGroupedWindows: Bool = false) -> [SwitcherItem] {
@@ -431,8 +435,11 @@ enum WindowEnumerator {
         let queryQueue = OperationQueue()
         queryQueue.qualityOfService = .userInteractive
         queryQueue.maxConcurrentOperationCount = min(maximumConcurrentQueries, orderedPIDs.count)
+        let pending = DispatchGroup()
         for pid in orderedPIDs {
+            pending.enter()
             queryQueue.addOperation {
+                defer { pending.leave() }
                 guard let windows = accessibilityWindows(
                     for: pid,
                     bundleIdentifier: bundleIdentifiers[pid],
@@ -444,7 +451,18 @@ enum WindowEnumerator {
                 resultLock.unlock()
             }
         }
-        queryQueue.waitUntilAllOperationsAreFinished()
+        // The operations need dispatch-pool threads; when the pool is starved
+        // (#971 stranded 64 workers in dead waitUntilExit calls) an unbounded
+        // wait here parked the caller forever — and Dock Preview and the
+        // switcher both enumerate from the main thread, so the whole app froze
+        // with it. The AX calls themselves are bounded by messaging timeouts,
+        // so a wait this long only means no thread will ever run them: hand
+        // back whatever finished instead of the whole app.
+        if pending.wait(timeout: .now() + accessibilityQueryDeadline) == .timedOut {
+            queryQueue.cancelAllOperations()
+        }
+        resultLock.lock()
+        defer { resultLock.unlock() }
         return result
     }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9811,6 +9811,59 @@ struct MetricsTests {
         expect(timedOutProcess.timedOut && timedOutProcess.status == -1
                 && Date().timeIntervalSince(timeoutStarted) < 1.5,
                "a stalled subprocess is terminated inside its deadline")
+        // #971: waitUntilExit parked on a pool thread stranded one worker per
+        // lost exit wakeup until the 64-thread soft limit froze the app, and
+        // the window enumerator then parked the main thread on that same pool
+        // with no deadline. Exits must ride the termination handler and the
+        // enumerator's fan-out wait must expire, so a starved pool degrades to
+        // a short window list instead of a dead app.
+        let runnerSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/BoundedProcessRunner.swift",
+            encoding: .utf8)) ?? ""
+        let runnerCode = runnerSource
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(!runnerCode.isEmpty && !runnerCode.contains("waitUntilExit")
+                && runnerCode.contains("terminationHandler"),
+               "subprocess exits are observed without parking a dispatch worker")
+        let enumeratorSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift",
+            encoding: .utf8)) ?? ""
+        let enumeratorCode = enumeratorSource
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(!enumeratorCode.isEmpty
+                && !enumeratorCode.contains("waitUntilAllOperationsAreFinished")
+                && enumeratorCode.contains("pending.wait(timeout: .now() + accessibilityQueryDeadline)"),
+               "window enumeration cannot park its caller behind a starved pool")
+        let concurrentGroup = DispatchGroup()
+        var concurrentResults = [BoundedProcessRunner.Result?](repeating: nil, count: 8)
+        let concurrentLock = NSLock()
+        let concurrentStarted = Date()
+        for index in 0..<8 {
+            concurrentGroup.enter()
+            Thread.detachNewThread {
+                let result = BoundedProcessRunner.run(
+                    "/usr/bin/printf", ["\(index)"], timeout: 5, maxOutputBytes: 16)
+                concurrentLock.lock()
+                concurrentResults[index] = result
+                concurrentLock.unlock()
+                concurrentGroup.leave()
+            }
+        }
+        let concurrentOutputs: () -> Set<String> = {
+            concurrentLock.lock()
+            defer { concurrentLock.unlock() }
+            return Set(concurrentResults.compactMap { result in
+                result.map { String(decoding: $0.output, as: UTF8.self) }
+            })
+        }
+        expect(concurrentGroup.wait(timeout: .now() + 10) == .success
+                && Date().timeIntervalSince(concurrentStarted) < 8
+                && concurrentOutputs().count == 8,
+               "concurrent subprocess runs each exit cleanly with their own output")
 
         var networkDelta = NetworkProcessDeltaTracker(maxGap: 10)
         let baselineNetwork = [


### PR DESCRIPTION
Refs #971 (candidate fix — the freeze needs hours of uptime to reproduce; the mechanism below is verified with a runtime harness).

## What was wrong

Two halves, each harmless alone:

1. `BoundedProcessRunner.run` parked one global-pool worker in `Process.waitUntilExit()` per child. Its caller-side timeout kills the child but abandons the worker, so any wait that never returns — the reporter sampled exactly that, `waitUntilExit` still parked after its child was dead and reaped — strands the thread forever. With the menu-bar Network metric's `nettop` fallback latched at a 2s interval (~1800 spawns/hour), stranded workers accumulate until the dispatch pool's 64-thread soft limit is reached. The reporter's sample shows `Dispatch Thread Soft Limit: 64 reached in 3643 of 3648 samples`.
2. `WindowEnumerator` fanned AX queries out on an `OperationQueue` and blocked the caller in `waitUntilAllOperationsAreFinished()`. The operations need pool threads; with the pool starved they never start, and the wait never ends. Dock Preview enumerates from the main thread (`DockPreviewService.beginSession`), so the first hover after exhaustion froze the app for good — matching the reporter's main-thread stack. The App Switcher's `beginPendingSession` also enumerates on the main thread (answering the open question in the report: it is dispatched to main from the tap route), so the switcher was a second door into the same freeze.

## The change

- Child exits are now observed through `terminationHandler`, delivered on Foundation's own reaper queue: an in-flight child costs zero pool threads, and a lost exit notification costs at most that call's timeout instead of a thread. The timeout → `terminate()` → `SIGKILL` escalation is unchanged.
- The enumerator's fan-out wait is now a `DispatchGroup.wait` with a 5s deadline — generous against the 0.2s per-app / 0.35s per-window AX messaging ceilings, so it only expires when no thread will ever run the queries. On expiry it returns the snapshots that finished instead of parking the caller.

## Verification

`./build.sh` with zero warnings, `./build.sh --test` → TESTS OK (8544 checks), `./build/Vorssaint --selftest` → SELFTEST OK. A standalone harness running 70 concurrent 1s children and measuring mach task threads mid-flight: the old runner parks 78 threads beyond the callers; this one parks none, with identical results, statuses and timeout behavior. Tests pin the mechanism (no `waitUntilExit`, handler-based exits; deadline-bounded enumeration wait) and add a concurrent-run semantics check.

The `nettop` fallback staying latched on an interface whose inbound counter never advances is a separate topic this PR deliberately leaves alone.
