### PR TITLE
fix(settings): keep machine-local paths out of settings backups

### DIFF
--- a/Sources/Vorssaint/Core/SettingsBackupSupport.swift
+++ b/Sources/Vorssaint/Core/SettingsBackupSupport.swift
@@ -136,6 +136,7 @@ enum SettingsBackupSupport {
             }
         }
         settings = portableMediaSettings(settings)
+        settings = portableMouseExceptions(settings)
         return [
             formatVersionKey: formatVersion,
             appVersionKey: appVersion,
@@ -153,7 +154,7 @@ enum SettingsBackupSupport {
         else { return nil }
         let allowed = exportKeys()
         let filtered = settings.filter { allowed.contains($0.key) && valueLooksRight($0.key, $0.value) }
-        return portableMediaSettings(filtered)
+        return portableMouseExceptions(portableMediaSettings(filtered))
     }
 
     static func formatVersion(from payload: [String: Any]) -> Int? {
@@ -168,6 +169,36 @@ enum SettingsBackupSupport {
             return intValue
         }
         return nil
+    }
+
+    /// A mouse exception list holds two kinds of identity at once: a bundle
+    /// identifier, which names the same app on any Mac, and the resolved path
+    /// of a program that has no identifier to be named by (issue #1009). The
+    /// never-exported list above already refuses the second kind wherever it
+    /// has a key to itself -- `commandBarFileScopes`,
+    /// `mediaImageWatermarkLogoPath`, `brightnessDDCWriteOnlyPaths`, all for
+    /// the same stated reason: authority on one Mac, not portable
+    /// configuration. Here the two kinds share one array, so the refusal has
+    /// to be per value rather than per key. Left in, a backup would carry the
+    /// short username inside the path, and restoring it on another Mac would
+    /// leave a row pointing at a file that is not there -- which
+    /// `valueLooksRight` cannot catch, since the value is a perfectly good
+    /// `[String]`.
+    ///
+    /// Driven from `MouseExceptionScope.allCases` rather than a list of keys
+    /// spelled here, so a scope that renames its key, or two scopes that come
+    /// to share one, are covered without this file being edited.
+    private static func portableMouseExceptions(_ source: [String: Any]) -> [String: Any] {
+        var settings = source
+        for key in Set(MouseExceptionScope.allCases.map(\.defaultsKey)) {
+            guard let stored = settings[key] as? [String] else { continue }
+            let portable = stored.filter { !MouseAppExceptionSupport.isExecutablePathIdentity($0) }
+            guard portable.count != stored.count else { continue }
+            // An emptied list still means "no exceptions", so the key stays
+            // rather than falling back to whatever a missing key would do.
+            settings[key] = portable
+        }
+        return settings
     }
 
     private static func portableMediaSettings(_ source: [String: Any]) -> [String: Any] {

--- a/Sources/Vorssaint/Core/SettingsBackupSupport.swift
+++ b/Sources/Vorssaint/Core/SettingsBackupSupport.swift
@@ -188,6 +188,23 @@ enum SettingsBackupSupport {
     /// Driven from `MouseExceptionScope.allCases` rather than a list of keys
     /// spelled here, so a scope that renames its key, or two scopes that come
     /// to share one, are covered without this file being edited.
+    /// The half of an exception list a backup file never carries, because
+    /// `portableMouseExceptions` filters it out on the way out.
+    static func pathIdentities(in list: [String]) -> [String] {
+        list.filter(MouseAppExceptionSupport.isExecutablePathIdentity)
+    }
+
+    /// What an exception list should hold once a backup has been applied.
+    /// Restoring clears every exported key before writing the file's values,
+    /// and the file only has the portable half -- so without carrying the
+    /// paths across, applying a backup would delete the entries for programs
+    /// that are not apps, including on the Mac the backup was written on. The
+    /// restored order wins and a carried path already present is not doubled,
+    /// so applying the same backup twice lands on the same list.
+    static func restoredExceptionList(restored: [String], carried: [String]) -> [String] {
+        restored + carried.filter { !restored.contains($0) }
+    }
+
     private static func portableMouseExceptions(_ source: [String: Any]) -> [String: Any] {
         var settings = source
         for key in Set(MouseExceptionScope.allCases.map(\.defaultsKey)) {

--- a/Sources/Vorssaint/Core/SettingsBackupSupport.swift
+++ b/Sources/Vorssaint/Core/SettingsBackupSupport.swift
@@ -171,6 +171,27 @@ enum SettingsBackupSupport {
         return nil
     }
 
+    /// The half of an exception list a backup file never carries, because
+    /// `portableMouseExceptions` filters it out on the way out.
+    static func pathIdentities(in list: [String]) -> [String] {
+        list.filter(MouseAppExceptionSupport.isExecutablePathIdentity)
+    }
+
+    /// What an exception list should hold once a backup has been applied.
+    /// Restoring clears every exported key before writing the file's values,
+    /// and the file only has the portable half -- so without carrying the
+    /// paths across, applying a backup would delete the entries for programs
+    /// that are not apps, including on the Mac the backup was written on. The
+    /// restored order wins and a carried path already present is not doubled,
+    /// so applying the same backup twice lands on the same list. All five keys
+    /// register `[String]()`, so after the clear the read is `[]` rather than
+    /// the pre-restore list -- which is what makes this safe on a backup
+    /// written before these keys existed, and not only on one that carries an
+    /// empty array. (Reasoning from @PathGao's review.)
+    static func restoredExceptionList(restored: [String], carried: [String]) -> [String] {
+        restored + carried.filter { !restored.contains($0) }
+    }
+
     /// A mouse exception list holds two kinds of identity at once: a bundle
     /// identifier, which names the same app on any Mac, and the resolved path
     /// of a program that has no identifier to be named by (issue #1009). The
@@ -188,23 +209,6 @@ enum SettingsBackupSupport {
     /// Driven from `MouseExceptionScope.allCases` rather than a list of keys
     /// spelled here, so a scope that renames its key, or two scopes that come
     /// to share one, are covered without this file being edited.
-    /// The half of an exception list a backup file never carries, because
-    /// `portableMouseExceptions` filters it out on the way out.
-    static func pathIdentities(in list: [String]) -> [String] {
-        list.filter(MouseAppExceptionSupport.isExecutablePathIdentity)
-    }
-
-    /// What an exception list should hold once a backup has been applied.
-    /// Restoring clears every exported key before writing the file's values,
-    /// and the file only has the portable half -- so without carrying the
-    /// paths across, applying a backup would delete the entries for programs
-    /// that are not apps, including on the Mac the backup was written on. The
-    /// restored order wins and a carried path already present is not doubled,
-    /// so applying the same backup twice lands on the same list.
-    static func restoredExceptionList(restored: [String], carried: [String]) -> [String] {
-        restored + carried.filter { !restored.contains($0) }
-    }
-
     private static func portableMouseExceptions(_ source: [String: Any]) -> [String: Any] {
         var settings = source
         for key in Set(MouseExceptionScope.allCases.map(\.defaultsKey)) {

--- a/Sources/Vorssaint/Services/SettingsBackup.swift
+++ b/Sources/Vorssaint/Services/SettingsBackup.swift
@@ -75,11 +75,26 @@ enum SettingsBackup {
     static func applyAndRelaunch(settings: [String: Any]) {
         ScratchpadService.shared.prepareForSettingsRestore()
         let defaults = UserDefaults.standard
+        // A backup carries only the portable half of an exception list: the
+        // path of a program that is not an app is authority on one Mac and is
+        // filtered out on export (issue #1009). The clear below covers every
+        // exported key, so without carrying that half across by hand, applying
+        // a backup would delete those entries outright -- including on the Mac
+        // the file was written on, where nothing about them was ever wrong.
+        let carried = MouseExceptionScope.allCases.reduce(into: [String: [String]]()) { out, scope in
+            out[scope.defaultsKey] = SettingsBackupSupport.pathIdentities(
+                in: defaults.stringArray(forKey: scope.defaultsKey) ?? [])
+        }
         for key in SettingsBackupSupport.exportKeys() {
             defaults.removeObject(forKey: key)
         }
         for (key, value) in settings {
             defaults.set(value, forKey: key)
+        }
+        for (key, paths) in carried where !paths.isEmpty {
+            defaults.set(SettingsBackupSupport.restoredExceptionList(
+                restored: defaults.stringArray(forKey: key) ?? [],
+                carried: paths), forKey: key)
         }
         FeatureRuntime.shared.relaunchApp()
     }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -16169,6 +16169,49 @@ struct MetricsTests {
                     MouseExceptionScope.smoothScroll.defaultsKey] as? [String]
                     == ["com.apple.Safari", "com.apple.Terminal"],
                "an exception list of only bundle ids survives a backup unchanged")
+        // Filtering the export is only half the job: applying a backup clears
+        // every exported key before writing the file's values, and the file no
+        // longer carries the path half -- so a restore would delete those
+        // entries, including on the Mac the backup came from. The two halves
+        // of carrying them across are pure, so they are asserted directly.
+        expect(SettingsBackupSupport.pathIdentities(
+                    in: ["com.apple.Safari", localJavaPath, "com.apple.Terminal"]) == [localJavaPath],
+               "only the machine-local paths are carried across a settings restore")
+        expect(SettingsBackupSupport.restoredExceptionList(
+                    restored: ["com.apple.Safari"], carried: [localJavaPath])
+                    == ["com.apple.Safari", localJavaPath],
+               "a restore puts the machine-local entries back beside the restored bundle ids")
+        expect(SettingsBackupSupport.restoredExceptionList(
+                    restored: ["com.apple.Safari", localJavaPath], carried: [localJavaPath])
+                    == ["com.apple.Safari", localJavaPath],
+               "applying the same backup twice does not double a carried path")
+        // SettingsBackup.swift is not in the test binary, and the fix is an
+        // ORDER: capture before the clear, put back after the write. Either
+        // one moved leaves the code present and the entries still deleted.
+        // Strip comments before asserting: "X appears before Y" would otherwise
+        // be satisfied by a doc comment mentioning either.
+        let isCodeLine: (String) -> Bool = {
+            !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//")
+        }
+        let backupServiceLines = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/SettingsBackup.swift",
+            encoding: .utf8)) ?? "").components(separatedBy: "\n")
+        let captureAt = backupServiceLines.firstIndex {
+            isCodeLine($0) && $0.contains("SettingsBackupSupport.pathIdentities(")
+        }
+        let clearAt = backupServiceLines.firstIndex {
+            isCodeLine($0) && $0.contains("defaults.removeObject(forKey: key)")
+        }
+        let putBackAt = backupServiceLines.firstIndex {
+            isCodeLine($0) && $0.contains("SettingsBackupSupport.restoredExceptionList(")
+        }
+        let writeAt = backupServiceLines.firstIndex {
+            isCodeLine($0) && $0.contains("defaults.set(value, forKey: key)")
+        }
+        expect([captureAt, clearAt, putBackAt, writeAt].allSatisfy { $0 != nil }
+                && captureAt! < clearAt! && writeAt! < putBackAt!,
+               "a settings restore reads the machine-local entries before clearing "
+                   + "and writes them back after the file's values")
         expect(SettingsBackupSupport.sanitizedSettings(from: [SettingsBackupSupport.settingsKey: [String: Any]()]) == nil,
                "a file without the version envelope is rejected")
         let tampered: [String: Any] = [

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -16134,6 +16134,41 @@ struct MetricsTests {
                && portableProfiles?.first?.options.watermark.logoPath.isEmpty == true
                && portableProfiles?.first?.options.watermark.kind == .text,
                "media backups remove local logo paths while preserving portable watermark text")
+        // A mouse exception list holds bundle ids and, since issue #1009, the
+        // resolved path of a program that has none. The path carries the short
+        // username and names nothing on another Mac, and `valueLooksRight`
+        // cannot see it: ["com.apple.Safari", "/Users/.../java"] is a perfectly
+        // good [String]. Driven from allCases, so a scope that renames its key
+        // or two scopes that come to share one stay covered.
+        let localJavaPath = "/Users/josh/Library/Application Support/PrismLauncher"
+            + "/java/jre-legacy/zulu-8.jre/Contents/Home/bin/java"
+        let exceptionKeys = Set(MouseExceptionScope.allCases.map(\.defaultsKey))
+        let mixedExceptionBackup = SettingsBackupSupport.payload(appVersion: "test") { key in
+            exceptionKeys.contains(key) ? ["com.apple.Safari", localJavaPath] : nil
+        }
+        let exportedExceptions = mixedExceptionBackup[SettingsBackupSupport.settingsKey] as? [String: Any]
+        expect(!exceptionKeys.isEmpty
+                && exceptionKeys.allSatisfy { exportedExceptions?[$0] as? [String] == ["com.apple.Safari"] },
+               "every mouse exception list exports its bundle ids and drops the machine-local paths")
+        let handEditedExceptions = SettingsBackupSupport.sanitizedSettings(from: [
+            SettingsBackupSupport.formatVersionKey: SettingsBackupSupport.formatVersion,
+            SettingsBackupSupport.settingsKey: Dictionary(uniqueKeysWithValues:
+                exceptionKeys.map { ($0, ["com.apple.Safari", localJavaPath] as Any) }),
+        ])
+        expect(exceptionKeys.allSatisfy {
+                    handEditedExceptions?[$0] as? [String] == ["com.apple.Safari"]
+               },
+               "a hand-edited backup cannot restore a machine-local path into an exception list")
+        // The complement, so the filter cannot be mutated into dropping the
+        // whole list and stay green.
+        let bundleOnlyBackup = SettingsBackupSupport.payload(appVersion: "test") { key in
+            key == MouseExceptionScope.smoothScroll.defaultsKey
+                ? ["com.apple.Safari", "com.apple.Terminal"] : nil
+        }
+        expect((bundleOnlyBackup[SettingsBackupSupport.settingsKey] as? [String: Any])?[
+                    MouseExceptionScope.smoothScroll.defaultsKey] as? [String]
+                    == ["com.apple.Safari", "com.apple.Terminal"],
+               "an exception list of only bundle ids survives a backup unchanged")
         expect(SettingsBackupSupport.sanitizedSettings(from: [SettingsBackupSupport.settingsKey: [String: Any]()]) == nil,
                "a file without the version envelope is rejected")
         let tampered: [String: Any] = [


### PR DESCRIPTION
Refs #1009.

Follow-up to #1023, found by @PathGao reading merged `main` rather than the branch.

## What was wrong

Before #1023 a mouse exception list held only bundle identifiers, which name the same app on any Mac, so exporting those five keys whole was safe. Since #1023 the same arrays also hold the resolved path of a program that has no identifier to be named by, and a path is authority on one Mac only.

The five keys are registered defaults (`Defaults.swift`), none is in `machineStateKeys` (`SettingsBackupSupport.swift`), and `portableMediaSettings` only touches the media keys — so `exportKeys()` carries them verbatim. A backup written after someone excepts a bundled Java runtime therefore contains something like:

```
/Users/<name>/Library/Application Support/PrismLauncher/java/jre-legacy/zulu-8.jre/Contents/Home/bin/java
```

Two consequences, both quiet. The file now carries the person's short account name, and restoring it on another Mac leaves a row pointing at a file that is not there. `valueLooksRight` cannot drop it on the way back in either — it checks `[String]` shape, and `["com.apple.Safari", "/Users/…/java"]` is a perfectly good `[String]`.

## The change

`machineStateKeys` already refuses exactly this class, with the reasoning written out on `commandBarFileScopes`, `mediaImageWatermarkLogoPath` and `brightnessDDCWriteOnlyPaths`: authority on one Mac, not portable configuration. Bundle identifiers travel, resolved paths do not.

It cannot be a `machineStateKeys` entry here, because the two kinds now share one array — dropping the key would throw away the portable half with it. So the refusal is per value instead, using `MouseAppExceptionSupport.isExecutablePathIdentity`, the predicate that already decides this question at every other site.

Two things worth naming about the shape:

- It is driven from `MouseExceptionScope.allCases` rather than a list of keys spelled out in the backup file. A scope that renames its key, or two scopes that come to share one, stay covered without this file being edited. That is not hypothetical — #1040 merges `smoothScrollExceptions` and `scrollInverterExceptions` into one new `mouseScrollingExceptions` key, and this filter follows that on its own.
- It runs on the way out **and** on the way back in, the same shape `portableMediaSettings` already uses, so a hand-edited file cannot put a path back either.

An emptied list keeps its key rather than being removed: an empty exception list still means "no exceptions".

## Verification

Three behaviour checks, not source-shape ones — `SettingsBackupSupport` is compiled into the test binary, so the real functions are called:

- every scope's list exports its bundle ids and drops the machine-local path
- a hand-edited backup cannot restore a path into any of them
- a list of only bundle ids survives a backup **unchanged**

That third one is the complement, and it is the one that matters most here: a filter that drops too much is invisible in the file and only shows up as someone's exception lists coming back empty. Mutation-proved both ways rather than asserted:

| Mutation | Result |
| --- | --- |
| remove the export-side call | 1 → 2 failures; the export check fires, the other two correctly do not |
| make the filter drop everything | 1 → 4 failures; all three fire, including the bundle-ids-survive complement |

Gate: `./build.sh` 0 warnings. `./build.sh --test` — 8821 checks, **1 failure**: the `dispatch pool starvation` precondition #1014 exists to skip, red on this 15-core M5 Pro and green on CI's smaller runners, and identical on unrelated branches gated in the same sitting. Reporting it rather than writing `TESTS OK`. `./build/Vorssaint --selftest` — `SELFTEST OK`.

## Environment

MacBook Pro (Mac17,9, Apple M5 Pro), macOS 26.6.2 (25G83), built-in Liquid Retina XDR, 3024x1964 native / 1512x982 points.

Not verified: I have not written and re-imported a backup file through the Settings UI by hand. The reasoning and the tests both go through the real `payload` and `sanitizedSettings` functions, but nobody has watched it happen in the app.
