### PR TITLE
fix(settings): coordinate file reading and accept XML for backup import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to this project are documented here. The format follows
 - Super key now shows why it could not remap Caps Lock, instead of staying on with a key that still only toggles capitals. Thanks to @PathGao.
 - Holding Super key now also moves and resizes windows by dragging. Thanks to @iltonandrew and @felixblaschke.
 - Shelf drop zone and menu bar icon hit testing no longer use off-screen coordinates when the menu bar is hidden in full screen. Thanks to @iltonandrew.
+- Settings backup import now coordinates file reading for cloud files and accepts XML backup files.
 
 ## [3.3.3-beta.2] - 2026-08-22
 

--- a/Sources/Vorssaint/Core/SettingsBackupSupport.swift
+++ b/Sources/Vorssaint/Core/SettingsBackupSupport.swift
@@ -147,13 +147,27 @@ enum SettingsBackupSupport {
     /// and exports — unknown, renamed or never-exported keys are dropped, so
     /// a tampered or future file can never write outside the allowed set.
     static func sanitizedSettings(from payload: [String: Any]) -> [String: Any]? {
-        guard let version = payload[formatVersionKey] as? Int,
+        guard let version = formatVersion(from: payload),
               version >= 1, version <= formatVersion,
               let settings = payload[settingsKey] as? [String: Any]
         else { return nil }
         let allowed = exportKeys()
         let filtered = settings.filter { allowed.contains($0.key) && valueLooksRight($0.key, $0.value) }
         return portableMediaSettings(filtered)
+    }
+
+    static func formatVersion(from payload: [String: Any]) -> Int? {
+        if let intValue = payload[formatVersionKey] as? Int {
+            return intValue
+        }
+        if let number = payload[formatVersionKey] as? NSNumber {
+            return number.intValue
+        }
+        if let string = payload[formatVersionKey] as? String,
+           let intValue = Int(string.trimmingCharacters(in: .whitespacesAndNewlines)) {
+            return intValue
+        }
+        return nil
     }
 
     private static func portableMediaSettings(_ source: [String: Any]) -> [String: Any] {

--- a/Sources/Vorssaint/Services/SettingsBackup.swift
+++ b/Sources/Vorssaint/Services/SettingsBackup.swift
@@ -40,7 +40,7 @@ enum SettingsBackup {
     /// Shows the open panel; nil = user cancelled.
     static func runImportPanel() -> URL? {
         let panel = NSOpenPanel()
-        panel.allowedContentTypes = [.propertyList]
+        panel.allowedContentTypes = [.propertyList, .xml]
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
         NSApp.activate(ignoringOtherApps: true)
@@ -50,7 +50,19 @@ enum SettingsBackup {
 
     /// Reads and validates a backup; nil when the file is not one of ours.
     static func readSettings(at url: URL) -> [String: Any]? {
-        guard let data = try? Data(contentsOf: url),
+        let accessing = url.startAccessingSecurityScopedResource()
+        defer {
+            if accessing {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+        var coordinatedData: Data?
+        let coordinator = NSFileCoordinator()
+        var error: NSError?
+        coordinator.coordinate(readingItemAt: url, options: .withoutChanges, error: &error) { readURL in
+            coordinatedData = try? Data(contentsOf: readURL)
+        }
+        guard let data = coordinatedData ?? (try? Data(contentsOf: url)),
               let payload = try? PropertyListSerialization.propertyList(from: data,
                                                                         options: [],
                                                                         format: nil) as? [String: Any]

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15136,6 +15136,20 @@ struct MetricsTests {
             SettingsBackupSupport.formatVersionKey: 99,
             SettingsBackupSupport.settingsKey: [String: Any](),
         ]) == nil, "a future format version is rejected")
+        expect(SettingsBackupSupport.formatVersion(from: [SettingsBackupSupport.formatVersionKey: 1]) == 1
+                && SettingsBackupSupport.formatVersion(from: [SettingsBackupSupport.formatVersionKey: NSNumber(value: 1)]) == 1
+                && SettingsBackupSupport.formatVersion(from: [SettingsBackupSupport.formatVersionKey: "1"]) == 1
+                && SettingsBackupSupport.formatVersion(from: [SettingsBackupSupport.formatVersionKey: " 1 \n"]) == 1
+                && SettingsBackupSupport.formatVersion(from: [SettingsBackupSupport.formatVersionKey: "invalid"]) == nil,
+               "backup format version accepts integer, NSNumber and string representations")
+        let stringVersionBackup: [String: Any] = [
+            SettingsBackupSupport.formatVersionKey: "1",
+            SettingsBackupSupport.settingsKey: [
+                DefaultsKey.smoothScrollStep: 60,
+            ] as [String: Any],
+        ]
+        expect(SettingsBackupSupport.sanitizedSettings(from: stringVersionBackup)?[DefaultsKey.smoothScrollStep] as? Int == 60,
+               "a backup with a string-encoded format version restores correctly")
 
         // A backup file can be edited by hand, and a value of the wrong shape
         // would reach code that trusts its own settings.


### PR DESCRIPTION
### Summary
- Use `NSFileCoordinator` and security-scoped access when reading settings backups to ensure cloud-synced and evicted files (e.g. iCloud Drive) are downloaded and read cleanly.
- Allow `.xml` alongside `.plist` in the open panel to support backups saved or shared with an XML extension.
- Tolerate numeric strings and `NSNumber` representations when validating the backup format version envelope.

### Validation
- Unit tests pass with 8,640 checks in `MetricsTests`.
- Tested local Developer build and verified backup import.