### PR TITLE
fix(features): refuse an install the Mac has no hardware for

### DIFF
--- a/Sources/Vorssaint/App/FeatureRuntime.swift
+++ b/Sources/Vorssaint/App/FeatureRuntime.swift
@@ -47,11 +47,34 @@ final class FeatureRuntime: ObservableObject {
 
     var availableCount: Int { AppFeature.allCases.filter(\.isAvailable).count }
 
+    /// How many features this Mac can end up with. Counting against the whole
+    /// catalog instead would leave the hub's install-all button forever one
+    /// short of its own disabled condition on a Mac missing some hardware.
+    /// An install that predates the check still counts, so the tally can
+    /// never read more installed than installable.
+    var installableCount: Int {
+        AppFeature.allCases.filter { $0.isHardwareSupported || $0.isAvailable }.count
+    }
+
+    /// The one gate every install passes, whichever surface asks: the hub
+    /// row, the hub's install-all button, a preset and the first-run picker
+    /// all decide here. A feature the Mac cannot run never installs, so a
+    /// disabled row cannot be walked around from the button above it.
+    ///
+    /// Uninstalls are never refused and an existing install is never revoked:
+    /// the check reads hardware and can be wrong, and a wrong answer that
+    /// strands someone's settings costs far more than one that leaves a
+    /// feature reporting itself unsupported.
+    private func mayFlip(_ feature: AppFeature, to available: Bool) -> Bool {
+        guard feature.isAvailable != available else { return false }
+        return !available || feature.isHardwareSupported
+    }
+
     /// Flipping availability runs the feature's binding immediately: off
     /// tears every resource down on the spot, on restores whatever enabled
     /// state the feature had (its own keys are never touched).
     func setAvailable(_ feature: AppFeature, _ available: Bool) {
-        guard feature.isAvailable != available else { return }
+        guard mayFlip(feature, to: available) else { return }
         UserDefaults.standard.set(available, forKey: feature.availabilityKey)
         if available { loadedThisSession.insert(feature) }
         Self.bindings[feature]?()
@@ -74,7 +97,7 @@ final class FeatureRuntime: ObservableObject {
             UserDefaults.standard.set(true, forKey: key)
         }
         for feature in AppFeature.allCases
-        where feature.isAvailable != selected.contains(feature) {
+        where mayFlip(feature, to: selected.contains(feature)) {
             let joins = selected.contains(feature)
             UserDefaults.standard.set(joins, forKey: feature.availabilityKey)
             if joins { loadedThisSession.insert(feature) }
@@ -82,8 +105,10 @@ final class FeatureRuntime: ObservableObject {
         }
         // Features that stayed installed still need a sync: their enable
         // keys may have just flipped on. Syncs are idempotent, so a repeat
-        // for the ones handled above costs nothing.
-        for feature in selected {
+        // for the ones handled above costs nothing. A selected feature the
+        // gate refused is not installed, so it is skipped like any other
+        // unavailable one and its service never comes to life.
+        for feature in selected where feature.isAvailable {
             Self.bindings[feature]?()
         }
         revision += 1
@@ -93,7 +118,7 @@ final class FeatureRuntime: ObservableObject {
     /// bump, every changed feature's binding run.
     func setAllAvailable(_ available: Bool) {
         var changed = false
-        for feature in AppFeature.allCases where feature.isAvailable != available {
+        for feature in AppFeature.allCases where mayFlip(feature, to: available) {
             UserDefaults.standard.set(available, forKey: feature.availabilityKey)
             if available { loadedThisSession.insert(feature) }
             Self.bindings[feature]?()
@@ -229,5 +254,35 @@ final class FeatureRuntime: ObservableObject {
     private static func syncMonitor() {
         SystemMonitor.shared.planDidChange()
         MonitorAlertService.shared.syncWithPreferences()
+    }
+}
+
+/// Hardware a feature needs and this Mac may not have. One switch answers
+/// both questions, so a feature can never be unsupported without a reason to
+/// show for it, and a feature added here can never grey a row silently.
+/// It lives beside the runtime rather than in the catalog because the answer
+/// comes from a service, and the catalog stays a pure description.
+extension AppFeature {
+    /// Why this Mac cannot run the feature, ready to show. `nil` when it can,
+    /// or when the feature depends on no hardware at all.
+    var hardwareUnsupportedReason: String? {
+        switch self {
+        case .fanControl:
+            return FanControlHardware.hasControllableFan
+                ? nil : FeatureStrings.fanControl(L10n.shared.language).noFans
+        default:
+            return nil
+        }
+    }
+
+    var isHardwareSupported: Bool { hardwareUnsupportedReason == nil }
+
+    /// Why a feature list must refuse to install this feature, ready to show
+    /// as a tooltip. `nil` once it is installed: the check reads hardware and
+    /// can be wrong, so it is never allowed to strand an existing install
+    /// behind a greyed row. Both the hub and the first-run picker read this,
+    /// so neither can drift from the gate in `FeatureRuntime`.
+    var installBlockedReason: String? {
+        isAvailable ? nil : hardwareUnsupportedReason
     }
 }

--- a/Sources/Vorssaint/Services/FanControl/FanControlHardware.swift
+++ b/Sources/Vorssaint/Services/FanControl/FanControlHardware.swift
@@ -427,4 +427,13 @@ final class FanControlHardware {
         }
         return false
     }
+
+    /// Whether this Mac exposes a fan the app can actually drive. It asks the
+    /// same discovery the control path uses, so "controllable" means the very
+    /// keys a cooling write needs, not merely a reported fan count. Hardware
+    /// does not change under a running process, so the answer is computed once.
+    static let hasControllableFan: Bool = {
+        guard let hardware = FanControlHardware() else { return false }
+        return (try? hardware.discoverControlledFans())?.isEmpty == false
+    }()
 }

--- a/Sources/Vorssaint/UI/Onboarding/OnboardingView.swift
+++ b/Sources/Vorssaint/UI/Onboarding/OnboardingView.swift
@@ -237,7 +237,7 @@ private struct PurposeStep: View {
                     .tracking(1)
                 Spacer()
                 Text(String(format: hub.activeCountFormat,
-                            selectedFeatures.count, AppFeature.allCases.count))
+                            selectedFeatures.count, FeatureRuntime.shared.installableCount))
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
@@ -333,7 +333,12 @@ private struct PurposeStep: View {
 
     private func featureCard(_ feature: AppFeature) -> some View {
         let selected = selectedFeatures.contains(feature)
-        return Button {
+        // The picker writes availability through the same runtime gate as the
+        // hub, so a feature this Mac cannot run would silently stay off after
+        // being ticked here. It is shown and refused instead, exactly as the
+        // hub row does it.
+        let blocked = feature.installBlockedReason
+        let card = Button {
             selectedPreset = nil
             if selected {
                 selectedFeatures.remove(feature)
@@ -378,8 +383,15 @@ private struct PurposeStep: View {
             .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("\(feature.hubTitle(l10n.s, hub: hub)). \(feature.hubDescription(hub))")
+        .disabled(blocked != nil)
+        .opacity(blocked == nil ? 1 : 0.4)
+        .saturation(blocked == nil ? 1 : 0)
+        .accessibilityLabel("\(feature.hubTitle(l10n.s, hub: hub)). \(feature.hubDescription(hub))"
+                            + (blocked.map { ". \($0)" } ?? ""))
         .accessibilityAddTraits(selected ? .isSelected : [])
+        // .help() never fires on a disabled control, so the tooltip sits on a
+        // wrapper outside it, the same way the Features hub row does it.
+        return HStack(spacing: 0) { card }.help(blocked ?? "")
     }
 
     private func groupTitle(_ group: FeatureGroup) -> String {

--- a/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
@@ -34,14 +34,14 @@ struct FeatureHubSettings: View {
                 if tab == .features {
                     HStack(spacing: 8) {
                         Text(String(format: hub.activeCountFormat,
-                                    features.availableCount, AppFeature.allCases.count))
+                                    features.availableCount, features.installableCount))
                             .font(.caption)
                             .foregroundStyle(.tertiary)
                         Spacer(minLength: 8)
                         Button(hub.installAllButton) {
                             FeatureRuntime.shared.setAllAvailable(true)
                         }
-                        .disabled(features.availableCount == AppFeature.allCases.count)
+                        .disabled(features.availableCount == features.installableCount)
                         Button(hub.uninstallAllButton) {
                             FeatureRuntime.shared.setAllAvailable(false)
                         }
@@ -225,6 +225,11 @@ private struct FeatureHubRow: View {
 
     private var installed: Bool { feature.isAvailable }
 
+    /// Set only while this Mac cannot run the feature and it is not yet
+    /// installed, so an install that predates the check keeps an ordinary
+    /// row with its settings and Uninstall reachable.
+    private var unsupportedReason: String? { feature.installBlockedReason }
+
     private var accessibilityTitle: String {
         let title = feature.hubTitle(l10n.s, hub: hub)
         return feature.isBeta ? "\(title). \(l10n.s.betaFeatureWarning)" : title
@@ -258,6 +263,8 @@ private struct FeatureHubRow: View {
                 rowContent(showsChevron: false)
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel("\(accessibilityTitle). \(feature.hubDescription(hub))")
+                    .opacity(unsupportedReason == nil ? 1 : 0.4)
+                    .saturation(unsupportedReason == nil ? 1 : 0)
             }
             if working {
                 ProgressView()
@@ -267,6 +274,18 @@ private struct FeatureHubRow: View {
                     .buttonStyle(.bordered)
                     .controlSize(.small)
                     .accessibilityLabel("\(hub.uninstallButton) \(accessibilityTitle)")
+            } else if let reason = unsupportedReason {
+                // .help() never fires on a disabled control, so the tooltip
+                // has to sit on this wrapper. Flattening it loses the only
+                // place the reason is shown.
+                HStack(spacing: 0) {
+                    Button(hub.installButton) { flip(to: true) }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .disabled(true)
+                        .accessibilityLabel("\(hub.installButton) \(accessibilityTitle). \(reason)")
+                }
+                .help(reason)
             } else {
                 Button(hub.installButton) { flip(to: true) }
                     .buttonStyle(.borderedProminent)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -10197,6 +10197,46 @@ struct MetricsTests {
                 && AppFeature.fanControl.isBeta
                 && !AppFeature.monitorPower.isBeta,
                "fan control is an on-demand beta with no broad permission")
+
+        // MARK: Hardware-gated installs
+
+        // Availability is only ever written by the runtime that gates it, so
+        // a new install surface cannot walk around the hardware check the way
+        // the hub's install-all button and the first-run picker once did.
+        // Two files are allowed to write the key directly, and both run where
+        // the gate cannot matter: the first-run seed writes a preset holding
+        // no hardware-dependent feature (pinned below), and the fan control
+        // migration restores an install that already existed, which the gate
+        // never revokes. A third entry here is a bug, not a new allowance.
+        var availabilityWriters: Set<String> = []
+        if let sources = FileManager.default.enumerator(atPath: "Sources") {
+            for case let path as String in sources where path.hasSuffix(".swift") {
+                let text = (try? String(contentsOfFile: "Sources/" + path, encoding: .utf8)) ?? ""
+                let writes = text.split(separator: "\n").contains {
+                    $0.contains(".set(") && $0.contains("availabilityKey")
+                }
+                if writes { availabilityWriters.insert((path as NSString).lastPathComponent) }
+            }
+        }
+        expect(availabilityWriters == ["FeatureRuntime.swift",
+                                       "FeaturePresets.swift",
+                                       "Defaults.swift"],
+               "feature availability is written only where the hardware gate runs, "
+               + "found \(availabilityWriters.sorted())")
+        expect(FeaturePreset.allCases.allSatisfy { !$0.features.contains(.fanControl) },
+               "no first-run preset installs a feature whose hardware the Mac may lack")
+
+        let featureHubSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift",
+            encoding: .utf8)) ?? ""
+        let onboardingFeatureSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/UI/Onboarding/OnboardingView.swift",
+            encoding: .utf8)) ?? ""
+        expect(featureHubSource.contains("installBlockedReason")
+                && onboardingFeatureSource.contains("installBlockedReason"),
+               "both feature pickers refuse an unsupported install from the same rule")
+        expect(featureHubSource.contains("installableCount"),
+               "the hub counts against what this Mac can install, so install-all can finish")
         expect(AppFeature.diskImageInstaller.group == .clipboardFiles
                 && AppFeature.diskImageInstaller.enabledKeys.isEmpty
                 && AppFeature.diskImageInstaller.permissions == [.appManagement]


### PR DESCRIPTION
Builds on @Yahddyyp's work in #899 — the detection, the fail-soft policy and the greyed row are theirs, and the last round of that PR had already fixed the `FNum` spelling, the duplicate fan-count read and the suppressed settings link. This replaces it because the gate was on the wrong layer, not because the behaviour was wrong.

## The defect

`isHardwareSupported` was read by `FeatureHubRow` only. Availability is written from three places:

| Surface | Writes availability via | Gated in #899 |
|---|---|---|
| Hub row Install | `FeatureRuntime.setAvailable` | yes |
| Hub **Install All** | `FeatureRuntime.setAllAvailable` | no |
| First-run picker | `FeatureRuntime.replaceAvailable` | no |

The install-all button sits in the same view, roughly 200 lines above the row it walks around, and the first-run picker offers Fan Control on a fanless Mac with an ordinary tick box. Both then combine badly with the (correct) decision to leave installed rows alone: once Fan Control arrives by either route, the row looks normal forever and the user never learns why it does nothing.

## The change

- `AppFeature.hardwareUnsupportedReason` is the single switch. `isHardwareSupported` is derived from it, so a feature cannot be unsupported without a reason to show — the previous pair of parallel switches could drift into an empty tooltip and a VoiceOver label ending in `". "`.
- `AppFeature.installBlockedReason` adds the "not once it is installed" rule in one place, so the hub and the picker cannot disagree about it.
- `FeatureRuntime.mayFlip(_:to:)` is the gate. All three write paths route through it. Uninstalls are never refused and an existing install is never revoked.
- The picker greys and disables a blocked card, with the reason on the tooltip and the accessibility label, matching the hub row.
- `FeatureRuntime.installableCount` replaces `AppFeature.allCases.count` in the hub's tally and its install-all disabled condition. Without it that button is permanently enabled and does nothing on a Mac missing hardware — a bug the gate would otherwise have introduced.
- `replaceAvailable` now syncs `selected where feature.isAvailable`. A refused feature must not have its binding run, or the gate would block the install and start the service anyway.

Reuses `FeatureStrings.fanControl(…).noFans` ("This Mac has no controllable fan."), which is already translated into all 13 languages and is accurate for the strengthened check: `discoverControlledFans()` also rejects a Mac that reports fans it cannot drive.

## Alternatives not taken

- **Gate in the views.** Three views, three copies, and the next hardware-dependent feature adds three more. The write layer is one place and no future surface can miss it.
- **Auto-uninstall on a failed check.** Rejected in #899 and still rejected: `FNUM` made `hasControllableFan` false on every Mac, and that same code with auto-uninstall would have deleted everyone's Fan Control config on upgrade.
- **Hide unsupported features from the lists.** A greyed row with a reason tells the user the feature exists and why their Mac cannot have it; a missing row reads as a bug.
- **Move the check off the main thread.** `FanControlHardware.hasControllableFan` is a one-shot `static let` first touched while drawing a feature list. `FanControlService` uses `probeQueue` for `readOnlySnapshot()` because that repeats on a refresh timer and reads temperatures too; this is one SMC connection and ~6 key lookups per fan, once per process.

## Not changed

`Defaults.migrateFanControlVisibility` still restores a pre-existing opt-in on upgrade, and `FeaturePresets.prepareFirstRunAvailability` still seeds the essential preset directly. Both are correct: the first is exactly the install the gate refuses to revoke, and the second writes a preset that holds no hardware-dependent feature. Both are pinned by the test below.

## Testing

`./build.sh`, `./build/Vorssaint --selftest` and `./build.sh --test` all pass — TESTS OK (8553 checks), up from 8549.

New guardrails, each verified to go red when its rule is broken:

- Availability writes exist only in `FeatureRuntime.swift`, `FeaturePresets.swift` and `Defaults.swift`. A fourth install surface writing the key directly fails the build, which is precisely the class of bug this PR fixes. Sabotaged by adding a write to `MenuBarRenderer.swift`; test named the file.
- No `FeaturePreset` installs `.fanControl`, which is what makes the first-run seed safe.
- Both feature pickers read `installBlockedReason`. Sabotaged by removing it from `OnboardingView`; test failed.
- The hub counts against `installableCount`.

Hardware: on an M5 MacBook Air (Mac17,3) `hasControllableFan` is `false`, and the SMC client enumerates 2289 keys of which **none** begin with `F` — so this is a real absence, not a silent read failure like the `FNUM` spelling was. The positive case does not need a fan Mac to believe: `discoverControlledFans()` is the same call `readOnlySnapshot()` makes for every working Fan Control user today, so if it returned empty on fan hardware, Fan Control would already be broken for everyone.

## Related

- ref #899 — the PR this takes over. Its detection, fail-soft policy and greyed row are carried over unchanged; what moved is the layer the gate sits on. Left open for @Yahddyyp to close or repoint.
- ref #837 — tracks #899 in the open-PR index. Its remaining objection, the fan-specific reason string sitting in a row that renders every feature, is what `hardwareUnsupportedReason` resolves here.
- ref #574 — a MacBook Pro reporting "Fan control is not available on this Mac", fixed in v3.3.2. It is the case this gate must never catch: on that hardware `discoverControlledFans()` now succeeds, which is why the gate is backed by it rather than by a fan count or a model list.
