### PR TITLE
ci(issues): require the issue reference and point out the missing ones

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 <!--
-Nothing here is required, and a one-line fix needs only the first section.
-The shortest description ever merged here was five lines.
+Only the issue reference at the bottom is required. A one-line fix needs
+nothing else beyond the first section, and the shortest description ever
+merged here was five lines.
 
 Size is what decides how long this waits. The median merged pull request is
 +110 lines and lands within a day. Nothing under +200 lines is stuck right
@@ -43,7 +44,19 @@ translation is a failed build, not a missing string.
 
 ## Anything else
 
-`Refs #123` for a related issue, rather than `Closes` — the reporter confirms
-the fix. If the issue carries more than one report and this covers only one,
-say which, here and on the issue when this merges. `Depends on #123` if it
-has to land after another branch.
+**If an issue exists for this, reference it, written exactly as `Refs #N`.**
+Not `Closes`/`Fixes`, which closes the report on merge when the fix has not
+reached anyone's Mac yet, and not a bare `#N` or a sentence about it. That
+line is what the fix-status bot reads when this merges: it labels the issue,
+comments again when a release carries the fix, and closes the issue after two
+weeks of silence. A pull request that leaves it out drops the report out of
+that track, and nobody notices until the reporter asks months later.
+
+Several issues means several references, each on its own line and each
+starting with its own `Refs`. The bot reads the word and the number as a pair,
+so `Refs #N, #M` reaches the first number and leaves the second one
+sitting there.
+
+If the issue carries more than one report and this covers only one, say which,
+here and on the issue when this merges. `Depends on #N` if it has to land
+after another branch.

--- a/.github/workflows/issue-fix-status.yml
+++ b/.github/workflows/issue-fix-status.yml
@@ -1,6 +1,6 @@
 name: Issue fix status
 
-# Three mechanical steps, no judgement in any of them.
+# Four mechanical steps, no judgement in any of them.
 #
 #   a merged pull request that references an issue  ->  the issue gets
 #   `fixed (pending release)`, with the merge commit recorded in the bot's
@@ -11,6 +11,28 @@ name: Issue fix status
 #
 #   two weeks of silence after that                 ->  the issue is closed,
 #   after a comment saying so and how to reopen it
+#
+#   a description that closes its issue with a    ->  one comment on the pull
+#   keyword, or mentions one and references none        request, before it merges
+#
+# The fourth one is the only part of this that runs before a merge, and it is
+# the only part that changes nothing: it comments once and never touches the
+# issue. It exists because the first step is silent when a reference is
+# missing -- the run logs `references no issue` and nobody reads a green log.
+# The reference is the whole tie to the reporter, and the moment to notice it
+# is missing is while the author is still here.
+#
+# A closing keyword is the worse of the two and the quieter one. GitHub closes
+# the issue itself on merge, and the first step above skips closed issues, so
+# the reporter is never told anything at all. Of the merged pull requests that
+# used one, that is what happened to every single issue they named.
+#
+# It never guesses which issue is meant. A mention is not a reference, and most
+# of the numbers in a description here are prose -- `since #927 merged`,
+# `landed in #919 after this branch`. Widening the parser to treat those as
+# references was measured against sixty merged pull requests: it would have
+# labelled thirteen open reports as fixed. So the comment asks the author and
+# stops there.
 #
 # Neither of the first two decides that anything is fixed. A human decided that
 # when they merged. The label only says where the change is, and
@@ -37,7 +59,7 @@ name: Issue fix status
 
 on:
   pull_request_target:
-    types: [closed]
+    types: [opened, reopened, edited, closed]
   workflow_run:
     # Not `release: published`. The release is created by `gh release create`
     # with the built-in token, and an event raised by that token does not start
@@ -67,7 +89,10 @@ env:
 jobs:
   fixed-on-main:
     name: Label the issues a merged PR referenced
-    if: github.event_name == 'pull_request_target' && github.event.pull_request.merged == true
+    if: >-
+      github.event_name == 'pull_request_target'
+      && github.event.action == 'closed'
+      && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -127,6 +152,129 @@ jobs:
             gh issue comment "$number" --body-file comment.md
             echo "#$number: labelled $PENDING_LABEL ($MERGE_SHA)"
           done
+
+  reference-hint:
+    name: Point out a reference that will not reach the reporter
+    if: >-
+      github.event_name == 'pull_request_target'
+      && github.event.action != 'closed'
+      && github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # No checkout, for the same reason as the merge job: this runs with write
+      # access in the base repository context and must never execute anything
+      # from the pull request. The body is read through the API into a file and
+      # only ever grepped.
+      - name: Comment on a description that leaves the reporter out
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          gh api "repos/$GH_REPO/pulls/$PR_NUMBER" --jq '.body // ""' > pr-body.txt
+
+          # Wider than the merge job's pattern on purpose: this is GitHub's own
+          # closing-keyword list, and a form the merge job does not recognise
+          # still closes the issue. That is the worst case, not a lesser one --
+          # GitHub closes it and this bot never sees it.
+          closing=$(grep -oiE '(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]*:?[[:space:]]*#[0-9]+' pr-body.txt \
+                      | grep -oE '[0-9]+$' | sort -un) || true
+
+          plain=$(grep -oiE '(refs?|references?|related to)[[:space:]]*:?[[:space:]]*#[0-9]+' pr-body.txt \
+                    | grep -oE '[0-9]+$' | sort -un) || true
+
+          # A closing keyword is wrong even with a correct reference beside it,
+          # so it is checked first and independently.
+          if [ -n "$closing" ]; then
+            form=closing
+            candidates=$closing
+          elif [ -n "$plain" ]; then
+            echo "#$PR_NUMBER references an issue and closes nothing, nothing to say"
+            exit 0
+          else
+            form=missing
+            candidates=$(grep -oE '#[0-9]+' pr-body.txt | tr -d '#' | sort -un) || true
+            if [ -z "$candidates" ]; then
+              echo "#$PR_NUMBER mentions no number at all, nothing to say"
+              exit 0
+            fi
+          fi
+
+          # Said once per form. An edit to the description fires this again, and
+          # a second copy of the same comment is noise on somebody else's
+          # branch. Per form, because an author who is told about a missing
+          # reference and then adds a closing keyword has earned the other one.
+          if gh api --paginate "repos/$GH_REPO/issues/$PR_NUMBER/comments" --jq '.[].body' \
+               | grep -q "vorssaint-fix-status hint=.*form=$form"; then
+            echo "#$PR_NUMBER has been told about $form already"
+            exit 0
+          fi
+
+          # Only open reports. A pull request number, a closed issue or a number
+          # that belongs to nothing costs the reporter nothing either way.
+          : > hits.txt
+          for number in $candidates; do
+            issue=$(gh api "repos/$GH_REPO/issues/$number" 2>/dev/null) || continue
+            [ "$(jq 'has("pull_request")' <<<"$issue")" = false ] || continue
+            [ "$(jq -r '.state' <<<"$issue")" = open ] || continue
+            printf '%s\t%s\n' "$number" "$(jq -r '.title' <<<"$issue")" >> hits.txt
+          done
+
+          if [ ! -s hits.txt ]; then
+            echo "#$PR_NUMBER points at no open issue, nothing to say"
+            exit 0
+          fi
+
+          # A description that walks through a dozen reports is doing something
+          # other than fixing one, and a comment listing all twelve helps
+          # nobody. Five, and the count of what is not listed.
+          total=$(wc -l < hits.txt | tr -d ' ')
+          head -5 hits.txt > shown.txt
+          numbers=$(cut -f1 hits.txt | paste -sd, -)
+
+          : > lines.md
+          while IFS=$'\t' read -r number title; do
+            printf -- '- **Refs #%s** — %s\n' "$number" "$title" >> lines.md
+          done < shown.txt
+          if [ "$total" -gt 5 ]; then
+            printf -- '- ...and %s more, in the run log\n' "$((total - 5))" >> lines.md
+          fi
+
+          # Expanded heredocs below: keep the text free of backticks and `$`.
+          if [ "$form" = closing ]; then
+            cat > head.md <<COMMENT
+          This closes its issue with a keyword, and that keyword takes the report away from the person who filed it. GitHub closes the issue the moment this merges, before the fix is on anyone's Mac, and the fix-status bot then skips it, because it only speaks to open issues. Every merged pull request here that used one ended that way: the reporter was never told which release carried the fix, and never got to say whether it worked.
+
+          Use the plain reference form instead — the word Refs, one line each:
+
+          COMMENT
+            cat > tail.md <<COMMENT
+
+          The issue then stays open, gets labelled, and its reporter is asked to confirm on the release that actually carries the fix. It closes two weeks later if nobody says otherwise, so nothing stays open forever either.
+
+          <!-- vorssaint-fix-status hint=$numbers form=$form -->
+          COMMENT
+          else
+            cat > head.md <<COMMENT
+          This description mentions an open report but does not reference one, so nothing here is tied to the person who filed it.
+
+          If this pull request fixes any of these, add a line for it to the description — one line each, every line starting with the word Refs:
+
+          COMMENT
+            cat > tail.md <<COMMENT
+
+          On merge that line is what puts the report on the fix track: it gets labelled, its reporter is told which release carries the fix, and it closes two weeks later if nobody says otherwise. Without it the report stays where it is and nobody finds out until the reporter asks.
+
+          If the mention was only a mention, ignore this — a maintainer decides, not this comment, and nothing about it blocks the merge.
+
+          <!-- vorssaint-fix-status hint=$numbers form=$form -->
+          COMMENT
+          fi
+
+          cat head.md lines.md tail.md > comment.md
+          gh pr comment "$PR_NUMBER" --body-file comment.md
+          echo "#$PR_NUMBER: $form, asked about $numbers"
 
   reporter-check:
     name: Ask the reporters a stable release reached

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,12 +146,22 @@ For general help and every support channel, see [support](SUPPORT.md).
    is a conflict with every sibling PR and a wording that gets rewritten
    anyway. Say in the description what a user would notice; the entry is
    written from that.
-9. Link the issue with `Refs #123` rather than `Closes`/`Fixes`, and when the
-   branch merges, say on that issue which part of it this covered and which
-   part it did not. An issue here often carries more than one report, and a
-   fix for one of them reads as a fix for all of them until somebody says
-   otherwise. The issue itself stays open until the person who reported it
-   confirms on a real build.
+9. **A pull request that has an issue must link it, written exactly as `Refs
+   #123`.** Not `Closes`/`Fixes`, not a bare `#123`, not a sentence about it.
+   That one line is the whole tie between the change and the person who
+   reported it: the fix-status bot reads it on merge, labels the issue,
+   comments again when a release carries the fix, and closes the issue after
+   two weeks of silence. A branch that leaves it out drops that report out of
+   the track entirely, and nobody finds out until the reporter asks months
+   later. `Closes`/`Fixes` fails the other way, closing the report on merge
+   when the fix is not on anyone's Mac yet. Several issues means several
+   references, each on its own line and each starting with its own `Refs`:
+   the bot reads the word and the number as a pair, so `Refs #123, #456`
+   reaches #123 and leaves #456 sitting there. When the branch merges, say on
+   the issue which part of it this covered and which part it did not. An issue
+   here often carries more than one report, and a fix for one of them reads as
+   a fix for all of them until somebody says otherwise. The issue itself stays
+   open until the person who reported it confirms on a real build.
 10. Fix the cause, not the path the report happened to take. A reporter names
     the symptom they hit; the same mistake usually sits in every sibling call
     site. Find the other callers of whatever you are about to change before
@@ -168,8 +178,9 @@ For general help and every support channel, see [support](SUPPORT.md).
     on a different Mac. Building with a stable signing identity, see above,
     keeps granted permissions across rebuilds and makes this cheap.
 12. The pull request template lists the sections a description here usually
-    has. Nothing in it is required, and it is a prompt rather than a form, so
-    delete what does not apply and write prose.
+    has. Apart from the issue reference, nothing in it is required, and it is
+    a prompt rather than a form, so delete what does not apply and write
+    prose.
 13. A new feature is not ready the day it compiles. Install your own build,
     live with it for a few days, and fix what surfaces. The rough edge you
     only notice on the third day is the one a reviewer cannot find and a user


### PR DESCRIPTION
## Summary

The issue reference was the one thing in the pull request template that had to
be there and was written as if it were optional. It is not.
`.github/workflows/issue-fix-status.yml` reads it on merge, and it is the only
tie between a branch and the person who reported the problem — no reference, no
`fixed (pending release)` label, no comment when a release carries the fix, no
close after two weeks. The report sits there until the reporter comes back and
asks, and nothing in the repository shows that anything happened.

**The template and `CONTRIBUTING.md` rule 9** now require it when an issue
exists, in the exact form the workflow matches, worded the same way in both.
`Closes`/`Fixes` fails the other way — it closes the report on merge, when the
fix is not on anyone's Mac yet, and takes the confirmation away from the person
who is supposed to give it. **One reference per issue, each on its own line**:
the workflow matches the keyword and the number as a pair, so a comma-separated
list reaches the first number only. The header no longer says "nothing here is
required", and rule 12 no longer says the template is required-free.

## A fourth job: say something before the merge, not after

Requiring it in prose does nothing on its own — the merge job is silent when a
reference is missing. It logs `references no issue, nothing to do` and nobody
reads a green log. So this adds the one step that runs *before* a merge, and it
is also the only step that changes nothing: it comments once on the pull request
and never touches an issue. It speaks to two forms.

**A closing keyword** — `Fixes #NNN`, `Closes #NNN` — is the quieter and worse
of the two. GitHub closes the issue itself the moment the branch merges, before
the fix is on anyone's Mac, and step one above skips closed issues, so nothing
in the fix track ever sees it. Replaying the merged pull requests that used one:

```
Fixes/Closes  ->  8 issues named, 8 closed by GitHub, bot silent on all 8
Refs          ->  6 open issues named, bot spoke on the 3 that postdate #927
```

That is not a probability, it is the mechanism. Every reporter in that first row
was never told which release carried their fix and never got to say whether it
worked. The job's pattern for this is GitHub's own keyword list, which is wider
than the merge job's — a form the merge job does not parse still closes the
issue, and would then be invisible to both.

**A bare mention with no reference** gets the softer comment: here are the open
reports you mentioned, add a line if this fixes one. It does not guess. Most of
the numbers in a description here are prose — "since #927 merged", "landed in
#919 after this branch". Widening the parser to read every bare number as a
reference was measured before it was rejected, replaying sixty merged pull
requests:

```
matched by keyword today          21 numbers
added by reading bare numbers     39 numbers
   ...of those, open reports      13    <- labelled fixed, reporter pinged,
                                           closed two weeks later
```

Those thirteen are real reports — external monitor blackouts, the switcher, the
freeze on display power-off — plus the three summary issues, which must never
close on a timer. So the comment asks the author and stops there.

Its marker is `<!-- vorssaint-fix-status hint=NUMBERS form=FORM -->`, the same
family as the `sha=`/`confirm=` markers the other jobs leave, so a later bot can
read what was already asked and about which of the two. It says each form once:
an edit to the description fires the trigger again, and it checks for its own
marker first — per form, so an author told about a missing reference who then
adds a closing keyword still hears about that. It skips bot authors, whose
descriptions carry upstream release notes full of other repositories' numbers.
It lists at most five issues and says how many it did not list.

Two guards come with the wider trigger. The job takes no checkout, for the same
reason the merge job takes none — `pull_request_target` runs with write access
in the base repository context and must never execute anything from the branch.
And `fixed-on-main` is now pinned to `action == 'closed'`: with `edited` in the
trigger list, editing the description of an already-merged pull request would
otherwise re-run it and drag an issue back from `please confirm` to
`fixed (pending release)`.

## Verification

Ran against **every open pull request in this repository, 52 of them**, with the
posting step replaced by a print. No comment was posted.

```
references an issue and closes nothing   20   silent
would comment: closing keyword           12
would comment: mention with no reference  6
points at no open issue                   7   silent
mentions no number at all                 7   silent
```

Every number in those eighteen was checked afterwards: all are open issues, none
is a pull request, none is closed. The twelve carrying a closing keyword span
seven different contributors, which is the shape of a rule nobody has been told
at the moment it matters rather than of anyone being careless.

The multi-reference behavior and the placeholder scrub were run against the exact
`grep -oiE` line from the workflow. `grep -oE '#[0-9]+'` over the template now
returns nothing, so the explanation a contributor leaves in the description box
no longer carries a live reference. The old template named a closed issue, which
the merge job skips, so nothing has gone wrong yet; it would the day that number
belonged to an open one. `CONTRIBUTING.md` keeps its literal examples — it is
never copied into a description.

YAML parses; the job script passes `bash -n`.

## Anything else

No issue to reference — this comes out of the workflow added in #936, not a
report. `CHANGELOG.md` untouched, and no repository setting changes.

What this deliberately does not do: no required check, nothing that blocks a
merge. Turning a first-time contributor's pull request red over a formatting
detail is the wrong trade for something a maintainer catches while merging, and
a comment that a maintainer can overrule is the whole point.

The other gaps between `CONTRIBUTING.md` and the template — leave `CHANGELOG.md`
alone, name the callers you checked, the title format, opening a draft, living
with a new feature for a few days — are left out on purpose. They are prompts
about what to write, not a mechanical requirement, and belong in a separate pass
over the template's prose.
