### PR TITLE
fix(monitor): bound the waits that freeze the app

### DIFF
--- a/Sources/Vorssaint/Services/BoundedProcessRunner.swift
+++ b/Sources/Vorssaint/Services/BoundedProcessRunner.swift
@@ -59,18 +59,24 @@ enum BoundedProcessRunner {
             }
         }
 
+        // The child is watched through its termination handler. A blocking
+        // `waitUntilExit()` has to be parked on a thread of its own, and the
+        // timeout below makes `run` walk away from it while it still holds one
+        // worker of the shared 64-thread pool. Those abandoned waits pile up
+        // faster than they drain, and a full pool starves every later user of
+        // it, the main thread's window walk included (issue #971). It also
+        // starves this runner, which then reports timeouts for commands that
+        // exited at once and abandons another wait doing it. A termination
+        // handler occupies no thread, so none of that accumulates.
+        let finished = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in finished.signal() }
+
         do {
             try process.run()
         } catch {
             reader.readabilityHandler = nil
             try? reader.close()
             return Result(status: -1, output: Data(), timedOut: false)
-        }
-
-        let finished = DispatchSemaphore(value: 0)
-        DispatchQueue.global(qos: .utility).async {
-            process.waitUntilExit()
-            finished.signal()
         }
 
         var didFinish = finished.wait(timeout: .now() + max(0, timeout)) == .success

--- a/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
@@ -29,6 +29,12 @@ enum WindowEnumerator {
     /// tree within the process thread budget while collapsing it into a few
     /// bounded AX batches.
     private static let maximumConcurrentQueries = 24
+    /// Ceiling on the whole batch, which the main thread waits out. Generous
+    /// against the messaging timeouts above even with every query as slow as
+    /// they allow, so only a dispatch pool with no thread to give can outlast
+    /// it (issue #971) — and then no answer was ever coming. A stalled main
+    /// thread stalls the event taps with it (issue #189), so it must expire.
+    private static let accessibilityBatchBudget: TimeInterval = 5.0
 
     static func listWindows(groupByApp: Bool = UserDefaults.standard.bool(forKey: DefaultsKey.switcherMergeTabs),
                             preservingGroupedWindows: Bool = false) -> [SwitcherItem] {
@@ -423,7 +429,8 @@ enum WindowEnumerator {
         guard !orderedPIDs.isEmpty else { return [:] }
         let screenFrames = NSScreen.screens.map(\.frame)
         var result: [pid_t: AccessibilityWindowSnapshotList] = [:]
-        let resultLock = NSLock()
+        var pendingQueries = orderedPIDs.count
+        let resultLock = NSCondition()
         // A remote app can consume its whole messaging timeout. Overlap those
         // independent calls so several slow background helpers cost one wait,
         // not one wait each, while preserving Accessibility-only windows. The
@@ -433,19 +440,31 @@ enum WindowEnumerator {
         queryQueue.maxConcurrentOperationCount = min(maximumConcurrentQueries, orderedPIDs.count)
         for pid in orderedPIDs {
             queryQueue.addOperation {
-                guard let windows = accessibilityWindows(
+                let windows = accessibilityWindows(
                     for: pid,
                     bundleIdentifier: bundleIdentifiers[pid],
                     acceptsUndescribedSubroles: undescribedSubrolePids.contains(pid),
                     screenFrames: screenFrames
-                ) else { return }
+                )
                 resultLock.lock()
-                result[pid] = windows
+                if let windows { result[pid] = windows }
+                pendingQueries -= 1
+                if pendingQueries == 0 { resultLock.broadcast() }
                 resultLock.unlock()
             }
         }
-        queryQueue.waitUntilAllOperationsAreFinished()
-        return result
+        // Operations still queued when the budget runs out are cancelled and
+        // the answers already in hand are returned. An app missing from that
+        // map reads downstream like an app that could not answer Accessibility,
+        // which every caller already handles.
+        let deadline = Date(timeIntervalSinceNow: accessibilityBatchBudget)
+        resultLock.lock()
+        while pendingQueries > 0, resultLock.wait(until: deadline) {}
+        let exhaustedBudget = pendingQueries > 0
+        let collected = result
+        resultLock.unlock()
+        if exhaustedBudget { queryQueue.cancelAllOperations() }
+        return collected
     }
 
     private static func accessibilityWindows(for pid: pid_t,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9812,6 +9812,40 @@ struct MetricsTests {
                 && Date().timeIntervalSince(timeoutStarted) < 1.5,
                "a stalled subprocess is terminated inside its deadline")
 
+        // Reproduces the freeze in issue #971 from the other side: the app's
+        // own abandoned waits had filled the shared dispatch pool, so nothing
+        // submitted to it ran any more. A runner that waits on a pool thread
+        // reports a timeout here for a command that exits instantly, and parks
+        // one more worker doing it. Waiting on the child itself is immune, so
+        // the pool the runner starved can no longer starve the runner.
+        let poolGate = DispatchSemaphore(value: 0)
+        let poolOccupied = DispatchSemaphore(value: 0)
+        // The dispatch pool's soft limit is 64 threads blocked in synchronous
+        // work; one block per thread takes every one of them.
+        for _ in 0..<64 {
+            DispatchQueue.global(qos: .utility).async {
+                poolOccupied.signal()
+                poolGate.wait()
+            }
+        }
+        var occupiedWorkers = 0
+        for _ in 0..<64 where poolOccupied.wait(timeout: .now() + 5) == .success { occupiedWorkers += 1 }
+        let starvedProbe = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .utility).async { starvedProbe.signal() }
+        let poolIsStarved = starvedProbe.wait(timeout: .now() + 0.5) == .timedOut
+        let starvedStarted = Date()
+        let starvedPoolProcess = BoundedProcessRunner.run(
+            "/bin/echo", ["ready"], timeout: 1, maxOutputBytes: 1_024)
+        let starvedPoolElapsed = Date().timeIntervalSince(starvedStarted)
+        for _ in 0..<64 { poolGate.signal() }
+        _ = starvedProbe.wait(timeout: .now() + 5)
+        expect(occupiedWorkers == 64 && poolIsStarved,
+               "the dispatch pool starvation this check needs was actually reached")
+        expect(!starvedPoolProcess.timedOut && starvedPoolProcess.status == 0
+                && String(decoding: starvedPoolProcess.output, as: UTF8.self) == "ready\n"
+                && starvedPoolElapsed < 0.5,
+               "a subprocess is watched off the dispatch pool, so a starved pool cannot strand it")
+
         var networkDelta = NetworkProcessDeltaTracker(maxGap: 10)
         let baselineNetwork = [
             NetworkProcessSample(pid: 10, name: "Browser", bytesIn: 1_000, bytesOut: 500),
@@ -13337,6 +13371,29 @@ struct MetricsTests {
         }
         expect(unpinnedBorderlessMenus.isEmpty,
                "every borderless menu keeps its own size: \(unpinnedBorderlessMenus)")
+
+        // `waitUntilAllOperationsAreFinished` has no deadline, and the window
+        // walk that used it runs on the main thread while its operations run on
+        // the shared dispatch pool. Once unrelated work had taken every worker
+        // in that pool, not one operation started and the wait never returned,
+        // taking the whole app with it (issue #971). The call is unusable here
+        // for that reason, so the rule is the absence of it rather than the one
+        // caller that was found holding it.
+        var unboundedOperationWaits: [String] = []
+        let appSources = FileManager.default
+            .enumerator(atPath: "Sources/Vorssaint")?
+            .compactMap { $0 as? String }
+            .filter { $0.hasSuffix(".swift") && !$0.contains(" 2") } ?? []
+        for file in appSources.sorted() {
+            guard let source = try? String(contentsOfFile: "Sources/Vorssaint/\(file)",
+                                           encoding: .utf8) else { continue }
+            for (index, line) in source.components(separatedBy: "\n").enumerated()
+            where line.contains("waitUntilAllOperationsAreFinished") {
+                unboundedOperationWaits.append("\(file):\(index + 1)")
+            }
+        }
+        expect(!appSources.isEmpty && unboundedOperationWaits.isEmpty,
+               "no operation queue is waited on without a deadline: \(unboundedOperationWaits)")
         expect(ScratchpadRetention.sanitized("day") == .day
                 && ScratchpadRetention.sanitized("week") == .week
                 && ScratchpadRetention.sanitized("month") == .month


### PR DESCRIPTION
Two waits combine into the freeze in #971. Either one alone is survivable.

This consolidates #980, which found the same two defects independently and reached the same fix; its deadline value and the reasoning for it are carried over here, and @iltonandrew is credited on the commit.

**The runner.** `BoundedProcessRunner.run` parks `waitUntilExit()` on the shared global dispatch pool and walks away from it when the timeout fires, still holding a worker. Nine call sites reach it, five of them periodic samplers, so abandoned waits can arrive faster than they drain. A full pool then starves the runner itself: it reports timeouts for commands that already exited, and abandons one more wait doing it.

**The window walk.** `WindowEnumerator.accessibilityWindows(for:)` ran `waitUntilAllOperationsAreFinished()` with no deadline, on the main thread. `DockPreviewService` reaches it through `DispatchQueue.main.asyncAfter`; `AppSwitcher` reaches it through the `DispatchQueue.main.async` at `AppSwitcher.swift:536`, which answers the open question in #971 about whether the switcher is a second way in — it is. Those operations run on the same pool, so when the pool has nothing left, none of them start and the wait never returns.

**What changed.** The child is watched through `process.terminationHandler`, which occupies no thread while it waits, so an abandoned wait costs a semaphore and nothing else. The Accessibility batch gets a 1.5s ceiling: operations still queued when it runs out are cancelled and the answers already collected are returned.

**Effect.** Both implementations built standalone and driven by the reproduction in the issue:

- With 64 workers blocked on the utility pool, `/bin/echo hi` on a 1s timeout: before, a false timeout after 2.016s; after, status 0 in 0.001s.
- 350 timed-out runs across 70 concurrent callers: 66 threads at peak before, 10 after. File descriptors flat and no unreaped children either way.

Being precise about what that does and does not show: the saturation and the false timeouts reproduce deterministically, and the thread peak drains on its own in both versions. The permanently stranded waiters in the issue's sample — 64 of them, identical 20 minutes apart, every child already reaped — did not reproduce locally. The fix does not rest on that question: a wait that never occupies a pool thread cannot strand one, however it ends.

**Alternatives considered.** For the runner, counting the abandoned waiters and capping or reclaiming them keeps the blocking wait and adds bookkeeping plus a ceiling to tune; removing the thread from the wait removes the accounting problem instead of managing it. For the batch, moving the walk off the main thread is a far larger change to callers that need the result synchronously, and it would leave the unbounded wait in place on a different thread. A deadline bounds it where it is. The truncation a deadline can cause lands on an existing path: an app missing from that map reads downstream exactly like an app that could not answer Accessibility.

The ceiling is 5s, taken from @iltonandrew's #980. A healthy batch takes hundredths of a second, so a much tighter ceiling is tempting, but the individual AX calls are already bounded by their messaging timeouts: the only thing that can outlast 5s is a pool with no thread to give, where no answer was ever coming. A tighter ceiling would buy nothing there and would truncate a genuinely slow batch on a busy Mac.

**Not changed.** The `nettop` fallback in `NetworkSampler` / `NetworkCounterFallback`. On the reporter's machine every inbound byte lands on a `utun` interface, which `MetricFormat.includeNetworkInterface` excludes, so the latch holds forever and `nettop` runs on every tick. That is the load that exposed both waits, but the fallback is doing its job there — it is what gives that machine correct download figures. Changing the sample rate is an accuracy trade-off that belongs in its own issue. The other `waitUntilExit()` callers (`HomebrewManager`, `DiskImageInstallerService`, `JunkCleaner`) are also untouched: none of them abandon their wait, and none run it on the shared pool.

**Tests.** 8544 checks. Two added, both verified red on the unmodified sources: the pool-starvation behaviour above, which also asserts that the starvation it needs was actually reached so it cannot pass vacuously; and an absence proposition over all of `Sources/Vorssaint`, since `waitUntilAllOperationsAreFinished` has no deadline and is unusable on these paths — the rule is the absence of the call rather than the one caller found holding it.

#887 reports the app going unresponsive at random with the command bar steps not reproducing it, which #971 reads as closer to this than to the pasteboard lane stall #903 addresses. Unconfirmed either way, so it is listed as a candidate below rather than claimed. #189 is the event-tap stall that the main-thread ceiling cites.

ref #971
ref #887
