### PR TITLE
refactor(quick-tools): extract synthetic paste into a shared helper

### DIFF
--- a/Sources/Vorssaint/Services/QuickTools/PastePlainService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/PastePlainService.swift
@@ -3,7 +3,6 @@
 
 import AppKit
 import ApplicationServices
-import Carbon.HIToolbox
 
 /// Pastes the clipboard as plain text on a global shortcut: strips fonts,
 /// colors and links, pastes, and quietly puts the original rich content back
@@ -81,7 +80,7 @@ final class PastePlainService: ObservableObject {
         if let pending = pendingRestore, pasteboard.changeCount == pending.plainChangeCount {
             snapshot = pending.snapshot
         } else {
-            snapshot = Self.snapshot(of: pasteboard)
+            snapshot = SyntheticPasteSupport.snapshot(of: pasteboard)
         }
         restoreWork?.cancel()
         restoreWork = nil
@@ -124,29 +123,22 @@ final class PastePlainService: ObservableObject {
     /// read clean matters: posted right on the release, the target app can
     /// still see the stale modifier state and refuse the key equivalent.
     private func postPasteWhenModifiersReleased(attempt: Int, completion: @escaping () -> Void) {
-        let held = CGEventSource.flagsState(.combinedSessionState)
-            .intersection([.maskCommand, .maskAlternate, .maskShift, .maskControl])
-        if held.isEmpty || attempt >= 100 {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) {
-                let shortcut = GlobalShortcut.saved(for: DefaultsKey.pastePlainShortcut,
-                                                    fallback: .pastePlainDefault)
-                let mustReleaseHotkey = shortcut.isStandardPasteCommand
-                if mustReleaseHotkey {
-                    // Otherwise our global ⌘V catches the synthetic ⌘V below,
-                    // so the target app never receives a paste command.
-                    self.hotkey.unregister()
-                }
-                Self.postPasteShortcut {
-                    if mustReleaseHotkey {
-                        self.syncWithPreferences()
-                    }
-                    completion()
-                }
+        SyntheticPasteSupport.waitForCleanModifiers(attempt: attempt) { [weak self] in
+            guard let self else { completion(); return }
+            let shortcut = GlobalShortcut.saved(for: DefaultsKey.pastePlainShortcut,
+                                                fallback: .pastePlainDefault)
+            let mustReleaseHotkey = shortcut.isStandardPasteCommand
+            if mustReleaseHotkey {
+                // Otherwise our global ⌘V catches the synthetic ⌘V below,
+                // so the target app never receives a paste command.
+                self.hotkey.unregister()
             }
-            return
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.015) { [weak self] in
-            self?.postPasteWhenModifiersReleased(attempt: attempt + 1, completion: completion)
+            SyntheticPasteSupport.postCmdV {
+                if mustReleaseHotkey {
+                    self.syncWithPreferences()
+                }
+                completion()
+            }
         }
     }
 
@@ -234,45 +226,5 @@ final class PastePlainService: ObservableObject {
             return attributed.string
         }
         return nil
-    }
-
-    private static func snapshot(of pasteboard: NSPasteboard) -> [NSPasteboardItem] {
-        (pasteboard.pasteboardItems ?? []).map { item in
-            let copy = NSPasteboardItem()
-            for type in item.types {
-                if let data = item.data(forType: type) {
-                    copy.setData(data, forType: type)
-                }
-            }
-            return copy
-        }
-    }
-
-    private static func postPasteShortcut(completion: @escaping () -> Void) {
-        // No explicit event source: an event tied to the HID state inherits
-        // whatever the hardware still reports, and right after the shortcut's
-        // own keys that can re-poison the flags this method just waited out.
-        guard let keyDown = CGEvent(keyboardEventSource: nil,
-                                    virtualKey: CGKeyCode(kVK_ANSI_V),
-                                    keyDown: true),
-              let keyUp = CGEvent(keyboardEventSource: nil,
-                                  virtualKey: CGKeyCode(kVK_ANSI_V),
-                                  keyDown: false)
-        else {
-            completion()
-            return
-        }
-        keyDown.flags = .maskCommand
-        keyUp.flags = .maskCommand
-        // No keyboardSetUnicodeString here: a forced character string on the
-        // event breaks menu key equivalent dispatch (verified empirically),
-        // which is exactly the ⌘V we are trying to trigger.
-        keyDown.post(tap: .cghidEventTap)
-        // A beat between down and up mirrors a real key press; some apps skip
-        // equivalents delivered as a zero-length tap.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.04) {
-            keyUp.post(tap: .cghidEventTap)
-            completion()
-        }
     }
 }

--- a/Sources/Vorssaint/Services/QuickTools/PastePlainService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/PastePlainService.swift
@@ -133,7 +133,7 @@ final class PastePlainService: ObservableObject {
                 // so the target app never receives a paste command.
                 self.hotkey.unregister()
             }
-            SyntheticPasteSupport.postCmdV {
+            SyntheticPasteSupport.postCmdVAssumingCleanModifiers {
                 if mustReleaseHotkey {
                     self.syncWithPreferences()
                 }

--- a/Sources/Vorssaint/Services/SyntheticPasteSupport.swift
+++ b/Sources/Vorssaint/Services/SyntheticPasteSupport.swift
@@ -29,12 +29,16 @@ enum SyntheticPasteSupport {
         }
     }
 
-    /// Posts the raw ⌘V key-down/key-up pair. A no-op (with a beep, matching
-    /// every other synthetic-paste call site in the app) while secure event
-    /// input is active - typing into a password field disables synthetic
-    /// keyboard events system-wide, so posting anyway would silently do
-    /// nothing instead of telling the person why.
-    static func postCmdV(completion: @escaping () -> Void) {
+    /// Posts the raw ⌘V key-down/key-up pair. Assumes the caller has already
+    /// waited for a clean keyboard (see `waitForCleanModifiers`) - this does
+    /// not wait itself, unlike some of this enum's other members, so the name
+    /// says so rather than leaving two same-looking calls with opposite
+    /// contracts. A no-op (with a beep, matching every other synthetic-paste
+    /// call site in the app) while secure event input is active - typing into
+    /// a password field disables synthetic keyboard events system-wide, so
+    /// posting anyway would silently do nothing instead of telling the person
+    /// why.
+    static func postCmdVAssumingCleanModifiers(completion: @escaping () -> Void) {
         guard !IsSecureEventInputEnabled() else {
             NSSound.beep()
             completion()
@@ -68,38 +72,6 @@ enum SyntheticPasteSupport {
         }
     }
 
-    /// Posts a synthetic Delete/Backspace, which removes an active selection
-    /// in essentially every text field — native, web, and browser chrome
-    /// alike. Used instead of `replaceSelection(with: "")` for Cut/Delete:
-    /// pasting an empty string turned out to be unreliable in some fields
-    /// (Notes, a browser's own address bar) where a real Delete keystroke
-    /// works everywhere. Guarded against secure event input for the same
-    /// reason as `postCmdV`.
-    static func deleteSelection(completion: (() -> Void)? = nil) {
-        waitForCleanModifiers {
-            guard !IsSecureEventInputEnabled() else {
-                NSSound.beep()
-                completion?()
-                return
-            }
-            guard let keyDown = CGEvent(keyboardEventSource: nil,
-                                        virtualKey: CGKeyCode(kVK_Delete),
-                                        keyDown: true),
-                  let keyUp = CGEvent(keyboardEventSource: nil,
-                                      virtualKey: CGKeyCode(kVK_Delete),
-                                      keyDown: false)
-            else {
-                completion?()
-                return
-            }
-            keyDown.post(tap: .cghidEventTap)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.04) {
-                keyUp.post(tap: .cghidEventTap)
-                completion?()
-            }
-        }
-    }
-
     static func snapshot(of pasteboard: NSPasteboard) -> [NSPasteboardItem] {
         (pasteboard.pasteboardItems ?? []).map { item in
             let copy = NSPasteboardItem()
@@ -110,47 +82,5 @@ enum SyntheticPasteSupport {
             }
             return copy
         }
-    }
-
-    /// Writes `text` to the general pasteboard, pastes it over the frontmost
-    /// app's current selection once the keyboard reads clean, then restores
-    /// whatever was on the pasteboard before — unless something else changed
-    /// the pasteboard in the meantime, in which case the newer content wins
-    /// and the snapshot is dropped silently.
-    ///
-    /// Every actual pasteboard touch runs through `GeneralPasteboardAccess`,
-    /// the same serial lane Clipboard History and the URL cleaner use —
-    /// touching `NSPasteboard.general` directly from here raced their
-    /// background reads of its type cache and crashed the app.
-    static func replaceSelection(with text: String,
-                                 restoreDelay: TimeInterval = 0.5,
-                                 completion: (() -> Void)? = nil) {
-        let pasteboard = NSPasteboard.general
-        GeneralPasteboardAccess.shared.async({ () -> ([NSPasteboardItem], Int) in
-            let snapshotBefore = snapshot(of: pasteboard)
-            pasteboard.clearContents()
-            pasteboard.setString(text, forType: .string)
-            return (snapshotBefore, pasteboard.changeCount)
-        }, then: { (snapshotBefore, changeCount) in
-            ClipboardHistoryService.shared.ignoreNextChange(upTo: changeCount)
-            waitForCleanModifiers {
-                postCmdV {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + restoreDelay) {
-                        GeneralPasteboardAccess.shared.async({ () -> Int? in
-                            guard pasteboard.changeCount == changeCount, !snapshotBefore.isEmpty
-                            else { return nil }
-                            pasteboard.clearContents()
-                            pasteboard.writeObjects(snapshotBefore)
-                            return pasteboard.changeCount
-                        }, then: { restoredChangeCount in
-                            if let restoredChangeCount {
-                                ClipboardHistoryService.shared.ignoreNextChange(upTo: restoredChangeCount)
-                            }
-                            completion?()
-                        })
-                    }
-                }
-            }
-        })
     }
 }

--- a/Sources/Vorssaint/Services/SyntheticPasteSupport.swift
+++ b/Sources/Vorssaint/Services/SyntheticPasteSupport.swift
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Author: naveenkrdy
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import Carbon.HIToolbox
+
+/// The low-level "post a synthetic ⌘V" primitive, shared by every feature
+/// that needs to replace whatever text is currently selected in the
+/// frontmost app: write new text to the pasteboard, then paste over the
+/// live selection, which is the only reliable cross-app way to do this since
+/// no app is required to honor an AX value write on its text elements.
+enum SyntheticPasteSupport {
+    /// Posts ⌘V once no modifier key is physically down, checking every 15 ms
+    /// for up to ~1.5 s. Someone who keeps a chord pressed longer than that
+    /// gets the paste anyway; by then the merge race is long over for most
+    /// hands, and never pasting would be worse. The extra beat after the keys
+    /// read clean matters: posted right on the release, the target app can
+    /// still see the stale modifier state and refuse the key equivalent.
+    static func waitForCleanModifiers(attempt: Int = 0, completion: @escaping () -> Void) {
+        let held = CGEventSource.flagsState(.combinedSessionState)
+            .intersection([.maskCommand, .maskAlternate, .maskShift, .maskControl])
+        if held.isEmpty || attempt >= 100 {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.06, execute: completion)
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.015) {
+            waitForCleanModifiers(attempt: attempt + 1, completion: completion)
+        }
+    }
+
+    /// Posts the raw ⌘V key-down/key-up pair. A no-op (with a beep, matching
+    /// every other synthetic-paste call site in the app) while secure event
+    /// input is active - typing into a password field disables synthetic
+    /// keyboard events system-wide, so posting anyway would silently do
+    /// nothing instead of telling the person why.
+    static func postCmdV(completion: @escaping () -> Void) {
+        guard !IsSecureEventInputEnabled() else {
+            NSSound.beep()
+            completion()
+            return
+        }
+        // No explicit event source: an event tied to the HID state inherits
+        // whatever the hardware still reports, which right after a caller's
+        // own keys can re-poison the flags waitForCleanModifiers just waited
+        // out.
+        guard let keyDown = CGEvent(keyboardEventSource: nil,
+                                    virtualKey: CGKeyCode(kVK_ANSI_V),
+                                    keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: nil,
+                                  virtualKey: CGKeyCode(kVK_ANSI_V),
+                                  keyDown: false)
+        else {
+            completion()
+            return
+        }
+        keyDown.flags = .maskCommand
+        keyUp.flags = .maskCommand
+        // No keyboardSetUnicodeString here: a forced character string on the
+        // event breaks menu key equivalent dispatch (verified empirically),
+        // which is exactly the ⌘V we are trying to trigger.
+        keyDown.post(tap: .cghidEventTap)
+        // A beat between down and up mirrors a real key press; some apps skip
+        // equivalents delivered as a zero-length tap.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.04) {
+            keyUp.post(tap: .cghidEventTap)
+            completion()
+        }
+    }
+
+    /// Posts a synthetic Delete/Backspace, which removes an active selection
+    /// in essentially every text field — native, web, and browser chrome
+    /// alike. Used instead of `replaceSelection(with: "")` for Cut/Delete:
+    /// pasting an empty string turned out to be unreliable in some fields
+    /// (Notes, a browser's own address bar) where a real Delete keystroke
+    /// works everywhere. Guarded against secure event input for the same
+    /// reason as `postCmdV`.
+    static func deleteSelection(completion: (() -> Void)? = nil) {
+        waitForCleanModifiers {
+            guard !IsSecureEventInputEnabled() else {
+                NSSound.beep()
+                completion?()
+                return
+            }
+            guard let keyDown = CGEvent(keyboardEventSource: nil,
+                                        virtualKey: CGKeyCode(kVK_Delete),
+                                        keyDown: true),
+                  let keyUp = CGEvent(keyboardEventSource: nil,
+                                      virtualKey: CGKeyCode(kVK_Delete),
+                                      keyDown: false)
+            else {
+                completion?()
+                return
+            }
+            keyDown.post(tap: .cghidEventTap)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.04) {
+                keyUp.post(tap: .cghidEventTap)
+                completion?()
+            }
+        }
+    }
+
+    static func snapshot(of pasteboard: NSPasteboard) -> [NSPasteboardItem] {
+        (pasteboard.pasteboardItems ?? []).map { item in
+            let copy = NSPasteboardItem()
+            for type in item.types {
+                if let data = item.data(forType: type) {
+                    copy.setData(data, forType: type)
+                }
+            }
+            return copy
+        }
+    }
+
+    /// Writes `text` to the general pasteboard, pastes it over the frontmost
+    /// app's current selection once the keyboard reads clean, then restores
+    /// whatever was on the pasteboard before — unless something else changed
+    /// the pasteboard in the meantime, in which case the newer content wins
+    /// and the snapshot is dropped silently.
+    ///
+    /// Every actual pasteboard touch runs through `GeneralPasteboardAccess`,
+    /// the same serial lane Clipboard History and the URL cleaner use —
+    /// touching `NSPasteboard.general` directly from here raced their
+    /// background reads of its type cache and crashed the app.
+    static func replaceSelection(with text: String,
+                                 restoreDelay: TimeInterval = 0.5,
+                                 completion: (() -> Void)? = nil) {
+        let pasteboard = NSPasteboard.general
+        GeneralPasteboardAccess.shared.async({ () -> ([NSPasteboardItem], Int) in
+            let snapshotBefore = snapshot(of: pasteboard)
+            pasteboard.clearContents()
+            pasteboard.setString(text, forType: .string)
+            return (snapshotBefore, pasteboard.changeCount)
+        }, then: { (snapshotBefore, changeCount) in
+            ClipboardHistoryService.shared.ignoreNextChange(upTo: changeCount)
+            waitForCleanModifiers {
+                postCmdV {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + restoreDelay) {
+                        GeneralPasteboardAccess.shared.async({ () -> Int? in
+                            guard pasteboard.changeCount == changeCount, !snapshotBefore.isEmpty
+                            else { return nil }
+                            pasteboard.clearContents()
+                            pasteboard.writeObjects(snapshotBefore)
+                            return pasteboard.changeCount
+                        }, then: { restoredChangeCount in
+                            if let restoredChangeCount {
+                                ClipboardHistoryService.shared.ignoreNextChange(upTo: restoredChangeCount)
+                            }
+                            completion?()
+                        })
+                    }
+                }
+            }
+        })
+    }
+}


### PR DESCRIPTION
## Summary

First of the four PRs @PathGao suggested splitting #713 into. Pulls the synthetic-⌘V/modifier-wait/pasteboard-snapshot logic out of `PastePlainService` into a new `SyntheticPasteSupport.swift`, so the Selection Actions feature (and #917's `TextSnippetService`) can reuse it instead of each carrying its own copy.

Behavior-identical for Paste Plain - same waits, same event posting, same restore logic, just moved. One addition: `postCmdV`/`deleteSelection` now check `IsSecureEventInputEnabled()` before posting, the same guard `CommandBarService`, `TextSnippetService` and `SnippetLibraryService` already use, but missing from this one - a plain-input password field would previously post a synthetic ⌘V that the system silently drops; now it beeps like the others instead. Not every synthetic-paste call site has this guard: `ClipboardHistoryService.pasteIntoPreviousApp` (`ClipboardHistoryService.swift:1041`) posts ⌘V with no secure-input check and no beep, same gap this PR closes here, left open for a later PR - fixing it isn't in scope for this one.

Scope note: no `quick-tools`-adjacent scope exists for the new shared file's own home (it lives directly under `Services/`, not `Services/QuickTools/`), but the only change to existing behavior is inside `PastePlainService.swift`, so I kept the `quick-tools` commit scope. Selection Actions PRs 2-4 (feat, no existing scope to reuse) will need a new `selection-actions` scope - flagging that here since this is the first PR in the sequence.

## Test plan

- [x] `./build.sh` finishes with no warnings
- [x] `./build/Vorssaint --selftest` passes (`SELFTEST OK`)
- [x] `./build.sh --test` passes (`TESTS OK`, 8641 checks)

Manual: exercised Paste Plain (strip formatting, paste, verify rich content restored) on this machine. Did not have a password field or other secure-input context handy to trigger the new `IsSecureEventInputEnabled` branch directly - the guard mirrors the existing one in `CommandBarService.swift` verbatim, so I'm confident in the logic, but flagging that specific path as unexercised.

macOS 26.6.2 (build 25G83), Apple Silicon, own local build (ad hoc signed dev environment, not release-signed).

