### PR TITLE
feat(screenshot): open an image file in the capture editor

### DIFF
--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotService.swift
@@ -480,16 +480,33 @@ final class ScreenshotService: ObservableObject {
         }
     }
 
+    /// Opens the editor on an image file instead of on a capture, so the media
+    /// tools can hand it a dropped file the way they already hand a dropped
+    /// video to the recorder editor. Returns false when the file is not an
+    /// image the editor can hold, leaving the caller to say so.
+    @discardableResult
+    func openEditor(imageAt url: URL) -> Bool {
+        guard AppFeature.screenshot.isAvailable,
+              let image = NSImage(contentsOf: url),
+              let capture = Self.capture(from: image)
+        else { return false }
+        openEditor(with: capture)
+        return true
+    }
+
     private static func clipboardCapture(
         from pasteboard: NSPasteboard
     ) -> ScreenshotSelectionController.Capture? {
-        guard let image = clipboardImage(from: pasteboard),
-              image.size.width > 0, image.size.height > 0
-        else { return nil }
+        guard let image = clipboardImage(from: pasteboard) else { return nil }
+        return capture(from: image)
+    }
+
+    private static func capture(from image: NSImage) -> ScreenshotSelectionController.Capture? {
+        guard image.size.width > 0, image.size.height > 0 else { return nil }
         var rect = CGRect(origin: .zero, size: image.size)
         guard let cgImage = image.cgImage(forProposedRect: &rect, context: nil, hints: nil),
-              cgImage.width > 0, cgImage.height > 0,
-              cgImage.width <= ScreenshotSupport.scrollingCaptureMaximumPixels / cgImage.height
+              ScreenshotSupport.editorAcceptsImage(
+                  pixelSize: CGSize(width: cgImage.width, height: cgImage.height))
         else { return nil }
         let pixelSize = CGSize(width: cgImage.width, height: cgImage.height)
         let scale = ScreenshotSupport.clipboardImageScale(pixelSize: pixelSize,

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
@@ -560,6 +560,16 @@ enum ScreenshotSupport {
         return CGFloat(scale)
     }
 
+    /// An image that arrives from outside a capture can be far larger than
+    /// anything the screen produces, so it is refused before a window opens on
+    /// it rather than after the editor has tried to hold it.
+    static func editorAcceptsImage(pixelSize: CGSize) -> Bool {
+        guard pixelSize.width.isFinite, pixelSize.height.isFinite,
+              pixelSize.width >= 1, pixelSize.height >= 1
+        else { return false }
+        return pixelSize.width * pixelSize.height <= CGFloat(scrollingCaptureMaximumPixels)
+    }
+
     /// Uses the logical size carried by a copied image when it describes one
     /// consistent display scale. Imported files without that metadata edit at 1x.
     static func clipboardImageScale(pixelSize: CGSize, pointSize: CGSize) -> CGFloat {

--- a/Sources/Vorssaint/UI/Media/MediaWorkspaceView.swift
+++ b/Sources/Vorssaint/UI/Media/MediaWorkspaceView.swift
@@ -403,6 +403,17 @@ struct MediaWorkspaceView: View {
                 }
             }
 
+            // The editor belongs to the screenshot feature, so the button is
+            // absent rather than inert when that feature is turned off.
+            if selectedTool == .imageCompressor, AppFeature.screenshot.isAvailable {
+                Button {
+                    openImageEditor()
+                } label: {
+                    Label(screenshotText.editButton, systemImage: "crop")
+                }
+                .disabled(inputURLs.count != 1 || isRunning)
+            }
+
             if isRunning {
                 Button {
                     media.cancel()
@@ -1310,6 +1321,19 @@ struct MediaWorkspaceView: View {
     }
 
     @MainActor
+    /// The dropped image goes straight to the capture editor: nothing is
+    /// imported or copied first, because that editor works on an image rather
+    /// than on a file it has to own.
+    private func openImageEditor() {
+        guard AppFeature.mediaTools.isAvailable, AppFeature.screenshot.isAvailable,
+              let url = inputURL, inputURLs.count == 1
+        else { return }
+        localMessage = nil
+        if !ScreenshotService.shared.openEditor(imageAt: url) {
+            localMessage = l10n.s.mediaErrorUnsupported
+        }
+    }
+
     private func openVideoEditor() {
         guard AppFeature.mediaTools.isAvailable, let url = inputURL,
               !isImportingVideo else { return }

--- a/Sources/Vorssaint/UI/Media/MediaWorkspaceView.swift
+++ b/Sources/Vorssaint/UI/Media/MediaWorkspaceView.swift
@@ -1320,7 +1320,6 @@ struct MediaWorkspaceView: View {
         return (duration * 10).rounded() / 10
     }
 
-    @MainActor
     /// The dropped image goes straight to the capture editor: nothing is
     /// imported or copied first, because that editor works on an image rather
     /// than on a file it has to own.
@@ -1329,11 +1328,18 @@ struct MediaWorkspaceView: View {
               let url = inputURL, inputURLs.count == 1
         else { return }
         localMessage = nil
-        if !ScreenshotService.shared.openEditor(imageAt: url) {
+        // An image the editor cannot hold is not an unsupported format: say
+        // which of the two it is, since the tool's own limit is the likelier
+        // of the two here.
+        if let size = MediaSupport.imageDisplaySize(at: url),
+           !ScreenshotSupport.editorAcceptsImage(pixelSize: size) {
+            localMessage = imageText.tooLarge
+        } else if !ScreenshotService.shared.openEditor(imageAt: url) {
             localMessage = l10n.s.mediaErrorUnsupported
         }
     }
 
+    @MainActor
     private func openVideoEditor() {
         guard AppFeature.mediaTools.isAvailable, let url = inputURL,
               !isImportingVideo else { return }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -13833,6 +13833,15 @@ struct MetricsTests {
             pixelSize: CGSize(width: 1200, height: 800),
             pointSize: CGSize(width: 600, height: 800)) == 1,
                "copied images with inconsistent metadata safely use 1x")
+        expect(ScreenshotSupport.editorAcceptsImage(pixelSize: CGSize(width: 4_000, height: 3_000))
+                && ScreenshotSupport.editorAcceptsImage(
+                    pixelSize: CGSize(width: 10_000, height: 6_000)),
+               "an imported image up to the capture ceiling opens in the editor")
+        expect(!ScreenshotSupport.editorAcceptsImage(pixelSize: CGSize(width: 10_000, height: 6_001))
+                && !ScreenshotSupport.editorAcceptsImage(pixelSize: .zero)
+                && !ScreenshotSupport.editorAcceptsImage(
+                    pixelSize: CGSize(width: CGFloat.infinity, height: 1)),
+               "an image beyond the ceiling, empty or unmeasurable never opens a window")
 
         expect(Defaults.registeredDefaults[DefaultsKey.cameraPreviewShortcutEnabled] as? Bool == false,
                "the camera preview shortcut ships off like the other quick tools")


### PR DESCRIPTION
Does **not** close #677 — see the thread below. This adds a way *into* the
capture editor from the media tools; #677 asks for a drag source *out* of it.

## Before

An image already on disk cannot reach the capture editor. #677 puts it
plainly: the editor has to be fed from Finder, and there is no way to hand it
a file. The media tools have an Edit button for video, which imports a dropped
file and opens the recorder editor on it; the image tool has no equivalent, so
an image that needs a crop or an arrow before it is compressed has to leave the
app and come back.

## After

**An Edit button in the media tools' image tab**, beside the one the video tab
has carried since the media tools shipped. An image loaded there opens in the
capture editor.

## How it works

The capture editor works on an image, not on a file it has to own. That is the
whole reason this is small: the recorder editor works on takes it owns, which
is why the video path has to import the file into a private store first, while
an image only has to be read.

The pasteboard path was already doing exactly that work, down to reading a file
URL with `NSImage(contentsOf:)`, so both entry points now share one capture
builder instead of each carrying its own. The size ceiling that guarded it
moves to `ScreenshotSupport.editorAcceptsImage(pixelSize:)`, where a file —
which can be far larger than anything a screen produces — is refused before a
window opens on it rather than after.

The button is absent rather than inert when the screenshot feature is turned
off, since the editor belongs to that feature.

## Notes

No new user-facing text: the Edit label already exists in every supported
language, since it is the recorder editor's own.

## Checks

- `./build.sh` finishes with no warnings.
- `./build/Vorssaint --selftest` prints `SELFTEST OK`.
- `./build.sh --test` passes, with new assertions for the size ceiling: an
  image at the ceiling opens, one past it, one empty, and one with an
  unmeasurable dimension do not.
- Exercised by hand on JPEG, PNG and HEIC files, dropped on the editor and
  opened from the media tools.



## On #677, and on the body this PR opened with

Two corrections, both mine.

The body claimed a drop-on-the-editor entry point. That code is not in this
commit — it lives on a working branch and never made it here. @PathGao caught
it before anyone could read it as shipped.

And `Closes #677` was wrong. The issue reads as "there is no way to get an
image into the editor", which is what this was built for, but @Yahddyyp has
clarified that the ask is the opposite direction: a drag source in the editor,
near Save and Copy, to pull the picture out into Finder.

That handle already exists — `dragOutHandle`, the thumbnail in the dimensions
chip at the bottom left — so #677 is about where it sits rather than about
building it, and that belongs in its own change. #677 stays open.

## Since the review

- An image past the editor's ceiling now says so, instead of reporting
  `mediaErrorUnsupported`. That is the likelier of the two failures in the
  image compressor, and it was the wrong message.
- `openVideoEditor` has its `@MainActor` back: the new function was inserted
  directly under the attribute and consumed it.
