### PR TITLE
test(monitor): skip the pool starvation check where the pool cannot be starved

### DIFF
--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9993,7 +9993,10 @@ struct MetricsTests {
             "/bin/echo", ["ready"], timeout: 1, maxOutputBytes: 1_024)
         let starvedPoolElapsed = Date().timeIntervalSince(starvedStarted)
         for _ in 0..<64 { poolGate.signal() }
-        _ = starvedProbe.wait(timeout: .now() + 5)
+        // Only when the probe never ran: its one signal was already taken above
+        // otherwise, and waiting for a second that no one sends costs the full
+        // timeout on every run of a machine whose pool cannot be starved.
+        if poolIsStarved { _ = starvedProbe.wait(timeout: .now() + 5) }
         expect(occupiedWorkers == 64,
                "the dispatch pool's blocking workers were all taken")
         // 64 is where libdispatch reports the soft limit, not where it stops:
@@ -10021,7 +10024,10 @@ struct MetricsTests {
             .split(separator: "\n", omittingEmptySubsequences: false)
             .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
             .joined(separator: "\n")
-        expect(!runnerCode.isEmpty && !runnerCode.contains("DispatchQueue.global"),
+        // Matching `.global(` rather than the one spelling: a queue bound to a
+        // local first (`let q: DispatchQueue = .global(qos:)`) reaches the same
+        // pool by a name this rule would otherwise never see.
+        expect(!runnerCode.isEmpty && !runnerCode.contains(".global("),
                "a bounded subprocess is never waited on from the shared dispatch pool")
 
         var networkDelta = NetworkProcessDeltaTracker(maxGap: 10)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -10017,17 +10017,23 @@ struct MetricsTests {
         // to the shared pool, because the runner's own spawns are what filled
         // it (issue #971). Absence rather than the one call that was found
         // holding it, so a new one cannot reintroduce the freeze quietly.
-        let runnerSource = (try? String(
-            contentsOfFile: "Sources/Vorssaint/Services/BoundedProcessRunner.swift",
-            encoding: .utf8)) ?? ""
+        // Anchored to this file's compiled path rather than the process's
+        // working directory, so running the binary from anywhere still finds
+        // the runner instead of reading "" and blaming the pool invariant.
+        let runnerURL = URL(fileURLWithPath: #filePath)  // Tests/MetricsTests.swift
+            .deletingLastPathComponent()                 // Tests/
+            .deletingLastPathComponent()                 // repo root
+            .appendingPathComponent("Sources/Vorssaint/Services/BoundedProcessRunner.swift")
+        let runnerSource = (try? String(contentsOf: runnerURL, encoding: .utf8)) ?? ""
         let runnerCode = runnerSource
             .split(separator: "\n", omittingEmptySubsequences: false)
             .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
             .joined(separator: "\n")
+        expect(!runnerCode.isEmpty, "the bounded runner's source was found")
         // Matching `.global(` rather than the one spelling: a queue bound to a
         // local first (`let q: DispatchQueue = .global(qos:)`) reaches the same
         // pool by a name this rule would otherwise never see.
-        expect(!runnerCode.isEmpty && !runnerCode.contains(".global("),
+        expect(!runnerCode.contains(".global("),
                "a bounded subprocess is never waited on from the shared dispatch pool")
 
         var networkDelta = NetworkProcessDeltaTracker(maxGap: 10)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9994,12 +9994,35 @@ struct MetricsTests {
         let starvedPoolElapsed = Date().timeIntervalSince(starvedStarted)
         for _ in 0..<64 { poolGate.signal() }
         _ = starvedProbe.wait(timeout: .now() + 5)
-        expect(occupiedWorkers == 64 && poolIsStarved,
-               "the dispatch pool starvation this check needs was actually reached")
-        expect(!starvedPoolProcess.timedOut && starvedPoolProcess.status == 0
-                && String(decoding: starvedPoolProcess.output, as: UTF8.self) == "ready\n"
-                && starvedPoolElapsed < 0.5,
-               "a subprocess is watched off the dispatch pool, so a starved pool cannot strand it")
+        expect(occupiedWorkers == 64,
+               "the dispatch pool's blocking workers were all taken")
+        // 64 is where libdispatch reports the soft limit, not where it stops:
+        // on a machine with enough cores it hands out a 65th thread and the
+        // pool cannot be starved this way at all. Measured on a 15-core M5,
+        // where all 64 workers block and a further submission still runs
+        // immediately. So the scenario is checked when it can be built and
+        // skipped when it cannot, rather than failing a machine for refusing
+        // to starve. The absence rule below is what holds everywhere.
+        if poolIsStarved {
+            expect(!starvedPoolProcess.timedOut && starvedPoolProcess.status == 0
+                    && String(decoding: starvedPoolProcess.output, as: UTF8.self) == "ready\n"
+                    && starvedPoolElapsed < 0.5,
+                   "a subprocess is watched off the dispatch pool, so a starved pool cannot strand it")
+        }
+        // The invariant the fix rests on, and the one a pool that refuses to
+        // starve cannot demonstrate: the wait for a child must not be handed
+        // to the shared pool, because the runner's own spawns are what filled
+        // it (issue #971). Absence rather than the one call that was found
+        // holding it, so a new one cannot reintroduce the freeze quietly.
+        let runnerSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/BoundedProcessRunner.swift",
+            encoding: .utf8)) ?? ""
+        let runnerCode = runnerSource
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(!runnerCode.isEmpty && !runnerCode.contains("DispatchQueue.global"),
+               "a bounded subprocess is never waited on from the shared dispatch pool")
 
         var networkDelta = NetworkProcessDeltaTracker(maxGap: 10)
         let baselineNetwork = [

--- a/build.sh
+++ b/build.sh
@@ -177,6 +177,8 @@ if (( TEST )); then
     # The full app build below remains optimized and is the optimizer gate.
     # Unit assertions do not need optimization; avoiding it cuts most of the
     # test harness compile time without reducing the code the tests exercise.
+    # The test file is passed absolute so `#filePath` bakes in a real path:
+    # assertions anchored to it then work from any working directory.
     swiftc -Onone -target "$TARGET" -sdk "$SDK" "${SDK_COMPAT_FLAGS[@]}" \
         "${VM_STATISTICS_COMPAT_FLAGS[@]}" \
         Sources/Vorssaint/Services/Media/MediaSupport.swift \
@@ -328,7 +330,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/Cleaner/CleanerSchedule.swift \
         Sources/Vorssaint/Services/Uninstall/UninstallerSupport.swift \
         Sources/Vorssaint/Services/ManagedDownloads/WhatsAppDownloadSupport.swift \
-        Tests/MetricsTests.swift \
+        "$PWD/Tests/MetricsTests.swift" \
         -o build/metrics-tests
     # `set -e` would end the script on a failing run before the sweep below.
     test_status=0


### PR DESCRIPTION
Follow-up to #989, taken up at @PathGao's suggestion — `main` is currently red on high-core machines.

## What was wrong

The starvation check asserted its own precondition:

```swift
expect(occupiedWorkers == 64 && poolIsStarved,
       "the dispatch pool starvation this check needs was actually reached")
```

64 is where libdispatch *reports* the soft limit — the `Dispatch Thread Soft Limit: 64 reached` line in the #971 sample — not a cap it enforces. On a machine with enough cores it hands out a 65th thread, so blocking 64 workers doesn't starve the pool at all and the precondition can never hold. Measured on a 15-core M5 with a standalone harness replicating the setup exactly:

```
activeProcessorCount=15
occupiedWorkers=64   (test wants 64)     ✓
poolIsStarved=false  (test wants true)   ✗
```

Deterministic across runs. That failed the whole suite for a property the build simply cannot observe on that hardware — and since CI's smaller runners do starve, it only shows up locally, where it gets misattributed to whatever branch happens to be checked out.

## The change

Per @PathGao's call — skip rather than grow, since growing the loop only relocates the same case to a machine whose real limit sits above the ceiling, having spent a few hundred blocked threads getting there:

- The starved-pool assertion runs when the scenario can be built, and is skipped when it cannot. `occupiedWorkers == 64` still asserts unconditionally, so a failure to take the workers at all is still a failure.
- Paired with an absence rule, so the skip doesn't leave the check covering nothing: `BoundedProcessRunner.swift` must not contain `.global(`. The wider spelling catches `DispatchQueue.global(qos:)` and the type-annotated `let q: DispatchQueue = .global(qos:)` form alike. That is the invariant the fix actually rests on — the wait for a child must not be handed to the shared pool the runner's own spawns were filling — it holds on every machine, and it makes the starvation check a stronger conditional version of it rather than the only line of defence.

On your caveat: the file contains no `.global(` anywhere, so the rule needs no narrowing to the wait specifically.

## Verification

`./build.sh` zero warnings, `./build.sh --test` → **TESTS OK (8582 checks)** on the machine that was red, `./build/Vorssaint --selftest` → SELFTEST OK.

The absence rule bites: adding a bare `_ = DispatchQueue.global(qos: .utility)` to the runner fails it with `a bounded subprocess is never waited on from the shared dispatch pool`. Reverted.
