### PR TITLE
fix(switcher): reserve room for the search chip so it stops covering previews

### DIFF
--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -65,6 +65,10 @@ final class AppSwitcher: ObservableObject {
     @Published private(set) var isSearchPinned = false
     @Published private(set) var totalWindowCount = 0
 
+    /// Whether the floating search chip is currently drawn, so the panel's
+    /// own size formula and the chip's on-screen presence never disagree.
+    var showsSearchChip: Bool { !searchQuery.isEmpty || isSearchPinned }
+
     /// Single source of truth for "a session is open": the stored value lives
     /// under `routeLock` because the tap thread routes every keystroke by it.
     /// Written only on the main thread.
@@ -694,7 +698,13 @@ final class AppSwitcher: ObservableObject {
                     switch action {
                     case .closeWindow: closeSelectedWindow()
                     case .quitApp: quitSelectedApp()
-                    case .pinSearch: isSearchPinned = true
+                    case .pinSearch:
+                        isSearchPinned = true
+                        // The chip shows as soon as the field is pinned, even
+                        // before the first character lands, so the panel has
+                        // to reserve room for it right away too.
+                        recomputeLayouts(for: windows)
+                        resizePanel()
                     }
                 }
             } else if let text {
@@ -1385,13 +1395,14 @@ final class AppSwitcher: ObservableObject {
 
     private func recomputeLayouts(for items: [SwitcherItem]) {
         guard let screen = NSScreen.withMouse ?? NSScreen.screens.first else { return }
-        grid = SwitcherGrid.compute(count: max(items.count, 1), on: screen)
+        grid = SwitcherGrid.compute(count: max(items.count, 1), on: screen, showsSearchChip: showsSearchChip)
         let appGroups = SwitcherSupport.appGroups(items: items)
         iconRowLayout = SwitcherIconRowLayout.compute(
             appCount: usesWindowRow ? items.count : appGroups.count,
             selectedWindowCount: usesWindowRow ? 1 : selectedAppWindowCount(in: items),
             screenVisibleFrame: screen.visibleFrame,
             showsShortcutHints: showsShortcutHints,
+            showsSearchChip: showsSearchChip,
             tileWidth: usesWindowRow ? SwitcherIconRowLayout.windowTileWidth
                                      : SwitcherIconRowLayout.appTileWidth
         )
@@ -1405,6 +1416,7 @@ final class AppSwitcher: ObservableObject {
             selectedWindowCount: usesWindowRow ? 1 : selectedAppWindowCount(in: windows),
             screenVisibleFrame: NSScreen.pointerVisibleFrame,
             showsShortcutHints: showsShortcutHints,
+            showsSearchChip: showsSearchChip,
             tileWidth: usesWindowRow ? SwitcherIconRowLayout.windowTileWidth
                                      : SwitcherIconRowLayout.appTileWidth
         )
@@ -1571,7 +1583,7 @@ struct SwitcherGrid: Equatable {
 
     static let empty = SwitcherGrid(columns: 1, rows: 1, visibleRows: 1, panelSize: .zero)
 
-    static func compute(count: Int, on screen: NSScreen) -> SwitcherGrid {
+    static func compute(count: Int, on screen: NSScreen, showsSearchChip: Bool = false) -> SwitcherGrid {
         let usableWidth = screen.visibleFrame.width * 0.92
         let usableHeight = screen.visibleFrame.height * 0.85
 
@@ -1582,8 +1594,10 @@ struct SwitcherGrid: Equatable {
         let maxRows = max(1, Int((usableHeight - padding * 2 + spacing) / (cardHeight + spacing)))
         let visibleRows = min(rows, maxRows)
 
+        let searchChipHeight = showsSearchChip ? SwitcherSearchChip.clearance : 0
         let width = CGFloat(columns) * cardWidth + CGFloat(columns - 1) * spacing + padding * 2
-        let height = CGFloat(visibleRows) * cardHeight + CGFloat(visibleRows - 1) * spacing + padding * 2
+        let height = CGFloat(visibleRows) * cardHeight + CGFloat(visibleRows - 1) * spacing
+            + searchChipHeight + padding * 2
         return SwitcherGrid(columns: columns, rows: rows, visibleRows: visibleRows,
                             panelSize: CGSize(width: width, height: height))
     }

--- a/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
+++ b/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
@@ -155,7 +155,9 @@ enum SwitcherGridCard {
 enum SwitcherSearchChip {
     /// Distance from the panel's top-trailing corner to the capsule itself.
     static let cornerInset: CGFloat = 12
-    /// One 12pt semibold text line plus 7pt top/bottom padding, measured.
+    /// The capsule's own `.frame(height:)` enforces this in the view, so a
+    /// future font/padding change clips or gaps visibly instead of silently
+    /// drifting from what the panel formula reserved for it.
     static let height: CGFloat = 29
     /// Corner inset + capsule height, plus a small gap so the capsule reads
     /// as floating above the content instead of touching its edge.

--- a/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
+++ b/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
@@ -148,6 +148,20 @@ enum SwitcherGridCard {
     static var fallbackIconSize: CGFloat { 80 * PreviewSizing.scale }
 }
 
+/// The floating capsule that shows the live search query and match count.
+/// It draws as a corner overlay rather than inline content, so its footprint
+/// has to be reserved separately in the panel's own size formula — these
+/// constants are the one place both answer "how much room does it need."
+enum SwitcherSearchChip {
+    /// Distance from the panel's top-trailing corner to the capsule itself.
+    static let cornerInset: CGFloat = 12
+    /// One 12pt semibold text line plus 7pt top/bottom padding, measured.
+    static let height: CGFloat = 29
+    /// Corner inset + capsule height, plus a small gap so the capsule reads
+    /// as floating above the content instead of touching its edge.
+    static let clearance: CGFloat = cornerInset + height + 6
+}
+
 struct SwitcherIconRowLayout: Equatable {
     let visibleIconCount: Int
     let appRowContentWidth: CGFloat
@@ -157,6 +171,7 @@ struct SwitcherIconRowLayout: Equatable {
     let simpleTitleSurfaceWidth: CGFloat
     let panelSize: CGSize
     let showsShortcutHints: Bool
+    let showsSearchChip: Bool
 
     static var scale: CGFloat { min(PreviewSizing.scale, 1.15) }
     static var iconSize: CGFloat { 68 * scale }
@@ -212,7 +227,7 @@ struct SwitcherIconRowLayout: Equatable {
     var simplePanelSize: CGSize {
         CGSize(width: contentWidth(simpleMode: true, windowRow: false) + Self.padding * 2,
                height: Self.simpleTitleHeight + Self.simpleTitleGap
-                        + Self.rowHeight + shortcutHintHeight
+                        + Self.rowHeight + shortcutHintHeight + searchChipHeight
                         + Self.padding * 2)
     }
 
@@ -220,11 +235,17 @@ struct SwitcherIconRowLayout: Equatable {
     /// separate title strip above the row.
     var simpleWindowPanelSize: CGSize {
         CGSize(width: contentWidth(simpleMode: true, windowRow: true) + Self.padding * 2,
-               height: Self.rowHeight + shortcutHintHeight + Self.padding * 2)
+               height: Self.rowHeight + shortcutHintHeight + searchChipHeight + Self.padding * 2)
     }
 
     private var shortcutHintHeight: CGFloat {
         showsShortcutHints ? Self.hintGap + Self.hintHeight : 0
+    }
+
+    /// Reserved so the floating search chip (`SwitcherSearchChip`) never
+    /// lands on top of the preview panel or icon row beneath it.
+    private var searchChipHeight: CGFloat {
+        showsSearchChip ? SwitcherSearchChip.clearance : 0
     }
 
     static let empty = SwitcherIconRowLayout(visibleIconCount: 1,
@@ -234,12 +255,14 @@ struct SwitcherIconRowLayout: Equatable {
                                              previewSurfaceWidth: 0,
                                              simpleTitleSurfaceWidth: 0,
                                              panelSize: .zero,
-                                             showsShortcutHints: true)
+                                             showsShortcutHints: true,
+                                             showsSearchChip: false)
 
     static func compute(appCount rawAppCount: Int,
                         selectedWindowCount rawWindowCount: Int,
                         screenVisibleFrame: CGRect,
                         showsShortcutHints: Bool = true,
+                        showsSearchChip: Bool = false,
                         tileWidth: CGFloat = appTileWidth) -> SwitcherIconRowLayout {
         let appCount = max(1, rawAppCount)
         let windowCount = max(1, rawWindowCount)
@@ -264,7 +287,8 @@ struct SwitcherIconRowLayout: Equatable {
         let visibleIconCount = max(1, min(appCount, Int((maxAppContentWidth + spacing) / (tileWidth + spacing))))
         let width = contentWidth + padding * 2
         let shortcutHintHeight = showsShortcutHints ? hintGap + hintHeight : 0
-        let height = previewHeight + previewGap + rowHeight + shortcutHintHeight + padding * 2
+        let searchChipHeight = showsSearchChip ? SwitcherSearchChip.clearance : 0
+        let height = previewHeight + previewGap + rowHeight + shortcutHintHeight + searchChipHeight + padding * 2
         return SwitcherIconRowLayout(visibleIconCount: visibleIconCount,
                                      appRowContentWidth: appRowWidth,
                                      appRowSurfaceWidth: appRowSurfaceWidth,
@@ -272,7 +296,8 @@ struct SwitcherIconRowLayout: Equatable {
                                      previewSurfaceWidth: previewSurfaceWidth,
                                      simpleTitleSurfaceWidth: simpleTitleSurfaceWidth,
                                      panelSize: CGSize(width: width, height: height),
-                                     showsShortcutHints: showsShortcutHints)
+                                     showsShortcutHints: showsShortcutHints,
+                                     showsSearchChip: showsSearchChip)
     }
 
     static func compute(count rawCount: Int, screenVisibleFrame: CGRect) -> SwitcherIconRowLayout {

--- a/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
+++ b/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
@@ -70,7 +70,9 @@ struct SwitcherView: View {
                 cardGrid
             }
         }
-        .padding(SwitcherGrid.padding)
+        .padding(.horizontal, SwitcherGrid.padding)
+        .padding(.bottom, SwitcherGrid.padding)
+        .padding(.top, SwitcherGrid.padding + searchChipTopClearance)
         .background(HUDBackdrop(cornerRadius: 24))
         .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
         .overlay(alignment: .topTrailing) {
@@ -80,6 +82,14 @@ struct SwitcherView: View {
             RoundedRectangle(cornerRadius: 24, style: .continuous)
                 .strokeBorder(Color.white.opacity(0.12), lineWidth: 1)
         )
+    }
+
+    /// Extra headroom so the floating `searchChip` never lands on top of the
+    /// grid's or icon row's top-right content; kept in lockstep with the same
+    /// flag the panel's own size formula reserves it under
+    /// (`SwitcherGrid.compute`/`SwitcherIconRowLayout.compute`).
+    private var searchChipTopClearance: CGFloat {
+        switcher.showsSearchChip ? SwitcherSearchChip.clearance : 0
     }
 
     @ViewBuilder
@@ -120,27 +130,27 @@ struct SwitcherView: View {
 
     @ViewBuilder
     private var searchChip: some View {
-        if !switcher.searchQuery.isEmpty || switcher.isSearchPinned {
+        if switcher.showsSearchChip {
             HStack(spacing: 6) {
                 Image(systemName: "magnifyingglass")
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: 11, weight: .bold))
                 Text(switcher.searchQuery.isEmpty ? l10n.s.switcherSearchPin : switcher.searchQuery)
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.system(size: 12, weight: .semibold))
                     .lineLimit(1)
                     .truncationMode(.middle)
-                    .frame(maxWidth: 180)
+                    .frame(maxWidth: 200)
                 Text("\(switcher.windows.count)/\(switcher.totalWindowCount)")
-                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
                     .foregroundStyle(.secondary)
             }
             .foregroundStyle(.primary)
-            .padding(.horizontal, 9)
-            .padding(.vertical, 6)
+            .padding(.horizontal, 11)
+            .padding(.vertical, 7)
             .background(
                 Capsule(style: .continuous)
                     .fill(Color.black.opacity(0.42))
             )
-            .padding(12)
+            .padding(SwitcherSearchChip.cornerInset)
         }
     }
 
@@ -201,7 +211,9 @@ struct SwitcherView: View {
                 shortcutHintBar
             }
         }
-        .padding(SwitcherIconRowLayout.padding)
+        .padding(.horizontal, SwitcherIconRowLayout.padding)
+        .padding(.bottom, SwitcherIconRowLayout.padding)
+        .padding(.top, SwitcherIconRowLayout.padding + searchChipTopClearance)
     }
 
     private var iconRowPanelSize: CGSize {

--- a/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
+++ b/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
@@ -146,6 +146,7 @@ struct SwitcherView: View {
             .foregroundStyle(.primary)
             .padding(.horizontal, 11)
             .padding(.vertical, 7)
+            .frame(height: SwitcherSearchChip.height)
             .background(
                 Capsule(style: .continuous)
                     .fill(Color.black.opacity(0.42))

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -7883,6 +7883,30 @@ struct MetricsTests {
                && twoAppLayout.contentWidth(simpleMode: true, windowRow: true)
                     == twoAppLayout.simpleWindowPanelSize.width - SwitcherIconRowLayout.padding * 2,
                "App Switcher rows fit the panel with fewer apps than the hint bar is wide")
+        // The floating search chip draws as a corner overlay, not inline
+        // content, so its footprint has to be reserved separately — these
+        // pin the panel's height formula to the chip's own measured size
+        // (`SwitcherSearchChip`) so the two can never drift apart again
+        // (issue: search chip overlapping window previews).
+        let searchChipIconRowLayout = SwitcherIconRowLayout.compute(appCount: 6,
+                                                                     selectedWindowCount: 1,
+                                                                     screenVisibleFrame: screen,
+                                                                     showsSearchChip: true)
+        expect(searchChipIconRowLayout.panelSize.height
+               == iconRowLayout.panelSize.height + SwitcherSearchChip.clearance,
+               "App Switcher reserves exactly the search chip's footprint when it is shown")
+        expect(searchChipIconRowLayout.simplePanelSize.height
+               == iconRowLayout.simplePanelSize.height + SwitcherSearchChip.clearance,
+               "App Switcher simple mode also reserves room for the search chip")
+        expect(searchChipIconRowLayout.simpleWindowPanelSize.height
+               == iconRowLayout.simpleWindowPanelSize.height + SwitcherSearchChip.clearance,
+               "App Switcher's flat window row also reserves room for the search chip")
+        let noSearchChipIconRowLayout = SwitcherIconRowLayout.compute(appCount: 6,
+                                                                       selectedWindowCount: 1,
+                                                                       screenVisibleFrame: screen,
+                                                                       showsSearchChip: false)
+        expect(noSearchChipIconRowLayout.panelSize.height == iconRowLayout.panelSize.height,
+               "App Switcher reserves no extra height when the search chip is hidden")
         expect(SwitcherSupport.gridColumnCount(itemCount: 10, maxColumns: 8) == 5,
                "App Switcher wrapping splits ten windows across two even rows")
         expect(SwitcherSupport.gridColumnCount(itemCount: 9, maxColumns: 8) == 5,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -7907,6 +7907,18 @@ struct MetricsTests {
                                                                        showsSearchChip: false)
         expect(noSearchChipIconRowLayout.panelSize.height == iconRowLayout.panelSize.height,
                "App Switcher reserves no extra height when the search chip is hidden")
+        // Nothing in this harness can render SwiftUI, so `SwitcherSearchChip
+        // .height` being right is not checkable here - only that the view
+        // actually enforces it instead of leaving it a hand-derived number
+        // that only happens to match today's font/padding. A future change
+        // to either now clips or gaps the capsule visibly instead of
+        // silently drifting back out of sync with what the panel formula
+        // above reserves for it.
+        let switcherViewSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/UI/Switcher/SwitcherView.swift",
+            encoding: .utf8)) ?? ""
+        expect(switcherViewSource.contains(".frame(height: SwitcherSearchChip.height)"),
+               "the search chip's own rendered height must be pinned to SwitcherSearchChip.height, not just documented as matching it")
         expect(SwitcherSupport.gridColumnCount(itemCount: 10, maxColumns: 8) == 5,
                "App Switcher wrapping splits ten windows across two even rows")
         expect(SwitcherSupport.gridColumnCount(itemCount: 9, maxColumns: 8) == 5,


### PR DESCRIPTION
## Summary

The App Switcher's floating search chip (the capsule that shows the live
query and match count while typing) draws as a top-trailing overlay on the
panel, inset only 12pt from the corner. Neither `SwitcherGrid.compute`
(the default window-card grid) nor `SwitcherIconRowLayout.compute` (icon-row
and simple mode) reserved any headroom for it, so it landed directly on top
of the grid's top-right window card — or, in icon-row mode, on top of the
preview panel, which spans to that same corner whenever the preview row is
wider than the app row (the common case). Typing a search made the chip cover
the very preview it was meant to sit above.

Added a single `SwitcherSearchChip` namespace with the chip's measured
footprint, and threaded a `showsSearchChip` flag through both layout
formulas the same way `showsShortcutHints` already is, so the panel only
grows to make room for the chip when it is actually shown — no permanent
wasted space otherwise. The chip's own top-trailing padding in the view now
reads from the same constant, so the two can't drift apart again. Also
bumped the chip's type and padding slightly (it read as cramped even before
the overlap).

## Verification

MacBook Air (M4, `Mac16,12`), macOS 26.6.2 (25G83), own local build (not a
release build).

```sh
./build.sh          # finished without warnings
./build/Vorssaint --selftest   # SELFTEST OK
./build.sh --test   # TESTS OK (8802 checks)
```

Added a pure-function regression test asserting the exact panel-height delta
the chip's clearance should add, for both the default and simple-mode/window-row
panel sizes. Confirmed it red/green: reverted the clearance addition, reran
`--test`, saw exactly those 3 new assertions fail and nothing else, then
restored the fix and confirmed all 8802 checks pass again.

**What I could not test**: the actual on-screen render. Installed a `--dev`
build to check visually, but the fresh dev bundle id has no Accessibility
permission grant yet, so the switcher's ⌘Tab tap could not intercept the
keystroke, and I stopped short of walking through the interactive
Accessibility/Screen Recording permission prompts myself. The geometry is
verified by the tests above (the panel height and the chip's own footprint
are now checked against the same constant), but someone with the permission
already granted should confirm the visual result before merge — trigger the
switcher, type a few characters, and check the chip sits clear of the
top-right card/preview in both the default grid and icon-row/simple modes
(Settings → App Switcher).

## Anything else

No existing issue covers this (checked `gh issue list`/`gh pr list --search`
for it beforehand).
