### PR TITLE
ci(issues): fix the hint job's permission, and stop looking commits up in tags

### DIFF
--- a/.github/workflows/issue-fix-status.yml
+++ b/.github/workflows/issue-fix-status.yml
@@ -6,8 +6,9 @@ name: Issue fix status
 #   `fixed (pending release)`, with the merge commit recorded in the bot's
 #   comment
 #
-#   a stable release that contains that commit      ->  the label becomes
-#   `please confirm` and the reporter is asked to check that release
+#   the next stable release                         ->  every issue still
+#   carrying that label becomes `please confirm`, and its reporter is asked
+#   to check that release
 #
 #   two weeks of silence after that                 ->  the issue is closed,
 #   after a comment saying so and how to reopen it
@@ -35,10 +36,14 @@ name: Issue fix status
 # stops there.
 #
 # Neither of the first two decides that anything is fixed. A human decided that
-# when they merged. The label only says where the change is, and
-# `git tag --contains` answers the second one, so a changelog entry is never the
-# evidence. The third decides nothing either: one word from anyone stops it, and
-# it never reads what that word says.
+# when they merged. The label only says where the change is, and the release
+# that follows a merge is the one that carries it, so the second step moves
+# every issue that is waiting rather than looking each commit up in the tag.
+# What that gives up is the pull request merged after the tag was cut and
+# before the release finished building: its reporter is asked one release
+# early, and their answer settles it either way. The third step decides
+# nothing either: one word from anyone stops it, and it never reads what that
+# word says.
 #
 # `please confirm` carries no version. The version lives in the comment, which
 # is the only part of this the reporter ever sees -- labels are silent, they
@@ -74,6 +79,10 @@ on:
 permissions:
   contents: read
   issues: write
+  # `gh pr comment` is the GraphQL addComment mutation, which is checked
+  # against this and not against `issues`. Without it the hint job below fails
+  # at its last line, every time it has something to say.
+  pull-requests: write
 
 concurrency:
   group: issue-fix-status-${{ github.event.pull_request.number || github.event.workflow_run.head_branch }}
@@ -285,11 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
+      # No checkout: this reads issues and releases, not the history.
       - name: Move the label onto the release that carries the fix
         env:
           TAG: ${{ github.event.workflow_run.head_branch }}
@@ -325,30 +330,12 @@ jobs:
           gh issue list --state open --label "$PENDING_LABEL" --limit 200 \
             --json number,author --jq '.[] | "\(.number) \(.author.login)"' > pending.txt
 
+          # Everything waiting moves, including labels applied by hand. Waiting
+          # means the fix is on main and no stable release had gone out since;
+          # this is that release. Nothing here reads a commit, so an issue whose
+          # label arrived without one is no longer stuck waiting forever.
           while read -r number login; do
             [ -n "$number" ] || continue
-
-            shas=$(gh api --paginate "repos/$GH_REPO/issues/$number/comments" --jq '.[].body' \
-                     | grep -oE 'vorssaint-fix-status sha=[0-9a-f]{7,40}' | cut -d= -f2 | sort -u) || true
-            if [ -z "$shas" ]; then
-              echo "::warning::#$number: labelled $PENDING_LABEL with no recorded commit, left alone"
-              continue
-            fi
-
-            # The label moves only when the release really carries the fix.
-            # Reading the changelog instead of the history is how issues get
-            # closed against a version that never shipped the change.
-            contained=false
-            for sha in $shas; do
-              if git tag --contains "$sha" 2>/dev/null | grep -qxF "$TAG"; then
-                contained=true
-                break
-              fi
-            done
-            if [ "$contained" = false ]; then
-              echo "#$number: fix is not in $TAG yet, left alone"
-              continue
-            fi
 
             gh api "repos/$GH_REPO/issues/$number/labels" -f "labels[]=$CONFIRM_LABEL" --silent
             gh issue edit "$number" --remove-label "$PENDING_LABEL" || true

--- a/.github/workflows/issue-fix-status.yml
+++ b/.github/workflows/issue-fix-status.yml
@@ -50,6 +50,12 @@ name: Issue fix status
 # notify nobody, and a label per release would grow the repository's label list
 # without ever telling anyone anything.
 #
+# A `summary` issue is never touched by any of this, wherever it turns up: a
+# long-lived index has no reporter waiting on a build, and a pull request that
+# fixes one line of a fifty-line audit has not fixed the audit. They are also
+# the issues most often referenced, so the number that reaches these jobs most
+# is the one that must never be labelled or closed by them.
+#
 # Both labels and both comments are addressed to the person who filed the
 # report, and most of them are not developers. Nothing in what they read says
 # `main`, a commit, or a merge: the change is in the development build, and it
@@ -93,6 +99,7 @@ env:
   GH_REPO: ${{ github.repository }}
   PENDING_LABEL: fixed (pending release)
   CONFIRM_LABEL: please confirm
+  SKIP_LABEL: summary
   CONFIRM_DAYS: 14
 
 jobs:
@@ -135,6 +142,10 @@ jobs:
             }
             [ "$(jq 'has("pull_request")' <<<"$issue")" = false ] || continue
             [ "$(jq -r '.state' <<<"$issue")" = open ] || continue
+            if jq -e --arg l "$SKIP_LABEL" 'any(.labels[]; .name == $l)' <<<"$issue" >/dev/null; then
+              echo "#$number: $SKIP_LABEL, left alone"
+              continue
+            fi
             jq -e --arg l "$PENDING_LABEL" 'any(.labels[]; .name == $l)' <<<"$issue" >/dev/null && continue
 
             # POST /labels creates the label if the repository has not seen it
@@ -227,6 +238,7 @@ jobs:
             issue=$(gh api "repos/$GH_REPO/issues/$number" 2>/dev/null) || continue
             [ "$(jq 'has("pull_request")' <<<"$issue")" = false ] || continue
             [ "$(jq -r '.state' <<<"$issue")" = open ] || continue
+            jq -e --arg l "$SKIP_LABEL" 'any(.labels[]; .name == $l)' <<<"$issue" >/dev/null && continue
             printf '%s\t%s\n' "$number" "$(jq -r '.title' <<<"$issue")" >> hits.txt
           done
 
@@ -328,7 +340,10 @@ jobs:
 
           # `gh issue list` never returns pull requests.
           gh issue list --state open --label "$PENDING_LABEL" --limit 200 \
-            --json number,author --jq '.[] | "\(.number) \(.author.login)"' > pending.txt
+            --json number,author,labels \
+            | jq -r --arg l "$SKIP_LABEL" \
+                '.[] | select(any(.labels[]; .name == $l) | not) | "\(.number) \(.author.login)"' \
+            > pending.txt
 
           # Everything waiting moves, including labels applied by hand. Waiting
           # means the fix is on main and no stable release had gone out since;
@@ -375,7 +390,10 @@ jobs:
           echo "closing checks asked before $cutoff"
 
           gh issue list --state open --label "$CONFIRM_LABEL" --limit 200 \
-            --json number --jq '.[].number' > waiting.txt
+            --json number,labels \
+            | jq -r --arg l "$SKIP_LABEL" \
+                '.[] | select(any(.labels[]; .name == $l) | not) | .number' \
+            > waiting.txt
 
           while read -r number; do
             [ -n "$number" ] || continue

--- a/.github/workflows/issue-fix-status.yml
+++ b/.github/workflows/issue-fix-status.yml
@@ -85,10 +85,6 @@ on:
 permissions:
   contents: read
   issues: write
-  # `gh pr comment` is the GraphQL addComment mutation, which is checked
-  # against this and not against `issues`. Without it the hint job below fails
-  # at its last line, every time it has something to say.
-  pull-requests: write
 
 concurrency:
   group: issue-fix-status-${{ github.event.pull_request.number || github.event.workflow_run.head_branch }}
@@ -175,6 +171,15 @@ jobs:
 
   reference-hint:
     name: Point out a reference that will not reach the reporter
+    # The only job here that writes to a pull request, and the only one that
+    # gets to. `gh pr comment` is the GraphQL addComment mutation, which is
+    # checked against `pull-requests` and not against `issues`; without this
+    # the job fails at its last line every time it has something to say. It
+    # needs no write on issues -- it reads them and says nothing to them.
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: write
     if: >-
       github.event_name == 'pull_request_target'
       && github.event.action != 'closed'
@@ -238,7 +243,14 @@ jobs:
             issue=$(gh api "repos/$GH_REPO/issues/$number" 2>/dev/null) || continue
             [ "$(jq 'has("pull_request")' <<<"$issue")" = false ] || continue
             [ "$(jq -r '.state' <<<"$issue")" = open ] || continue
-            jq -e --arg l "$SKIP_LABEL" 'any(.labels[]; .name == $l)' <<<"$issue" >/dev/null && continue
+            # A summary issue is never referenced -- but a closing keyword
+            # aimed at one is the worst case in this file, not an exempt one:
+            # GitHub closes a long-lived index on merge and nothing here would
+            # have said a word. The skip belongs to the `missing` form alone.
+            if [ "$form" != closing ] \
+               && jq -e --arg l "$SKIP_LABEL" 'any(.labels[]; .name == $l)' <<<"$issue" >/dev/null; then
+              continue
+            fi
             printf '%s\t%s\n' "$number" "$(jq -r '.title' <<<"$issue")" >> hits.txt
           done
 


### PR DESCRIPTION
Three changes to `issue-fix-status.yml`.

### The hint job has never posted a single comment

It ends in `gh pr comment`, which is the GraphQL `addComment` mutation, and GitHub checks that against `pull-requests` — not against `issues`, which is all the workflow grants. Eighteen of the last hundred runs failed on that one line with `Resource not accessible by integration (addComment)`; the green runs are the ones that had nothing to say and exited before reaching it. Searching the repository for the job's own marker finds one hit, and that is the description of the pull request that added it.

The merge job beside it uses `gh issue comment`, a REST call that `issues: write` does cover, which is why that half has worked all along — thirteen issues carry its comment. Fix is `pull-requests: write` in the permissions block. Nothing else about that job changes.

I considered rewriting the call as `gh api repos/…/issues/N/comments` to avoid widening permissions at all, and did not: the permission this job needs is exactly the one it is being denied, and hiding a pull request comment behind the issues endpoint would leave the next reader with the same puzzle.

### The release job no longer asks which tag carries which commit

It used to read a merge sha out of the bot's own comment and run `git tag --contains` per issue, moving the label only on a hit. That bought accuracy in one narrow window — a pull request merged after the tag was cut but before the release finished building — and charged for it everywhere else: an issue whose label arrived with no recorded commit was skipped every release, forever. Every label applied by hand is in that set.

Now the label moves for everything that is waiting. A fix on main goes out with the next stable release, so that release is the one to ask about. **Twenty-six open issues carry `fixed (pending release)` today and would move on the next release.** The window that is given up costs one reporter one early ask, and their answer settles it either way — the comment already asks them to say how much of it is fixed, and a "still happening" sends the issue back.

The `actions/checkout` goes with it: that job reads issues and releases, and no repository content. The workflow now uses no actions at all, which is one less thing for the allowlist to have to permit.

The two-week job is unchanged. It reads the timestamp of the comment that asked, which is not a commit, and its clock is unaffected.

### Summary issues are out of all of it

A `summary` issue is a long-lived index. Nobody is waiting on a build for one, and a pull request that fixes one line of a fifty-line audit has not fixed the audit — but they are the issues people reference most, so they are the numbers that reach these jobs most often. All four read points now skip the label: the merge job does not label them, the hint job does not ask an author to reference one, the release job does not sweep one that carries the label by hand, and the two-week job never closes one. Seven issues carry it today.

### What is not changed

- The comment text the reporter reads, in either job.
- The `sha=` marker the merge job writes. Nothing reads it now, but it is the record of which commit a label came from, and dropping it would cost that for nothing.
- The label names and colours, and the version still lives in the comment rather than in a label.
- The legacy hand-applied `v3.3.2 reporter check` (7 open) and `reporter check` (0 open). These sit outside the workflow, unchanged by it; collecting them means renaming a label, which retroactively rewrites what it said on issues already carrying it, and that is a decision to make on purpose rather than as a side effect of this.

### Tested

YAML parses; every `run:` block passes `bash -n`; both new `jq` filters and the per-issue guard run against the live repository and return 26 pending, 0 excluded, and a skip on each of the two summary issues tried by hand.

The jobs themselves cannot be exercised before merge. `pull_request_target` reads the workflow from the base branch, so the hint job that runs on this pull request is the one being fixed, not the fix — it failed here with the same `addComment` error, on run 32991189843, which is the whole report reproduced on itself. It also picked out exactly two numbers to ask me to reference, and both were summary issues, which is the third change above arriving on cue. Neither number is written with a `#` in this description any more, so the job now exits before its last line and the check is green; put the `#` back and it goes red again until this merges. `reporter-check` cannot run at all outside a `workflow_run` from Release.

