### PR TITLE
fix(display): decide the display power button without asking the display server

### DIFF
--- a/Sources/Vorssaint/Services/Display/BrightnessService.swift
+++ b/Sources/Vorssaint/Services/Display/BrightnessService.swift
@@ -58,6 +58,14 @@ final class BrightnessService: ObservableObject {
                                     category: "display")
 
     @Published private(set) var displays: [BrightnessDisplay] = []
+    /// The displays that currently put a picture in front of a person, as the
+    /// last rebuild found them. The panel decides from this snapshot instead
+    /// of asking the display server itself: `canToggleDisplay` is read from a
+    /// SwiftUI body, and a body is laid out again from inside the display
+    /// reconfiguration this app drives on the main thread, where a question
+    /// for the display server is one the same thread is already busy
+    /// answering (issue #969).
+    @Published private(set) var drawableDisplays = Set<CGDirectDisplayID>()
     @Published private(set) var pendingDisplayIDs = Set<CGDirectDisplayID>()
     @Published private(set) var displayControlFailure: DisplayControlFailure?
     @Published private(set) var brightnessOSDSupported = false
@@ -285,6 +293,7 @@ final class BrightnessService: ObservableObject {
         brightnessOSDSupported = false
         BrightnessOSD.teardown()
         if !displays.isEmpty { displays = [] }
+        if !drawableDisplays.isEmpty { drawableDisplays = [] }
         // Queue on the work queue first so this lands AFTER any operation
         // already in flight, then hand the reconfigurations to the main
         // thread, which is the only place they may run (see
@@ -382,12 +391,8 @@ final class BrightnessService: ObservableObject {
     func canToggleDisplay(_ display: BrightnessDisplay) -> Bool {
         guard displaySwitchingAvailable, !isDisplayPending(display.id) else { return false }
         guard display.isActive else { return true }
-        stateLock.lock()
-        let online = knownTopology
-        let active = knownActiveTopology
-        stateLock.unlock()
-        let drawable = Self.drawableDisplayIDs(online: online, active: active)
-        return BrightnessSupport.canDisableDisplay(drawableDisplayIDs: drawable, target: display.id)
+        return BrightnessSupport.canDisableDisplay(drawableDisplayIDs: drawableDisplays,
+                                                  target: display.id)
     }
 
     /// Enables or disables one connected display without changing the saved
@@ -1189,12 +1194,17 @@ final class BrightnessService: ObservableObject {
         var built: [BrightnessDisplay] = []
         var newRoutes: [CGDirectDisplayID: Route] = [:]
         var ddcCandidates: [(index: Int, identity: BrightnessSupport.DisplayIdentity)] = []
+        var virtualIDs = Set<CGDirectDisplayID>()
 
         for id in onlineIDs {
+            let info = Self.displayInfoDictionary(id)
+            // Read before the mirroring guard below, so the snapshot the panel
+            // decides from covers every online display, exactly like the live
+            // reading it replaces.
+            if (info?["kCGDisplayIsVirtualDevice"] as? Bool ?? false) { virtualIDs.insert(id) }
             // A mirroring display follows its source; the source's slider is
             // the real control.
             guard CGDisplayMirrorsDisplay(id) == 0 else { continue }
-            let info = Self.displayInfoDictionary(id)
             if let info,
                (info["kCGDisplayIsVirtualDevice"] as? Bool ?? false)
                 || (info["kCGDisplayIsAirPlay"] as? Bool ?? false) {
@@ -1251,6 +1261,10 @@ final class BrightnessService: ObservableObject {
                                            brightness: 0.5, readable: false))
         }
 
+        let drawableIDs = BrightnessSupport.drawableDisplayIDs(
+            onlineDisplayIDs: seenTopology, activeDisplayIDs: activeTopology,
+            virtualDisplayIDs: virtualIDs)
+
         stateLock.lock()
         let disabledSnapshots = managedDisabledDisplays
         // Still the previous rebuild's set at this point: what was not in it
@@ -1288,6 +1302,7 @@ final class BrightnessService: ObservableObject {
             DispatchQueue.main.async { [weak self] in
                 guard let self, self.running, generation == self.rebuildGeneration else { return }
                 if self.displays != discovered { self.displays = discovered }
+                if self.drawableDisplays != drawableIDs { self.drawableDisplays = drawableIDs }
             }
         }
 
@@ -1468,6 +1483,7 @@ final class BrightnessService: ObservableObject {
         DispatchQueue.main.async { [weak self] in
             guard let self, self.running, generation == self.rebuildGeneration else { return }
             if self.displays != resolved { self.displays = resolved }
+            if self.drawableDisplays != drawableIDs { self.drawableDisplays = drawableIDs }
             if self.brightnessOSDSupported != supportsBrightnessOSD {
                 self.brightnessOSDSupported = supportsBrightnessOSD
             }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11409,6 +11409,27 @@ struct MetricsTests {
                && lockedRegions.allSatisfy { !$0.contains("SwitchedOff(") },
                "the list of displays switched off is never written while stateLock is held")
 
+        // The same transaction relays its screen change to AppKit inline, and
+        // switching off the display the panel is on makes AppKit lay that panel
+        // out again right there: the power button's body is evaluated while
+        // this app holds the display server busy, so anything it asks the
+        // display server is a question the same thread is still answering, and
+        // the app freezes with nothing left that can end it (issue #969). The
+        // body decides from the published snapshot instead, and the live
+        // reading stays where it guards the switch itself. Comments are
+        // stripped first: a note naming what it bans is not a call.
+        let canToggleCode = ((brightnessSource
+            .components(separatedBy: "func canToggleDisplay(").last ?? "")
+            .components(separatedBy: "\n    }").first ?? "")
+            .components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(!canToggleCode.isEmpty
+               && canToggleCode.contains("drawableDisplays")
+               && !canToggleCode.contains("Self.drawableDisplayIDs(")
+               && !canToggleCode.contains("stateLock"),
+               "the panel reads whether a display can be switched off without asking the display server")
+
         expect(BrightnessSupport.ddcCommandDelay(nowMicroseconds: 1_000_000,
                                                  lastCommandEndMicroseconds: nil) == 0,
                "the first DDC command to a display waits nothing")


### PR DESCRIPTION
Candidate fix for #969 — reasoned from the code, not reproduced; I have no second display here.

## Problem

With an external display connected, opening the Displays section and pressing off on the built-in display freezes the app — beachball, "not responding" (reported on 3.3.2, macOS 27). Switching off an external display is fine, and with no external display the button is correctly disabled, which is why only this exact combination hangs.

## Root cause

A display power change runs its reconfiguration transaction synchronously on the main thread, which is where it has to run: CoreGraphics relays the change to AppKit inline on the thread driving the transaction (#747, #762). Switching off the built-in display is the case where that inline work has to move the open panel off the display that is going away and lay it out again, right there inside the transaction.

That layout evaluates `DisplayPowerButton`'s body, and the body called `canToggleDisplay`, which asked the display server for each display's info dictionary (`CoreDisplay_DisplayCreateInfoDictionary`) to filter out virtual devices. So the main thread put a question to the display server about the display it was, at that moment, still busy switching off. Nothing can answer it and nothing can time it out: the transaction cannot finish because its own callback never returns.

## The change

The set of displays that actually put a picture in front of a person is now published by the rebuild that already reads every display's info dictionary, and `canToggleDisplay` reads that snapshot. The body no longer touches the display server or the state lock.

The live reading stays exactly where it guards the switch itself — `toggleDisplay` still checks it before starting, the work queue checks it again against live topology, and headless recovery is untouched — so a stale snapshot can only make the button look more conservative, never let the last drawable display be switched off.

## Verification

`./build.sh` with zero warnings, `./build.sh --test` → TESTS OK (8542 checks), `./build/Vorssaint --selftest` → SELFTEST OK. `BrightnessService.swift` is not in the test binary, so the shape is pinned in `Tests/MetricsTests.swift` next to the existing display pins: the body of `canToggleDisplay` may not ask the display server or take the state lock. Reverting the change turns that pin red.

@dmitryuchkin, could you check whether switching off the built-in display from the Displays section still freezes the app on this build?

Refs #747
Refs #969
