### PR TITLE
fix(auto-quit): stop waking Electron renderers when watching apps

### DIFF
--- a/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
+++ b/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
@@ -159,8 +159,17 @@ final class AutoQuitService: ObservableObject {
         // it: typing dies system wide (issue #189). Give up fast and retry
         // with growing spacing until the app services its run loop again.
         AXUIElementSetMessagingTimeout(appElement, 0.35)
-        var role: CFTypeRef?
-        if AXUIElementCopyAttributeValue(appElement, kAXRoleAttribute as CFString, &role) == .cannotComplete {
+        // The probe asks for windows rather than the application's role. A
+        // Chromium app (Electron, and the browsers) answers a role query on its
+        // application element by switching its renderers into full
+        // accessibility mode, and from then on it rebuilds and ships an
+        // accessibility tree on every DOM change for the life of the process —
+        // a few percent of a core, forever, in an app this feature only ever
+        // needed a window count from (issue #953). Windows are the same
+        // liveness signal, are what the refresh below reads anyway, and leave
+        // that mode alone; WindowEnumerator probes the same way.
+        var windows: CFTypeRef?
+        if AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &windows) == .cannotComplete {
             guard attempt < 6 else { retryingApps.remove(pid); return }
             retryingApps.insert(pid)
             let delay = 5.0 * pow(2.0, Double(attempt))

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -3882,6 +3882,27 @@ struct MetricsTests {
                                                             visibleSpaces: nil,
                                                             hasTitle: true),
                "without Spaces to compare, the old cautious rule stands")
+
+        // Attaching to a watched app must never ask its application element for
+        // a role. A Chromium app (Electron, and the browsers) answers that by
+        // switching its renderers into full accessibility mode, and then pays
+        // to rebuild and ship an accessibility tree on every DOM change for the
+        // rest of its life — measured on an idle app that this feature only
+        // ever needed a window count from (issue #953). Windows are the same
+        // liveness signal and leave that mode alone. Comments are stripped
+        // first: the note above the probe names the attribute it avoids, and a
+        // check that cannot tell prose from a call would go red for it.
+        let autoQuitServiceCode = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift",
+            encoding: .utf8)) ?? "")
+            .components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(autoQuitServiceCode.contains(
+                   "AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &windows) == .cannotComplete"),
+               "AutoQuit probes a watched app for liveness by asking for its windows")
+        expect(!autoQuitServiceCode.contains("appElement, kAXRoleAttribute"),
+               "AutoQuit never asks a watched app's application element for its role")
         expect(Defaults.sanitizedPanelItemOrder("uninstaller,homebrew,homebrew,bad",
                                                 defaultOrder: ["homebrew", "media", "uninstaller", "cleanURL", "cleaning"])
                == ["uninstaller", "homebrew", "media", "cleanURL", "cleaning"],


### PR DESCRIPTION
Fixes #953 (mechanism proven on local Chromium apps; the UpNote-specific percentage is the one thing only the reporter can confirm).

## Problem

With Quit on close enabled, an Electron app's Helper (Renderer) burns 4–10% of a core continuously, even minimized and idle, with nothing querying the app.

## Root cause

`attach()` probed each watched app for liveness by reading `kAXRole` on its *application* element. A Chromium app (Electron, and the browsers) answers that query by switching its renderers into full accessibility mode, and from then on rebuilds and ships an accessibility tree on every DOM change for the life of the process. Enabling the feature sweeps every running app, so it fires at all of them at once — which is why the report starts at the toggle.

Isolating each AX call against a fresh Electron app (accessibility off ≈ 13 nodes, no `AXWebArea`): `kAXWindows`, `kAXMainWindow`/`kAXFocusedWindow`, the full window scan, observer registration, and the close-button hit test all leave it at 13. The role read alone takes it to 156 with two `AXWebArea`s. Chrome behaves the same (17 → 1222 nodes — the whole page materialized). Renderer CPU, sampled after the probe had already exited: idle Electron note app 0.32% → 0.39%; a Chromium tab holding a 3000-paragraph document with light churn 4.7% → 6.0%. The cost scales with document size and DOM churn and never comes back down — a renderer already flipped only settles after the app restarts.

## The change

Probe with `kAXWindows` instead. Same synchronous call, same `.cannotComplete` signal the issue #189 retry ladder needs, the role value was written and never read, and it is what the refresh reads a moment later anyway — `WindowEnumerator` has always probed exactly this way; AutoQuit was the lone outlier. The post-fix attach shape, including observers and a 1Hz refresh, leaves the app at 13 nodes.

## Verification

`./build.sh` with zero warnings, `./build.sh --test` → TESTS OK (8551 checks), `./build/Vorssaint --selftest` → SELFTEST OK. Source-shape assertions pin the windows probe and ban a role read on the application element; reverting the line turns both red.

@Sirtx — after this lands, restart UpNote once (the flipped accessibility mode only clears on relaunch) and the renderer should settle.