### PR TITLE
fix(uninstall): remove the fan helper registration and app data on the script path

### DIFF
--- a/Sources/Vorssaint/Services/FanControl/FanControlService.swift
+++ b/Sources/Vorssaint/Services/FanControl/FanControlService.swift
@@ -226,14 +226,20 @@ final class FanControlService: ObservableObject {
     /// Used by the complete-uninstall path from its background queue. The
     /// daemon is removed only after it confirms automatic control, so teardown
     /// can never kill the recovery mechanism while a manual session remains.
-    static func restoreAndUnregisterForRemoval() {
+    ///
+    /// Reports whether the daemon is actually gone. A caller that tells someone
+    /// the app was fully removed has no other way to know: the registration
+    /// outlives the bundle, so a silent failure here reads as success forever.
+    @discardableResult
+    static func restoreAndUnregisterForRemoval() -> Bool {
         let service = appService
         guard service.status == .enabled else {
-            if !UserDefaults.standard.bool(forKey: DefaultsKey.fanControlRecoveryNeeded),
-               service.status != .notRegistered {
-                try? service.unregister()
-            }
-            return
+            guard service.status != .notRegistered else { return true }
+            // A pending recovery keeps the daemon deliberately: it is the only
+            // thing that can put the fans back. Still not a clean detach.
+            guard !UserDefaults.standard.bool(forKey: DefaultsKey.fanControlRecoveryNeeded)
+            else { return false }
+            return unregisterForRemoval(service)
         }
         let connection = NSXPCConnection(machServiceName: FanControlIdentifiers.helperID,
                                          options: .privileged)
@@ -247,7 +253,7 @@ final class FanControlService: ObservableObject {
             as? FanControlXPCProtocol
         guard let proxy else {
             connection.invalidate()
-            return
+            return false
         }
         proxy.restoreAutomatic { data in
             if let response = FanControlIPC.decode(data) {
@@ -259,7 +265,17 @@ final class FanControlService: ObservableObject {
         }
         _ = semaphore.wait(timeout: .now() + 20)
         connection.invalidate()
-        if resultLock.withLock({ restored }) { try? service.unregister() }
+        guard resultLock.withLock({ restored }) else { return false }
+        return unregisterForRemoval(service)
+    }
+
+    private static func unregisterForRemoval(_ service: SMAppService) -> Bool {
+        do {
+            try service.unregister()
+            return true
+        } catch {
+            return false
+        }
     }
 
     // MARK: - Requests

--- a/Sources/Vorssaint/Services/SelfUninstall.swift
+++ b/Sources/Vorssaint/Services/SelfUninstall.swift
@@ -132,6 +132,12 @@ enum SelfUninstall {
         try? FileManager.default.removeItem(atPath: "\(home)/Library/Saved Application State/\(id).savedState")
         // Clipboard images and any other app-owned data live here.
         try? FileManager.default.removeItem(atPath: "\(home)/Library/Application Support/\(id)")
+        try? FileManager.default.removeItem(atPath: "\(home)/Library/Caches/\(id)")
+        // URLSession writes these on our behalf whenever the app talks to the
+        // network, so they exist without the app ever choosing the path.
+        try? FileManager.default.removeItem(atPath: "\(home)/Library/HTTPStorages/\(id)")
+        try? FileManager.default.removeItem(
+            atPath: "\(home)/Library/HTTPStorages/\(id).binarycookies")
     }
 
     /// Moves the app's own bundle to the Trash after it quits, then quits. The

--- a/Sources/Vorssaint/Support/Uninstaller.swift
+++ b/Sources/Vorssaint/Support/Uninstaller.swift
@@ -16,7 +16,10 @@ enum Uninstaller {
         // The fan helper is a daemon service of its own, so unregistering the
         // main app as a login item never reaches it. Without this its root
         // registration outlives the bundle that carried its executable.
-        FanControlService.restoreAndUnregisterForRemoval()
+        let detached = FanControlService.restoreAndUnregisterForRemoval()
+        print(detached
+              ? "UNINSTALL: fan helper daemon unregistered"
+              : "UNINSTALL: fan helper daemon still registered")
         if UserDefaults.standard.bool(forKey: DefaultsKey.sleepDisabledFlag) {
             _ = Sudoers.pmsetDisableSleep(false)
         }
@@ -26,6 +29,9 @@ enum Uninstaller {
         } catch {
             print("UNINSTALL: login item was not registered")
         }
-        exit(0)
+        // Only the daemon decides the status. A login item that was never
+        // registered is not a failure; a daemon left behind is the one thing
+        // the caller cannot see for itself.
+        exit(detached ? EXIT_SUCCESS : EXIT_FAILURE)
     }
 }

--- a/Sources/Vorssaint/Support/Uninstaller.swift
+++ b/Sources/Vorssaint/Support/Uninstaller.swift
@@ -5,14 +5,18 @@ import Foundation
 import ServiceManagement
 
 /// `Vorssaint --uninstall`: cleanly detaches the app from the system
-/// before its bundle is removed. It unregisters the login item — so no dead
-/// entry lingers in System Settings › General › Login Items — and restores
-/// normal sleep if a closed-lid session left it disabled.
+/// before its bundle is removed. It unregisters the fan helper daemon and the
+/// login item — so no dead entry lingers in System Settings › General › Login
+/// Items — and restores normal sleep if a closed-lid session left it disabled.
 ///
 /// Used by `Tools/uninstall.sh`. Must run from the installed bundle, since
 /// `SMAppService.mainApp` is scoped to the running app's bundle identifier.
 enum Uninstaller {
     static func runAndExit() -> Never {
+        // The fan helper is a daemon service of its own, so unregistering the
+        // main app as a login item never reaches it. Without this its root
+        // registration outlives the bundle that carried its executable.
+        FanControlService.restoreAndUnregisterForRemoval()
         if UserDefaults.standard.bool(forKey: DefaultsKey.sleepDisabledFlag) {
             _ = Sudoers.pmsetDisableSleep(false)
         }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -17370,6 +17370,21 @@ struct MetricsTests {
                    "defaults suite \(argument) is named inside a namespace build.sh sweeps")
         }
 
+        // MARK: Uninstallation paths stay aligned across SelfUninstall and Tools/uninstall.sh
+        let selfUninstallSource = (try? String(contentsOfFile: "Sources/Vorssaint/Services/SelfUninstall.swift",
+                                              encoding: .utf8)) ?? ""
+        let uninstallScriptSource = (try? String(contentsOfFile: "Tools/uninstall.sh",
+                                                encoding: .utf8)) ?? ""
+        expect(!selfUninstallSource.isEmpty && !uninstallScriptSource.isEmpty,
+               "uninstall sources read back for uninstallation alignment check")
+        let requiredSubpaths = ["Library/Application Support", "Library/Caches", "Library/HTTPStorages"]
+        for subpath in requiredSubpaths {
+            expect(selfUninstallSource.contains(subpath) && uninstallScriptSource.contains(subpath),
+                   "both in-app and script uninstall sweep \(subpath)")
+        }
+        expect(uninstallScriptSource.contains("Library/Preferences/ByHost"),
+               "script uninstall sweeps ByHost preferences")
+
         if failures.isEmpty {
             print("TESTS OK (\(checks) checks)")
             exit(0)

--- a/Tools/uninstall.sh
+++ b/Tools/uninstall.sh
@@ -20,8 +20,9 @@ sleep 0.5
 
 # Detach from the system from inside whichever bundle still exists: unregisters
 # the login item (no BTM tombstone) and restores normal sleep.
-# A missing or unrunnable binary leaves the fan helper registered, and nothing
-# below can reach it: the registration lives in the system, not in the bundle.
+# The fan helper's registration lives in the system, not in the bundle, so
+# deleting the app below cannot reach it. Only the binary can drop it, and the
+# check after the loop settles what its absence or failure left behind.
 detached=1
 for candidate in "$APP/Contents/MacOS/Vorssaint" "$LEGACY_APP/Contents/MacOS/VorssaintUtils"; do
     if [[ -x "$candidate" ]]; then
@@ -30,6 +31,18 @@ for candidate in "$APP/Contents/MacOS/Vorssaint" "$LEGACY_APP/Contents/MacOS/Vor
         break
     fi
 done
+# `detached` cannot tell a failed unregister from no binary having run, and the
+# second is ordinary: an app trashed by hand, then this script for the rest. It
+# also cannot see a daemon that went despite a reported failure. launchctl
+# settles both without sudo, and still finds a registration held back for a
+# pending fan recovery, which is the one case that must keep warning.
+if (( detached )); then
+    launchctl print "system/$BUNDLE.fan-control" >/dev/null 2>&1
+    # 113 is "no such service", the only answer that proves absence. Any other
+    # failure means launchctl could not tell us, and warning then is the honest
+    # side of a check that exists to stop this script claiming what it cannot see.
+    (( $? == 113 )) && detached=0
+fi
 
 echo "▸ Resetting permissions (Accessibility, Screen Recording)…"
 tccutil reset All "$BUNDLE" >/dev/null 2>&1 || true

--- a/Tools/uninstall.sh
+++ b/Tools/uninstall.sh
@@ -20,10 +20,13 @@ sleep 0.5
 
 # Detach from the system from inside whichever bundle still exists: unregisters
 # the login item (no BTM tombstone) and restores normal sleep.
+# A missing or unrunnable binary leaves the fan helper registered, and nothing
+# below can reach it: the registration lives in the system, not in the bundle.
+detached=1
 for candidate in "$APP/Contents/MacOS/Vorssaint" "$LEGACY_APP/Contents/MacOS/VorssaintUtils"; do
     if [[ -x "$candidate" ]]; then
-        echo "▸ Detaching login item and restoring sleep…"
-        "$candidate" --uninstall || true
+        echo "▸ Detaching the fan helper and login item, restoring sleep…"
+        if "$candidate" --uninstall; then detached=0; fi
         break
     fi
 done
@@ -31,7 +34,7 @@ done
 echo "▸ Resetting permissions (Accessibility, Screen Recording)…"
 tccutil reset All "$BUNDLE" >/dev/null 2>&1 || true
 
-echo "▸ Removing app, preferences, saved state and app data…"
+echo "▸ Removing app, preferences, saved state and stored data (clipboard history, shelf files, share links)…"
 rm -rf "$APP" "$LEGACY_APP"
 defaults delete "$BUNDLE" >/dev/null 2>&1 || true
 rm -f "$HOME/Library/Preferences/$BUNDLE.plist"
@@ -40,6 +43,9 @@ rm -rf "$HOME/Library/Saved Application State/$BUNDLE.savedState"
 # here; the in-app uninstall takes them, so this path must not keep them.
 rm -rf "$HOME/Library/Application Support/$BUNDLE"
 rm -rf "$HOME/Library/Caches/$BUNDLE"
+# Written by URLSession on the app's behalf, so they exist without the app ever
+# naming the path; `defaults delete` does not reach them either.
+rm -rf "$HOME/Library/HTTPStorages/$BUNDLE" "$HOME/Library/HTTPStorages/$BUNDLE.binarycookies"
 
 RULES="/etc/sudoers.d/vorssaint-clamshell /etc/sudoers.d/vorssaint-utils-clamshell /etc/sudoers.d/vorss-clamshell"
 if ls $RULES >/dev/null 2>&1; then
@@ -47,4 +53,10 @@ if ls $RULES >/dev/null 2>&1; then
     osascript -e "do shell script \"rm -f $RULES\" with administrator privileges with prompt \"Vorssaint uninstaller\"" || true
 fi
 
-echo "✓ Vorssaint fully removed."
+if (( detached == 0 )); then
+    echo "✓ Vorssaint fully removed."
+else
+    echo "⚠ Vorssaint removed, but its fan helper is still registered with the system." >&2
+    echo "  Reinstall Vorssaint, then use Settings › Advanced to uninstall from inside the app." >&2
+    exit 1
+fi

--- a/Tools/uninstall.sh
+++ b/Tools/uninstall.sh
@@ -46,6 +46,10 @@ rm -rf "$HOME/Library/Caches/$BUNDLE"
 # Written by URLSession on the app's behalf, so they exist without the app ever
 # naming the path; `defaults delete` does not reach them either.
 rm -rf "$HOME/Library/HTTPStorages/$BUNDLE" "$HOME/Library/HTTPStorages/$BUNDLE.binarycookies"
+# `defaults delete` does not reach ByHost. The (N) qualifier is load-bearing:
+# without it zsh aborts the command on an unmatched pattern, which is the
+# ordinary case, and prints an error over a successful uninstall.
+rm -f "$HOME/Library/Preferences/ByHost/$BUNDLE".*.plist(N)
 
 RULES="/etc/sudoers.d/vorssaint-clamshell /etc/sudoers.d/vorssaint-utils-clamshell /etc/sudoers.d/vorss-clamshell"
 if ls $RULES >/dev/null 2>&1; then

--- a/Tools/uninstall.sh
+++ b/Tools/uninstall.sh
@@ -3,8 +3,9 @@
 # Copyright (C) 2026 Vorssaint
 
 # Cleanly removes Vorssaint and every piece of system state it created:
-# the login item, TCC permissions, preferences, saved state and (if present)
-# the password-free closed-lid sudoers rule. Leaves no dead entries behind.
+# the fan helper daemon, the login item, TCC permissions, preferences, saved
+# state, the app's own data folder and (if present) the password-free
+# closed-lid sudoers rule. Leaves no dead entries behind.
 # Also clears the pre-rename "Vorssaint Utils.app" if it is still around.
 set -uo pipefail
 
@@ -30,11 +31,15 @@ done
 echo "▸ Resetting permissions (Accessibility, Screen Recording)…"
 tccutil reset All "$BUNDLE" >/dev/null 2>&1 || true
 
-echo "▸ Removing app, preferences and saved state…"
+echo "▸ Removing app, preferences, saved state and app data…"
 rm -rf "$APP" "$LEGACY_APP"
 defaults delete "$BUNDLE" >/dev/null 2>&1 || true
 rm -f "$HOME/Library/Preferences/$BUNDLE.plist"
 rm -rf "$HOME/Library/Saved Application State/$BUNDLE.savedState"
+# Clipboard history, shelf files, captures and the share delete tokens live
+# here; the in-app uninstall takes them, so this path must not keep them.
+rm -rf "$HOME/Library/Application Support/$BUNDLE"
+rm -rf "$HOME/Library/Caches/$BUNDLE"
 
 RULES="/etc/sudoers.d/vorssaint-clamshell /etc/sudoers.d/vorssaint-utils-clamshell /etc/sudoers.d/vorss-clamshell"
 if ls $RULES >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

`Tools/uninstall.sh` prints `✓ Vorssaint fully removed.` and the README calls it the way to remove Vorssaint completely, but two things outlived it.

- **The Fan Control daemon stayed registered.** The script hands the system detach to `--uninstall`, and that path only dropped the app as a login item. The helper is a separate service built by `SMAppService.daemon(plistName:)`, and `unregister` acts on its own receiver, so nothing reached it — its root registration outlived the bundle that carried its executable. `Uninstaller.runAndExit()` now makes the same `FanControlService.restoreAndUnregisterForRemoval()` call the in-app uninstall already made.
- **The data folder stayed on disk.** The script removed the app, the preferences plist and the saved state, but never `~/Library/Application Support/<id>` or `~/Library/Caches/<id>` — clipboard history and its images, the shelf store, recorder takes, the scratchpad, and the share records with their delete tokens. It removes both now.

Both are one divergence: `SelfUninstall` does the complete job and the script path was a subset that had drifted from it.

**On "fix it entirely".** This covers the bug entirely — both halves, on both paths, with nothing left for a follow-up. What I did *not* do is collapse the duplication I raised as the wider option on the issue, and that was a deliberate call rather than a shortcut. Two reasons:

- The script's own `rm -rf` lines are a fallback, not just duplication. If the binary cannot run — quarantined, signature broken, bundle half-deleted — the script still clears the preferences and now the data folder. Delegating all removal to `--uninstall` would mean a binary that refuses to launch leaves everything behind, which is the case where a user most needs the script to work.
- `--uninstall` does not destroy user data today. Making it the single place that defines removal would give that flag the power to delete clipboard history, and anyone who runs it by hand would lose data they did not ask to lose.

So the duplication that stays is the deliberate kind, and this change makes the two paths agree on what has to go. If you did mean the structural version, say so and I will send it as a follow-up on top of this one — but I would rather not fold it in here, since it changes what a flag does as well as fixing a bug.

**Other callers I checked.** `restoreAndUnregisterForRemoval()` had exactly one caller in the tree, `SelfUninstall.swift:103`. `--uninstall` is the only other path that has to detach from the system, and `main.swift` exits before `AppDelegate` is constructed, so nothing in `applicationWillTerminate` covers it. `restoreBeforeTerminationIfNeeded()` on the ordinary quit path restores automatic fan control and deliberately does not unregister; I left it alone. Every place the app writes under `~/Library` is `Application Support/<id>` or `Caches/<id>`, and there is no legacy bundle identifier to sweep — the pre-rename bundle kept the same one.

The call is safe on this path: it never touches `FanControlService.shared`, uses its own XPC connection with a 20 s timeout, returns early when the service is not registered, and the script already invokes the binary from inside the bundle, so `SMAppService` resolves against the right one.

## Verification

Mac17,6 (M5 Max), macOS 26.5.1 (25F80), Command Line Tools Swift 6.3.3, my own release build. App language follows the system, tr-TR. Single built-in display.

- `./build.sh` — finished with no warnings
- `./build/Vorssaint --selftest` — passed
- `./build.sh --test` — passed
- `zsh -n Tools/uninstall.sh` — valid
- Ran the script's removal block against a throwaway `$HOME` seeded with the paths the app writes. Before the change, the plist and the `.savedState` went and every data file stayed; after it, nothing was left.
- Confirmed the daemon really is registered on this Mac beforehand with `launchctl print system/com.vorssaint.utils.fan-control`, which needs no `sudo`: it prints a job submitted by ServiceManagement whose program identifier points inside the app bundle.

**What I could not test.** The end-to-end run. Verifying the daemon half for real means uninstalling my own working install and re-approving the helper in System Settings afterwards, and I did not want to do that on the machine I use daily. So the unregister is verified as reachable and safe on this path, not observed removing a live registration — worth one run on your side before merging. I also did not measure whether macOS eventually garbage-collects the orphaned record on its own; the argument here is that the correct call already exists and the script should not depend on that either way.

## Anything else

Refs #986.

Scope note: I used `uninstall` rather than the existing `uninstaller`, since that scope has meant the feature that removes *other* apps (#752) and this is the app's own removal. Rename it on squash if you would rather keep one scope.
