### PR TITLE
fix(menu-bar): preserve battery icon aspect ratio in menu bar

### DIFF
--- a/Sources/Vorssaint/App/MenuBarRenderer.swift
+++ b/Sources/Vorssaint/App/MenuBarRenderer.swift
@@ -1208,10 +1208,17 @@ enum MenuBarRenderer {
             if let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
                 .withSymbolConfiguration(symbolConfig) {
                 let symbolSize = symbol.size
+                // draw(in:) stretches the image to exactly fill the rect, so
+                // clamping only the width while leaving height at
+                // the symbol's full natural size squished wide glyphs like
+                // the battery icon. Scale both dimensions together to keep
+                // the glyph's own proportions.
+                let scale = min(symbolWidth / symbolSize.width, 1)
+                let drawSize = NSSize(width: symbolSize.width * scale, height: symbolSize.height * scale)
                 let symbolRect = NSRect(x: 0,
-                                        y: (height - symbolSize.height) / 2,
-                                        width: min(symbolWidth, symbolSize.width),
-                                        height: symbolSize.height)
+                                        y: (height - drawSize.height) / 2,
+                                        width: drawSize.width,
+                                        height: drawSize.height)
                 symbol.draw(in: symbolRect)
             }
             let valueAttrs = dynamicTextAttributes(font: valueFont)


### PR DESCRIPTION
Resolves #769

### Root cause

`MenuBarRenderer.batteryBlockImage(percent:isCharging:style:)` draws the battery SF Symbol into a rect whose **width is clamped** to the reserved column (`min(symbolWidth, symbolSize.width)`) but whose **height is left at the symbol's full natural size**, uncapped. `NSImage.draw(in:)` stretches its image to exactly fill the given rect, so this squeezes the symbol's width while keeping its full height — distorting the aspect ratio.

Since the battery SF Symbols are naturally wider than they are tall, and their natural width exceeds the reserved column, this consistently compressed the glyph into something closer to a square than the true wide rectangle.

### Fix

Scale both dimensions together from a single `scale` factor instead of clamping only width. The symbol keeps its natural proportions and simply shrinks to fit the reserved column when it's too wide, rather than getting stretched out of shape.

### Testing

- Rebuilt and verified in "Separate metrics into their own items" mode with Battery enabled — icon renders as a proper wide rectangle, matching the shape shown in the Settings preview.
- Confirmed no other block-style metric icon uses this draw pattern — `cpu`/`gpu`/etc. render text labels via `metricBlockImage`, not SF Symbols — so this was the only place the distortion could occur.

### Before and after 
**On battery**
<img width="460" height="57" alt="image" src="https://github.com/user-attachments/assets/641113c8-3732-4f0a-be61-592e0ce3cf68" />

**Charging**
<img width="478" height="61" alt="image" src="https://github.com/user-attachments/assets/9f3896c2-d978-4291-910c-20a61973d52c" />

You can increase the size of the battery symbol to make it look nicer but that is out of scope of this pr.