### PR TITLE
fix(shelf): ignore parked status-item frames for Shelf placement and icon hit testing

### DIFF
--- a/Sources/Vorssaint/App/AppDelegate.swift
+++ b/Sources/Vorssaint/App/AppDelegate.swift
@@ -96,7 +96,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         ShelfService.shared.statusItemFrameProvider = { [weak self] in
             guard let item = self?.statusController.statusItem, item.isVisible,
                   let window = self?.statusController.button?.window else { return nil }
-            return window.frame
+            let frame = window.frame
+            guard StatusItemAnchorSupport.isTrustworthyStatusFrame(
+                frame, screenFrames: NSScreen.screens.map(\.frame)) else { return nil }
+            return frame
         }
 
         setUpPopover()

--- a/Sources/Vorssaint/App/AppDelegate.swift
+++ b/Sources/Vorssaint/App/AppDelegate.swift
@@ -97,8 +97,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
             guard let item = self?.statusController.statusItem, item.isVisible,
                   let window = self?.statusController.button?.window else { return nil }
             let frame = window.frame
-            guard StatusItemAnchorSupport.isTrustworthyStatusFrame(
-                frame, screenFrames: NSScreen.screens.map(\.frame)) else { return nil }
+            guard StatusItemAnchorSupport.isTrustworthyStatusFrame(frame) else { return nil }
             return frame
         }
 
@@ -531,8 +530,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
     /// itself parks the window out of the visible area) the anchor takes over.
     private func frameStillDescribesMenuBar(_ anchor: PanelAnchor) -> Bool {
         guard let frame = anchor.button?.window?.frame else { return false }
-        return StatusItemAnchorSupport.isTrustworthyStatusFrame(
-            frame, screenFrames: NSScreen.screens.map(\.frame))
+        return StatusItemAnchorSupport.isTrustworthyStatusFrame(frame)
     }
 
     /// The spot the panel must hold while it is open, decided at the moment it
@@ -544,7 +542,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         let screen = statusScreen(for: button)
         let statusFrame = button.window?.frame
         let frameIsSound = statusFrame.map {
-            StatusItemAnchorSupport.isTrustworthyStatusFrame($0, screenFrames: NSScreen.screens.map(\.frame))
+            StatusItemAnchorSupport.isTrustworthyStatusFrame($0)
         } ?? false
         if frameIsSound, statusFrame != nil {
             // Where the popover has just been placed is the anchor: with a

--- a/Sources/Vorssaint/App/StatusItemAnchorSupport.swift
+++ b/Sources/Vorssaint/App/StatusItemAnchorSupport.swift
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Vorssaint
 
+import AppKit
 import CoreGraphics
 import Foundation
 
@@ -38,6 +39,10 @@ enum StatusItemAnchorSupport {
     /// How far down from the top of a screen a status item's window can sit and
     /// still describe a menu bar. Clears the taller bar drawn around a camera
     /// housing with room to spare, while staying far from any ordinary window.
+    /// Measured off the screen's own top edge, never off the area left over
+    /// after the bar: a fullscreen screen reserves nothing, and a band derived
+    /// from the visible area would collapse there and reject a status item
+    /// revealed on hover exactly while it is on screen and clickable.
     static let menuBarBand: CGFloat = 48
 
     /// Breathing room kept between the panel and the edges of the usable area.
@@ -49,7 +54,7 @@ enum StatusItemAnchorSupport {
     /// through it collapses into a screen corner. A frame only counts when it
     /// has real size and its middle sits in the bar band of an attached screen.
     static func isTrustworthyStatusFrame(_ frame: CGRect,
-                                         screenFrames: [CGRect],
+                                         screenFrames: [CGRect] = NSScreen.screens.map(\.frame),
                                          band: CGFloat = menuBarBand) -> Bool {
         guard frame.width > 0, frame.height > 0 else { return false }
         return screenFrames.contains { screen in

--- a/Sources/Vorssaint/App/StatusItemController.swift
+++ b/Sources/Vorssaint/App/StatusItemController.swift
@@ -58,9 +58,13 @@ final class StatusItemController {
 
     func containsStatusItem(at screenPoint: NSPoint) -> Bool {
         let buttons = ([statusItem?.button] + metricStatusItems.values.map(\.button)).compactMap { $0 }
+        // Bound once for the whole scan: a default argument is evaluated per
+        // call, so leaving it to the default would rebuild this per button.
+        let screenFrames = NSScreen.screens.map(\.frame)
         return buttons.contains { button in
             guard let frame = button.window?.frame,
-                  StatusItemAnchorSupport.isTrustworthyStatusFrame(frame) else { return false }
+                  StatusItemAnchorSupport.isTrustworthyStatusFrame(frame, screenFrames: screenFrames)
+            else { return false }
             return frame.insetBy(dx: -4, dy: -8).contains(screenPoint)
         }
     }

--- a/Sources/Vorssaint/App/StatusItemController.swift
+++ b/Sources/Vorssaint/App/StatusItemController.swift
@@ -59,7 +59,9 @@ final class StatusItemController {
     func containsStatusItem(at screenPoint: NSPoint) -> Bool {
         let buttons = ([statusItem?.button] + metricStatusItems.values.map(\.button)).compactMap { $0 }
         return buttons.contains { button in
-            guard let frame = button.window?.frame else { return false }
+            guard let frame = button.window?.frame,
+                  StatusItemAnchorSupport.isTrustworthyStatusFrame(
+                      frame, screenFrames: NSScreen.screens.map(\.frame)) else { return false }
             return frame.insetBy(dx: -4, dy: -8).contains(screenPoint)
         }
     }

--- a/Sources/Vorssaint/App/StatusItemController.swift
+++ b/Sources/Vorssaint/App/StatusItemController.swift
@@ -60,8 +60,7 @@ final class StatusItemController {
         let buttons = ([statusItem?.button] + metricStatusItems.values.map(\.button)).compactMap { $0 }
         return buttons.contains { button in
             guard let frame = button.window?.frame,
-                  StatusItemAnchorSupport.isTrustworthyStatusFrame(
-                      frame, screenFrames: NSScreen.screens.map(\.frame)) else { return false }
+                  StatusItemAnchorSupport.isTrustworthyStatusFrame(frame) else { return false }
             return frame.insetBy(dx: -4, dy: -8).contains(screenPoint)
         }
     }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -2784,6 +2784,19 @@ struct MetricsTests {
                                                                  screenFrames: attachedScreens),
                "a frame down at the bottom of a screen is not a menu bar item")
 
+        // A screen showing a fullscreen window reserves no menu bar: its
+        // visible area is the whole frame. The band is a fixed thickness off
+        // the screen's own top edge, so an item revealed on hover still counts;
+        // a band measured as `frame.maxY - visibleFrame.maxY` would collapse to
+        // nothing here and decline the icon while it is visible and clickable.
+        let fullscreenScreen = CGRect(x: 0, y: 0, width: 1470, height: 956)
+        let fullscreenVisibleFrame = fullscreenScreen
+        expect(StatusItemAnchorSupport.menuBarBand > fullscreenScreen.maxY - fullscreenVisibleFrame.maxY,
+               "the menu bar band does not shrink to what a fullscreen screen reserves")
+        expect(StatusItemAnchorSupport.isTrustworthyStatusFrame(CGRect(x: 1135, y: 919, width: 38, height: 37),
+                                                                screenFrames: [fullscreenScreen]),
+               "a status item revealed over a fullscreen window is a trustworthy anchor")
+
         // These AppKit owners are not part of the pure-helper test binary, so
         // pin that neither caller can consume a parked status-item frame.
         let statusAnchorAppDelegateSource = (try? String(
@@ -2794,15 +2807,18 @@ struct MetricsTests {
                 .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
                 .joined(separator: "\n")
         }
+        // Sliced at the closing brace of the closure/function itself, so the
+        // slice can never run past it into an unrelated body that happens to
+        // carry the same words.
         let shelfProviderCode = stripCommentLines((statusAnchorAppDelegateSource
             .components(separatedBy: "ShelfService.shared.statusItemFrameProvider =").last ?? "")
-            .components(separatedBy: "\n        setUpPopover()").first ?? "")
+            .components(separatedBy: "\n        }").first ?? "")
         let statusControllerSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/App/StatusItemController.swift",
             encoding: .utf8)) ?? ""
         let statusHitTestCode = stripCommentLines((statusControllerSource
             .components(separatedBy: "func containsStatusItem(at screenPoint: NSPoint) -> Bool {").last ?? "")
-            .components(separatedBy: "\n    init()").first ?? "")
+            .components(separatedBy: "\n    }").first ?? "")
         let statusFrameCall = "StatusItemAnchorSupport.isTrustworthyStatusFrame("
         expect(shelfProviderCode.contains("guard \(statusFrameCall)") && shelfProviderCode.contains("return nil"),
                "the Shelf provider rejects an untrustworthy status-item frame")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -2784,6 +2784,31 @@ struct MetricsTests {
                                                                  screenFrames: attachedScreens),
                "a frame down at the bottom of a screen is not a menu bar item")
 
+        // These AppKit owners are not part of the pure-helper test binary, so
+        // pin that neither caller can consume a parked status-item frame.
+        let statusAnchorAppDelegateSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/App/AppDelegate.swift",
+            encoding: .utf8)) ?? ""
+        let stripCommentLines: (String) -> String = {
+            $0.split(separator: "\n", omittingEmptySubsequences: false)
+                .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+                .joined(separator: "\n")
+        }
+        let shelfProviderCode = stripCommentLines((statusAnchorAppDelegateSource
+            .components(separatedBy: "ShelfService.shared.statusItemFrameProvider =").last ?? "")
+            .components(separatedBy: "\n        setUpPopover()").first ?? "")
+        let statusControllerSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/App/StatusItemController.swift",
+            encoding: .utf8)) ?? ""
+        let statusHitTestCode = stripCommentLines((statusControllerSource
+            .components(separatedBy: "func containsStatusItem(at screenPoint: NSPoint) -> Bool {").last ?? "")
+            .components(separatedBy: "\n    init()").first ?? "")
+        let statusFrameCall = "StatusItemAnchorSupport.isTrustworthyStatusFrame("
+        expect(shelfProviderCode.contains("guard \(statusFrameCall)") && shelfProviderCode.contains("return nil"),
+               "the Shelf provider rejects an untrustworthy status-item frame")
+        expect(statusHitTestCode.contains(statusFrameCall) && statusHitTestCode.contains("return false"),
+               "status-item hit testing rejects an untrustworthy frame")
+
         // The panel keeps its top edge and its center while its content resizes.
         let panelArea = CGRect(x: 0, y: 0, width: 1470, height: 932)
         let shortPanel = StatusItemAnchorSupport.pinnedPanelFrame(size: CGSize(width: 332, height: 375),


### PR DESCRIPTION
Refs #940 — the follow-up split out of #930's review, implemented per the direction in the issue.

## What was wrong

When macOS hides the menu bar in fullscreen, a status item window can report a parked fallback frame that no longer describes the visible icon, and two callers trusted it raw:

- `AppDelegate` fed `button.window.frame` straight through `ShelfService.statusItemFrameProvider`, so `positionDocked` and `mouseNearDock` could place the Shelf pill and hover band at the parked coordinate.
- `StatusItemController.containsStatusItem(at:)` read the same frame directly, so the popover's outside-click monitor could stop recognizing a click on the status icon in that state.

## The change

Both call sites now gate the raw frame through `StatusItemAnchorSupport.isTrustworthyStatusFrame` — the trust rule the popover anchoring already uses (#930): positive size, intersects an attached screen, midpoint inside the menu-bar band. The Shelf provider returns nil on an untrustworthy frame, which engages its existing fallback (pointer-screen placement, hover band disabled); hit testing declines instead of testing a coordinate that describes nothing. Trustworthy frames behave exactly as before — the guard only rejects frames the trust rule already classifies as parked.

Against the acceptance criteria: a hidden fullscreen menu bar no longer sends the docked Shelf or its hover band to the parked coordinate (provider returns nil); clicking the visible icon still works when the menu bar is visible, including the fullscreen reveal-on-hover state — a revealed status window sits inside the menu-bar band, so the trust rule passes there by construction; trustworthy frames take the unchanged code path.

## Verification

`./build.sh` with zero warnings, `./build.sh --test` → TESTS OK (8551 checks), `./build/Vorssaint --selftest` → SELFTEST OK. Two source-shape assertions pin the wiring (the Shelf provider guards through the trust rule and returns nil; hit testing consults the same rule); the trust rule itself keeps its existing direct geometry coverage.
