### PR TITLE
fix(window-layout): keep window size when moving between displays

### DIFF
--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
@@ -71,7 +71,7 @@ final class WindowLayoutService: ObservableObject {
     /// Read on every pointer event, so it is resolved once instead of per
     /// click.
     private static let ownProcessID = Int64(getpid())
-    private let frameTolerance: CGFloat = 8
+    private let frameTolerance = WindowLayoutGeometry.frameTolerance
     private let anchorTolerance: CGFloat = 36
     private let moveGestureUpdateInterval: TimeInterval = 1.0 / 120.0
     // AX frame mutations are not atomic. Complex windows can visibly render

--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutSupport.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutSupport.swift
@@ -531,19 +531,56 @@ enum WindowLayoutGeometry {
               destinationVisibleFrame.height > 0
         else { return current.integral }
 
-        let widthRatio = min(max(current.width / sourceVisibleFrame.width, 0.08), 1)
-        let heightRatio = min(max(current.height / sourceVisibleFrame.height, 0.08), 1)
-        let xRatio = (current.minX - sourceVisibleFrame.minX) / sourceVisibleFrame.width
-        let yRatio = (current.minY - sourceVisibleFrame.minY) / sourceVisibleFrame.height
+        // Scaling by each screen's size stretches a laptop window across an
+        // ultrawide and squashes it onto a portrait panel. Keep the current
+        // size, only shrinking to fit, and keep the same alignment in the
+        // leftover space. A window that already fills the source still fills
+        // the destination, so Maximize stays Maximize. 8pt matches the
+        // settle tolerance used when judging a placement as stuck.
+        let fillTolerance: CGFloat = 8
+        if current.width >= sourceVisibleFrame.width - fillTolerance,
+           current.height >= sourceVisibleFrame.height - fillTolerance {
+            return destinationVisibleFrame.integral
+        }
 
-        let width = min(destinationVisibleFrame.width, max(1, destinationVisibleFrame.width * widthRatio))
-        let height = min(destinationVisibleFrame.height, max(1, destinationVisibleFrame.height * heightRatio))
-        let unclampedX = destinationVisibleFrame.minX + destinationVisibleFrame.width * xRatio
-        let unclampedY = destinationVisibleFrame.minY + destinationVisibleFrame.height * yRatio
-        let x = min(max(unclampedX, destinationVisibleFrame.minX), destinationVisibleFrame.maxX - width)
-        let y = min(max(unclampedY, destinationVisibleFrame.minY), destinationVisibleFrame.maxY - height)
+        let width = min(destinationVisibleFrame.width, max(1, current.width))
+        let height = min(destinationVisibleFrame.height, max(1, current.height))
+        let x = alignedOrigin(sourceMin: sourceVisibleFrame.minX,
+                              sourceSpan: sourceVisibleFrame.width,
+                              currentMin: current.minX,
+                              currentSpan: current.width,
+                              destinationMin: destinationVisibleFrame.minX,
+                              destinationSpan: destinationVisibleFrame.width,
+                              size: width)
+        let y = alignedOrigin(sourceMin: sourceVisibleFrame.minY,
+                              sourceSpan: sourceVisibleFrame.height,
+                              currentMin: current.minY,
+                              currentSpan: current.height,
+                              destinationMin: destinationVisibleFrame.minY,
+                              destinationSpan: destinationVisibleFrame.height,
+                              size: height)
+        let clampedX = min(max(x, destinationVisibleFrame.minX),
+                           destinationVisibleFrame.maxX - width)
+        let clampedY = min(max(y, destinationVisibleFrame.minY),
+                           destinationVisibleFrame.maxY - height)
+        return CGRect(x: clampedX, y: clampedY, width: width, height: height).integral
+    }
 
-        return CGRect(x: x, y: y, width: width, height: height).integral
+    /// Maps a window's inset along one axis so left/right (or top/bottom)
+    /// alignment is preserved when the size stays the same.
+    private static func alignedOrigin(sourceMin: CGFloat,
+                                      sourceSpan: CGFloat,
+                                      currentMin: CGFloat,
+                                      currentSpan: CGFloat,
+                                      destinationMin: CGFloat,
+                                      destinationSpan: CGFloat,
+                                      size: CGFloat) -> CGFloat {
+        let sourceSlack = sourceSpan - currentSpan
+        if sourceSlack <= 0 {
+            return destinationMin
+        }
+        let t = (currentMin - sourceMin) / sourceSlack
+        return destinationMin + (destinationSpan - size) * t
     }
 
     static func adjacentDisplayIndex(currentIndex: Int,

--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutSupport.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutSupport.swift
@@ -240,6 +240,11 @@ enum WindowLayoutAction: String, CaseIterable, Identifiable {
 }
 
 enum WindowLayoutGeometry {
+    /// Points the settle path allows a window to miss its target by. Display
+    /// transfer uses the same value to treat a window as filling the source
+    /// or flush with an edge, so tuning settle cannot split those checks.
+    static let frameTolerance: CGFloat = 8
+
     static func effectiveAction(for action: WindowLayoutAction,
                                 current _: CGRect,
                                 visibleFrame _: CGRect,
@@ -536,11 +541,8 @@ enum WindowLayoutGeometry {
         // size, only shrinking to fit, and keep the same edge insets rather
         // than spreading leftover space. A window that already fills the
         // source still fills the destination, so Maximize stays Maximize.
-        // 8pt matches the settle tolerance used when judging a placement
-        // as stuck.
-        let fillTolerance: CGFloat = 8
-        if current.width >= sourceVisibleFrame.width - fillTolerance,
-           current.height >= sourceVisibleFrame.height - fillTolerance {
+        if current.width >= sourceVisibleFrame.width - frameTolerance,
+           current.height >= sourceVisibleFrame.height - frameTolerance {
             return destinationVisibleFrame.integral
         }
 
@@ -585,14 +587,24 @@ enum WindowLayoutGeometry {
                                        preferMax: Bool) -> CGFloat {
         let minInset = currentMin - sourceMin
         let maxInset = sourceMax - currentMax
-        let flushTolerance: CGFloat = 8
+        let sourceSlack = (sourceMax - sourceMin) - (currentMax - currentMin)
+        // Near-zero leftover space makes flush-edge detection a coin flip:
+        // a 1pt jitter picks left vs right and becomes a thousand-point
+        // jump on an ultrawide. Keep the preferred-edge inset instead;
+        // the caller already clamps.
+        if sourceSlack <= frameTolerance {
+            if preferMax {
+                return destinationMax - maxInset - size
+            }
+            return destinationMin + minInset
+        }
         if preferMax {
-            if minInset <= flushTolerance, minInset < maxInset {
+            if minInset <= frameTolerance, minInset < maxInset {
                 return destinationMin + minInset
             }
             return destinationMax - maxInset - size
         }
-        if maxInset <= flushTolerance, maxInset < minInset {
+        if maxInset <= frameTolerance, maxInset < minInset {
             return destinationMax - maxInset - size
         }
         return destinationMin + minInset

--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutSupport.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutSupport.swift
@@ -533,10 +533,11 @@ enum WindowLayoutGeometry {
 
         // Scaling by each screen's size stretches a laptop window across an
         // ultrawide and squashes it onto a portrait panel. Keep the current
-        // size, only shrinking to fit, and keep the same alignment in the
-        // leftover space. A window that already fills the source still fills
-        // the destination, so Maximize stays Maximize. 8pt matches the
-        // settle tolerance used when judging a placement as stuck.
+        // size, only shrinking to fit, and keep the same edge insets rather
+        // than spreading leftover space. A window that already fills the
+        // source still fills the destination, so Maximize stays Maximize.
+        // 8pt matches the settle tolerance used when judging a placement
+        // as stuck.
         let fillTolerance: CGFloat = 8
         if current.width >= sourceVisibleFrame.width - fillTolerance,
            current.height >= sourceVisibleFrame.height - fillTolerance {
@@ -545,20 +546,22 @@ enum WindowLayoutGeometry {
 
         let width = min(destinationVisibleFrame.width, max(1, current.width))
         let height = min(destinationVisibleFrame.height, max(1, current.height))
-        let x = alignedOrigin(sourceMin: sourceVisibleFrame.minX,
-                              sourceSpan: sourceVisibleFrame.width,
-                              currentMin: current.minX,
-                              currentSpan: current.width,
-                              destinationMin: destinationVisibleFrame.minX,
-                              destinationSpan: destinationVisibleFrame.width,
-                              size: width)
-        let y = alignedOrigin(sourceMin: sourceVisibleFrame.minY,
-                              sourceSpan: sourceVisibleFrame.height,
-                              currentMin: current.minY,
-                              currentSpan: current.height,
-                              destinationMin: destinationVisibleFrame.minY,
-                              destinationSpan: destinationVisibleFrame.height,
-                              size: height)
+        let x = unscaledOrigin(sourceMin: sourceVisibleFrame.minX,
+                               sourceMax: sourceVisibleFrame.maxX,
+                               currentMin: current.minX,
+                               currentMax: current.maxX,
+                               destinationMin: destinationVisibleFrame.minX,
+                               destinationMax: destinationVisibleFrame.maxX,
+                               size: width,
+                               preferMax: false)
+        let y = unscaledOrigin(sourceMin: sourceVisibleFrame.minY,
+                               sourceMax: sourceVisibleFrame.maxY,
+                               currentMin: current.minY,
+                               currentMax: current.maxY,
+                               destinationMin: destinationVisibleFrame.minY,
+                               destinationMax: destinationVisibleFrame.maxY,
+                               size: height,
+                               preferMax: true)
         let clampedX = min(max(x, destinationVisibleFrame.minX),
                            destinationVisibleFrame.maxX - width)
         let clampedY = min(max(y, destinationVisibleFrame.minY),
@@ -566,21 +569,33 @@ enum WindowLayoutGeometry {
         return CGRect(x: clampedX, y: clampedY, width: width, height: height).integral
     }
 
-    /// Maps a window's inset along one axis so left/right (or top/bottom)
-    /// alignment is preserved when the size stays the same.
-    private static func alignedOrigin(sourceMin: CGFloat,
-                                      sourceSpan: CGFloat,
-                                      currentMin: CGFloat,
-                                      currentSpan: CGFloat,
-                                      destinationMin: CGFloat,
-                                      destinationSpan: CGFloat,
-                                      size: CGFloat) -> CGFloat {
-        let sourceSlack = sourceSpan - currentSpan
-        if sourceSlack <= 0 {
-            return destinationMin
+    /// Keeps the inset from the leading edge of an axis, unless the window is
+    /// already flush with the trailing one. Horizontal placement prefers the
+    /// left so a window in the middle of a laptop does not fly to the middle
+    /// of an ultrawide; a right-half stays on the right. Vertical placement
+    /// prefers the top (AppKit maxY, under the menu bar) so a full-height
+    /// window is not dropped onto the dock of a taller display.
+    private static func unscaledOrigin(sourceMin: CGFloat,
+                                       sourceMax: CGFloat,
+                                       currentMin: CGFloat,
+                                       currentMax: CGFloat,
+                                       destinationMin: CGFloat,
+                                       destinationMax: CGFloat,
+                                       size: CGFloat,
+                                       preferMax: Bool) -> CGFloat {
+        let minInset = currentMin - sourceMin
+        let maxInset = sourceMax - currentMax
+        let flushTolerance: CGFloat = 8
+        if preferMax {
+            if minInset <= flushTolerance, minInset < maxInset {
+                return destinationMin + minInset
+            }
+            return destinationMax - maxInset - size
         }
-        let t = (currentMin - sourceMin) / sourceSlack
-        return destinationMin + (destinationSpan - size) * t
+        if maxInset <= flushTolerance, maxInset < minInset {
+            return destinationMax - maxInset - size
+        }
+        return destinationMin + minInset
     }
 
     static func adjacentDisplayIndex(currentIndex: Int,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -4339,8 +4339,14 @@ struct MetricsTests {
         expect(WindowLayoutGeometry.rectForDisplay(current: rightHalfWindow,
                                                    sourceVisibleFrame: visibleFrame,
                                                    destinationVisibleFrame: nextDisplayFrame)
-               == CGRect(x: 2640, y: 80, width: 720, height: 860),
-               "window layout display transfer keeps the window size and right alignment")
+               == CGRect(x: 2640, y: 220, width: 720, height: 860),
+               "window layout display transfer keeps a right-half on the right and under the menu bar")
+        let leftHalfWindow = CGRect(x: 0, y: 40, width: 720, height: 860)
+        expect(WindowLayoutGeometry.rectForDisplay(current: leftHalfWindow,
+                                                   sourceVisibleFrame: visibleFrame,
+                                                   destinationVisibleFrame: nextDisplayFrame)
+               == CGRect(x: 1440, y: 220, width: 720, height: 860),
+               "window layout display transfer keeps a left-half on the left and under the menu bar")
         let oversizedWindow = CGRect(x: -40, y: 0, width: 2000, height: 1200)
         expect(WindowLayoutGeometry.rectForDisplay(current: oversizedWindow,
                                                    sourceVisibleFrame: visibleFrame,
@@ -4362,8 +4368,8 @@ struct MetricsTests {
         expect(WindowLayoutGeometry.rectForDisplay(current: currentWindow,
                                                    sourceVisibleFrame: visibleFrame,
                                                    destinationVisibleFrame: ultrawideFrame)
-               == CGRect(x: 2265, y: 400, width: 800, height: 500),
-               "display transfer does not stretch a laptop window across an ultrawide")
+               == CGRect(x: 1640, y: 700, width: 800, height: 500),
+               "display transfer keeps a laptop window's size and top-left insets on an ultrawide")
         let horizontalDisplays = [
             CGRect(x: 0, y: 0, width: 1440, height: 900),
             CGRect(x: -1200, y: -200, width: 1200, height: 1920),
@@ -4397,16 +4403,16 @@ struct MetricsTests {
                "window layout leaves one display and invalid selections unchanged")
         let portraitFrame = CGRect(x: -1200, y: -200, width: 1200, height: 1800)
         let scaledFrame = CGRect(x: 1440, y: 100, width: 2000, height: 1000)
-        let portraitWindow = CGRect(x: -900, y: 250, width: 600, height: 900)
+        let portraitWindow = CGRect(x: -900, y: 1000, width: 600, height: 400)
         let scaledWindow = WindowLayoutGeometry.rectForDisplay(current: portraitWindow,
                                                                sourceVisibleFrame: portraitFrame,
                                                                destinationVisibleFrame: scaledFrame)
-        expect(scaledWindow == CGRect(x: 2140, y: 150, width: 600, height: 900)
+        expect(scaledWindow == CGRect(x: 1740, y: 500, width: 600, height: 400)
                 && WindowLayoutGeometry.rectForDisplay(current: scaledWindow,
                                                        sourceVisibleFrame: scaledFrame,
                                                        destinationVisibleFrame: portraitFrame)
                     == portraitWindow,
-               "display transfer keeps size and alignment across rotated frames")
+               "display transfer keeps size and edge insets across rotated frames")
         expect(WindowLayoutAction.shortcutActions.count == WindowLayoutAction.allCases.count,
                "every window layout action can register a global shortcut")
         expect(WindowLayoutAction.shortcutActions.contains(.previousDisplay)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -4339,14 +4339,31 @@ struct MetricsTests {
         expect(WindowLayoutGeometry.rectForDisplay(current: rightHalfWindow,
                                                    sourceVisibleFrame: visibleFrame,
                                                    destinationVisibleFrame: nextDisplayFrame)
-               == CGRect(x: 2400, y: 80, width: 960, height: 1000),
-               "window layout display transfer preserves relative placement and size")
+               == CGRect(x: 2640, y: 80, width: 720, height: 860),
+               "window layout display transfer keeps the window size and right alignment")
         let oversizedWindow = CGRect(x: -40, y: 0, width: 2000, height: 1200)
         expect(WindowLayoutGeometry.rectForDisplay(current: oversizedWindow,
                                                    sourceVisibleFrame: visibleFrame,
                                                    destinationVisibleFrame: nextDisplayFrame)
                == nextDisplayFrame,
                "window layout display transfer clamps oversized windows to the destination visible frame")
+        expect(WindowLayoutGeometry.rectForDisplay(current: visibleFrame,
+                                                   sourceVisibleFrame: visibleFrame,
+                                                   destinationVisibleFrame: nextDisplayFrame)
+               == nextDisplayFrame,
+               "display transfer fills the destination when the window already fills the source")
+        let almostFilled = CGRect(x: 4, y: 44, width: 1432, height: 852)
+        expect(WindowLayoutGeometry.rectForDisplay(current: almostFilled,
+                                                   sourceVisibleFrame: visibleFrame,
+                                                   destinationVisibleFrame: nextDisplayFrame)
+               == nextDisplayFrame,
+               "display transfer treats a window within settle tolerance of maximize as filling the destination")
+        let ultrawideFrame = CGRect(x: 1440, y: 0, width: 3440, height: 1400)
+        expect(WindowLayoutGeometry.rectForDisplay(current: currentWindow,
+                                                   sourceVisibleFrame: visibleFrame,
+                                                   destinationVisibleFrame: ultrawideFrame)
+               == CGRect(x: 2265, y: 400, width: 800, height: 500),
+               "display transfer does not stretch a laptop window across an ultrawide")
         let horizontalDisplays = [
             CGRect(x: 0, y: 0, width: 1440, height: 900),
             CGRect(x: -1200, y: -200, width: 1200, height: 1920),
@@ -4384,12 +4401,12 @@ struct MetricsTests {
         let scaledWindow = WindowLayoutGeometry.rectForDisplay(current: portraitWindow,
                                                                sourceVisibleFrame: portraitFrame,
                                                                destinationVisibleFrame: scaledFrame)
-        expect(scaledWindow == CGRect(x: 1940, y: 350, width: 1000, height: 500)
+        expect(scaledWindow == CGRect(x: 2140, y: 150, width: 600, height: 900)
                 && WindowLayoutGeometry.rectForDisplay(current: scaledWindow,
                                                        sourceVisibleFrame: scaledFrame,
                                                        destinationVisibleFrame: portraitFrame)
                     == portraitWindow,
-               "display transfer preserves relative size and placement across rotated and scaled frames")
+               "display transfer keeps size and alignment across rotated frames")
         expect(WindowLayoutAction.shortcutActions.count == WindowLayoutAction.allCases.count,
                "every window layout action can register a global shortcut")
         expect(WindowLayoutAction.shortcutActions.contains(.previousDisplay)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -4370,6 +4370,29 @@ struct MetricsTests {
                                                    destinationVisibleFrame: ultrawideFrame)
                == CGRect(x: 1640, y: 700, width: 800, height: 500),
                "display transfer keeps a laptop window's size and top-left insets on an ultrawide")
+        let nearFullWidth = CGRect(x: 2, y: 200, width: 1436, height: 500)
+        expect(WindowLayoutGeometry.rectForDisplay(current: nearFullWidth,
+                                                   sourceVisibleFrame: visibleFrame,
+                                                   destinationVisibleFrame: ultrawideFrame)
+               == CGRect(x: 1442, y: 700, width: 1436, height: 500),
+               "display transfer keeps a near-full-width window's left inset on an ultrawide")
+        let nearFullWidthRightish = CGRect(x: 6, y: 200, width: 1432, height: 500)
+        expect(WindowLayoutGeometry.rectForDisplay(current: nearFullWidthRightish,
+                                                   sourceVisibleFrame: visibleFrame,
+                                                   destinationVisibleFrame: ultrawideFrame)
+               == CGRect(x: 1446, y: 700, width: 1432, height: 500),
+               "display transfer does not treat a few points of leftover width as a right edge")
+        let shortDisplay = CGRect(x: 1440, y: 80, width: 1920, height: 400)
+        let shrunkWindow = WindowLayoutGeometry.rectForDisplay(current: currentWindow,
+                                                               sourceVisibleFrame: visibleFrame,
+                                                               destinationVisibleFrame: shortDisplay)
+        expect(shrunkWindow == CGRect(x: 1640, y: 80, width: 800, height: 400),
+               "display transfer shrinks a taller window to fit a shorter display")
+        expect(WindowLayoutGeometry.rectForDisplay(current: shrunkWindow,
+                                                   sourceVisibleFrame: shortDisplay,
+                                                   destinationVisibleFrame: visibleFrame)
+               == CGRect(x: 200, y: 500, width: 800, height: 400),
+               "display transfer does not restore the original height after shrinking to fit")
         let horizontalDisplays = [
             CGRect(x: 0, y: 0, width: 1440, height: 900),
             CGRect(x: -1200, y: -200, width: 1200, height: 1920),


### PR DESCRIPTION
## Summary

Next/previous display scaled a window as a fraction of the destination screen, so a window moved from the built-in display onto an ultrawide grew in both axes and the empty space around it was stretched the same way.

`rectForDisplay` now keeps the current point size, shrinking only to fit. Round trips are lossy: a window that has to shrink to fit a smaller display does not grow back to its original size (the ratio mapping used to restore it). If the shrink fills an axis, the return trip treats that edge as flush, so the origin moves too — the shrink test leaves at y 200 and comes back at y 500. If both axes were clamped, the return trip treats that as Maximize.

Position keeps physical edge insets instead of interpolating leftover space: a window flush with the right or bottom stays there (so a right-half stays a right-half), everything else keeps its left and top insets so it does not fly to the middle of an ultrawide, and a full-height window stays under the menu bar instead of dropping onto the dock of a taller display. A window within a few points of filling one axis keeps that preferred-edge inset instead of treating leftover space as a flush edge. A window that already fills the source within the settle tolerance still fills the destination. That tolerance is the same 8pt the settle path uses when judging a placement as stuck. Dock Preview drag, the move gesture, and native title-bar drags were already size-preserving; only this shared helper resized.

## Verification

MacBook Pro 16" (Mac16,5, M4 Max), macOS 27.0 (26A5416b). Built-in Liquid Retina XDR plus a 3840×1080 ultrawide, Spaces not mirrored. Installed a local `./build.sh --install` release build and confirmed Next/Previous display keeps the window size on the ultrawide. Position inset behaviour, near-full-width placement, and shrink-to-fit round trips are covered by unit tests; needs a rebuild to feel on the Mac.

```sh
./build.sh --test
```

8649 checks ran. The only failure is the existing dispatch-pool starvation probe, which is unrelated to this geometry change.

Could not re-test a portrait external display on hardware.

## Anything else

No existing issue. Reported from using Next/Previous display on a laptop plus ultrawide setup.