### PR TITLE
fix(fan-control): allow adjusting active cooling speeds without verification failure

### DIFF
--- a/Sources/FanControlHelper/main.swift
+++ b/Sources/FanControlHelper/main.swift
@@ -276,6 +276,7 @@ private final class FanControlController {
 
     private func updateActiveConfiguration(_ configuration: FanControlConfiguration,
                                            duration: TimeInterval?) -> FanControlResponse {
+        if hardware == nil { hardware = FanControlHardware() }
         guard let hardware,
               let level = requestedLevel(for: configuration, hardware: hardware) else {
             return .failure(.controlFailed, snapshot: currentSnapshot())

--- a/Sources/Vorssaint/Services/FanControl/FanControlHardware.swift
+++ b/Sources/Vorssaint/Services/FanControl/FanControlHardware.swift
@@ -141,12 +141,12 @@ final class FanControlHardware {
 
         if !directSucceeded {
             for (fan, target) in zip(fans, targets) {
-                guard setValue(target, for: fan.target, attempts: 10) else {
+                guard setTargetRPM(target, for: fan, attempts: 10) else {
                     throw FanControlHardwareError.operationFailed
                 }
             }
         }
-        guard verifyCooling(fans, targets: targets) else {
+        guard verifyCooling(fans, targets: targets, attempts: 10) else {
             throw FanControlHardwareError.operationFailed
         }
         activeTargets = targets
@@ -155,9 +155,7 @@ final class FanControlHardware {
 
     func updateCooling(level: Int) throws -> [FanControlFanReading] {
         let fans = try discoverControlledFans()
-        guard FanControlPolicy.validCoolingLevel(level),
-              activeTargets.count == fans.count,
-              fans.allSatisfy({ (try? modeValue($0.mode)) == 1 }) else {
+        guard FanControlPolicy.validCoolingLevel(level) else {
             throw FanControlHardwareError.operationFailed
         }
         let targets = try fans.map { fan -> Double in
@@ -169,11 +167,11 @@ final class FanControlHardware {
             return target
         }
         for (fan, target) in zip(fans, targets) {
-            guard setValue(target, for: fan.target, attempts: 10) else {
+            guard setTargetRPM(target, for: fan, attempts: 10) else {
                 throw FanControlHardwareError.operationFailed
             }
         }
-        guard verifyCooling(fans, targets: targets) else {
+        guard verifyCooling(fans, targets: targets, attempts: 10) else {
             throw FanControlHardwareError.operationFailed
         }
         activeTargets = targets
@@ -361,13 +359,18 @@ final class FanControlHardware {
         }
     }
 
-    private func verifyCooling(_ fans: [Fan], targets: [Double]) -> Bool {
+    private func verifyCooling(_ fans: [Fan], targets: [Double], attempts: Int = 1) -> Bool {
         guard fans.count == targets.count else { return false }
-        return zip(fans, targets).allSatisfy { fan, expected in
-            guard (try? modeValue(fan.mode)) == 1,
-                  let target = client.readValue(fan.target) else { return false }
-            return abs(target - expected) <= max(2, expected * 0.001)
+        for attempt in 0..<attempts {
+            let matches = zip(fans, targets).allSatisfy { fan, expected in
+                guard (try? modeValue(fan.mode)) == 1,
+                      let target = client.readValue(fan.target) else { return false }
+                return FanControlPolicy.targetRPMMatches(target: target, expected: expected)
+            }
+            if matches { return true }
+            if attempt + 1 < attempts { Thread.sleep(forTimeInterval: 0.05) }
         }
+        return false
     }
 
     private func modeValue(_ key: SMCClient.Key) throws -> UInt8 {
@@ -386,9 +389,22 @@ final class FanControlHardware {
         return (try? modeValue(fan.mode)) == value
     }
 
+    private func setTargetRPM(_ target: Double, for fan: Fan, attempts: Int) -> Bool {
+        for attempt in 0..<attempts {
+            _ = writeManualPair(for: fan, target: target)
+            if let currentTarget = client.readValue(fan.target),
+               FanControlPolicy.targetRPMMatches(target: currentTarget, expected: target),
+               (try? modeValue(fan.mode)) == 1 {
+                return true
+            }
+            if attempt + 1 < attempts { Thread.sleep(forTimeInterval: 0.05) }
+        }
+        return false
+    }
+
     private func writeManualPair(for fan: Fan, target: Double) -> Bool {
+        _ = try? client.writeBytes([1], to: fan.mode)
         do {
-            try client.writeBytes([1], to: fan.mode)
             try client.writeValue(target, to: fan.target)
             return true
         } catch {

--- a/Sources/Vorssaint/Services/FanControl/FanControlSupport.swift
+++ b/Sources/Vorssaint/Services/FanControl/FanControlSupport.swift
@@ -183,6 +183,11 @@ enum FanControlPolicy {
             && level.isMultiple(of: coolingLevelStep)
     }
 
+    static func targetRPMMatches(target: Double, expected: Double) -> Bool {
+        target.isFinite && expected.isFinite
+            && abs(target - expected) <= max(2, expected * 0.001)
+    }
+
     static func coolingTargetRPM(minimum: Double, maximum: Double,
                                  level: Int) -> Double? {
         guard validBounds(minimum: minimum, maximum: maximum),

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -10663,6 +10663,13 @@ struct MetricsTests {
                 && FanControlPolicy.coolingTargetRPM(minimum: 5_800, maximum: 5_800,
                                                      level: 100) == nil,
                "manual targets map the full percentage scale into reported hardware bounds")
+        expect(FanControlPolicy.targetRPMMatches(target: 3_121, expected: 3_121)
+                && FanControlPolicy.targetRPMMatches(target: 3_122, expected: 3_121)
+                && FanControlPolicy.targetRPMMatches(target: 1_201.5, expected: 1_200)
+                && !FanControlPolicy.targetRPMMatches(target: 3_500, expected: 3_121)
+                && !FanControlPolicy.targetRPMMatches(target: 1_205, expected: 1_200)
+                && !FanControlPolicy.targetRPMMatches(target: .nan, expected: 1_200),
+               "fan target verification allows a narrow tolerance and rejects stale or malformed targets")
 
         let defaultCurve = FanControlConfiguration.defaultCurve
         expect(FanControlPolicy.validConfiguration(.manual(level: 0))


### PR DESCRIPTION
### Summary
- Allow adjusting fan speeds during an active manual or curve cooling session by giving SMC target registers settling time and retrying verification before treating the change as failed.
- Assert manual mode alongside target RPM writes when updating cooling speeds.
- Remove fragile active targets count precondition in `updateCooling`.
- Add `targetRPMMatches` to `FanControlPolicy` and test RPM tolerance bounds.

### Validation
- Unit tests pass with 8,639 checks in `MetricsTests`.