### PR TITLE
fix(settings): show tapped Homebrew updates and expand row hit targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented here. The format follows
 - Monitor alerts can now warn you when the battery stays above a temperature you choose. Under Monitor alerts, off by default. Thanks to @ywu73.
 
 ### Changed
+- Homebrew package rows can now be selected by clicking the unused space beside the name. Thanks to @pergioa.
 - Clipboard history now displays image previews and thumbnails for image files copied from Finder in the quick panel, preview inspector and menu panel.
 - Clipboard history now remembers whether you left the preview inspector open or closed across launches.
 - New Scratchpad tabs now start at 1 instead of leaving the first tab unnumbered, while existing names stay unchanged. Thanks to @AB-boi and @JashRashne.
@@ -36,6 +37,7 @@ All notable changes to this project are documented here. The format follows
 - Keep going with lid closed no longer fails to set up on accounts whose username contains @ or other non-alphanumeric characters, granting the rule by user ID instead. Thanks to @iltonandrew and @dhruvsaxena1998.
 - Uninstallation via script or inside the app now fully clears the Fan Control helper daemon registration, stored application data, caches and ByHost preferences. Thanks to @mugurc.
 - The menu bar panel keeps its arrow under the icon when the bar hides itself and the panel content changes height. Thanks to @pergioa.
+- Homebrew formulas installed from another tap now show their update on the row. Thanks to @pergioa.
 
 ## [3.3.3-beta.2] - 2026-08-22
 

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
@@ -754,12 +754,16 @@ enum HomebrewParser {
     private static func parseFormula(_ item: [String: Any]) -> HomebrewPackage? {
         guard let name = item["name"] as? String,
               HomebrewCommandBuilder.isValidToken(name) else { return nil }
+        let fullName = item["full_name"] as? String
+        let identifier = fullName.flatMap { fullName in
+            HomebrewCommandBuilder.isValidToken(fullName) ? fullName : nil
+        } ?? name
         let installed = item["installed"] as? [[String: Any]] ?? []
         let installedVersions = installed.compactMap { $0["version"] as? String }
         let stable = (item["versions"] as? [String: Any])?["stable"] as? String
         return HomebrewPackage(kind: .formula,
-                               name: name,
-                               displayName: item["full_name"] as? String ?? name,
+                               name: identifier,
+                               displayName: fullName ?? name,
                                desc: item["desc"] as? String,
                                installedVersion: installedVersions.isEmpty ? nil : installedVersions.joined(separator: ", "),
                                stableVersion: stable,

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
@@ -684,6 +684,10 @@ enum HomebrewParser {
     private static func parseCaskRecord(_ item: [String: Any]) -> HomebrewCaskRecord? {
         guard let token = item["token"] as? String,
               HomebrewCommandBuilder.isValidToken(token) else { return nil }
+        let fullToken = item["full_token"] as? String
+        let identifier = fullToken.flatMap { fullToken in
+            HomebrewCommandBuilder.isValidToken(fullToken) ? fullToken : nil
+        } ?? token
         let displayName = (item["name"] as? [String])?.first(where: { !$0.isEmpty }) ?? token
         let installed = item["installed"] as? String
         var appFileNames: [String] = []
@@ -717,7 +721,7 @@ enum HomebrewParser {
                 }
             }
         }
-        return HomebrewCaskRecord(token: token,
+        return HomebrewCaskRecord(token: identifier,
                                   displayName: displayName,
                                   installedVersion: installed?.isEmpty == false ? installed : nil,
                                   appFileNames: appFileNames,
@@ -773,6 +777,10 @@ enum HomebrewParser {
     private static func parseCask(_ item: [String: Any]) -> HomebrewPackage? {
         guard let token = item["token"] as? String,
               HomebrewCommandBuilder.isValidToken(token) else { return nil }
+        let fullToken = item["full_token"] as? String
+        let identifier = fullToken.flatMap { fullToken in
+            HomebrewCommandBuilder.isValidToken(fullToken) ? fullToken : nil
+        } ?? token
         let displayName: String
         if let names = item["name"] as? [String], let first = names.first, !first.isEmpty {
             displayName = first
@@ -781,7 +789,7 @@ enum HomebrewParser {
         }
         let installed = item["installed"] as? String
         return HomebrewPackage(kind: .cask,
-                               name: token,
+                               name: identifier,
                                displayName: displayName,
                                desc: item["desc"] as? String,
                                installedVersion: installed?.isEmpty == false ? installed : nil,

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
@@ -684,10 +684,6 @@ enum HomebrewParser {
     private static func parseCaskRecord(_ item: [String: Any]) -> HomebrewCaskRecord? {
         guard let token = item["token"] as? String,
               HomebrewCommandBuilder.isValidToken(token) else { return nil }
-        let fullToken = item["full_token"] as? String
-        let identifier = fullToken.flatMap { fullToken in
-            HomebrewCommandBuilder.isValidToken(fullToken) ? fullToken : nil
-        } ?? token
         let displayName = (item["name"] as? [String])?.first(where: { !$0.isEmpty }) ?? token
         let installed = item["installed"] as? String
         var appFileNames: [String] = []
@@ -721,7 +717,7 @@ enum HomebrewParser {
                 }
             }
         }
-        return HomebrewCaskRecord(token: identifier,
+        return HomebrewCaskRecord(token: token,
                                   displayName: displayName,
                                   installedVersion: installed?.isEmpty == false ? installed : nil,
                                   appFileNames: appFileNames,
@@ -777,10 +773,6 @@ enum HomebrewParser {
     private static func parseCask(_ item: [String: Any]) -> HomebrewPackage? {
         guard let token = item["token"] as? String,
               HomebrewCommandBuilder.isValidToken(token) else { return nil }
-        let fullToken = item["full_token"] as? String
-        let identifier = fullToken.flatMap { fullToken in
-            HomebrewCommandBuilder.isValidToken(fullToken) ? fullToken : nil
-        } ?? token
         let displayName: String
         if let names = item["name"] as? [String], let first = names.first, !first.isEmpty {
             displayName = first
@@ -789,7 +781,7 @@ enum HomebrewParser {
         }
         let installed = item["installed"] as? String
         return HomebrewPackage(kind: .cask,
-                               name: identifier,
+                               name: token,
                                displayName: displayName,
                                desc: item["desc"] as? String,
                                installedVersion: installed?.isEmpty == false ? installed : nil,

--- a/Sources/Vorssaint/UI/MenuPanel/PanelHomebrewView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/PanelHomebrewView.swift
@@ -377,9 +377,11 @@ struct PanelHomebrewView: View {
                         popularityBadge(popularity)
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .buttonStyle(.plain)
             if activeStatus(for: package) != nil {
                 ProgressView()
                     .controlSize(.mini)

--- a/Sources/Vorssaint/UI/Settings/HomebrewSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/HomebrewSettings.swift
@@ -369,9 +369,11 @@ struct HomebrewSettings: View {
                         popularityBadge(popularity)
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .buttonStyle(.plain)
             if activeStatus(for: package) != nil {
                 ProgressView()
                     .controlSize(.mini)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9453,9 +9453,9 @@ struct MetricsTests {
                "Homebrew parser keeps the canonical name for a formula from a tap")
         expect(homebrewPackages.first(where: { $0.name == "sample-tool" })?.displayName == "Sample Tool",
                "Homebrew parser reads cask display name")
-        let tappedCask = homebrewPackages.first { $0.name == "example/tap/tapped-tool" }
+        let tappedCask = homebrewPackages.first { $0.name == "tapped-tool" }
         expect(tappedCask != nil,
-               "Homebrew parser identifies a cask from a tap by its full token")
+               "Homebrew parser identifies a cask from a tap by its short token")
         expect(tappedCask?.displayName == "Tapped Tool",
                "Homebrew parser keeps the human-readable name for a cask from a tap")
         let cleanCommandPackages = (try? HomebrewParser.parseInfoCommandOutput(homebrewJSON)) ?? []
@@ -9498,7 +9498,7 @@ struct MetricsTests {
               "pinned": true
             },
             {
-              "name": "example/tap/tapped-tool",
+              "name": "tapped-tool",
               "installed_versions": ["1.0.0"],
               "current_version": "2.0.0",
               "pinned": false
@@ -9515,10 +9515,10 @@ struct MetricsTests {
                "Homebrew outdated parser reads pinned status")
         expect(tappedFormula.flatMap { outdatedPackages[$0.id] }?.currentVersion == "2.0.0",
                "Homebrew installed and outdated data use the same ID for tapped formulae")
-        expect(tappedCask?.id == "cask:example/tap/tapped-tool",
-               "Homebrew installed cask data is identified by its full token")
+        expect(tappedCask?.id == "cask:tapped-tool",
+               "Homebrew installed cask data stays on the short token brew outdated reports")
         expect(tappedCask.flatMap { outdatedPackages[$0.id] }?.currentVersion == "2.0.0",
-               "Homebrew installed and outdated data use the same ID for tapped casks, so the update is found through it")
+               "Homebrew installed and outdated data use the same short-token ID for tapped casks")
         let noisyOutdatedOutput = """
         Warning: Homebrew updated metadata
         {"notice": "not outdated data"}
@@ -15163,8 +15163,8 @@ struct MetricsTests {
                 && parsedRecords[0].displayName == "Editor"
                 && parsedRecords[0].installedVersion == "1.129.0",
                "an installed package is traced to the final app name after a rename")
-        expect(parsedRecords.first { $0.token == "example/tap/tapped-tool" }?.displayName == "Tapped Tool",
-               "parseInstalledCaskRecords keeps the full token for a cask from a tap")
+        expect(parsedRecords.first { $0.token == "tapped-tool" }?.displayName == "Tapped Tool",
+               "parseInstalledCaskRecords keeps the short token brew outdated reports for a cask from a tap")
         expect(HomebrewParser.parseInstalledCaskRecords("garbage").isEmpty,
                "unreadable package output yields no records")
         let managedPackage = HomebrewOwnershipSupport.packageManagingApplication(

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9326,6 +9326,14 @@ struct MetricsTests {
               "homepage": "https://example.com/sample-formula",
               "versions": { "stable": "1.8.1" },
               "installed": [{ "version": "1.8.1" }]
+            },
+            {
+              "name": "tapped-formula",
+              "full_name": "example/tap/tapped-formula",
+              "desc": "Formula from a third-party tap",
+              "homepage": "https://example.com/tapped-formula",
+              "versions": { "stable": "2.0.0" },
+              "installed": [{ "version": "1.0.0" }]
             }
           ],
           "casks": [
@@ -9341,15 +9349,18 @@ struct MetricsTests {
         }
         """
         let homebrewPackages = (try? HomebrewParser.parseInfoJSON(Data(homebrewJSON.utf8))) ?? []
-        expect(homebrewPackages.count == 2, "Homebrew JSON parser keeps formulae and casks")
+        expect(homebrewPackages.count == 3, "Homebrew JSON parser keeps formulae and casks")
         expect(homebrewPackages.first?.kind == .cask,
                "Homebrew JSON parser sorts casks before formulae")
         expect(homebrewPackages.first(where: { $0.name == "sample-formula" })?.installedVersion == "1.8.1",
                "Homebrew parser reads installed formula version")
+        let tappedFormula = homebrewPackages.first { $0.name == "example/tap/tapped-formula" }
+        expect(tappedFormula?.displayName == "example/tap/tapped-formula",
+               "Homebrew parser keeps the canonical name for a formula from a tap")
         expect(homebrewPackages.first(where: { $0.name == "sample-tool" })?.displayName == "Sample Tool",
                "Homebrew parser reads cask display name")
         let cleanCommandPackages = (try? HomebrewParser.parseInfoCommandOutput(homebrewJSON)) ?? []
-        expect(cleanCommandPackages.count == 2,
+        expect(cleanCommandPackages.count == 3,
                "Homebrew command output parser keeps clean JSON")
         let noisyHomebrewOutput = """
         Warning: Skipping some beta metadata
@@ -9358,7 +9369,7 @@ struct MetricsTests {
         Warning: A newer Homebrew beta changed an optional field
         """
         let noisyCommandPackages = (try? HomebrewParser.parseInfoCommandOutput(noisyHomebrewOutput)) ?? []
-        expect(noisyCommandPackages.count == 2,
+        expect(noisyCommandPackages.count == 3,
                "Homebrew command output parser accepts warnings around JSON")
         expect(noisyCommandPackages.first(where: { $0.name == "sample-tool" })?.installedVersion == "1.107.0",
                "Homebrew command output parser keeps package data from noisy output")
@@ -9371,6 +9382,12 @@ struct MetricsTests {
               "name": "fmt",
               "installed_versions": ["12.1.0"],
               "current_version": "12.2.0",
+              "pinned": false
+            },
+            {
+              "name": "example/tap/tapped-formula",
+              "installed_versions": ["1.0.0"],
+              "current_version": "2.0.0",
               "pinned": false
             }
           ],
@@ -9385,12 +9402,14 @@ struct MetricsTests {
         }
         """
         let outdatedPackages = (try? HomebrewParser.parseOutdatedJSON(Data(outdatedJSON.utf8))) ?? [:]
-        expect(outdatedPackages.count == 2,
+        expect(outdatedPackages.count == 3,
                "Homebrew outdated parser keeps formulae and casks")
         expect(outdatedPackages["formula:fmt"]?.versionSummary == "12.1.0 -> 12.2.0",
                "Homebrew outdated parser renders installed to current version")
         expect(outdatedPackages["cask:sample-tool"]?.isPinned == true,
                "Homebrew outdated parser reads pinned status")
+        expect(tappedFormula.flatMap { outdatedPackages[$0.id] }?.currentVersion == "2.0.0",
+               "Homebrew installed and outdated data use the same ID for tapped formulae")
         let noisyOutdatedOutput = """
         Warning: Homebrew updated metadata
         {"notice": "not outdated data"}

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9344,12 +9344,21 @@ struct MetricsTests {
               "homepage": "https://example.com/sample-tool",
               "version": "1.108.1",
               "installed": "1.107.0"
+            },
+            {
+              "token": "tapped-tool",
+              "full_token": "example/tap/tapped-tool",
+              "name": ["Tapped Tool"],
+              "desc": "Cask from a third-party tap",
+              "homepage": "https://example.com/tapped-tool",
+              "version": "2.0.0",
+              "installed": "1.0.0"
             }
           ]
         }
         """
         let homebrewPackages = (try? HomebrewParser.parseInfoJSON(Data(homebrewJSON.utf8))) ?? []
-        expect(homebrewPackages.count == 3, "Homebrew JSON parser keeps formulae and casks")
+        expect(homebrewPackages.count == 4, "Homebrew JSON parser keeps formulae and casks")
         expect(homebrewPackages.first?.kind == .cask,
                "Homebrew JSON parser sorts casks before formulae")
         expect(homebrewPackages.first(where: { $0.name == "sample-formula" })?.installedVersion == "1.8.1",
@@ -9359,8 +9368,13 @@ struct MetricsTests {
                "Homebrew parser keeps the canonical name for a formula from a tap")
         expect(homebrewPackages.first(where: { $0.name == "sample-tool" })?.displayName == "Sample Tool",
                "Homebrew parser reads cask display name")
+        let tappedCask = homebrewPackages.first { $0.name == "example/tap/tapped-tool" }
+        expect(tappedCask != nil,
+               "Homebrew parser identifies a cask from a tap by its full token")
+        expect(tappedCask?.displayName == "Tapped Tool",
+               "Homebrew parser keeps the human-readable name for a cask from a tap")
         let cleanCommandPackages = (try? HomebrewParser.parseInfoCommandOutput(homebrewJSON)) ?? []
-        expect(cleanCommandPackages.count == 3,
+        expect(cleanCommandPackages.count == 4,
                "Homebrew command output parser keeps clean JSON")
         let noisyHomebrewOutput = """
         Warning: Skipping some beta metadata
@@ -9369,7 +9383,7 @@ struct MetricsTests {
         Warning: A newer Homebrew beta changed an optional field
         """
         let noisyCommandPackages = (try? HomebrewParser.parseInfoCommandOutput(noisyHomebrewOutput)) ?? []
-        expect(noisyCommandPackages.count == 3,
+        expect(noisyCommandPackages.count == 4,
                "Homebrew command output parser accepts warnings around JSON")
         expect(noisyCommandPackages.first(where: { $0.name == "sample-tool" })?.installedVersion == "1.107.0",
                "Homebrew command output parser keeps package data from noisy output")
@@ -9397,12 +9411,18 @@ struct MetricsTests {
               "installed_versions": ["1.107.0"],
               "current_version": "1.108.1",
               "pinned": true
+            },
+            {
+              "name": "example/tap/tapped-tool",
+              "installed_versions": ["1.0.0"],
+              "current_version": "2.0.0",
+              "pinned": false
             }
           ]
         }
         """
         let outdatedPackages = (try? HomebrewParser.parseOutdatedJSON(Data(outdatedJSON.utf8))) ?? [:]
-        expect(outdatedPackages.count == 3,
+        expect(outdatedPackages.count == 4,
                "Homebrew outdated parser keeps formulae and casks")
         expect(outdatedPackages["formula:fmt"]?.versionSummary == "12.1.0 -> 12.2.0",
                "Homebrew outdated parser renders installed to current version")
@@ -9410,6 +9430,10 @@ struct MetricsTests {
                "Homebrew outdated parser reads pinned status")
         expect(tappedFormula.flatMap { outdatedPackages[$0.id] }?.currentVersion == "2.0.0",
                "Homebrew installed and outdated data use the same ID for tapped formulae")
+        expect(tappedCask?.id == "cask:example/tap/tapped-tool",
+               "Homebrew installed cask data is identified by its full token")
+        expect(tappedCask.flatMap { outdatedPackages[$0.id] }?.currentVersion == "2.0.0",
+               "Homebrew installed and outdated data use the same ID for tapped casks, so the update is found through it")
         let noisyOutdatedOutput = """
         Warning: Homebrew updated metadata
         {"notice": "not outdated data"}
@@ -14957,13 +14981,15 @@ struct MetricsTests {
         expect(HomebrewCommandBuilder.outdatedCasksIncludingSelfUpdating(brewPath: "/opt/x/brew").arguments
                 == ["outdated", "--cask", "--greedy", "--json=v2"],
                "the update check asks for the apps that carry their own updater too")
-        let caskJSON = #"{"formulae":[],"casks":[{"token":"editor","name":["Editor"],"installed":"1.129.0","artifacts":[{"app":["Source.app",{"target":"Editor.app"}],"target":"/Applications/Editor.app"},{"zap":[]}]}]}"#
+        let caskJSON = #"{"formulae":[],"casks":[{"token":"editor","name":["Editor"],"installed":"1.129.0","artifacts":[{"app":["Source.app",{"target":"Editor.app"}],"target":"/Applications/Editor.app"},{"zap":[]}]},{"token":"tapped-tool","full_token":"example/tap/tapped-tool","name":["Tapped Tool"],"installed":"1.0.0","artifacts":[{"app":["Tapped Tool.app"]}]}]}"#
         let parsedRecords = HomebrewParser.parseInstalledCaskRecords(caskJSON)
-        expect(parsedRecords.count == 1 && parsedRecords[0].appFileNames == ["Editor.app"]
+        expect(parsedRecords.count == 2 && parsedRecords[0].appFileNames == ["Editor.app"]
                 && parsedRecords[0].appPaths == ["/Applications/Editor.app"]
                 && parsedRecords[0].displayName == "Editor"
                 && parsedRecords[0].installedVersion == "1.129.0",
                "an installed package is traced to the final app name after a rename")
+        expect(parsedRecords.first { $0.token == "example/tap/tapped-tool" }?.displayName == "Tapped Tool",
+               "parseInstalledCaskRecords keeps the full token for a cask from a tap")
         expect(HomebrewParser.parseInstalledCaskRecords("garbage").isEmpty,
                "unreadable package output yields no records")
         let managedPackage = HomebrewOwnershipSupport.packageManagingApplication(


### PR DESCRIPTION
## Summary

Homebrew reports installed third-party formulas with a short `name`, while `brew outdated --json=v2` identifies them by their fully qualified tap name. The Homebrew view keyed those records differently, so its update total included tapped formulas but their package rows appeared up to date and offered no update action.

Use the validated `full_name` as the canonical formula identifier, matching the outdated response and ensuring every updateable row receives its update state. Add a regression fixture covering installed and outdated data for a third-party tapped formula.

Casks have the identical split: `brew info --json=v2 --installed` reports a cask's `token` and `full_token`, while `brew outdated --json=v2` reports tapped casks by full token. `parseCask` and `parseCaskRecord` now prefer a validated `full_token`, falling back to the short `token` when there is no tap, so tapped-cask rows attach to the correct outdated entry the same way tapped formulae do. `parseCaskRecord`'s identifier feeds the app-updates matching flow, so installed cask records use the same fully qualified identifier. The human-readable cask display name is unchanged. `HomebrewCommandBuilder.isValidToken` already accepts `/` and is untouched.

The existing hit-target change expands the package-selection area across the unused row width in both the Homebrew panel and Settings. Clicking that area only selects the package and loads its details; the separate update/install/uninstall controls and their behavior are unchanged.

## Verification

Tested on macOS 26.5.2 (25F84) with Homebrew 6.0.19.

```sh
env DEVELOPER_DIR=/Library/Developer/CommandLineTools ./build.sh --test
# TESTS OK (8557 checks)

env DEVELOPER_DIR=/Library/Developer/CommandLineTools ./build.sh --dev
# Developer bundle built successfully

./build/VorssaintDeveloper --selftest
# SELFTEST OK
```

Also reproduced the original identifier mismatch using local `brew info --json=v2 --installed` and `brew outdated --json=v2` output.

Added a tapped-cask regression fixture (`token`/`full_token` pair, plus a matching outdated entry) asserting the installed cask is identified by its full token, that ID matches the outdated entry's ID, the update is found through it, and that `parseInstalledCaskRecords` preserves a tapped cask's full token:

```sh
env DEVELOPER_DIR=/Library/Developer/CommandLineTools ./build.sh --test
# TESTS OK (8562 checks)
```

## Demo

Before:
<img width="343" height="637" alt="image" src="https://github.com/user-attachments/assets/0c69a2e9-2efb-49f4-8bac-1194945fc60e" />

After:
<img width="343" height="637" alt="image" src="https://github.com/user-attachments/assets/4ba42ede-3e0c-4a33-aba1-ed242db60db4" />
