### PR TITLE
fix(clipboard): stop Esc from closing the preview pane

### DIFF
--- a/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
+++ b/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
@@ -1127,14 +1127,9 @@ final class ClipboardHistoryService: ObservableObject {
             }
             let modifiers = event.modifierFlags.intersection([.command, .option, .shift, .control])
             if event.keyCode == UInt16(kVK_Escape) {
-                // Esc backs out one layer at a time: preview, selection,
-                // then the window.
-                if self.quickPreviewPresented {
-                    self.setQuickPreviewPresented(false)
-                } else if self.quickBatchCount > 0 {
-                    self.clearQuickBatchSelection()
-                } else {
-                    self.hideHistoryWindow()
+                switch ClipboardHistoryEscape.action(batchCount: self.quickBatchCount) {
+                case .clearBatchSelection: self.clearQuickBatchSelection()
+                case .hideWindow: self.hideHistoryWindow()
                 }
                 return nil
             }

--- a/Sources/Vorssaint/Services/Clipboard/ClipboardHistorySupport.swift
+++ b/Sources/Vorssaint/Services/Clipboard/ClipboardHistorySupport.swift
@@ -287,8 +287,10 @@ enum ClipboardHistoryEscape {
     }
 
     /// Esc backs out one layer at a time - selection, then the window.
-    /// Preview is a persistent view setting, not a layer: it stays open
-    /// until its own toggle (the button, or Space for Quick Look) is used,
+    /// Preview is a persistent view setting, not a layer: only clicking its
+    /// own toggle turns it off (or Space, but only once arrow-key navigation
+    /// has made a row's selection visible - see `ClipboardHistoryPreview
+    /// .handlesSpace`; while the search field has focus, Space just types),
     /// so a keystroke meant to close the panel can never silently re-hide
     /// it first.
     static func action(batchCount: Int) -> Action {

--- a/Sources/Vorssaint/Services/Clipboard/ClipboardHistorySupport.swift
+++ b/Sources/Vorssaint/Services/Clipboard/ClipboardHistorySupport.swift
@@ -280,6 +280,22 @@ enum ClipboardHistoryPreview {
     }
 }
 
+enum ClipboardHistoryEscape {
+    enum Action: Equatable {
+        case clearBatchSelection
+        case hideWindow
+    }
+
+    /// Esc backs out one layer at a time - selection, then the window.
+    /// Preview is a persistent view setting, not a layer: it stays open
+    /// until its own toggle (the button, or Space for Quick Look) is used,
+    /// so a keystroke meant to close the panel can never silently re-hide
+    /// it first.
+    static func action(batchCount: Int) -> Action {
+        batchCount > 0 ? .clearBatchSelection : .hideWindow
+    }
+}
+
 enum ClipboardHistoryBatch {
     static func combinedText(_ texts: [String]) -> String {
         texts.joined(separator: "\n")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -359,6 +359,10 @@ struct MetricsTests {
                "clipboard preview uses Space after keyboard navigation")
         expect(!ClipboardHistoryPreview.handlesSpace(selectionIsVisible: true, hasModifiers: true),
                "clipboard preview never steals modified Space shortcuts")
+        expect(ClipboardHistoryEscape.action(batchCount: 0) == .hideWindow,
+               "Esc closes the panel when nothing is selected, regardless of preview")
+        expect(ClipboardHistoryEscape.action(batchCount: 2) == .clearBatchSelection,
+               "Esc clears a batch selection before it closes the panel")
         expect(ClipboardHistoryEditing.canSave(original: "First draft", draft: "Second draft"),
                "clipboard text can save a real edit")
         expect(!ClipboardHistoryEditing.canSave(original: "Same", draft: "Same"),

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -360,7 +360,7 @@ struct MetricsTests {
         expect(!ClipboardHistoryPreview.handlesSpace(selectionIsVisible: true, hasModifiers: true),
                "clipboard preview never steals modified Space shortcuts")
         expect(ClipboardHistoryEscape.action(batchCount: 0) == .hideWindow,
-               "Esc closes the panel when nothing is selected, regardless of preview")
+               "Esc closes the panel when nothing is selected")
         expect(ClipboardHistoryEscape.action(batchCount: 2) == .clearBatchSelection,
                "Esc clears a batch selection before it closes the panel")
         expect(ClipboardHistoryEditing.canSave(original: "First draft", draft: "Second draft"),


### PR DESCRIPTION
Pressing Esc in the Clipboard Quick Panel treated the preview sidebar as the first layer to back out of, so with preview on, a single Esc only retracted the sidebar and left the panel open - a second Esc was needed to actually close it. Preview should behave as a persistent view setting instead: once turned on, only clicking its own toggle button turns it off (Space also does, but only once arrow-key navigation has made a row's selection visible - see `ClipboardHistoryPreview.handlesSpace` - while the search field has focus, Space just types). Esc now goes straight to clearing a batch selection if one exists, or closing the panel, exactly as it does when preview is off.

`quickPreviewPresented` already persists to `UserDefaults`, and `hideHistoryWindow()` never touched it:

```swift
func hideHistoryWindow() {
    removeKeyMonitor()
    removeDismissMonitors()
    panel?.orderOut(nil)
    clearQuickBatchSelection()
}
```

so removing the preview branch is enough on its own - preview now survives both a panel-closing Esc and a full relaunch, matching how the toggle button already worked.

Moved the decision into a small pure function, `ClipboardHistoryEscape.action(batchCount:)`, next to the existing `ClipboardHistoryPreview.handlesSpace` helper it sits beside in `ClipboardHistorySupport.swift`, and added two `expect` cases pinning it in `MetricsTests.swift`. The function takes no preview argument by design - the fix removes preview from the Esc decision entirely, so there's nothing preview-related left for it to take.

Checked every other place `quickPreviewPresented`/`toggleQuickPreview` is touched, since the same mistake tends to sit at more than one call site:
- The toolbar preview button (`ClipboardQuickPanelView.swift`) - a click, untouched.
- The preview sidebar's own close button - a click on the preview UI itself, untouched.
- The Space-bar Finder-style Quick Look toggle - a separate, pre-existing affordance, untouched, but see the precise precondition above.
- The Esc branch - the only unwanted path, and the only thing this PR changes.

No CHANGELOG.md edit, no linked issue (searched open issues/PRs for existing reports of this before starting; the two related open issues, `#884` and `#453`, are about making preview the default and about the command palette's own clipboard preview/resizing respectively - neither is what this PR fixes).

## Verification

```
./build.sh                     # clean, no warnings
./build/Vorssaint --selftest   # SELFTEST OK
./build.sh --test              # TESTS OK, including the two new expects
```

On macOS 26.6.2 (build 25G83), Apple Silicon, own local build (ad hoc signed dev environment, not release-signed).

What I could not verify myself: an interactive click-through of the actual panel (open panel, turn preview on, press Esc, confirm it closes with preview still flagged, reopen and confirm preview is still showing) - this session has no Accessibility permission to drive the UI, so I could not simulate the keystroke/click sequence end to end. The logic itself is covered by the two new tests and by reading `hideHistoryWindow()`'s implementation above, but a real click-through on a Mac with Accessibility available is worth doing before merge.
