### PR TITLE
fix(switcher): stop a partial AX read from vetoing a real window

### DIFF
--- a/Sources/Vorssaint/Services/Switcher/AXWindowResolver.swift
+++ b/Sources/Vorssaint/Services/Switcher/AXWindowResolver.swift
@@ -13,8 +13,18 @@ private func _AXUIElementGetWindow(_ element: AXUIElement,
 
 enum AXWindowResolver {
     static func windowID(for element: AXUIElement) -> CGWindowID? {
+        readWindowID(for: element).id
+    }
+
+    /// Same lookup as `windowID(for:)`, but reports whether the read hit its
+    /// messaging timeout instead of collapsing that into the same `nil` as
+    /// "this element genuinely has no window id" — a caller deciding whether
+    /// a missing id proves a window does not exist needs to tell those two
+    /// apart.
+    static func readWindowID(for element: AXUIElement) -> (id: CGWindowID?, timedOut: Bool) {
         var id: CGWindowID = 0
-        guard _AXUIElementGetWindow(element, &id) == .success, id != 0 else { return nil }
-        return id
+        let error = _AXUIElementGetWindow(element, &id)
+        guard error == .success, id != 0 else { return (nil, error == .cannotComplete) }
+        return (id, false)
     }
 }

--- a/Sources/Vorssaint/Services/Switcher/SpaceHopSupport.swift
+++ b/Sources/Vorssaint/Services/Switcher/SpaceHopSupport.swift
@@ -45,6 +45,19 @@ enum SpaceHopSupport {
         windowSpaces.contains { fullscreenSpaces.contains($0) }
     }
 
+    /// Whether an owner's "no window here" answer for a hidden-Space surface
+    /// can actually be trusted. `hasNoWindowsForOwner` being true only proves
+    /// this owner truly has nothing else when the pass that produced it was
+    /// otherwise reliable — a per-window Accessibility read that failed
+    /// partway through (the 0.35s messaging timeout can drop one real window
+    /// out of the results while its siblings still answer) means some
+    /// window's true answer was simply never obtained, not that it does not
+    /// exist, so an incomplete pass does not get to vouch for a window it is
+    /// missing.
+    static func ownerVouchIsIncomplete(hasNoWindowsForOwner: Bool, hadAttributeReadFailure: Bool) -> Bool {
+        hasNoWindowsForOwner || hadAttributeReadFailure
+    }
+
     /// The window server marks surfaces that must stay out of app window
     /// cycling. This remains meaningful when Accessibility cannot inspect a
     /// window because it lives on another Space.

--- a/Sources/Vorssaint/Services/Switcher/SpaceHopSupport.swift
+++ b/Sources/Vorssaint/Services/Switcher/SpaceHopSupport.swift
@@ -45,16 +45,15 @@ enum SpaceHopSupport {
         windowSpaces.contains { fullscreenSpaces.contains($0) }
     }
 
-    /// Whether an owner's "no window here" answer for a hidden-Space surface
-    /// can actually be trusted. `hasNoWindowsForOwner` being true only proves
-    /// this owner truly has nothing else when the pass that produced it was
-    /// otherwise reliable — a per-window Accessibility read that failed
-    /// partway through (the 0.35s messaging timeout can drop one real window
-    /// out of the results while its siblings still answer) means some
-    /// window's true answer was simply never obtained, not that it does not
-    /// exist, so an incomplete pass does not get to vouch for a window it is
-    /// missing.
-    static func ownerVouchIsIncomplete(hasNoWindowsForOwner: Bool, hadAttributeReadFailure: Bool) -> Bool {
+    /// Whether the hidden-Space stale-surface veto should be skipped for this
+    /// owner: either it genuinely reported zero windows (the original #339
+    /// forgiveness case, and the most complete a vouch can be), or a
+    /// per-window Accessibility read failed partway through this pass (the
+    /// 0.35s messaging timeout can drop one real window out of the results
+    /// while its siblings still answer) — that window's true answer was
+    /// simply never obtained, not proven absent, so this incomplete pass
+    /// does not get to veto a window it is missing.
+    static func shouldSkipStaleSurfaceVeto(hasNoWindowsForOwner: Bool, hadAttributeReadFailure: Bool) -> Bool {
         hasNoWindowsForOwner || hadAttributeReadFailure
     }
 

--- a/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
@@ -278,11 +278,11 @@ enum WindowEnumerator {
             // pass does not get to vouch for a window it is missing), or when
             // the window server puts this exact surface on a native
             // fullscreen Space.
-            let ownerVouchIsIncomplete = SpaceHopSupport.ownerVouchIsIncomplete(
+            let staleSurfaceVetoShouldBeSkipped = SpaceHopSupport.shouldSkipStaleSurfaceVeto(
                 hasNoWindowsForOwner: axSnapshot?.ordered.isEmpty ?? true,
                 hadAttributeReadFailure: axSnapshot?.hadAttributeReadFailure ?? false)
             let hiddenSpaceSurfaceIsWitnessed = isOnHiddenSpace(CGWindowID(windowID))
-                && (ownerVouchIsIncomplete
+                && (staleSurfaceVetoShouldBeSkipped
                     || isOnFullscreenSpace(CGWindowID(windowID)))
             if axSnapshot != nil, axWindow == nil {
                 // WindowServer kept a surface Accessibility does not vouch for:
@@ -551,8 +551,12 @@ enum WindowEnumerator {
         var byID: [CGWindowID: AccessibilityWindowSnapshot] = [:]
         var ordered: [(id: CGWindowID, snapshot: AccessibilityWindowSnapshot)] = []
         for window in axWindows {
-            if let id = AXWindowResolver.windowID(for: window) {
-                let frame = accessibilityFrame(for: window)
+            let idAttr = AXWindowResolver.readWindowID(for: window)
+            if idAttr.timedOut { hadAttributeReadFailure = true }
+            if let id = idAttr.id {
+                let frameAttr = accessibilityFrame(for: window)
+                if frameAttr.timedOut { hadAttributeReadFailure = true }
+                let frame = frameAttr.frame
                 let isMinimizedAttr = readBoolAttribute(window, kAXMinimizedAttribute as String)
                 if isMinimizedAttr.timedOut { hadAttributeReadFailure = true }
                 let snapshot = AccessibilityWindowSnapshot(title: accessibilityTitle(for: window),
@@ -642,23 +646,30 @@ enum WindowEnumerator {
         return value as? String ?? ""
     }
 
-    private static func accessibilityFrame(for window: AXUIElement) -> CGRect? {
+    /// Reports whether either attribute read hit its messaging timeout, same
+    /// reason as `readStringAttribute`/`readBoolAttribute`: a caller deciding
+    /// whether an absent frame means "AX has nothing to say" needs to tell
+    /// that apart from "AX never answered in time".
+    private static func accessibilityFrame(for window: AXUIElement) -> (frame: CGRect?, timedOut: Bool) {
         var positionValue: CFTypeRef?
         var sizeValue: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(window, kAXPositionAttribute as CFString, &positionValue) == .success,
-              AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &sizeValue) == .success,
+        let positionResult = AXUIElementCopyAttributeValue(window, kAXPositionAttribute as CFString, &positionValue)
+        let sizeResult = AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &sizeValue)
+        let timedOut = positionResult == .cannotComplete || sizeResult == .cannotComplete
+        guard positionResult == .success,
+              sizeResult == .success,
               let positionValue,
               let sizeValue,
               CFGetTypeID(positionValue) == AXValueGetTypeID(),
               CFGetTypeID(sizeValue) == AXValueGetTypeID()
-        else { return nil }
+        else { return (nil, timedOut) }
 
         var position = CGPoint.zero
         var size = CGSize.zero
         guard AXValueGetValue(positionValue as! AXValue, .cgPoint, &position),
               AXValueGetValue(sizeValue as! AXValue, .cgSize, &size)
-        else { return nil }
-        return CGRect(origin: position, size: size)
+        else { return (nil, timedOut) }
+        return (CGRect(origin: position, size: size), timedOut)
     }
 
     private static func frameIsSwitchable(_ frame: CGRect) -> Bool {
@@ -709,8 +720,10 @@ enum WindowEnumerator {
             if roleAttr.timedOut { hadReadFailure = true }
             let role = roleAttr.value
             let canBePlaybackSurface = subrole == "AXUnknown" || subrole == "AXFloatingWindow"
+            let frameAttr = accessibilityFrame(for: window)
+            if frameAttr.timedOut { hadReadFailure = true }
             let fillsScreen = canBePlaybackSurface
-                && frameLooksFullscreen(accessibilityFrame(for: window), screenFrames: screenFrames)
+                && frameLooksFullscreen(frameAttr.frame, screenFrames: screenFrames)
             // Compatibility-layer processes draw their own window chrome on
             // borderless surfaces, which Accessibility reports as AXUnknown;
             // for them the window role is the real signal.
@@ -773,14 +786,6 @@ enum WindowEnumerator {
             return (value as? Bool, false)
         }
         return (CFBooleanGetValue((value as! CFBoolean)), false)
-    }
-
-    private static func stringAttribute(_ element: AXUIElement, _ attribute: String) -> String? {
-        readStringAttribute(element, attribute).value
-    }
-
-    private static func boolAttribute(_ element: AXUIElement, _ attribute: String) -> Bool {
-        readBoolAttribute(element, attribute).value ?? false
     }
 
     /// Adds the apps that are running with no window to switch to, so the list

--- a/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
@@ -273,10 +273,16 @@ enum WindowEnumerator {
             let axWindow = axSnapshot?.byID[CGWindowID(windowID)]
             // A stale dialog can keep an old ordinary-Space tag indefinitely.
             // Trust an unmatched hidden surface only when Accessibility could
-            // not describe any window for that owner, or when the window
-            // server puts this exact surface on a native fullscreen Space.
+            // not describe any window for that owner (and that pass was not
+            // itself cut short by a per-window read timeout — an incomplete
+            // pass does not get to vouch for a window it is missing), or when
+            // the window server puts this exact surface on a native
+            // fullscreen Space.
+            let ownerVouchIsIncomplete = SpaceHopSupport.ownerVouchIsIncomplete(
+                hasNoWindowsForOwner: axSnapshot?.ordered.isEmpty ?? true,
+                hadAttributeReadFailure: axSnapshot?.hadAttributeReadFailure ?? false)
             let hiddenSpaceSurfaceIsWitnessed = isOnHiddenSpace(CGWindowID(windowID))
-                && ((axSnapshot?.ordered.isEmpty ?? true)
+                && (ownerVouchIsIncomplete
                     || isOnFullscreenSpace(CGWindowID(windowID)))
             if axSnapshot != nil, axWindow == nil {
                 // WindowServer kept a surface Accessibility does not vouch for:
@@ -445,6 +451,13 @@ enum WindowEnumerator {
     private struct AccessibilityWindowSnapshotList {
         let ordered: [(id: CGWindowID, snapshot: AccessibilityWindowSnapshot)]
         let byID: [CGWindowID: AccessibilityWindowSnapshot]
+        /// True when at least one of this owner's windows hit the 0.35s
+        /// per-window AX messaging timeout during this pass. A window that
+        /// times out is silently absent from `byID` just like a window that
+        /// genuinely does not exist, so callers deciding whether an absence
+        /// means "AX vouches this owner has nothing else" must also check
+        /// this flag — an incomplete read is not a vouch.
+        let hadAttributeReadFailure: Bool
     }
 
     private static func accessibilityWindows(for pids: Set<pid_t>,
@@ -509,13 +522,15 @@ enum WindowEnumerator {
         let windowsResult = AXUIElementCopyAttributeValue(app, kAXWindowsAttribute as CFString, &value)
         // Not responding: skip the remaining calls, each would block again.
         guard windowsResult != .cannotComplete else { return nil }
+        var hadAttributeReadFailure = false
         if windowsResult == .success, let windows = value as? [AXUIElement] {
             for window in windows {
                 AXUIElementSetMessagingTimeout(window, 0.35)
                 if isUserFacingWindow(window,
                                       bundleIdentifier: bundleIdentifier,
                                       acceptsUndescribedSubroles: acceptsUndescribedSubroles,
-                                      screenFrames: screenFrames) {
+                                      screenFrames: screenFrames,
+                                      hadReadFailure: &hadAttributeReadFailure) {
                     appendUnique(window, to: &axWindows)
                 }
             }
@@ -526,7 +541,8 @@ enum WindowEnumerator {
                 if isUserFacingWindow(window,
                                       bundleIdentifier: bundleIdentifier,
                                       acceptsUndescribedSubroles: acceptsUndescribedSubroles,
-                                      screenFrames: screenFrames) {
+                                      screenFrames: screenFrames,
+                                      hadReadFailure: &hadAttributeReadFailure) {
                     appendUnique(window, to: &axWindows)
                 }
             }
@@ -537,10 +553,12 @@ enum WindowEnumerator {
         for window in axWindows {
             if let id = AXWindowResolver.windowID(for: window) {
                 let frame = accessibilityFrame(for: window)
+                let isMinimizedAttr = readBoolAttribute(window, kAXMinimizedAttribute as String)
+                if isMinimizedAttr.timedOut { hadAttributeReadFailure = true }
                 let snapshot = AccessibilityWindowSnapshot(title: accessibilityTitle(for: window),
                                                            frame: frame,
-                                                           isMinimized: boolAttribute(window, kAXMinimizedAttribute as String),
-                                                           isFullscreen: isFullscreenWindow(window)
+                                                           isMinimized: isMinimizedAttr.value ?? false,
+                                                           isFullscreen: isFullscreenWindow(window, hadReadFailure: &hadAttributeReadFailure)
                                                             || frameLooksFullscreen(frame,
                                                                                     screenFrames: screenFrames))
                 byID[id] = snapshot
@@ -555,12 +573,14 @@ enum WindowEnumerator {
         if axWindows.isEmpty {
             return acceptsUndescribedSubroles
                 ? nil
-                : AccessibilityWindowSnapshotList(ordered: ordered, byID: byID)
+                : AccessibilityWindowSnapshotList(ordered: ordered, byID: byID,
+                                                  hadAttributeReadFailure: hadAttributeReadFailure)
         }
         // If an app reports AX windows but none resolve to WindowServer ids,
         // keep the old behavior instead of hiding a real window for that app.
         if !ordered.isEmpty {
-            return AccessibilityWindowSnapshotList(ordered: ordered, byID: byID)
+            return AccessibilityWindowSnapshotList(ordered: ordered, byID: byID,
+                                                  hadAttributeReadFailure: hadAttributeReadFailure)
         }
         return nil
     }
@@ -667,17 +687,27 @@ enum WindowEnumerator {
     private static func isUserFacingWindow(_ window: AXUIElement,
                                            bundleIdentifier: String? = nil,
                                            acceptsUndescribedSubroles: Bool = false,
-                                           screenFrames: [CGRect]) -> Bool {
-        if isFullscreenWindow(window) { return true }
-        if boolAttribute(window, kAXMinimizedAttribute as String),
-           stringAttribute(window, kAXRoleAttribute as String) == (kAXWindowRole as String) {
-            return true
+                                           screenFrames: [CGRect],
+                                           hadReadFailure: inout Bool) -> Bool {
+        if isFullscreenWindow(window, hadReadFailure: &hadReadFailure) { return true }
+        let minimizedAttr = readBoolAttribute(window, kAXMinimizedAttribute as String)
+        if minimizedAttr.timedOut { hadReadFailure = true }
+        if minimizedAttr.value == true {
+            let roleAttr = readStringAttribute(window, kAXRoleAttribute as String)
+            if roleAttr.timedOut { hadReadFailure = true }
+            if roleAttr.value == (kAXWindowRole as String) {
+                return true
+            }
         }
-        if let subrole = stringAttribute(window, kAXSubroleAttribute as String) {
+        let subroleAttr = readStringAttribute(window, kAXSubroleAttribute as String)
+        if subroleAttr.timedOut { hadReadFailure = true }
+        if let subrole = subroleAttr.value {
             if subrole == "AXStandardWindow" || subrole == "AXFullScreenWindow" { return true }
             if SwitcherSupport.isSupportedMediaFloatingWindow(bundleIdentifier: bundleIdentifier,
                                                               subrole: subrole) { return true }
-            let role = stringAttribute(window, kAXRoleAttribute as String)
+            let roleAttr = readStringAttribute(window, kAXRoleAttribute as String)
+            if roleAttr.timedOut { hadReadFailure = true }
+            let role = roleAttr.value
             let canBePlaybackSurface = subrole == "AXUnknown" || subrole == "AXFloatingWindow"
             let fillsScreen = canBePlaybackSurface
                 && frameLooksFullscreen(accessibilityFrame(for: window), screenFrames: screenFrames)
@@ -692,12 +722,18 @@ enum WindowEnumerator {
                 fillsScreen: fillsScreen,
                 acceptsUndescribedSubroles: acceptsUndescribedSubroles)
         }
-        return stringAttribute(window, kAXRoleAttribute as String) == "AXWindow"
+        let finalRoleAttr = readStringAttribute(window, kAXRoleAttribute as String)
+        if finalRoleAttr.timedOut { hadReadFailure = true }
+        return finalRoleAttr.value == "AXWindow"
     }
 
-    private static func isFullscreenWindow(_ window: AXUIElement) -> Bool {
-        if boolAttribute(window, "AXFullScreen") { return true }
-        return stringAttribute(window, kAXSubroleAttribute as String) == "AXFullScreenWindow"
+    private static func isFullscreenWindow(_ window: AXUIElement, hadReadFailure: inout Bool) -> Bool {
+        let fullscreenAttr = readBoolAttribute(window, "AXFullScreen")
+        if fullscreenAttr.timedOut { hadReadFailure = true }
+        if fullscreenAttr.value == true { return true }
+        let subroleAttr = readStringAttribute(window, kAXSubroleAttribute as String)
+        if subroleAttr.timedOut { hadReadFailure = true }
+        return subroleAttr.value == "AXFullScreenWindow"
     }
 
     private static func appendUnique(_ window: AXUIElement, to windows: inout [AXUIElement]) {
@@ -714,21 +750,37 @@ enum WindowEnumerator {
         return (value as! AXUIElement)
     }
 
-    private static func stringAttribute(_ element: AXUIElement, _ attribute: String) -> String? {
+    /// A messaging timeout (`AXUIElementSetMessagingTimeout`) makes
+    /// `AXUIElementCopyAttributeValue` return `.cannotComplete` rather than
+    /// hang, but that error looks identical to "this attribute legitimately
+    /// has no value" unless the caller checks for it specifically. Callers
+    /// that need to tell "AX answered false/absent" apart from "AX never
+    /// answered" read `timedOut` instead of collapsing both into `nil`/`false`.
+    private static func readStringAttribute(_ element: AXUIElement,
+                                             _ attribute: String) -> (value: String?, timedOut: Bool) {
         var value: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success,
-              let value else { return nil }
-        return value as? String
+        let error = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+        guard error == .success, let value else { return (nil, error == .cannotComplete) }
+        return (value as? String, false)
+    }
+
+    private static func readBoolAttribute(_ element: AXUIElement,
+                                          _ attribute: String) -> (value: Bool?, timedOut: Bool) {
+        var value: CFTypeRef?
+        let error = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+        guard error == .success, let value else { return (nil, error == .cannotComplete) }
+        guard CFGetTypeID(value) == CFBooleanGetTypeID() else {
+            return (value as? Bool, false)
+        }
+        return (CFBooleanGetValue((value as! CFBoolean)), false)
+    }
+
+    private static func stringAttribute(_ element: AXUIElement, _ attribute: String) -> String? {
+        readStringAttribute(element, attribute).value
     }
 
     private static func boolAttribute(_ element: AXUIElement, _ attribute: String) -> Bool {
-        var value: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success,
-              let value else { return false }
-        guard CFGetTypeID(value) == CFBooleanGetTypeID() else {
-            return (value as? Bool) ?? false
-        }
-        return CFBooleanGetValue((value as! CFBoolean))
+        readBoolAttribute(element, attribute).value ?? false
     }
 
     /// Adds the apps that are running with no window to switch to, so the list

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1951,24 +1951,36 @@ struct MetricsTests {
                && !SpaceHopSupport.isOnFullscreenSpace(windowSpaces: [4], fullscreenSpaces: [8])
                && !SpaceHopSupport.isOnFullscreenSpace(windowSpaces: [], fullscreenSpaces: [8]),
                "App Switcher identifies fullscreen from Space type instead of window size")
-        expect(!SpaceHopSupport.ownerVouchIsIncomplete(hasNoWindowsForOwner: false, hadAttributeReadFailure: false),
-               "a clean pass that found at least one window is a real vouch")
-        expect(SpaceHopSupport.ownerVouchIsIncomplete(hasNoWindowsForOwner: true, hadAttributeReadFailure: false),
+        expect(!SpaceHopSupport.shouldSkipStaleSurfaceVeto(hasNoWindowsForOwner: false, hadAttributeReadFailure: false),
+               "a clean pass that found at least one window is a real vouch - the veto still applies")
+        expect(SpaceHopSupport.shouldSkipStaleSurfaceVeto(hasNoWindowsForOwner: true, hadAttributeReadFailure: false),
                "an owner with zero windows and no read failures is the original #339 forgiveness case")
-        expect(SpaceHopSupport.ownerVouchIsIncomplete(hasNoWindowsForOwner: false, hadAttributeReadFailure: true),
-               "a read failure makes the vouch incomplete even when other windows for the same owner were found - the exact Dock Preview regression this guards against, where a busier hover pattern hits the 0.35s per-window AX timeout more often than the App Switcher's one-shot enumeration")
-        expect(SpaceHopSupport.ownerVouchIsIncomplete(hasNoWindowsForOwner: true, hadAttributeReadFailure: true),
-               "zero windows and a read failure together still count as incomplete")
+        expect(SpaceHopSupport.shouldSkipStaleSurfaceVeto(hasNoWindowsForOwner: false, hadAttributeReadFailure: true),
+               "a read failure skips the veto even when other windows for the same owner were found - the exact Dock Preview regression this guards against, where a busier hover pattern hits the 0.35s per-window AX timeout more often than the App Switcher's one-shot enumeration")
+        expect(SpaceHopSupport.shouldSkipStaleSurfaceVeto(hasNoWindowsForOwner: true, hadAttributeReadFailure: true),
+               "zero windows and a read failure together still skip the veto")
         // WindowEnumerator's hidden-Space veto must route the owner-vouch
-        // decision through ownerVouchIsIncomplete, not the bare
+        // decision through shouldSkipStaleSurfaceVeto, not the bare
         // `axSnapshot?.ordered.isEmpty` it wraps - reverting that one call
         // site back to the bare check silently reopens the Dock Preview
         // ghost/hidden-window regression this test file guards against.
         let enumeratorSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift",
             encoding: .utf8)) ?? ""
-        expect(enumeratorSource.contains("SpaceHopSupport.ownerVouchIsIncomplete("),
-               "the hidden-Space veto's owner-vouch check routes through ownerVouchIsIncomplete")
+        expect(enumeratorSource.contains("SpaceHopSupport.shouldSkipStaleSurfaceVeto("),
+               "the hidden-Space veto's owner-vouch check routes through shouldSkipStaleSurfaceVeto")
+        // The owner-vouch decision is only as complete as every reader that
+        // feeds `hadAttributeReadFailure`. A timed-out window-id resolve or
+        // frame read is just as silent a drop as the bool/string readers -
+        // both must set the flag too, or a real window whose id/frame read
+        // timed out (as opposed to a bool/string attribute) still gets
+        // vetoed with no visible difference from before this fix.
+        expect(enumeratorSource.contains("idAttr.timedOut { hadAttributeReadFailure = true }"),
+               "a timed-out AXWindowResolver window-id resolve in the snapshot loop must mark hadAttributeReadFailure, not just get silently dropped from ordered/byID")
+        expect(enumeratorSource.contains("frameAttr.timedOut { hadAttributeReadFailure = true }"),
+               "a timed-out accessibilityFrame read in the snapshot loop must mark hadAttributeReadFailure")
+        expect(enumeratorSource.contains("frameAttr.timedOut { hadReadFailure = true }"),
+               "a timed-out accessibilityFrame read inside isUserFacingWindow's fillsScreen check must mark hadReadFailure too")
         expect(SpaceHopSupport.isExcludedFromWindowCycle(windowTagsLow: 1 << 18),
                "a window-server surface marked to ignore cycling is excluded from the switcher")
         expect(!SpaceHopSupport.isExcludedFromWindowCycle(windowTagsLow: (1 << 19) | (1 << 22)),

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1951,6 +1951,24 @@ struct MetricsTests {
                && !SpaceHopSupport.isOnFullscreenSpace(windowSpaces: [4], fullscreenSpaces: [8])
                && !SpaceHopSupport.isOnFullscreenSpace(windowSpaces: [], fullscreenSpaces: [8]),
                "App Switcher identifies fullscreen from Space type instead of window size")
+        expect(!SpaceHopSupport.ownerVouchIsIncomplete(hasNoWindowsForOwner: false, hadAttributeReadFailure: false),
+               "a clean pass that found at least one window is a real vouch")
+        expect(SpaceHopSupport.ownerVouchIsIncomplete(hasNoWindowsForOwner: true, hadAttributeReadFailure: false),
+               "an owner with zero windows and no read failures is the original #339 forgiveness case")
+        expect(SpaceHopSupport.ownerVouchIsIncomplete(hasNoWindowsForOwner: false, hadAttributeReadFailure: true),
+               "a read failure makes the vouch incomplete even when other windows for the same owner were found - the exact Dock Preview regression this guards against, where a busier hover pattern hits the 0.35s per-window AX timeout more often than the App Switcher's one-shot enumeration")
+        expect(SpaceHopSupport.ownerVouchIsIncomplete(hasNoWindowsForOwner: true, hadAttributeReadFailure: true),
+               "zero windows and a read failure together still count as incomplete")
+        // WindowEnumerator's hidden-Space veto must route the owner-vouch
+        // decision through ownerVouchIsIncomplete, not the bare
+        // `axSnapshot?.ordered.isEmpty` it wraps - reverting that one call
+        // site back to the bare check silently reopens the Dock Preview
+        // ghost/hidden-window regression this test file guards against.
+        let enumeratorSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift",
+            encoding: .utf8)) ?? ""
+        expect(enumeratorSource.contains("SpaceHopSupport.ownerVouchIsIncomplete("),
+               "the hidden-Space veto's owner-vouch check routes through ownerVouchIsIncomplete")
         expect(SpaceHopSupport.isExcludedFromWindowCycle(windowTagsLow: 1 << 18),
                "a window-server surface marked to ignore cycling is excluded from the switcher")
         expect(!SpaceHopSupport.isExcludedFromWindowCycle(windowTagsLow: (1 << 19) | (1 << 22)),


### PR DESCRIPTION
## Summary

Follow-up to #1062. That PR fixed the hidden-Space ghost/hidden-window bug
for the App Switcher, but the same class of bug is still reachable through
`WindowEnumerator`'s shared enumerator (`listWindows`), used identically by
App Switcher, Dock Preview and Command Bar.

`WindowEnumerator`'s hidden-Space veto trusts an owner's "no window here"
answer whenever Accessibility found zero windows for that owner. But a
per-window attribute read that hits the 0.35s messaging timeout
(`AXUIElementCopyAttributeValue` returning `.cannotComplete`) was silently
dropped from the results, indistinguishable from a window that never
existed. So if one window from an app timed out while a sibling window from
the same app answered fine, the owner still looked like it "vouched" for a
complete list, and the timed-out (but real) window got vetoed as a stale
surface.

This is shared code, so it isn't a separate bug per surface — it's a
probability difference. Dock Preview re-enumerates on every Dock hover, far
more often and under more concurrent Accessibility load than the App
Switcher's one-shot per-keypress enumeration, so the same 0.35s timeout
fires there much more often and the bug stays visible in Dock Preview even
after #1062 landed.

Fix distinguishes "Accessibility timed out" from "Accessibility answered
false/absent" in the attribute readers, threads that signal through the
per-window admission checks, and folds it into the owner-vouch decision via
`SpaceHopSupport.ownerVouchIsIncomplete`, so an incomplete pass no longer
gets to vouch for a window it is missing.

## Verification

MacBook Air (M4, `Mac16,12`), macOS 26.6.2 (25G83), own local build (not a
release build).

```sh
./build.sh          # finished without warnings
./build/Vorssaint --selftest   # SELFTEST OK
./build.sh --test   # TESTS OK (8803 checks)
```

Added pure-function tests for `ownerVouchIsIncomplete` plus a structural
guard that the veto site actually routes through it. Confirmed red/green:
reverted the call site to the old bare check, reran `--test`, saw exactly
the new structural-guard assertion fail and nothing else, then restored the
fix and confirmed all 8803 checks pass again.

**What I could not test live**: this bug is inherently timing/load-dependent
(a real 0.35s AX messaging timeout under real app/window-server contention),
so it isn't reliably reproducible on demand — the pure-function regression
test above is the primary evidence, the same approach the existing test
suite already uses for the adjacent `SpaceHopSupport` logic. Someone hitting
the original Dock Preview symptom should confirm it stops recurring on a
real build.

## Anything else

Refs #1061
