### PR TITLE
fix(keep-awake): grant the closed-lid sudoers rule by uid so any short username works

### DIFF
--- a/Sources/Vorssaint/Services/ShellSupport.swift
+++ b/Sources/Vorssaint/Services/ShellSupport.swift
@@ -133,12 +133,6 @@ enum Sudoers {
         "/etc/sudoers.d/vorss-clamshell",
     ]
 
-    private static var safeUser: String? {
-        let user = NSUserName()
-        let valid = user.range(of: "^[A-Za-z0-9._-]+$", options: .regularExpression) != nil
-        return valid ? user : nil
-    }
-
     /// Serializes every touch of the SleepDisabled state. The probe below
     /// re-applies the value it just read; racing it against a concurrent
     /// disable (launch recovery, a session ending) could resurrect a stale
@@ -167,11 +161,10 @@ enum Sudoers {
     }
 
     static func install(completion: @escaping (Bool) -> Void) {
-        guard let user = safeUser else {
-            completion(false)
-            return
-        }
-        let rule = "\(user) ALL=(root) NOPASSWD: /usr/bin/pmset disablesleep 1, /usr/bin/pmset disablesleep 0"
+        // Granted by uid, not username: a short name is free-form text on
+        // SSO-enrolled Macs (name@company.com, #915) and the old validation
+        // rejected it before the password prompt could even appear.
+        let rule = SudoersSupport.clamshellRule(uid: getuid())
         // Clear any earlier-named rule first, then write and validate the new one
         // (a failed check rolls back). Same password prompt either way.
         let legacy = legacyRulePaths.joined(separator: " ")

--- a/Sources/Vorssaint/Services/SudoersSupport.swift
+++ b/Sources/Vorssaint/Services/SudoersSupport.swift
@@ -8,4 +8,13 @@ enum SudoersSupport {
     static func sleepDisabled(inPmsetOutput output: String) -> Bool {
         output.range(of: #"SleepDisabled\s+1"#, options: .regularExpression) != nil
     }
+
+    /// The closed-lid NOPASSWD rule, granted by uid (`#uid` user spec). A
+    /// username would have to be sanitized against sudoers *and* shell
+    /// metacharacters — short names on SSO-enrolled Macs can be full email
+    /// addresses (#915) — while a uid interpolates as bare digits, which
+    /// neither interpreter can read as anything else.
+    static func clamshellRule(uid: uid_t) -> String {
+        "#\(uid) ALL=(root) NOPASSWD: /usr/bin/pmset disablesleep 1, /usr/bin/pmset disablesleep 0"
+    }
 }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1569,6 +1569,17 @@ struct MetricsTests {
                "a pmset report with SleepDisabled 0 reads as lid sleep enabled")
         expect(!SudoersSupport.sleepDisabled(inPmsetOutput: ""),
                "an empty pmset report reads as lid sleep enabled")
+        // The rule is granted by uid so every short name works, including the
+        // email-style ones SSO enrollment produces (#915). The uid renders as
+        // bare digits and the rest is a fixed literal, so the whole line must
+        // stay inside a character set that neither sudoers nor a single-quoted
+        // shell string can read as anything but itself.
+        expect(SudoersSupport.clamshellRule(uid: 501)
+               == "#501 ALL=(root) NOPASSWD: /usr/bin/pmset disablesleep 1, /usr/bin/pmset disablesleep 0",
+               "the closed-lid sudoers rule grants pmset disablesleep to the uid")
+        expect(SudoersSupport.clamshellRule(uid: uid_t.max)
+               .range(of: #"^#[0-9]+ [A-Za-z0-9()=:,./ ]+$"#, options: .regularExpression) != nil,
+               "the closed-lid sudoers rule never contains shell or sudoers metacharacters")
         expect(registeredDefaults[DefaultsKey.switcherEnabled] as? Bool == true,
                "window switcher is on for clean installs")
         expect(registeredDefaults[DefaultsKey.switcherShortcut] as? String == "command:48",


### PR DESCRIPTION
Refs #915.

## What was wrong

"Keep going with lid closed" installs a NOPASSWD sudoers rule for `pmset disablesleep`, and guarded the username it interpolated with `^[A-Za-z0-9._-]+$`. On SSO-enrolled Macs (Entra ID / Jamf / Google Workspace) the short name can be a full email address; `@` fails the guard, `install` bails before the password prompt ever fires, and every later toggle runs `sudo -n` against a rule that was never written — exactly the instant, promptless "Couldn't turn on closed-lid mode" in the report. As the reporter showed with `visudo -c`, sudoers itself accepts these usernames: the guard was stricter than the thing it guarded.

## The change

The rule is now granted by uid using the standard sudoers `#uid` user spec, built from `getuid()`:

```
#501 ALL=(root) NOPASSWD: /usr/bin/pmset disablesleep 1, /usr/bin/pmset disablesleep 0
```

The username guard existed because the name passed through two interpreters — the sudoers grammar and the single-quoted shell string that writes the file. A uid interpolates as bare digits, which neither can read as anything else, so the guard moves into the construction instead of rejecting real accounts. This also grants to the account that actually runs `sudo -n` (the process uid), and it covers short names the old guard rejected beyond `@`. Widening the regex was rejected on purpose: `@` can take a user@host reading in sudoers, and ambiguity in a NOPASSWD grant is disqualifying.

Nothing else changes: the rule path is the same, install still validates with `visudo -c -f` and rolls back on failure, `isConfigured()` still proves the passwordless path by running it, and removal/uninstall are path-based — an existing username-form rule (including the issue's manual workaround) keeps working and is replaced on the next install.

## Verification

`./build.sh` with zero warnings, `./build.sh --test` → TESTS OK (8549 checks), `./build/Vorssaint --selftest` → SELFTEST OK. Tests pin the exact rule shape and that a rule for any uid stays inside a character set with no shell or sudoers metacharacters. `visudo -c -f` on generated rule files parses OK for the uid form (and, for the record, for the email-style username the old guard rejected). I don't have an SSO-enrolled account here, so the end-to-end confirmation that the prompt now appears on an email-style short name is one only the reporter's machine can give — but the rejection happened strictly before any system interaction, and that rejection is gone.

Ref #828

