### PR TITLE
fix(command-bar): stop waiting on the shared pasteboard lane

### DIFF
--- a/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
+++ b/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
@@ -97,81 +97,101 @@ final class ClipboardHistoryService: ObservableObject {
         lastChangeCount = max(lastChangeCount, changeCount)
     }
 
-    @discardableResult
-    func copy(_ entry: ClipboardHistoryEntry) -> Bool {
-        guard writeToPasteboard([entry]) else { return false }
-        touch([entry.id])
-        return true
+    func copy(_ entry: ClipboardHistoryEntry, completion: @escaping (Bool) -> Void) {
+        writeToPasteboard([entry]) { [weak self] copied in
+            if copied { self?.touch([entry.id]) }
+            completion(copied)
+        }
     }
 
-    @discardableResult
-    func copy(_ selectedEntries: [ClipboardHistoryEntry]) -> Bool {
-        guard !selectedEntries.isEmpty, writeToPasteboard(selectedEntries) else { return false }
-        touch(selectedEntries.map(\.id))
-        return true
+    func copy(_ selectedEntries: [ClipboardHistoryEntry], completion: @escaping (Bool) -> Void) {
+        guard !selectedEntries.isEmpty else {
+            completion(false)
+            return
+        }
+        writeToPasteboard(selectedEntries) { [weak self] copied in
+            if copied { self?.touch(selectedEntries.map(\.id)) }
+            completion(copied)
+        }
     }
 
-    /// Resolves the payload before touching the pasteboard: a stale entry
-    /// (image purged from the store, files deleted or on an ejected volume)
-    /// must abort with the user's current clipboard intact, not after a
-    /// clearContents() already destroyed it.
-    private func writeToPasteboard(_ list: [ClipboardHistoryEntry]) -> Bool {
-        GeneralPasteboardAccess.shared.sync {
+    /// Puts the entries on the general pasteboard through the shared lane and
+    /// reports on the main queue. The caller never waits: a lane wedged behind
+    /// an app that promised pasteboard content and stopped answering delays
+    /// the copy instead of freezing the app (issue #887).
+    private func writeToPasteboard(_ list: [ClipboardHistoryEntry],
+                                   completion: @escaping (Bool) -> Void) {
+        guard let write = Self.plannedWrite(for: list) else {
+            completion(false)
+            return
+        }
+        GeneralPasteboardAccess.shared.async({ () -> Int in
             let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            write(pasteboard)
+            return pasteboard.changeCount
+        }, then: { [weak self] changeCount in
+            // lastChangeCount stays owned by the main queue, where the capture
+            // poll compares against it. Assigning it on the lane would let a
+            // copy's own change count land after the poll had already read the
+            // old one, and history would record the app's own write as a new
+            // copy by the user.
+            if let self { self.lastChangeCount = max(self.lastChangeCount, changeCount) }
+            completion(true)
+        })
+    }
 
-            if list.count == 1, let entry = list.first {
-                switch entry.kind {
-                case .text:
-                    pasteboard.clearContents()
-                    pasteboard.setString(entry.text, forType: .string)
-                case .image:
-                    guard let name = entry.imageFile,
-                          let data = ClipboardImageStore.imageData(named: name) else { return false }
-                    pasteboard.clearContents()
+    /// What to put on the pasteboard once it is cleared, or nil when the
+    /// content is gone (image purged from the store, files deleted or on an
+    /// ejected volume) and the copy must abort with the user's clipboard
+    /// intact. Resolving on the caller's thread also keeps the AppKit work a
+    /// write may need — RTFD attachments, TIFF rendering — on the main thread
+    /// it has always run on; only the pasteboard calls move to the lane.
+    private static func plannedWrite(for list: [ClipboardHistoryEntry])
+        -> ((NSPasteboard) -> Void)? {
+        if list.count == 1, let entry = list.first {
+            switch entry.kind {
+            case .text:
+                return { $0.setString(entry.text, forType: .string) }
+            case .image:
+                guard let name = entry.imageFile,
+                      let data = ClipboardImageStore.imageData(named: name) else { return nil }
+                // TIFF alongside PNG: some paste targets only take TIFF.
+                let tiff = NSBitmapImageRep(data: data)?.tiffRepresentation
+                return { pasteboard in
                     pasteboard.setData(data, forType: .png)
-                    // TIFF alongside PNG: some paste targets only take TIFF.
-                    if let tiff = NSBitmapImageRep(data: data)?.tiffRepresentation {
-                        pasteboard.setData(tiff, forType: .tiff)
-                    }
-                case .files:
-                    let urls = entry.filePaths
-                        .map { URL(fileURLWithPath: $0) }
-                        .filter { FileManager.default.fileExists(atPath: $0.path) }
-                    guard !urls.isEmpty else { return false }
-                    pasteboard.clearContents()
-                    pasteboard.writeObjects(urls as [NSURL])
+                    if let tiff { pasteboard.setData(tiff, forType: .tiff) }
                 }
-                lastChangeCount = pasteboard.changeCount
-                return true
-            }
-
-            // Batches: an all-files selection pastes as the files themselves; a
-            // selection with images pastes as rich text with the images embedded;
-            // anything else combines as text (files contribute paths).
-            switch ClipboardHistoryBatch.pasteMode(for: list) {
-            case let .files(paths):
-                let urls = paths.map { URL(fileURLWithPath: $0) }
+            case .files:
+                let urls = entry.filePaths
+                    .map { URL(fileURLWithPath: $0) }
                     .filter { FileManager.default.fileExists(atPath: $0.path) }
-                guard !urls.isEmpty else { return false }
-                pasteboard.clearContents()
-                pasteboard.writeObjects(urls as [NSURL])
-            case let .text(combined):
-                pasteboard.clearContents()
-                pasteboard.setString(combined, forType: .string)
-            case let .rich(parts):
-                guard let rich = Self.richBatchAttributedString(parts) else { return false }
-                pasteboard.clearContents()
-                pasteboard.writeObjects([rich])
-                let plain = ClipboardHistoryBatch.richPlainText(parts)
-                if !plain.isEmpty {
-                    pasteboard.setString(plain, forType: .string)
-                }
-            case nil:
-                guard let first = list.first else { return false }
-                return writeToPasteboard([first])
+                guard !urls.isEmpty else { return nil }
+                return { $0.writeObjects(urls as [NSURL]) }
             }
-            lastChangeCount = pasteboard.changeCount
-            return true
+        }
+
+        // Batches: an all-files selection pastes as the files themselves; a
+        // selection with images pastes as rich text with the images embedded;
+        // anything else combines as text (files contribute paths).
+        switch ClipboardHistoryBatch.pasteMode(for: list) {
+        case let .files(paths):
+            let urls = paths.map { URL(fileURLWithPath: $0) }
+                .filter { FileManager.default.fileExists(atPath: $0.path) }
+            guard !urls.isEmpty else { return nil }
+            return { $0.writeObjects(urls as [NSURL]) }
+        case let .text(combined):
+            return { $0.setString(combined, forType: .string) }
+        case let .rich(parts):
+            guard let rich = richBatchAttributedString(parts) else { return nil }
+            let plain = ClipboardHistoryBatch.richPlainText(parts)
+            return { pasteboard in
+                pasteboard.writeObjects([rich])
+                if !plain.isEmpty { pasteboard.setString(plain, forType: .string) }
+            }
+        case nil:
+            guard let first = list.first else { return nil }
+            return plannedWrite(for: [first])
         }
     }
 
@@ -440,34 +460,41 @@ final class ClipboardHistoryService: ObservableObject {
         quickSelectionIndex = min(max(quickSelectionIndex + delta, 0), count - 1)
     }
 
+    /// The window leaves the screen at once; the paste waits for the write,
+    /// because pasting before it lands would paste whatever the user had
+    /// copied before. A stale entry leaves the clipboard untouched and pastes
+    /// nothing at all.
     func copyQuickEntry(_ entry: ClipboardHistoryEntry) {
-        let copied = copy(entry)
         let target = pasteTargetApp
         hideHistoryWindow()
         pasteTargetApp = nil
-        // A stale entry leaves the clipboard untouched; pasting now would
-        // paste whatever the user had copied before, out of nowhere.
-        guard copied else { return }
-        pasteIntoPreviousApp(target)
+        copy(entry) { [weak self] copied in
+            guard copied else { return }
+            self?.pasteIntoPreviousApp(target)
+        }
     }
 
     func copyQuickEntries(_ selectedEntries: [ClipboardHistoryEntry]) {
-        let copied = copy(selectedEntries)
         let target = pasteTargetApp
         hideHistoryWindow()
         pasteTargetApp = nil
-        guard copied else { return }
-        pasteIntoPreviousApp(target)
+        copy(selectedEntries) { [weak self] copied in
+            guard copied else { return }
+            self?.pasteIntoPreviousApp(target)
+        }
     }
 
+    /// No paste follows these two, so nothing has to wait for the write: the
+    /// window closes now and a stale entry simply leaves the clipboard as the
+    /// user left it.
     func copyOnlyQuickEntry(_ entry: ClipboardHistoryEntry) {
-        copy(entry)
+        copy(entry) { _ in }
         hideHistoryWindow()
         pasteTargetApp = nil
     }
 
     func copyOnlyQuickEntries(_ selectedEntries: [ClipboardHistoryEntry]) {
-        copy(selectedEntries)
+        copy(selectedEntries) { _ in }
         hideHistoryWindow()
         pasteTargetApp = nil
     }

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarCatalog.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarCatalog.swift
@@ -1140,12 +1140,17 @@ enum CommandBarCatalog {
         return (free, UInt64(total))
     }
 
+    /// The HUD travels with the write rather than racing it: it says the value
+    /// is on the clipboard, so it appears once it is. The bar itself is never
+    /// held up — the lane can be wedged behind an app that promised pasteboard
+    /// content and stopped answering (issue #887).
     private static func copyAnswer(_ value: String) {
-        GeneralPasteboardAccess.shared.sync {
+        GeneralPasteboardAccess.shared.async({
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(value, forType: .string)
-        }
-        QuickToolHUD.show(icon: "doc.on.doc", message: value)
+        }, then: {
+            QuickToolHUD.show(icon: "doc.on.doc", message: value)
+        })
     }
 
     // MARK: - Emoji
@@ -1230,27 +1235,43 @@ enum CommandBarCatalog {
         }
         // Everything below opens something, so the bar is done. A row that
         // takes a query is still on screen; one that does not was already
-        // hidden, and hiding twice costs nothing.
-        defer { service.hide() }
+        // hidden, and hiding twice costs nothing. It goes now, not when the
+        // clipboard answers, which may be never.
         let date = DateFormatter.localizedString(from: Date(), dateStyle: .short, timeStyle: .none)
-        let copied = GeneralPasteboardAccess.shared.sync {
-            NSPasteboard.general.string(forType: .string)
-        } ?? ""
-        let expanded = CommandBarLinks.expand(link.destination,
-                                              kind: link.kind,
-                                              query: argument,
-                                              clipboard: copied,
-                                              selection: service.selectionWhenRun,
-                                              date: date)
-        guard let url = CommandBarLinks.url(for: link, expanded: expanded) else {
-            NSSound.beep()
+        let selection = service.selectionWhenRun
+        service.hide()
+        withClipboard(neededBy: link.destination) { copied in
+            let expanded = CommandBarLinks.expand(link.destination,
+                                                  kind: link.kind,
+                                                  query: argument,
+                                                  clipboard: copied,
+                                                  selection: selection,
+                                                  date: date)
+            guard let url = CommandBarLinks.url(for: link, expanded: expanded) else {
+                NSSound.beep()
+                return
+            }
+            if link.kind == .place, !FileManager.default.fileExists(atPath: url.path) {
+                QuickToolHUD.show(icon: "folder.badge.questionmark", message: link.name)
+                return
+            }
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    /// The general pasteboard, handed back on the main queue. A destination
+    /// without the clipboard placeholder never reads it at all, and one that
+    /// does reads it on the shared lane, so a stalled pasteboard provider
+    /// delays this one row rather than freezing the app (issue #887).
+    private static func withClipboard(neededBy destination: String,
+                                      _ body: @escaping (String) -> Void) {
+        guard destination.contains(CommandBarLinkPlaceholder.clipboard.token) else {
+            body("")
             return
         }
-        if link.kind == .place, !FileManager.default.fileExists(atPath: url.path) {
-            QuickToolHUD.show(icon: "folder.badge.questionmark", message: link.name)
-            return
-        }
-        NSWorkspace.shared.open(url)
+        GeneralPasteboardAccess.shared.async({
+            NSPasteboard.general.string(forType: .string) ?? ""
+        }, then: body)
     }
 
     /// Return pressed before a script's debounced run has answered yet: runs
@@ -1531,28 +1552,35 @@ enum CommandBarCatalog {
         appDelegate()?.openSettingsWindow()
     }
 
+    /// Reads through the shared lane like every other clipboard row: a direct
+    /// main-thread read races the lane's readers and freezes the app on a
+    /// promised flavour nobody is left to render (issue #887).
     private static func cleanClipboardURL() {
-        let s = L10n.shared.s
-        guard let raw = NSPasteboard.general.string(forType: .string),
-              !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            QuickToolHUD.show(icon: "link", message: s.urlCleanerNoURL)
-            return
-        }
-        let cleaned = URLCleanerService.shared.clean(raw)
-        switch URLCleaning.outcome(for: cleaned, input: raw) {
-        case .notAURL:
-            QuickToolHUD.show(icon: "link", message: s.urlCleanerNoURL)
-        case .unchanged:
-            QuickToolHUD.show(icon: "checkmark.circle", message: s.urlCleanerNoChange)
-        case .rewritten:
-            cleaned.map { URLCleanerService.shared.copy($0.url) }
-            QuickToolHUD.show(icon: "link", message: s.urlCleanerCleaned)
-        case .removed(let names):
-            cleaned.map { URLCleanerService.shared.copy($0.url) }
-            QuickToolHUD.show(icon: "link",
-                              message: String(format: s.urlCleanerRemovedFormat,
-                                              names.joined(separator: ", ")))
-        }
+        GeneralPasteboardAccess.shared.async({
+            NSPasteboard.general.string(forType: .string)
+        }, then: { raw in
+            let s = L10n.shared.s
+            guard let raw,
+                  !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                QuickToolHUD.show(icon: "link", message: s.urlCleanerNoURL)
+                return
+            }
+            let cleaned = URLCleanerService.shared.clean(raw)
+            switch URLCleaning.outcome(for: cleaned, input: raw) {
+            case .notAURL:
+                QuickToolHUD.show(icon: "link", message: s.urlCleanerNoURL)
+            case .unchanged:
+                QuickToolHUD.show(icon: "checkmark.circle", message: s.urlCleanerNoChange)
+            case .rewritten:
+                cleaned.map { URLCleanerService.shared.copy($0.url) }
+                QuickToolHUD.show(icon: "link", message: s.urlCleanerCleaned)
+            case .removed(let names):
+                cleaned.map { URLCleanerService.shared.copy($0.url) }
+                QuickToolHUD.show(icon: "link",
+                                  message: String(format: s.urlCleanerRemovedFormat,
+                                                  names.joined(separator: ", ")))
+            }
+        })
     }
 
     /// Brightness lands on the display under the pointer, the screen where

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
@@ -1947,12 +1947,14 @@ final class CommandBarService: ObservableObject {
             }
             return
         }
-        guard ClipboardHistoryService.shared.copy(entry) else {
-            NSSound.beep()
-            return
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-            Self.postPasteWhenModifiersReleased(attempt: 0)
+        ClipboardHistoryService.shared.copy(entry) { copied in
+            guard copied else {
+                NSSound.beep()
+                return
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                Self.postPasteWhenModifiersReleased(attempt: 0)
+            }
         }
     }
 

--- a/Sources/Vorssaint/Services/GeneralPasteboardAccess.swift
+++ b/Sources/Vorssaint/Services/GeneralPasteboardAccess.swift
@@ -3,31 +3,33 @@
 
 import Foundation
 
-/// Serializes the app's background observers of the general pasteboard.
+/// Serializes every access the app makes to the general pasteboard.
 /// NSPasteboard keeps a mutable type cache on its shared instance, so reading
-/// it from two queues at once can race inside AppKit. Slow reads stay off the
-/// main thread while the services that continuously inspect the clipboard use
-/// one access lane.
+/// it from two queues at once can race inside AppKit, and a read has no time
+/// limit: content can be promised and rendered only on demand, so an app that
+/// stops answering leaves the reader hanging. Hence one serial lane, off the
+/// main thread, and no way to wait for it — a caller waiting on the main
+/// thread is a frozen app (issue #887).
 final class GeneralPasteboardAccess {
     static let shared = GeneralPasteboardAccess()
 
     private let queue: DispatchQueue
-    private let queueKey = DispatchSpecificKey<UInt8>()
-    private let queueValue: UInt8 = 1
 
     init(label: String = "Vorssaint.Pasteboard.general") {
         queue = DispatchQueue(label: label, qos: .utility)
-        queue.setSpecific(key: queueKey, value: queueValue)
     }
 
     func async(_ work: @escaping () -> Void) {
         queue.async(execute: work)
     }
 
-    func sync<T>(_ work: () throws -> T) rethrows -> T {
-        if DispatchQueue.getSpecific(key: queueKey) == queueValue {
-            return try work()
+    /// Runs `work` on the lane and hands its result to `completion` on the
+    /// main queue. The caller returns immediately: a wedged lane delays the
+    /// completion, it never blocks whoever asked.
+    func async<T>(_ work: @escaping () -> T, then completion: @escaping (T) -> Void) {
+        queue.async {
+            let result = work()
+            DispatchQueue.main.async { completion(result) }
         }
-        return try queue.sync(execute: work)
     }
 }

--- a/Sources/Vorssaint/Services/Snippets/SnippetLibraryService.swift
+++ b/Sources/Vorssaint/Services/Snippets/SnippetLibraryService.swift
@@ -165,9 +165,12 @@ final class SnippetLibraryService: ObservableObject {
             }
             return
         }
+        let clipboard = TextSnippetSupport.needsClipboard(snippet.replacement)
+            ? NSPasteboard.general.string(forType: .string)
+            : nil
         let text = TextSnippetSupport.expand(snippet.replacement,
                                              date: Date(),
-                                             clipboard: NSPasteboard.general.string(forType: .string))
+                                             clipboard: clipboard)
         // A beat for the panel to leave the screen; the target app kept focus
         // (the panel never activates), so the caret is exactly where the user
         // left it.

--- a/Sources/Vorssaint/Services/Snippets/TextSnippetService.swift
+++ b/Sources/Vorssaint/Services/Snippets/TextSnippetService.swift
@@ -316,10 +316,17 @@ final class TextSnippetService {
                         trailingKeyCode: CGKeyCode?,
                         trailingFlags: CGEventFlags) {
         let post = {
+            // The replacement has to be posted before this callback returns,
+            // so later typing cannot overtake it — the read cannot move off
+            // this thread. It can be skipped, though, and for every snippet
+            // that does not name the clipboard it now is.
+            let clipboard = TextSnippetSupport.needsClipboard(snippet.replacement)
+                ? NSPasteboard.general.string(forType: .string)
+                : nil
             let text = TextSnippetSupport.expand(
                 snippet.replacement,
                 date: Date(),
-                clipboard: NSPasteboard.general.string(forType: .string)
+                clipboard: clipboard
             )
             Self.postExpansion(deleteCount: deleteCount,
                                text: text,

--- a/Sources/Vorssaint/Services/Snippets/TextSnippetSupport.swift
+++ b/Sources/Vorssaint/Services/Snippets/TextSnippetSupport.swift
@@ -105,6 +105,14 @@ enum TextSnippetSupport {
 
     /// Replaces the dynamic variables. Unknown {{tags}} pass through
     /// untouched, so a typo stays visible instead of vanishing silently.
+    /// The one variable whose value comes from somewhere that can hang: the
+    /// general pasteboard may hold content an app renders only on demand, and
+    /// an app that stops answering never answers. Both expansion paths ask
+    /// this first, so a replacement without the variable pays nothing.
+    static func needsClipboard(_ replacement: String) -> Bool {
+        replacement.contains("{{clipboard}}")
+    }
+
     static func expand(_ replacement: String,
                        date: Date,
                        clipboard: String?,

--- a/Sources/Vorssaint/Services/URLCleanerService.swift
+++ b/Sources/Vorssaint/Services/URLCleanerService.swift
@@ -62,13 +62,19 @@ final class URLCleanerService: ObservableObject {
         URLCleaning.clean(text, rules: Self.rules)
     }
 
+    /// Writes on the shared lane and settles the change count on the main
+    /// queue, where the poll compares against it. The caller never waits: the
+    /// lane can be wedged behind an app that promised pasteboard content and
+    /// stopped answering (issue #887).
     func copy(_ urlString: String) {
         cancelPoll()
-        let changeCount = GeneralPasteboardAccess.shared.sync {
-            Self.writeToPasteboard(urlString)
-        }
-        lastChangeCount = changeCount
         lastCleaned = urlString
+        GeneralPasteboardAccess.shared.async({
+            Self.writeToPasteboard(urlString)
+        }, then: { [weak self] changeCount in
+            guard let self else { return }
+            self.lastChangeCount = max(self.lastChangeCount, changeCount)
+        })
     }
 
     func stop() {

--- a/Sources/Vorssaint/UI/MenuPanel/PanelClipboardView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/PanelClipboardView.swift
@@ -230,8 +230,12 @@ struct PanelClipboardView: View {
                 .controlSize(.mini)
                 .help(entry.isPinned ? text.unpin : text.pin)
                 Button {
-                    history.copy(entry)
-                    copiedID = entry.id
+                    // The tick means "it is on the clipboard", so it waits for
+                    // the write instead of announcing one still queued behind
+                    // a stalled pasteboard provider.
+                    history.copy(entry) { copied in
+                        if copied { copiedID = entry.id }
+                    }
                 } label: {
                     Label(copiedID == entry.id ? text.copied : text.copy,
                           systemImage: copiedID == entry.id ? "checkmark" : "doc.on.doc")

--- a/Sources/Vorssaint/UI/MenuPanel/PanelURLCleanerView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/PanelURLCleanerView.swift
@@ -128,9 +128,16 @@ struct PanelURLCleanerView: View {
         }
     }
 
+    /// Through the shared lane: a direct read here would both race the
+    /// clipboard services on AppKit's pasteboard cache and hang the button
+    /// (and with it the app) on a promised flavour nobody renders any more.
     private func paste() {
-        input = NSPasteboard.general.string(forType: .string) ?? ""
-        clean()
+        GeneralPasteboardAccess.shared.async({
+            NSPasteboard.general.string(forType: .string) ?? ""
+        }, then: { pasted in
+            self.input = pasted
+            self.clean()
+        })
     }
 
     private func clean() {

--- a/Sources/Vorssaint/UI/Settings/URLCleanerSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/URLCleanerSettings.swift
@@ -313,9 +313,16 @@ struct URLCleanerSettings: View {
         }
     }
 
+    /// Through the shared lane: a direct read here would both race the
+    /// clipboard services on AppKit's pasteboard cache and hang the button
+    /// (and with it the app) on a promised flavour nobody renders any more.
     private func paste() {
-        input = NSPasteboard.general.string(forType: .string) ?? ""
-        clean()
+        GeneralPasteboardAccess.shared.async({
+            NSPasteboard.general.string(forType: .string) ?? ""
+        }, then: { pasted in
+            self.input = pasted
+            self.clean()
+        })
     }
 
     private func clean() {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -588,7 +588,7 @@ struct MetricsTests {
         for _ in 0..<16 {
             pasteboardGroup.enter()
             DispatchQueue.global(qos: .userInitiated).async {
-                pasteboardAccess.sync {
+                pasteboardAccess.async {
                     pasteboardStateLock.lock()
                     activePasteboardOperations += 1
                     maximumPasteboardOperations = max(maximumPasteboardOperations,
@@ -598,19 +598,45 @@ struct MetricsTests {
                     pasteboardStateLock.lock()
                     activePasteboardOperations -= 1
                     pasteboardStateLock.unlock()
+                    pasteboardGroup.leave()
                 }
-                pasteboardGroup.leave()
             }
         }
-        expect(pasteboardGroup.wait(timeout: .now() + 2) == .success,
+        expect(pasteboardGroup.wait(timeout: .now() + 5) == .success,
                "pasteboard access operations finish without deadlock")
         expect(maximumPasteboardOperations == 1,
                "pasteboard access serializes concurrent service work")
-        let nestedPasteboardValue = pasteboardAccess.sync {
-            pasteboardAccess.sync { 230 }
+
+        // The freeze this lane exists to prevent (issue #887): a read stuck
+        // behind an app that promised pasteboard content and stopped answering
+        // holds the lane, and any caller that waited for it would be frozen
+        // with it. Wedge the lane, then ask for work from the main thread: the
+        // ask must return at once and the answer must arrive later, on main.
+        let wedgeReleased = DispatchSemaphore(value: 0)
+        pasteboardAccess.async { wedgeReleased.wait() }
+        // Released on its own, so a caller that waited for the lane comes out
+        // measurably late instead of hanging the whole test run.
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.3) {
+            wedgeReleased.signal()
         }
-        expect(nestedPasteboardValue == 230,
-               "pasteboard access permits nested work without deadlock")
+        var laneAnswer: Int?
+        var laneAnsweredOnMain = false
+        let askedAt = Date()
+        pasteboardAccess.async({ 887 }, then: { value in
+            laneAnswer = value
+            laneAnsweredOnMain = Thread.isMainThread
+        })
+        let askDuration = Date().timeIntervalSince(askedAt)
+        expect(askDuration < 0.1,
+               "asking the wedged pasteboard lane for work returns without waiting "
+                   + "(took \(askDuration)s)")
+        expect(laneAnswer == nil, "the wedged lane has not answered yet")
+        let laneDeadline = Date().addingTimeInterval(5)
+        while laneAnswer == nil, Date() < laneDeadline {
+            RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
+        expect(laneAnswer == 887, "the queued work runs once the lane comes free")
+        expect(laneAnsweredOnMain, "the pasteboard lane answers on the main queue")
 
         let maxCapacityStringJSON = Data(#"{"SPPowerDataType":[{"sppower_battery_health_info":{"sppower_battery_health_maximum_capacity":"93%"}}]}"#.utf8)
         expect(MaxCapacityProbe.percent(fromSystemProfilerJSON: maxCapacityStringJSON) == 93,
@@ -11697,6 +11723,18 @@ struct MetricsTests {
                "unknown variables stay visible")
         expect(TextSnippetSupport.expand("plain", date: fixedDate, clipboard: nil) == "plain",
                "text without variables passes through untouched")
+
+        // Only a replacement that names the clipboard pays for reading it: the
+        // pasteboard can hang on content nobody renders any more, and that read
+        // sits on the keystroke path (issue #887).
+        expect(TextSnippetSupport.needsClipboard("clip: {{clipboard}}"),
+               "a replacement naming the clipboard needs it read")
+        expect(!TextSnippetSupport.needsClipboard("Report on {{date}} at {{time}}."),
+               "a replacement with only date variables never reads the clipboard")
+        expect(!TextSnippetSupport.needsClipboard("plain"),
+               "a replacement without variables never reads the clipboard")
+        expect(!TextSnippetSupport.needsClipboard("keep {{unknown}}"),
+               "an unknown variable is not the clipboard one")
 
         // Custom date patterns after a colon (issue #348)
         let enUS = Locale(identifier: "en_US")


### PR DESCRIPTION
## The freeze

Reading the general pasteboard has no time limit. An app can put *promised* content there and render it only when someone asks; an app that promises and then stops answering leaves the reader hanging with nothing to fall back on.

`GeneralPasteboardAccess` exists for that reason — one serial lane, off the main thread, so a slow read is somebody else's problem. But it also offered `sync`, and four main-thread callers used it: the answer rows' copy, the saved links' `{clipboard}` read, clipboard history writes, the URL cleaner's copy. The clipboard history poll hits a stalled provider regularly and wedges the lane; the next Return in the Command bar then parks the main thread in `_dispatch_sync_f_slow` behind it, and the app is frozen.

Two Command bar rows did not even use the lane: `Clean URL` and both URL cleaner paste buttons read `NSPasteboard.general.string(forType:)` straight from the main thread. That is the same hang, plus the AppKit type-cache race the lane was introduced to prevent.

## What changed

`GeneralPasteboardAccess` **drops `sync`** and gains `async(_:then:)` — work on the lane, result on the main queue, caller never waits. Deleting `sync` is the point: with no way left to wait for the lane, no future caller can freeze on it. All four callers moved over, and the three lane-less sites now go through the lane too.

Falling out of that:

- **`lastChangeCount` stays owned by the main queue.** `DispatchQueue.sync` used to run the closure on the calling thread, so assigning it inside the write was a main-queue assignment by accident. Assigning it from the lane would let a copy's own change count land *after* the capture poll read the old one — `guard changeCount > lastChangeCount` passes and history records the app's own write as a fresh copy by the user. The write now returns the change count and the main-queue completion assigns it.
- **AppKit work stays on the main thread.** `NSTextAttachment(fileWrapper:)` / RTFD via `writeObjects` and `NSBitmapImageRep(data:).tiffRepresentation` also ran on main only because of that same `sync`. The write is now resolved into a plan before the hop, so those keep running where they always did and only the pasteboard calls move. It also collapses six `clearContents()` calls into one and keeps the existing invariant intact: a stale entry aborts before anything is cleared.
- **Confirmations moved with the work they describe, not with the click.** The answer HUD, the quick panel's "Copied" tick and the paste that follows a quick-panel copy now wait for the write. The bar, the quick window and the URL cleaner panel leave the screen immediately — the two `copyOnly…` variants have no paste after them, so nothing there waits either.

## Snippets

`{{clipboard}}` is read from the event tap thread, where the replacement must be posted before the callback returns or later typing overtakes it. That read cannot move off the thread without answering the ordering question, so it stays — but it can be skipped, and both expansion paths now read the pasteboard only when the replacement actually names `{{clipboard}}`. A snippet that does not is no longer exposed at all.

## Alternatives

- **A timeout on the read.** There is no API for one; the only way to abandon a stalled read is to not be the one waiting for it. That is what the lane already does.
- **Keeping `sync` for "fast" call sites.** No read is reliably fast — the promise is the caller's problem whether the content looks small or not — and a `sync` left in the type is a footgun someone reaches for later. Deleting it is what makes this class of freeze unreachable rather than just currently absent.
- **Converting the snippet tap path too.** It would post expansions out of order. Out of scope here; see above.

## Not changed

`PastePlainService` reads and rewrites the general pasteboard on its hotkey path without the lane. It is a read-modify-write transaction with its own restore state, not a one-shot read, and it is not reachable from the Command bar. It stays as it is.

## Verification

`./build.sh --dev` builds clean; `./build.sh --test` passes 8562 checks, four of which are new: the lane serializes concurrent work, a wedged lane answers a main-thread caller *without* making it wait, the answer arrives on the main queue once the lane frees, and only a replacement naming `{{clipboard}}` asks for it. The wedge test was checked against a deliberately broken `async(_:then:)` (one that waits for the lane): it fails, naming the 0.31 s it waited.

ref #887
