### PR TITLE
feat(build): support building and running on intel macs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,8 @@ cd vorssaint-utils
 ./build.sh --install               # install into /Applications and launch
 ```
 
-You need macOS 14 or newer, Apple Silicon and the Xcode Command Line Tools. The
+You need macOS 14 or newer, an Apple Silicon or Intel Mac, and the Xcode Command
+Line Tools. The
 build is a plain `swiftc` invocation, see `build.sh`, with no Xcode project and
 no external dependencies, reproducible by design. `Package.swift` is there so
 SwiftPM aware editors can index the code.

--- a/README.md
+++ b/README.md
@@ -203,8 +203,25 @@ The shelf and almost every quick toggle need no permission at all. Finder cut an
 
 ## What you need
 
-- A Mac with Apple Silicon
+- A Mac with Apple Silicon, or an Intel Mac (this fork — see below)
 - macOS 14 Sonoma or newer
+
+### Intel support (this fork)
+
+Upstream builds for `arm64` only. This fork builds and runs natively on Intel:
+
+- `build.sh` targets the host architecture (`VORSSAINT_ARCH=arm64|x86_64` to override)
+  instead of hardcoding `arm64`.
+- The SMC value decoder handles the whole generic `sp…`/`fp…` fixed-point family.
+  Intel Macs publish their power sensors as `spa5`, which decoded to nothing before —
+  which is why every Intel Mac reported "no power metrics".
+- Temperature sensors: Intel uses a different SMC namespace (`TC…` for the CPU,
+  `TG…` for the GPU) than Apple Silicon (`Tp…`/`Te…`/`Tg…`). The selector now knows
+  both, and prefers the Intel die sensors (`TC0c…TC9c`, `TCXc`) over the proximity
+  ones, which lag the die by ten degrees or more.
+- One unit test asserted that 64 blocked threads starve the libdispatch pool. They
+  do on Apple Silicon; an Intel Mac keeps handing out workers past that, so the test
+  now blocks in batches until the pool really is starved.
 
 ### Build it yourself
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   <a href="https://github.com/vorssaintapp/vorssaint-utils/releases"><img src="https://img.shields.io/github/v/release/vorssaintapp/vorssaint-utils?label=release&color=4c8dff" alt="Latest release"></a>
   <a href="https://github.com/vorssaintapp/vorssaint-utils/releases"><img src="https://img.shields.io/github/downloads/vorssaintapp/vorssaint-utils/total?color=4c8dff" alt="Downloads"></a>
   <a href="https://github.com/vorssaintapp/vorssaint-utils/actions/workflows/ci.yml"><img src="https://github.com/vorssaintapp/vorssaint-utils/actions/workflows/ci.yml/badge.svg?branch=main&event=push" alt="CI status"></a>
-  <a href="#what-you-need"><img src="https://img.shields.io/badge/macOS-14%2B%20Apple%20Silicon-black" alt="macOS 14 and newer, Apple Silicon"></a>
+  <a href="#what-you-need"><img src="https://img.shields.io/badge/macOS-14%2B%20Apple%20Silicon%20%7C%20Intel-black" alt="macOS 14 and newer, Apple Silicon or Intel"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPL--3.0--or--later-blue" alt="License GPL 3.0 or later"></a>
 </p>
 
@@ -203,25 +203,8 @@ The shelf and almost every quick toggle need no permission at all. Finder cut an
 
 ## What you need
 
-- A Mac with Apple Silicon, or an Intel Mac (this fork — see below)
+- A Mac with Apple Silicon or Intel
 - macOS 14 Sonoma or newer
-
-### Intel support (this fork)
-
-Upstream builds for `arm64` only. This fork builds and runs natively on Intel:
-
-- `build.sh` targets the host architecture (`VORSSAINT_ARCH=arm64|x86_64` to override)
-  instead of hardcoding `arm64`.
-- The SMC value decoder handles the whole generic `sp…`/`fp…` fixed-point family.
-  Intel Macs publish their power sensors as `spa5`, which decoded to nothing before —
-  which is why every Intel Mac reported "no power metrics".
-- Temperature sensors: Intel uses a different SMC namespace (`TC…` for the CPU,
-  `TG…` for the GPU) than Apple Silicon (`Tp…`/`Te…`/`Tg…`). The selector now knows
-  both, and prefers the Intel die sensors (`TC0c…TC9c`, `TCXc`) over the proximity
-  ones, which lag the die by ten degrees or more.
-- One unit test asserted that 64 blocked threads starve the libdispatch pool. They
-  do on Apple Silicon; an Intel Mac keeps handing out workers past that, so the test
-  now blocks in batches until the pool really is starved.
 
 ### Build it yourself
 

--- a/Sources/Vorssaint/Services/FanControl/FanControlHardware.swift
+++ b/Sources/Vorssaint/Services/FanControl/FanControlHardware.swift
@@ -313,14 +313,17 @@ final class FanControlHardware {
         if let temperatureKeys { return temperatureKeys }
         let keys = client.keys { name in
             TemperatureSensorSelector.isCPUTemperatureKey(name, platform: temperaturePlatform)
-                || name.hasPrefix("Tg")
+                || TemperatureSensorSelector.isGPUTemperatureKey(name, platform: temperaturePlatform)
         }
         let result = TemperatureKeys(
             cpu: keys.filter {
                 TemperatureSensorSelector.isCPUTemperatureKey($0.name,
                                                               platform: temperaturePlatform)
             },
-            gpu: keys.filter { $0.name.hasPrefix("Tg") }
+            gpu: keys.filter {
+                TemperatureSensorSelector.isGPUTemperatureKey($0.name,
+                                                              platform: temperaturePlatform)
+            }
         )
         temperatureKeys = result
         return result

--- a/Sources/Vorssaint/Services/FanControl/FanControlSupport.swift
+++ b/Sources/Vorssaint/Services/FanControl/FanControlSupport.swift
@@ -392,6 +392,21 @@ enum SMCValueCodec {
                 raw |= UInt64(byte) << UInt64(offset * 8)
             }
             return Double(raw) / 65_536.0
+        case let fixedPoint where bytes.count == 2
+            && (fixedPoint.hasPrefix("sp") || fixedPoint.hasPrefix("fp")):
+            // Generic "sp"/"fp" fixed point: the last character is the number of
+            // fractional bits in hex ("spa5" -> 5, "sp87" -> 7). Apple Silicon
+            // only ships sp78 and fpe2, both handled above, but Intel SMCs
+            // publish their power and current sensors (PSTR, PCPC, PC0C…) in the
+            // rest of the family — without this they decode to nothing and the
+            // app reports "no power metrics" on every Intel Mac.
+            guard let fractionBits = Int(String(fixedPoint.suffix(1)), radix: 16),
+                  fractionBits <= 15 else { return nil }
+            let raw = UInt16(bytes[0]) << 8 | UInt16(bytes[1])
+            let magnitude = fixedPoint.hasPrefix("sp")
+                ? Double(Int16(bitPattern: raw))
+                : Double(raw)
+            return magnitude / Double(1 << fractionBits)
         default:
             return nil
         }

--- a/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
+++ b/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
@@ -10,6 +10,7 @@ enum CPUTemperaturePlatform: Equatable {
     case appleM3Family
     case appleM4Family
     case appleM5Family
+    case intel
     case generic
 }
 
@@ -63,7 +64,12 @@ enum TemperatureSensorSelector {
         case 3: return .appleM3Family
         case 4: return .appleM4Family
         case 5: return .appleM5Family
-        default: return .generic
+        default:
+            // Intel Macs name their CPU in the same sysctl. They expose a
+            // completely different SMC namespace (TC…/TG… instead of Tp…/Tg…),
+            // so they need their own platform rather than the generic fallback,
+            // which finds no CPU sensor at all on them.
+            return brand.contains("Intel") ? .intel : .generic
         }
     }
 
@@ -95,6 +101,7 @@ enum TemperatureSensorSelector {
         switch platform {
         case .appleM1Family, .appleM2Family, .appleM3Family, .appleM4Family, .appleM5Family:
             return true
+        case .intel: return true
         case .generic: return false
         }
     }
@@ -111,15 +118,40 @@ enum TemperatureSensorSelector {
             return appleM4CPUCoreKeys.contains(key)
         case .appleM5Family:
             return appleM5CPUCoreKeys.contains(key)
+        case .intel:
+            return isIntelCPUCoreKey(key)
         case .generic:
             return false
         }
     }
 
+    /// Intel die sensors, the ones that actually track the cores: TC0c…TC9c per
+    /// core, TCXc/TCXC for the package (PECI), TC0D/TCXD for the die on the
+    /// notebooks. Deliberately excludes TC0P and TC0H — proximity and heatsink
+    /// sensors that lag the die by ten degrees or more.
+    static func isIntelCPUCoreKey(_ key: String) -> Bool {
+        let characters = Array(key)
+        guard characters.count == 4, characters[0] == "T", characters[1] == "C" else { return false }
+        guard characters[2].isNumber || characters[2] == "X" else { return false }
+        return characters[3] == "c" || characters[3] == "C"
+            || characters[3] == "d" || characters[3] == "D"
+    }
+
     static func isCPUTemperatureKey(_ key: String,
                                     platform: CPUTemperaturePlatform) -> Bool {
+        // Intel keeps its CPU sensors under TC…; Tp/Te on those machines are
+        // power-supply and enclosure probes, so matching them there would
+        // display a case temperature as the CPU temperature.
+        if platform == .intel { return key.hasPrefix("TC") }
         if key.hasPrefix("Tp") || key.hasPrefix("Te") { return true }
         return platform == .appleM3Family && key.hasPrefix("Tf")
+    }
+
+    /// GPU sensors: Tg… on Apple Silicon, TG… on Intel (one block per discrete
+    /// GPU, so a dual-GPU Mac Pro reports both).
+    static func isGPUTemperatureKey(_ key: String,
+                                    platform: CPUTemperaturePlatform) -> Bool {
+        platform == .intel ? key.hasPrefix("TG") : key.hasPrefix("Tg")
     }
 
     static func stabilizedTemperature(_ reading: Double?,

--- a/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
@@ -898,17 +898,23 @@ final class SystemMonitor: ObservableObject {
         guard needTemperature, !tempKeysPrepared else { return }
         tempKeysPrepared = true
 
+        let platform = cpuTemperaturePlatform
         let all = client.keys { name in
-            name.hasPrefix("Tp") || name.hasPrefix("Te") || name.hasPrefix("Tg")
+            TemperatureSensorSelector.isCPUTemperatureKey(name, platform: platform)
+                || TemperatureSensorSelector.isGPUTemperatureKey(name, platform: platform)
                 || name.range(of: "^TB[0-9]T$", options: .regularExpression) != nil
         }
-        cpuKeys = all.filter { $0.name.hasPrefix("Tp") || $0.name.hasPrefix("Te") }
+        cpuKeys = all.filter {
+            TemperatureSensorSelector.isCPUTemperatureKey($0.name, platform: platform)
+        }
         preferredCPUKeys = cpuKeys.filter {
             TemperatureSensorSelector.isCPUCoreKey($0.name, platform: cpuTemperaturePlatform)
         }
         let preferredNames = Set(preferredCPUKeys.map(\.name))
         fallbackCPUKeys = cpuKeys.filter { !preferredNames.contains($0.name) }
-        gpuKeys = all.filter { $0.name.hasPrefix("Tg") }
+        gpuKeys = all.filter {
+            TemperatureSensorSelector.isGPUTemperatureKey($0.name, platform: platform)
+        }
         batteryKeys = all.filter { $0.name.hasPrefix("TB") }
     }
 

--- a/Sources/Vorssaint/Support/SelfTest.swift
+++ b/Sources/Vorssaint/Support/SelfTest.swift
@@ -44,7 +44,11 @@ enum SelfTest {
         }
 
         if let smc = SMCClient() {
-            let keys = smc.keys { $0.hasPrefix("Tp") || $0.hasPrefix("Te") || $0.hasPrefix("Tg") }
+            let platform = TemperatureSensorSelector.currentPlatform()
+            let keys = smc.keys {
+                TemperatureSensorSelector.isCPUTemperatureKey($0, platform: platform)
+                    || TemperatureSensorSelector.isGPUTemperatureKey($0, platform: platform)
+            }
             if keys.isEmpty {
                 warnings.append("no SMC temperature keys")
             } else if keys.compactMap({ smc.readValue($0) }).isEmpty {
@@ -163,11 +167,12 @@ enum SensorDump {
             print("AppleSMC unavailable")
             exit(1)
         }
+        let cpuPlatform = TemperatureSensorSelector.currentPlatform()
         let keys = smc.keys { name in
-            name.hasPrefix("Tp") || name.hasPrefix("Te") || name.hasPrefix("Tg")
+            TemperatureSensorSelector.isCPUTemperatureKey(name, platform: cpuPlatform)
+                || TemperatureSensorSelector.isGPUTemperatureKey(name, platform: cpuPlatform)
                 || name.range(of: "^TB[0-9]T$", options: .regularExpression) != nil
         }
-        let cpuPlatform = TemperatureSensorSelector.currentPlatform()
         let hasCPUCoreSet = TemperatureSensorSelector.hasCPUCoreSet(platform: cpuPlatform)
         print("component    key   type   °C")
         for key in keys.sorted(by: { $0.name < $1.name }) {
@@ -175,7 +180,7 @@ enum SensorDump {
             let component: String
             if key.name.hasPrefix("TB") {
                 component = "battery"
-            } else if key.name.hasPrefix("Tg") {
+            } else if TemperatureSensorSelector.isGPUTemperatureKey(key.name, platform: cpuPlatform) {
                 component = "gpu"
             } else if hasCPUCoreSet {
                 component = TemperatureSensorSelector.isCPUCoreKey(key.name, platform: cpuPlatform) ? "cpu-core" : "cpu-aux"

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -10119,27 +10119,36 @@ struct MetricsTests {
         // one more worker doing it. Waiting on the child itself is immune, so
         // the pool the runner starved can no longer starve the runner.
         let poolGate = DispatchSemaphore(value: 0)
-        let poolOccupied = DispatchSemaphore(value: 0)
-        // The dispatch pool's soft limit is 64 threads blocked in synchronous
-        // work; one block per thread takes every one of them.
-        for _ in 0..<64 {
-            DispatchQueue.global(qos: .utility).async {
-                poolOccupied.signal()
-                poolGate.wait()
+        // How many blocked threads it takes to starve the pool is not a fixed
+        // number: 64 does it on Apple Silicon, while an Intel Mac keeps handing
+        // out workers well past that, so the fixed batch left the probe running
+        // and failed this precondition instead of the behaviour under test.
+        // Block in batches until the probe really is stranded.
+        var submittedPoolWorkers = 0
+        var poolIsStarved = false
+        var starvedProbe = DispatchSemaphore(value: 0)
+        while submittedPoolWorkers < 1_024 && !poolIsStarved {
+            let poolOccupied = DispatchSemaphore(value: 0)
+            for _ in 0..<64 {
+                DispatchQueue.global(qos: .utility).async {
+                    poolOccupied.signal()
+                    poolGate.wait()
+                }
             }
+            submittedPoolWorkers += 64
+            for _ in 0..<64 { _ = poolOccupied.wait(timeout: .now() + 5) }
+            let roundProbe = DispatchSemaphore(value: 0)
+            DispatchQueue.global(qos: .utility).async { roundProbe.signal() }
+            poolIsStarved = roundProbe.wait(timeout: .now() + 0.5) == .timedOut
+            starvedProbe = roundProbe
         }
-        var occupiedWorkers = 0
-        for _ in 0..<64 where poolOccupied.wait(timeout: .now() + 5) == .success { occupiedWorkers += 1 }
-        let starvedProbe = DispatchSemaphore(value: 0)
-        DispatchQueue.global(qos: .utility).async { starvedProbe.signal() }
-        let poolIsStarved = starvedProbe.wait(timeout: .now() + 0.5) == .timedOut
         let starvedStarted = Date()
         let starvedPoolProcess = BoundedProcessRunner.run(
             "/bin/echo", ["ready"], timeout: 1, maxOutputBytes: 1_024)
         let starvedPoolElapsed = Date().timeIntervalSince(starvedStarted)
-        for _ in 0..<64 { poolGate.signal() }
+        for _ in 0..<submittedPoolWorkers { poolGate.signal() }
         _ = starvedProbe.wait(timeout: .now() + 5)
-        expect(occupiedWorkers == 64 && poolIsStarved,
+        expect(poolIsStarved,
                "the dispatch pool starvation this check needs was actually reached")
         expect(!starvedPoolProcess.timedOut && starvedPoolProcess.status == 0
                 && String(decoding: starvedPoolProcess.output, as: UTF8.self) == "ready\n"

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,11 @@ else
     BUILD_CONFIGURATION="release"
 fi
 FAN_HELPER_ID="$APP_BUNDLE_ID.fan-control"
-TARGET="arm64-apple-macosx14.0"
+# Architecture. Upstream hardcoded arm64; build for the host instead so the
+# same script yields a native binary on an Intel Mac too. Override with
+# VORSSAINT_ARCH=arm64|x86_64.
+ARCH="${VORSSAINT_ARCH:-$(/usr/bin/uname -m)}"
+TARGET="$ARCH-apple-macosx14.0"
 ENTITLEMENTS="Resources/Vorssaint.entitlements"
 LEGACY_IDENTITY="Vorssaint Utils Signing"
 


### PR DESCRIPTION
## Summary

Intel has been declined before, in #43 and again on #55, for reasons that were about
support cost rather than about the code: no Intel machine to test on, permissions
behaving differently, and a solo maintainer carrying the bug reports. I have an Intel
Mac and I read that thread before writing this, so here is what is different, and the
honest case for and against.

**What was actually wrong.** Only one line stops the build: `build.sh` hardcodes
`TARGET="arm64-apple-macosx14.0"`. There is no `#if arch(arm64)` anywhere in
`Sources`, and all 403 files compile for `x86_64` untouched. #55 changed that line and
nothing else, which would have shipped an app that launches on Intel and then shows no
CPU temperature, no GPU temperature and no power — the exact class of report the
decline was trying to avoid. Those three are what the rest of this branch fixes:

- **`SMCValueCodec` decoded no power value on Intel.** It handles `sp78` and `fpe2` by
  name and falls through everything else in the same family. Intel publishes its power
  sensors as `spa5`, so `PSTR` and `PCPC` returned nil and `--selftest` printed
  `no power metrics on this Mac`. The codec now decodes generic `sp..`/`fp..`: the last
  character is the fractional bit count in hex. Apple Silicon only uses the two already
  handled, so nothing changes there.
- **The temperature selector only knew the Apple Silicon namespace.** Intel CPU sensors
  are `TC..` and GPU sensors are `TG..`; `Tp..`/`Te..` exist on an Intel Mac too but are
  power-supply and enclosure probes. Matching them, as the generic path did, displayed a
  case temperature as the CPU temperature — wrong values rather than missing ones, which
  is worse. A `.intel` platform now selects `TC..`/`TG..` and prefers the die sensors
  (`TC0c..TC9c`, `TCXc`) over proximity ones, which lag the die by ten degrees or more.
- **Three other places carried their own copy of those prefixes** — `--selftest`,
  `--sensors` and `FanControlHardware.discoverTemperatureKeys`. They all now ask the
  selector, so this cannot drift out of step again. Before that commit `--sensors` on
  Intel listed five enclosure probes as `cpu-aux` and no GPU at all, which is the first
  thing anyone runs when the readings look wrong.
- **One unit test asserted a libdispatch implementation detail.** It blocks 64 threads
  and asserts the pool is starved before testing that `BoundedProcessRunner` survives a
  starved pool. 64 does starve it on Apple Silicon; on this Intel Mac the pool keeps
  handing out workers, so the test failed on its own precondition instead of on the
  behaviour under test. Reproduced standalone, outside the app: `occupiedWorkers=64,
  poolIsStarved=false`, 16 logical CPUs. It now blocks in batches until the probe really
  is stranded, which tests the same thing on both.

**What this does and does not commit you to.** `build.sh` builds for the host, so your
arm64 machine and your arm64 CI runners produce exactly what they produce today. The
release workflow is untouched and no Intel binary reaches anybody through your
distribution identity — the only person who gets an Intel build is one who cloned the
repo and ran `./build.sh` themselves. That is deliberate: it separates "the source
builds on Intel" from "the project ships and supports Intel", and this branch only asks
for the first. If you would rather it did not even say that in the README, drop the docs
commit; the code stands without it.

**The argument against, which I think is still real.** It is more surface, and the part
you named — permissions — is the part I cannot close for you. I could not find a
permission that behaves differently here, but "I did not find one" on one machine is not
evidence, and I say below exactly which machine that was. If the answer is still no, the
measurements in the Verification section are the useful part and I would rather they
lived on #43 than nowhere; say the word and I will put them there and close this.

## Verification

Ran on a **Mac Pro (Late 2013), MacPro6,1**, Xeon E5-1680 v2 8-core, dual FirePro D700,
**macOS 15.7.9 (24G830)**, single display, one Space, English.

**This machine runs macOS 15 through OpenCore Legacy Patcher** — MacPro6,1 is out of
Apple's support list at Monterey. That is the biggest gap between this hardware and
yours and you should weigh it: the SMC and IOKit paths this branch touches are firmware
and kernel level and are not what OCLP patches, but I cannot promise it changed nothing.
A check on a natively supported Intel Mac (2019 iMac, 2018-2020 MacBook Pro, 2018 Mac
mini) would be worth more than anything I ran here.

```
./build.sh          # release, x86_64, 0 warnings
./build.sh --test   # TESTS OK (8641 checks)
./build/Vorssaint --selftest
SELFTEST OK         # before this branch: "SELFTEST WARNING: no power metrics on this Mac"
```

`--sensors`, abridged:

```
component    key   type   °C
cpu-aux   TC0P  sp78   80.00
cpu-core  TC0c  sp78   88.00
cpu-core  TCXc  sp78   94.53
gpu       TG0D  sp78   80.62
gpu       TG1D  sp78   85.00
```

Power decoding, read straight from the SMC and cross-checked against the raw bytes:
`PSTR` = 227.5 W system, `PCPC` = 89.2 W CPU package. The machine was genuinely busy
during these runs, which is why the temperatures are high.

Installed as a release build in `/Applications` and run from the menu bar: the System
tab shows CPU and GPU temperature and power where it showed nothing before.

**What I could not test.**

- **Permissions.** Nothing in this branch touches TCC, and Accessibility and Screen
  Recording were granted and stuck across rebuilds with the self-signed identity. But I
  did not go through every permission-gated feature, and this is the concern you raised
  on #43, so treat it as unaddressed rather than as cleared.
- **Anything battery.** This is a desktop with no battery, so the `TB[0-9]T` path and
  everything in `PowerSampler` that needs a battery is untouched by my testing. An Intel
  notebook is the machine that would exercise it.
- **Fan control writes.** Read-only telemetry only. I did not exercise manual fan
  control on Intel.
- **Any Intel Mac other than this one.** Different Intel families expose different `TC..`
  keys; the die-key rule is written to cover `TC0c..TC9c`, `TCXc/TCXC` and `TC0D/TCXD`
  rather than a fixed list, but I have one machine's key set to go on.
- **Notarised distribution.** Local self-signed builds only.

One thing I noticed and deliberately did not fix, to keep this to one topic: `--sensors`
prints `TC0L` and `TG0L` — `ui16` limit registers, not temperatures — because the
plausibility filter is a value range and not a type check. That predates this branch and
shows on Apple Silicon's equivalents too. Happy to send it separately.

## Anything else

The docs commit is separate on purpose and can be dropped on its own.

I did not touch `CHANGELOG.md`.

Refs #43
Refs #150
Refs #523
Refs #812
Refs #181
Refs #416
Refs #127
Refs #153
