### PR TITLE
fix(update): run the installer in its own session

### DIFF
--- a/Sources/Vorssaint/App/AppDelegate.swift
+++ b/Sources/Vorssaint/App/AppDelegate.swift
@@ -1504,10 +1504,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
     /// process, so this is how the uninstaller picks up a just-granted grant.
     func relaunchApp() {
         let path = Bundle.main.bundlePath
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/bin/sh")
-        task.arguments = ["-c", "sleep 0.3; /usr/bin/open \"$1\"", "vorssaint-relaunch", path]
-        try? task.run()
+        // Its own session: the reopen fires after we terminate, so the child
+        // has to outlive the session it was started from.
+        _ = try? DetachedProcess.spawn(
+            "/bin/sh",
+            ["-c", "sleep 0.3; /usr/bin/open \"$1\"", "vorssaint-relaunch", path])
         NSApp.terminate(nil)
     }
 

--- a/Sources/Vorssaint/App/FeatureRuntime.swift
+++ b/Sources/Vorssaint/App/FeatureRuntime.swift
@@ -36,10 +36,9 @@ final class FeatureRuntime: ObservableObject {
     /// exits, so the fresh instance starts without the uninstalled features.
     func relaunchApp() {
         guard let bundleID = Bundle.main.bundleIdentifier else { return }
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/bin/sh")
-        task.arguments = ["-c", "sleep 0.6; /usr/bin/open -b '\(bundleID)'"]
-        try? task.run()
+        // Its own session: the reopen fires after we terminate, so the child
+        // has to outlive the session it was started from.
+        _ = try? DetachedProcess.spawn("/bin/sh", ["-c", "sleep 0.6; /usr/bin/open -b '\(bundleID)'"])
         NSApp.terminate(nil)
     }
 

--- a/Sources/Vorssaint/Core/BundleMigration.swift
+++ b/Sources/Vorssaint/Core/BundleMigration.swift
@@ -73,10 +73,9 @@ enum BundleMigration {
             .appendingPathComponent("vorssaint-rename-\(pid)-\(UUID().uuidString).sh")
         do {
             try script.write(to: scriptURL, atomically: true, encoding: .utf8)
-            let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/bin/sh")
-            task.arguments = [scriptURL.path, oldPath, newPath, "\(pid)"]
-            try task.run()
+            // Its own session: the script waits for this app to exit before it
+            // renames the bundle, which it can only do from outside our session.
+            try DetachedProcess.spawn("/bin/sh", [scriptURL.path, oldPath, newPath, "\(pid)"])
         } catch {
             try? FileManager.default.removeItem(at: scriptURL)
             return false   // could not stage the rename; keep running as we are

--- a/Sources/Vorssaint/Services/DetachedProcess.swift
+++ b/Sources/Vorssaint/Services/DetachedProcess.swift
@@ -4,8 +4,9 @@
 import Darwin
 import Foundation
 
-/// Starting something that has to outlive this app — the update installer,
-/// which replaces the very bundle we are running from.
+/// Starting something that has to outlive this app: the update installer, the
+/// uninstall and rename scripts, and the relaunch helpers — every one of them
+/// waits for this process to go away before it does its work.
 ///
 /// `nohup` is not enough: it only makes the child ignore SIGHUP. The child
 /// stays in this app's session and launchd job, so whatever tears that job
@@ -47,9 +48,18 @@ enum DetachedProcess {
     /// the command falls back to the previous nohup form — a child that may
     /// still be swept away beats an update that cannot start at all.
     ///
+    /// The branch is taken on whether perl is *there*, never on an exit code:
+    /// perl execs the payload, so the status the shell sees is the payload's
+    /// own, and an `||` fallback would rerun the whole installer — as root —
+    /// every time it exited non-zero. perl therefore carries the setsid(2)
+    /// failure case itself, degrading to nohup's ignored SIGHUP (a signal
+    /// disposition survives exec) instead of handing the decision back.
+    ///
     /// `quotedArgv` is the program and its arguments, already quoted for sh.
     static func detachedShellCommand(quotedArgv: String) -> String {
-        let setsid = "/usr/bin/perl -e 'use POSIX (); POSIX::setsid() > 0 or exit 127; exec @ARGV; exit 127'"
-        return "set -- \(quotedArgv); { \(setsid) \"$@\" || /usr/bin/nohup \"$@\"; } >/dev/null 2>&1 &"
+        let setsid = "/usr/bin/perl -e 'use POSIX (); "
+            + "POSIX::setsid(); $SIG{HUP} = \"IGNORE\"; exec @ARGV; exit 127'"
+        return "set -- \(quotedArgv); { if [ -x /usr/bin/perl ]; then exec \(setsid) \"$@\"; "
+            + "else exec /usr/bin/nohup \"$@\"; fi; } >/dev/null 2>&1 &"
     }
 }

--- a/Sources/Vorssaint/Services/DetachedProcess.swift
+++ b/Sources/Vorssaint/Services/DetachedProcess.swift
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Darwin
+import Foundation
+
+/// Starting something that has to outlive this app — the update installer,
+/// which replaces the very bundle we are running from.
+///
+/// `nohup` is not enough: it only makes the child ignore SIGHUP. The child
+/// stays in this app's session and launchd job, so whatever tears that job
+/// down takes the installer with it, and the swap never happens (issue #731,
+/// reported under Endpoint Privilege Management). Leaving the session is the
+/// property that makes the child survive, and setsid(2) is the only way to
+/// get it.
+enum DetachedProcess {
+    /// posix_spawn with POSIX_SPAWN_SETSID: the kernel makes the child its own
+    /// session leader before it execs, so there is no window where it belongs
+    /// to us. Returns the child pid. Throws the spawn errno so callers can
+    /// report the failure the same way `Process.run()` let them.
+    @discardableResult
+    static func spawn(_ executablePath: String, _ arguments: [String]) throws -> pid_t {
+        var attributes: posix_spawnattr_t?
+        posix_spawnattr_init(&attributes)
+        defer { posix_spawnattr_destroy(&attributes) }
+        posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETSID))
+
+        let argv: [UnsafeMutablePointer<CChar>?] =
+            ([executablePath] + arguments).map { strdup($0) } + [nil]
+        defer { for argument in argv { free(argument) } }
+
+        var pid: pid_t = 0
+        let status = posix_spawn(&pid, executablePath, nil, &attributes, argv, environ)
+        guard status == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(status),
+                          userInfo: [NSLocalizedDescriptionKey: String(cString: strerror(status))])
+        }
+        return pid
+    }
+
+    /// The same detachment for a command that can only travel as a shell
+    /// string: the elevated installer goes through the system administrator
+    /// prompt, which takes one command, not an argument vector.
+    ///
+    /// macOS ships no setsid(1), so the session is left by the smallest tool
+    /// present on every macOS that can call setsid(2). If it is ever missing,
+    /// the command falls back to the previous nohup form — a child that may
+    /// still be swept away beats an update that cannot start at all.
+    ///
+    /// `quotedArgv` is the program and its arguments, already quoted for sh.
+    static func detachedShellCommand(quotedArgv: String) -> String {
+        let setsid = "/usr/bin/perl -e 'use POSIX (); POSIX::setsid() > 0 or exit 127; exec @ARGV; exit 127'"
+        return "set -- \(quotedArgv); { \(setsid) \"$@\" || /usr/bin/nohup \"$@\"; } >/dev/null 2>&1 &"
+    }
+}

--- a/Sources/Vorssaint/Services/DetachedProcess.swift
+++ b/Sources/Vorssaint/Services/DetachedProcess.swift
@@ -15,23 +15,36 @@ import Foundation
 /// property that makes the child survive, and setsid(2) is the only way to
 /// get it.
 enum DetachedProcess {
-    /// posix_spawn with POSIX_SPAWN_SETSID: the kernel makes the child its own
-    /// session leader before it execs, so there is no window where it belongs
-    /// to us. Returns the child pid. Throws the spawn errno so callers can
-    /// report the failure the same way `Process.run()` let them.
+    /// POSIX_SPAWN_SETSID: the kernel makes the child its own session leader
+    /// before it execs, so there is no window where it belongs to us.
+    /// CLOEXEC_DEFAULT keeps this app's other descriptors out of a child that
+    /// outlives it, as `Process` already did for the children it spawned.
+    /// Returns the child pid, or throws the spawn errno.
     @discardableResult
     static func spawn(_ executablePath: String, _ arguments: [String]) throws -> pid_t {
         var attributes: posix_spawnattr_t?
         posix_spawnattr_init(&attributes)
         defer { posix_spawnattr_destroy(&attributes) }
-        posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETSID))
+        posix_spawnattr_setflags(&attributes,
+                                 Int16(POSIX_SPAWN_SETSID | POSIX_SPAWN_CLOEXEC_DEFAULT))
+
+        // CLOEXEC_DEFAULT closes 0/1/2 as well, and the child's first open()
+        // would take one of them — stdout landing inside a data file. Give
+        // those three /dev/null, the stdio the elevated command redirects to
+        // itself.
+        var fileActions: posix_spawn_file_actions_t?
+        posix_spawn_file_actions_init(&fileActions)
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+        posix_spawn_file_actions_addopen(&fileActions, 0, "/dev/null", O_RDONLY, 0)
+        posix_spawn_file_actions_addopen(&fileActions, 1, "/dev/null", O_WRONLY, 0)
+        posix_spawn_file_actions_addopen(&fileActions, 2, "/dev/null", O_WRONLY, 0)
 
         let argv: [UnsafeMutablePointer<CChar>?] =
             ([executablePath] + arguments).map { strdup($0) } + [nil]
         defer { for argument in argv { free(argument) } }
 
         var pid: pid_t = 0
-        let status = posix_spawn(&pid, executablePath, nil, &attributes, argv, environ)
+        let status = posix_spawn(&pid, executablePath, &fileActions, &attributes, argv, environ)
         guard status == 0 else {
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(status),
                           userInfo: [NSLocalizedDescriptionKey: String(cString: strerror(status))])

--- a/Sources/Vorssaint/Services/SelfUninstall.swift
+++ b/Sources/Vorssaint/Services/SelfUninstall.swift
@@ -174,10 +174,10 @@ enum SelfUninstall {
             .appendingPathComponent("vorssaint-uninstall-\(pid)-\(UUID().uuidString).sh")
         do {
             try script.write(to: scriptURL, atomically: true, encoding: .utf8)
-            let task = Process()
-            task.executableURL = URL(fileURLWithPath: "/bin/sh")
-            task.arguments = [scriptURL.path, app, "\(pid)"]
-            try task.run()
+            // Its own session: the script's first act is to wait for this app
+            // to exit, so a child left in our session would be torn down with
+            // us before it ever gets to move the bundle.
+            try DetachedProcess.spawn("/bin/sh", [scriptURL.path, app, "\(pid)"])
             NSApp.terminate(nil)
         } catch {
             try? FileManager.default.removeItem(at: scriptURL)

--- a/Sources/Vorssaint/Services/Update/UpdateInstallerSupport.swift
+++ b/Sources/Vorssaint/Services/Update/UpdateInstallerSupport.swift
@@ -168,8 +168,8 @@ enum UpdateInstallerSupport {
     /// The shell command run with admin rights when the app's folder is not
     /// writable by the current user. The whole installer travels inline (no
     /// script file that another process could rewrite before root runs it)
-    /// and is detached with nohup so the prompt returns while the installer
-    /// waits for the app to quit.
+    /// and is started in its own session (`DetachedProcess`) so the prompt
+    /// returns immediately and the installer outlives the app it replaces.
     static func elevatedInstallCommand(appPath: String,
                                        dmgPath: String,
                                        pid: Int32,
@@ -180,7 +180,8 @@ enum UpdateInstallerSupport {
         let args = [appPath, dmgPath, "\(pid)", resultPath, "\(uid)", expectedVersion]
             .map(shellSingleQuoted)
             .joined(separator: " ")
-        return "/usr/bin/nohup /bin/sh -c \(script) vorssaint-installer \(args) >/dev/null 2>&1 &"
+        return DetachedProcess.detachedShellCommand(
+            quotedArgv: "/bin/sh -c \(script) vorssaint-installer \(args)")
     }
 
     /// Whether the next install attempt should go straight through the admin

--- a/Sources/Vorssaint/Services/Update/UpdateService.swift
+++ b/Sources/Vorssaint/Services/Update/UpdateService.swift
@@ -353,12 +353,12 @@ final class UpdateService: ObservableObject {
             return
         }
 
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/bin/sh")
-        task.arguments = [scriptURL.path, appPath, dmgPath, "\(pid)", resultPath,
-                          "\(getuid())", expectedVersion]
         do {
-            try task.run()
+            // Its own session: a plain child would be swept away with this
+            // app's session and launchd job, before the swap it is here for.
+            try DetachedProcess.spawn("/bin/sh",
+                                      [scriptURL.path, appPath, dmgPath, "\(pid)", resultPath,
+                                       "\(getuid())", expectedVersion])
         } catch {
             try? FileManager.default.removeItem(at: scriptURL)
             failInstall(dmgPath: dmgPath, message: error.localizedDescription)
@@ -373,9 +373,9 @@ final class UpdateService: ObservableObject {
     /// Same installer, behind the system admin prompt via AdminShell, which
     /// serializes prompts and brings this menu bar app forward so the dialog
     /// cannot open behind another window. The script goes inline inside the
-    /// elevated command (never a user-writable file run as root), detached
-    /// with nohup so the prompt returns while the installer waits for our
-    /// exit.
+    /// elevated command (never a user-writable file run as root), started in
+    /// its own session so the prompt returns while the installer waits for our
+    /// exit — and so it survives that exit.
     private func launchAdminInstaller(appPath: String, dmgPath: String, pid: Int32,
                                       resultPath: String, expectedVersion: String) {
         let command = UpdateInstallerSupport.elevatedInstallCommand(appPath: appPath,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -7591,12 +7591,10 @@ struct MetricsTests {
                 .split(separator: "\n").count ?? 0
         }
         for _ in 0..<300 where detachedRunCount() == 0 { usleep(10_000) }
-        usleep(500_000)   // a rerun follows the first run immediately; wait it out
-        let detachedRuns = detachedRunCount()
-        expect(detachedRuns == 1,
-               "a detached command runs its payload once whatever the payload exits with "
-               + "(ran \(detachedRuns) time(s))")
-        try? FileManager.default.removeItem(at: detachRoot)
+        expect(detachedRunCount() == 1, "a detached command starts its payload once")
+        // The rerun is counted again at the very end of this suite instead of
+        // after a fixed wait here: a second run arriving late must not read as
+        // a pass.
 
         // A detached spawn is only detached if the child really is its own
         // session leader; `nohup` alone leaves it in ours.
@@ -7612,6 +7610,43 @@ struct MetricsTests {
         } catch {
             expect(false, "detached spawn failed: \(error.localizedDescription)")
         }
+
+        // A child built to outlive this app must not carry this app's open
+        // descriptors with it: the app is gone before the child does its work,
+        // so anything it inherited is held open by a process nobody can see or
+        // close. `Process` gave its children a clean table; these children get
+        // the same. 0/1/2 must still be open (on /dev/null), or the child's
+        // first open() takes stdout's slot.
+        let fdRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VorssaintDetachFDTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: fdRoot, withIntermediateDirectories: true)
+        let fdHolder = fdRoot.appendingPathComponent("holder")
+        let fdReport = fdRoot.appendingPathComponent("report")
+        // Opened WITHOUT O_CLOEXEC, the way a plain open() anywhere in the app
+        // leaves it — that is the descriptor that must not travel.
+        let holderDescriptor = open(fdHolder.path, O_RDWR | O_CREAT | O_TRUNC, 0o644)
+        expect(holderDescriptor >= 3, "fd probe holds a descriptor above stdio")
+        do {
+            let probe = "{ /bin/echo leaked >&\(holderDescriptor); } 2>/dev/null; INHERITED=$?; "
+                + "{ /bin/echo stdio; } 2>/dev/null; STDIO=$?; "
+                + "/bin/echo \"$INHERITED $STDIO\" > \(UpdateInstallerSupport.shellSingleQuoted(fdReport.path))"
+            let child = try DetachedProcess.spawn("/bin/sh", ["-c", probe])
+            var reaped: Int32 = 0
+            waitpid(child, &reaped, 0)
+            let report = ((try? String(contentsOf: fdReport, encoding: .utf8)) ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let status = report.split(separator: " ").map(String.init)
+            expect(status.count == 2 && status[0] != "0",
+                   "a detached child does not inherit this app's open descriptors (probe: \"\(report)\")")
+            expect(((try? String(contentsOf: fdHolder, encoding: .utf8)) ?? "").isEmpty,
+                   "a detached child cannot write through a descriptor this app opened")
+            expect(status.count == 2 && status[1] == "0",
+                   "a detached child still has stdout open (probe: \"\(report)\")")
+        } catch {
+            expect(false, "detached fd probe failed: \(error.localizedDescription)")
+        }
+        close(holderDescriptor)
+        try? FileManager.default.removeItem(at: fdRoot)
 
         // MARK: - UpdateServiceSupport & SemVer channel reconciliation
 
@@ -19206,6 +19241,16 @@ struct MetricsTests {
         }
         expect(uninstallScriptSource.contains("Library/Preferences/ByHost"),
                "script uninstall sweeps ByHost preferences")
+
+        // MARK: Detached command reruns (counted last, so a late rerun still fails)
+        // The `||` form reran the whole installer — as root — on every non-zero
+        // payload exit. Counting here rather than after a fixed wait leaves the
+        // check no window a second run can arrive behind.
+        let detachedRuns = detachedRunCount()
+        expect(detachedRuns == 1,
+               "a detached command runs its payload once whatever the payload exits with "
+               + "(ran \(detachedRuns) time(s))")
+        try? FileManager.default.removeItem(at: detachRoot)
 
         if failures.isEmpty {
             print("TESTS OK (\(checks) checks)")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -7566,6 +7566,38 @@ struct MetricsTests {
                && elevated.components(separatedBy: "\"$@\"").count == 3,
                "elevated installer names its arguments once and reuses them for the fallback")
 
+        // The fallback branch has to be chosen on whether perl is there, never
+        // on an exit code: perl execs the payload, so the status the shell sees
+        // is the payload's own. Every `exit 1` inside the installer script would
+        // otherwise start the whole installer a second time, as root.
+        let detachRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("VorssaintDetachTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: detachRoot, withIntermediateDirectories: true)
+        let detachPayload = detachRoot.appendingPathComponent("payload.sh")
+        let detachLedger = detachRoot.appendingPathComponent("runs")
+        try? "#!/bin/sh\n/bin/echo ran >> \"$1\"\nexit 1\n"
+            .write(to: detachPayload, atomically: true, encoding: .utf8)
+        let detachCommand = DetachedProcess.detachedShellCommand(
+            quotedArgv: ["/bin/sh", detachPayload.path, detachLedger.path]
+                .map(UpdateInstallerSupport.shellSingleQuoted)
+                .joined(separator: " "))
+        let detachShell = Process()
+        detachShell.executableURL = URL(fileURLWithPath: "/bin/sh")
+        detachShell.arguments = ["-c", detachCommand]
+        try? detachShell.run()
+        detachShell.waitUntilExit()
+        func detachedRunCount() -> Int {
+            (try? String(contentsOf: detachLedger, encoding: .utf8))?
+                .split(separator: "\n").count ?? 0
+        }
+        for _ in 0..<300 where detachedRunCount() == 0 { usleep(10_000) }
+        usleep(500_000)   // a rerun follows the first run immediately; wait it out
+        let detachedRuns = detachedRunCount()
+        expect(detachedRuns == 1,
+               "a detached command runs its payload once whatever the payload exits with "
+               + "(ran \(detachedRuns) time(s))")
+        try? FileManager.default.removeItem(at: detachRoot)
+
         // A detached spawn is only detached if the child really is its own
         // session leader; `nohup` alone leaves it in ours.
         do {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -7552,12 +7552,34 @@ struct MetricsTests {
             resultPath: "/tmp/result",
             uid: 501,
             expectedVersion: "3.3.3")
-        expect(elevated.contains("nohup") && elevated.hasSuffix("&"),
-               "elevated installer detaches so the app can quit")
+        expect(elevated.contains("POSIX::setsid()") && elevated.hasSuffix("&"),
+               "elevated installer leaves this app's session so it outlives the app it replaces")
+        expect(elevated.contains("nohup"),
+               "elevated installer keeps the nohup fallback if setsid is unavailable")
         expect(elevated.contains("'/Applications/Vorssaint.app'"),
                "elevated installer passes the app path quoted for the shell")
         expect(elevated.contains("'3.3.3'"),
                "elevated installer passes the expected version quoted for the shell")
+        // The script travels inline and is long; it must be spelled once, with
+        // both the setsid attempt and the fallback reusing the same "$@".
+        expect(elevated.components(separatedBy: "DMG_VERIFY_REQ=").count == 2
+               && elevated.components(separatedBy: "\"$@\"").count == 3,
+               "elevated installer names its arguments once and reuses them for the fallback")
+
+        // A detached spawn is only detached if the child really is its own
+        // session leader; `nohup` alone leaves it in ours.
+        do {
+            let child = try DetachedProcess.spawn("/bin/sleep", ["30"])
+            expect(getsid(child) == child,
+                   "a detached child is its own session leader")
+            expect(getsid(child) != getsid(0),
+                   "a detached child is not in this process's session")
+            kill(child, SIGKILL)
+            var reaped: Int32 = 0
+            waitpid(child, &reaped, 0)
+        } catch {
+            expect(false, "detached spawn failed: \(error.localizedDescription)")
+        }
 
         // MARK: - UpdateServiceSupport & SemVer channel reconciliation
 

--- a/build.sh
+++ b/build.sh
@@ -309,6 +309,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/SudoersSupport.swift \
         Sources/Vorssaint/Services/Metrics/BatteryTimeSupport.swift \
         Sources/Vorssaint/Services/BoundedProcessRunner.swift \
+        Sources/Vorssaint/Services/DetachedProcess.swift \
         Sources/Vorssaint/Services/ShellSupport.swift \
         Sources/Vorssaint/Services/Metrics/NetworkProcessSupport.swift \
         Sources/Vorssaint/Services/Metrics/NetworkSampler.swift \


### PR DESCRIPTION
## Summary

The installer has to outlive the app it replaces, and both spawn paths left it inside this app's own session and launchd job. `nohup` was never the property that mattered — it makes the child ignore SIGHUP, it does not leave the session — so whatever tears that job down takes the installer with it and the swap never happens. The reporter's `.dmg` surviving on disk is that failure: the script was killed inside its `while kill -0 "$PID"` wait, before any exit path could clean up.

Both paths now start the installer in its own session, through one `DetachedProcess`:

- The user path uses `posix_spawn` with `POSIX_SPAWN_SETSID`, so the kernel makes the child a session leader before it execs and there is no window where it still belongs to us.
- The elevated path can only travel as one string through the administrator prompt, so it composes the same detachment as a command. macOS ships no `setsid(1)` and no `daemon(8)`, so it reaches `setsid(2)` through perl, keeping today's `nohup` form as the fallback if perl is ever absent — a child that may still be swept beats an update that cannot start at all. The command names the ~4KB script once with `set --` and reuses `"$@"` for both branches, so the two forms cannot drift apart. The branch is taken on `[ -x /usr/bin/perl ]`, never on an exit code: perl execs the payload, so the status the shell sees is the payload's own, and an `||` fallback would restart the whole installer — as root — on every non-zero exit inside the script.

`DetachedProcess.spawn` also passes `POSIX_SPAWN_CLOEXEC_DEFAULT` with `/dev/null` opened on 0, 1 and 2. `Process` already gave its children a clean descriptor table; a bare `posix_spawn` does not, and a child specifically built to outlive us is the worst place to hand over the app's open files. No concrete failure is claimed for it: the installer mounts the `.dmg` itself, after its `while kill -0 "$PID"` wait, so there is no volume of ours for an inherited descriptor to hold busy, and the download handle is closed on the completion path before the install starts. What remains is that anything a child does inherit is then held open by a process nobody can see or close. The `/dev/null` opens are not decoration — `CLOEXEC_DEFAULT` on its own leaves 0/1/2 closed, and the child's first `open()` takes one of their slots, which puts a data file where stdout is meant to be. Measured here: with the flag alone, a directly spawned `perl`'s first `open()` landed on fd 2. Nothing reads these children's output — the installer reports through its marker file, `SelfUninstall` and `BundleMigration` redirect their own noise, and the elevated command already ends in `>/dev/null 2>&1` — so no diagnostic is lost.

Considered and rejected: `nohup` plus `disown` (same session, same sweep); `launchctl submit` (needs a label and leaves a job behind to clean up); a double-fork from Swift (`posix_spawn` already exposes the flag, so the fork dance buys nothing). For stdio, dup'ing the app's own 0/1/2 into the child the way `Process` does was rejected: those handles would then be held open past our exit, and `/dev/null` is what the elevated command already redirects to, so both paths now behave the same.

Four sibling sites spawn in-session children with the same requirement, and each is a one-line change onto the same primitive, so they are converted here rather than left as the last users of a pattern this PR replaces:

- `SelfUninstall` — the script waits for the app to exit before moving the bundle to the Trash.
- `BundleMigration` — the same wait before renaming the bundle after a rebrand.
- `AppDelegate.relaunchApp` and `FeatureRuntime`'s developer-variant relaunch — both `sleep` and then `open`, after `NSApp.terminate`.

Not changed: the installer script's own text, the authorization attribution fixed earlier, and the failure reporting — a spawn error still reaches `failInstall` carrying its errno description.

## Verification

MacBook Pro (Mac17,3, M5), macOS 26.5.2 build 25F84, built from source with the repo's own signing identity, single built-in display.

```sh
./build.sh                     # ✓ Bundle ready, 0 warnings
./build/Vorssaint --selftest   # SELFTEST OK
./build.sh --test              # TESTS OK (8857 checks)
```

Detachment checked at the process level rather than through the UI: a child spawned by `DetachedProcess.spawn` reports `getsid(child) == child` and a session id different from this process's; the composed elevated command was run in a real `/bin/sh` and its payload, exiting non-zero, ran exactly once. Descriptor handling is checked the same way: the suite opens a file without `O_CLOEXEC`, spawns a child that tries to write through that descriptor number, and asserts the write fails and the file stays empty, while the child's own stdout is still writable. Each new assertion was confirmed against the old behaviour — reverting to a bare `posix_spawn` turns 4 checks red, keeping `CLOEXEC_DEFAULT` without the `/dev/null` opens turns 1 red, and restoring the `||` fallback turns both rerun checks red, the payload having run twice.

The rerun count is taken at the end of the suite rather than after a fixed wait, so a second run that arrives late still fails the check instead of passing quietly; a deliberately delayed rerun was confirmed to fail it.

**Not tested.** No end-to-end update was run — nothing here exercised a real download, quit, swap and relaunch in either path. The four converted sibling sites were not driven either: no uninstall, no bundle rename after a rebrand, and neither relaunch was performed. They are covered only by the primitive's own tests and by the fact that their argument vectors are unchanged. The elevated path was never driven through a real administrator prompt, so root's environment, the authorization trampoline, and whatever descriptor table it hands the elevated shell are unverified — `posix_spawn` file actions do not reach that path, and the composed command's `>/dev/null 2>&1 &` covers only its stdio. Most importantly, this proves the child leaves the session; it does not prove that a new session is what EPM's sweep respects. If EPM kills by process tree or audit session rather than by session id, the installer still dies and the reporter sees the same symptom. No EPM-managed Mac here to check that on.

`/usr/bin/perl` is present on macOS 26.5.2, but Apple has been removing bundled scripting runtimes; if a future macOS drops it, the elevated path quietly reverts to today's behaviour rather than failing loudly.

## Anything else

No user-facing strings were added, so no localization changes.

Behaviour change worth naming for release notes: an update that is interrupted by a session teardown now completes instead of leaving the `.dmg` behind, and the uninstall, bundle rename and relaunch paths survive the same teardown.

Refs #731

