### PR TITLE
fix(command-bar): give the field back Cmd+A, C, X and V

### DIFF
--- a/Sources/Vorssaint/Core/KeyboardLetters.swift
+++ b/Sources/Vorssaint/Core/KeyboardLetters.swift
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Carbon.HIToolbox
+import Foundation
+
+/// What a keystroke means to a shortcut, on every layout.
+///
+/// A keyboard answers by the letter it types, so a shortcut stays on the key
+/// it is printed on even where the layout moves it: AZERTY puts A where ANSI
+/// has Q, Turkish moves both. Layouts that type no Latin letter at all, like
+/// Cyrillic and Greek, have no letter to answer with, so the key's position
+/// stands in — which is where macOS resolves those layouts' own command
+/// shortcuts anyway.
+enum KeyboardLetters {
+    /// The plain letter a keystroke typed, when it typed one. Accents fold
+    /// away, so a letter of a Latin alphabet is never mistaken for one of the
+    /// keys a panel claims.
+    static func latinLetter(in text: String?) -> Character? {
+        guard let folded = text?.folding(options: [.diacriticInsensitive, .caseInsensitive],
+                                         locale: .current),
+              folded.count == 1,
+              let letter = folded.first,
+              letter.isASCII,
+              letter.isLetter
+        else { return nil }
+        return letter
+    }
+
+    /// The character a key types on a US keyboard: the letters, plus the
+    /// comma the Command Bar claims for Settings.
+    static func usPositionCharacter(for keyCode: Int) -> Character? {
+        switch keyCode {
+        case kVK_ANSI_A: return "a"
+        case kVK_ANSI_B: return "b"
+        case kVK_ANSI_C: return "c"
+        case kVK_ANSI_D: return "d"
+        case kVK_ANSI_E: return "e"
+        case kVK_ANSI_F: return "f"
+        case kVK_ANSI_G: return "g"
+        case kVK_ANSI_H: return "h"
+        case kVK_ANSI_I: return "i"
+        case kVK_ANSI_J: return "j"
+        case kVK_ANSI_K: return "k"
+        case kVK_ANSI_L: return "l"
+        case kVK_ANSI_M: return "m"
+        case kVK_ANSI_N: return "n"
+        case kVK_ANSI_O: return "o"
+        case kVK_ANSI_P: return "p"
+        case kVK_ANSI_Q: return "q"
+        case kVK_ANSI_R: return "r"
+        case kVK_ANSI_S: return "s"
+        case kVK_ANSI_T: return "t"
+        case kVK_ANSI_U: return "u"
+        case kVK_ANSI_V: return "v"
+        case kVK_ANSI_W: return "w"
+        case kVK_ANSI_X: return "x"
+        case kVK_ANSI_Y: return "y"
+        case kVK_ANSI_Z: return "z"
+        case kVK_ANSI_Comma: return ","
+        default: return nil
+        }
+    }
+
+    /// The character a shortcut should be matched against: the letter the key
+    /// prints, the character itself when it prints punctuation the keyboard
+    /// owns outright, and the key's US position when it prints neither.
+    ///
+    /// The middle rule is what keeps AZERTY's comma, which sits on the ANSI M
+    /// key, from being read as a ⌘M the app's menu would swallow.
+    static func shortcutCharacter(typedCharacter: String?, keyCode: Int) -> Character? {
+        if let letter = latinLetter(in: typedCharacter) { return letter }
+        if let typed = typedCharacter, typed.count == 1, let character = typed.first,
+           character.isASCII, !character.isLetter, !character.isWhitespace {
+            return character
+        }
+        return usPositionCharacter(for: keyCode)
+    }
+}

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
@@ -2416,6 +2416,21 @@ final class CommandBarService: ObservableObject {
 
     // MARK: - Monitors
 
+    /// Sends one editing shortcut down the responder chain, to the field
+    /// editor of whichever panel is key. Answers whether something took it,
+    /// so a combination nobody wanted is handed back to the field untouched.
+    private func sendEditingAction(for event: NSEvent) -> Bool {
+        let action: Selector
+        switch event.charactersIgnoringModifiers?.lowercased() {
+        case "a": action = #selector(NSText.selectAll(_:))
+        case "c": action = #selector(NSText.copy(_:))
+        case "x": action = #selector(NSText.cut(_:))
+        case "v": action = #selector(NSText.paste(_:))
+        default: return false
+        }
+        return NSApp.sendAction(action, to: nil, from: nil)
+    }
+
     private func installMonitors(for panel: NSPanel) {
         removeMonitors()
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self, weak panel] event in
@@ -2467,25 +2482,41 @@ final class CommandBarService: ObservableObject {
             }
 
             if event.modifierFlags.contains(.command) {
-                switch Int(event.keyCode) {
-                case kVK_ANSI_Q, kVK_ANSI_W, kVK_ANSI_M, kVK_ANSI_H:
+                // Letters are read as they are printed on the keyboard, not by
+                // where the key sits: on AZERTY the key marked A is where Q
+                // lives on ANSI, so matching by position took every Cmd+A for
+                // a quit and swallowed it before the field could answer.
+                let onlyCommand = event.modifierFlags
+                    .intersection([.command, .option, .shift, .control]) == [.command]
+                switch event.charactersIgnoringModifiers?.lowercased() {
+                case "q", "w", "m", "h":
                     // The app's menu owns these combinations and the panel is
                     // key, so they would quit, close or hide Vorssaint while
                     // the person believes they are acting on the app the bar
                     // is floating over.
                     return nil
-                case kVK_ANSI_Comma:
+                case ",":
                     self.hide()
                     SettingsRouter.shared.page = .commandBar
                     appDelegate()?.openSettingsWindow()
                     return nil
+                case "k":
+                    self.openActions()
+                    return nil
+                case "a", "c", "x", "v":
+                    // The bar is a non-activating panel, so the app is key
+                    // without being active and the Edit menu never gets to
+                    // fire its own equivalents. That leaves the field without
+                    // the four shortcuts every text field is expected to
+                    // answer. Handing them to whatever is editing gives them
+                    // back; a combination nobody takes goes on its way, and
+                    // one carrying another modifier was never meant for the
+                    // field.
+                    guard onlyCommand else { break }
+                    return self.sendEditingAction(for: event) ? nil : event
                 default:
                     break
                 }
-            }
-            if event.modifierFlags.contains(.command), Int(event.keyCode) == kVK_ANSI_K {
-                self.openActions()
-                return nil
             }
             // ⌘Return shows the selected row where it lives. Guarded by the
             // row's own rule, so a row with nowhere to go hands the keys back

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
@@ -2503,6 +2503,12 @@ final class CommandBarService: ObservableObject {
                 case "k":
                     self.openActions()
                     return nil
+                case "p":
+                    if let entry = self.selectedEntry, !entry.isAnswer,
+                       CommandBarPreferences.acceptsPin(rowID: entry.id) {
+                        self.togglePin(entry)
+                    }
+                    return nil
                 case "a", "c", "x", "v":
                     // The bar is a non-activating panel, so the app is key
                     // without being active and the Edit menu never gets to
@@ -2528,13 +2534,6 @@ final class CommandBarService: ObservableObject {
                     self.revealInFinder(entry)
                     return nil
                 }
-            }
-            if event.modifierFlags.contains(.command), Int(event.keyCode) == kVK_ANSI_P {
-                if let entry = self.selectedEntry, !entry.isAnswer,
-                   CommandBarPreferences.acceptsPin(rowID: entry.id) {
-                    self.togglePin(entry)
-                }
-                return nil
             }
             switch Int(event.keyCode) {
             case kVK_Escape:

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
@@ -2416,12 +2416,19 @@ final class CommandBarService: ObservableObject {
 
     // MARK: - Monitors
 
+    /// The letter a keystroke means to the bar's shortcuts: what the key
+    /// prints, or where it sits when it prints no Latin letter.
+    private static func shortcutCharacter(for event: NSEvent) -> Character? {
+        KeyboardLetters.shortcutCharacter(typedCharacter: event.charactersIgnoringModifiers,
+                                          keyCode: Int(event.keyCode))
+    }
+
     /// Sends one editing shortcut down the responder chain, to the field
     /// editor of whichever panel is key. Answers whether something took it,
     /// so a combination nobody wanted is handed back to the field untouched.
     private func sendEditingAction(for event: NSEvent) -> Bool {
         let action: Selector
-        switch event.charactersIgnoringModifiers?.lowercased() {
+        switch Self.shortcutCharacter(for: event) {
         case "a": action = #selector(NSText.selectAll(_:))
         case "c": action = #selector(NSText.copy(_:))
         case "x": action = #selector(NSText.cut(_:))
@@ -2485,10 +2492,15 @@ final class CommandBarService: ObservableObject {
                 // Letters are read as they are printed on the keyboard, not by
                 // where the key sits: on AZERTY the key marked A is where Q
                 // lives on ANSI, so matching by position took every Cmd+A for
-                // a quit and swallowed it before the field could answer.
+                // a quit and swallowed it before the field could answer. A
+                // layout that prints no Latin letter has none to answer with,
+                // so the key's position stands in there, which is where macOS
+                // resolves that layout's command shortcuts: without it ⌘Q goes
+                // unrecognised on Cyrillic and Greek and the menu quits the
+                // app behind the bar.
                 let onlyCommand = event.modifierFlags
                     .intersection([.command, .option, .shift, .control]) == [.command]
-                switch event.charactersIgnoringModifiers?.lowercased() {
+                switch Self.shortcutCharacter(for: event) {
                 case "q", "w", "m", "h":
                     // The app's menu owns these combinations and the panel is
                     // key, so they would quit, close or hide Vorssaint while

--- a/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
+++ b/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
@@ -1232,11 +1232,11 @@ enum SwitcherSupport {
     /// their command shortcuts (measured: with Command held both translate
     /// that key to "w").
     static func letterAction(typedCharacter: String?, keyCode: Int64, pinSearchEnabled: Bool) -> SwitcherLetterAction? {
-        guard let letter = latinLetter(in: typedCharacter) else {
-            switch keyCode {
-            case USKeyPosition.w: return .closeWindow
-            case USKeyPosition.q: return .quitApp
-            case USKeyPosition.s where pinSearchEnabled: return .pinSearch
+        guard let letter = KeyboardLetters.latinLetter(in: typedCharacter) else {
+            switch KeyboardLetters.usPositionCharacter(for: Int(keyCode)) {
+            case "w": return .closeWindow
+            case "q": return .quitApp
+            case "s" where pinSearchEnabled: return .pinSearch
             default: return nil
             }
         }
@@ -1252,7 +1252,7 @@ enum SwitcherSupport {
             // the original typed character is non-ASCII, to avoid triggering on
             // remapped Latin layouts where the US-S key types another ASCII letter.
             if pinSearchEnabled,
-               keyCode == USKeyPosition.s,
+               KeyboardLetters.usPositionCharacter(for: Int(keyCode)) == "s",
                let typed = typedCharacter,
                !typed.unicodeScalars.allSatisfy({ $0.isASCII }) {
                 return .pinSearch
@@ -1263,26 +1263,6 @@ enum SwitcherSupport {
 
     /// Key positions on the US keyboard, the fallback for layouts with no
     /// Latin letters of their own.
-    private enum USKeyPosition {
-        static let q: Int64 = 12
-        static let w: Int64 = 13
-        static let s: Int64 = 1
-    }
-
-    /// The plain letter a keystroke typed, when it typed one. Accents fold
-    /// away, so a letter of a Latin alphabet is never mistaken for one of the
-    /// keys above.
-    private static func latinLetter(in text: String?) -> Character? {
-        guard let folded = text?.folding(options: [.diacriticInsensitive, .caseInsensitive],
-                                         locale: .current),
-              folded.count == 1,
-              let letter = folded.first,
-              letter.isASCII,
-              letter.isLetter
-        else { return nil }
-        return letter
-    }
-
     static func filteredSearchIDs(records: [SwitcherSearchRecord], query: String) -> [String] {
         let tokens = normalizedSearchTokens(query)
         guard !tokens.isEmpty else { return records.map(\.id) }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9874,6 +9874,32 @@ struct MetricsTests {
                "App Switcher panel follows a remapped Latin letter instead of the physical S position")
         expect(SwitcherSupport.letterAction(typedCharacter: "ы", keyCode: 1, pinSearchEnabled: true) == .pinSearch,
                "App Switcher panel falls back to the physical S position on a non-Latin layout")
+
+        // The same reading, shared with the Command Bar: the letter the key
+        // prints wins, punctuation it prints outright comes next, and the US
+        // position is the last resort.
+        expect(KeyboardLetters.shortcutCharacter(typedCharacter: "a", keyCode: 12) == "a"
+               && KeyboardLetters.shortcutCharacter(typedCharacter: "Q", keyCode: 0) == "q",
+               "a shortcut reads the letter the key prints, wherever the layout puts it")
+        // AZERTY types its comma on the US M key: read by position it would be
+        // a ⌘M the app's menu swallows as a minimise.
+        expect(KeyboardLetters.shortcutCharacter(typedCharacter: ",", keyCode: 46) == ","
+               && KeyboardLetters.shortcutCharacter(typedCharacter: "m", keyCode: 43) == "m",
+               "a comma the keyboard prints stays a comma, and the M next to it stays an M")
+        // Cyrillic prints no Latin letter, so the key position stands in —
+        // without it ⌘Q goes unrecognised and the menu quits the app.
+        expect(KeyboardLetters.shortcutCharacter(typedCharacter: "й", keyCode: 12) == "q"
+               && KeyboardLetters.shortcutCharacter(typedCharacter: "ф", keyCode: 0) == "a"
+               && KeyboardLetters.shortcutCharacter(typedCharacter: "б", keyCode: 43) == ",",
+               "a layout that prints no Latin letter answers by the key's position")
+        expect(KeyboardLetters.shortcutCharacter(typedCharacter: nil, keyCode: 35) == "p"
+               && KeyboardLetters.shortcutCharacter(typedCharacter: "", keyCode: 40) == "k",
+               "a key that prints nothing at all still answers by its position")
+        expect(KeyboardLetters.shortcutCharacter(typedCharacter: "é", keyCode: 14) == "e",
+               "an accent folds away rather than hiding the letter underneath")
+        expect(KeyboardLetters.shortcutCharacter(typedCharacter: "&", keyCode: 18) == "&"
+               && KeyboardLetters.usPositionCharacter(for: 18) == nil,
+               "the digit row is nobody's letter, so it is left to the code that reads it by position")
         let switcherPanelFrame = CGRect(x: 400, y: 300, width: 600, height: 400)
         expect(SwitcherSupport.shouldDismissForClick(panelIsVisible: true,
                                                      panelFrame: switcherPanelFrame,

--- a/build.sh
+++ b/build.sh
@@ -300,6 +300,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/SmoothScrollSupport.swift \
         Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseSupport.swift \
         Sources/Vorssaint/Services/Switcher/SwitcherModels.swift \
+        Sources/Vorssaint/Core/KeyboardLetters.swift \
         Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift \
         Sources/Vorssaint/Services/Switcher/SpaceHopSupport.swift \
         Sources/Vorssaint/Services/Switcher/WindowUseOrder.swift \


### PR DESCRIPTION
## Summary

The Command Bar's field answers none of the four editing shortcuts. Two things were in the way.

The Cmd combinations were matched on the key's position, so a layout that moves the letters aimed them at the wrong commands. On AZERTY the key printed A sits where Q lives on ANSI, so Cmd+A was read as a quit and swallowed before the field could see it; the key printed `,` lands on M and took Cmd+, away from Settings the same way. Matching the character the person sees printed follows every layout that prints a Latin letter, and every letter the bar claims goes through one switch, Cmd+K and Cmd+P included, so no two shortcuts in the same field disagree about what a letter is.

A layout that prints no Latin letter has none to answer with. Cyrillic and Greek go by the key's position instead, which is where macOS resolves those layouts' command shortcuts: without that fallback Cmd+Q is not recognised in the bar, the event goes back to the system, and the app's own menu quits Vorssaint behind it. That is measured, not reasoned — see below. The App Switcher already reads its letters this way, so the reading moved into `KeyboardLetters` and both sides share one definition; `SwitcherSupport.latinLetter` and its `USKeyPosition` are gone. Punctuation the keyboard prints outright is answered before the position, or AZERTY's comma, which sits on the US M key, would resolve to `m` and be swallowed as a minimise. Digits stay positional on purpose: the top row needs Shift to reach a number on AZERTY, so Cmd+1…9 has to keep reading key codes.

Even reaching the field, none of the four would have worked. The bar is a non-activating panel on purpose, so the app is key without ever being active and the Edit menu never gets to fire its equivalents; macOS binds none of these four on its own. They are handed to the responder chain directly, and an event nobody takes is returned to the field untouched, so a combination carrying another modifier still means what it meant before.

One side effect that belongs in writing: `charactersIgnoringModifiers` reports the character with Shift applied. Where the comma is unshifted, as on ANSI and AZERTY, Cmd+Shift+, no longer opens Settings the way the key code did; on a layout that puts the comma behind Shift, that combination now does open it. Same for q/w/m/h/k/p. None of them were meant to carry Shift, so it reads as a tightening rather than a loss, but it is a change.

No new setting and no new string. One new file, `Core/KeyboardLetters.swift`, added to the test harness's source list in `build.sh`.

## Verification

MacBook Air, Apple M5, macOS 26.5.2, single built-in display, French AZERTY layout with Russian added for the run below. Release build installed over the official one, signed with the self-signed identity from `Tools/setup-signing.sh`.

```sh
./build.sh                                                        # no warnings
./build.sh --test                                                 # TESTS OK (8935 checks)
/Applications/Vorssaint.app/Contents/MacOS/Vorssaint --selftest   # SELFTEST OK
```

What a key reports under Command, read off `NSEvent` in a throwaway window on the Russian layout:

```
⌘ + Й     keyCode=12  characters=q  charactersIgnoringModifiers=й
⌘ + Ф     keyCode=0   characters=a  charactersIgnoringModifiers=ф
Й alone   keyCode=12  characters=й  charactersIgnoringModifiers=й
```

macOS does translate to Latin under Command, but into `characters`; `charactersIgnoringModifiers`, which is what this monitor reads, keeps the Cyrillic. That is the whole failure: the bar recognises nothing, hands the event back, and the main menu — which matches on the translated character — quits the app.

In the bar, French AZERTY: Cmd+A selects the query, Cmd+X, Cmd+C and Delete then act on the selection, Cmd+V pastes. Cmd+, opens Settings from the bar. Cmd+K, Cmd+P, Cmd+Return and Cmd+1…9 still do what they did.

In the bar, Russian: Cmd+Й, on the US Q position, does nothing and Vorssaint stays up; Cmd+Ф selects the query; Cmd+Б, on the US comma position, opens Settings. On the same machine before the fallback, with the bar open, Cmd+Й quit Vorssaint. Cmd+Ф appeared to work there, which is the same leak with a harmless end: the bar recognised nothing and something downstream resolved the translated `a`.

The position table could be `characters` instead, since that is the system's own answer under Command. I kept the table: it is one definition shared with the App Switcher, and the suite can exercise it without a layout installed. They agree on the layout measured here. Worth a word if you would rather read the event.

What I could not test: QWERTZ, Turkish, Greek, and Dvorak. A Dvorak-QWERTY-Cmd layout swaps the layout while Cmd is held, and the measurement above says `charactersIgnoringModifiers` would report the layout's own letter there, so that case follows the key position rather than the overlay — untested either way, and I have no machine set up for it. Nothing was tested on Intel, on macOS 14 or 15, or with an external keyboard whose layout differs from the built-in one.

The Quick Launcher and the Scratchpad read key codes the same way and may well have the same problem, but I have neither read them closely nor tested them, so they are left alone here. Three more of the same shape turned up while answering review, all outside this PR: `ClipboardHistoryService.swift:1188` and `ScreenshotEditorController.swift:1088` pin by key code, and `paste(_:)` in this file synthesises its Cmd+V from `kVK_ANSI_V`, which prints `.` on Dvorak. The first two are switch-shaped like this one; the third wants `MouseNavigationKeys.keyStroke(for:)` and is closer to #1047.

The Ctrl branch in the same monitor, Ctrl+N and Ctrl+P, keeps matching the printed character with no positional fallback. No menu sits behind those two waiting to quit the app, and macOS translates for Command, not for Control, so a fallback there would add behaviour on Cyrillic that nobody has asked for.

## Anything else

Refs #1102
