### PR TITLE
feat(Shelf): Support Outlook emails and attachments in Shelf

### DIFF
--- a/Sources/Vorssaint/Core/Localization.swift
+++ b/Sources/Vorssaint/Core/Localization.swift
@@ -1079,6 +1079,7 @@ struct Strings {
     let switcherCurrentSpaceOnly: String
     let switcherCurrentSpaceOnlyCaption: String
     let shelfFileMissing: String
+    let shelfDropFailed: String
     let previewSizeSmall: String
     let mixerSoundEffectsOutputTitle: String
     let mixerSoundEffectsOutputTooltip: String
@@ -2064,6 +2065,7 @@ extension Strings {
         switcherCurrentSpaceOnly: "Mostrar só a Mesa atual",
         switcherCurrentSpaceOnlyCaption: "Mostra no alternador apenas as janelas da Mesa em que você está. Escolher uma janela nunca leva você para outra Mesa.",
         shelfFileMissing: "O arquivo não existe mais",
+        shelfDropFailed: "Não foi possível adicionar o item arrastado à área temporária.",
         previewSizeSmall: "Pequeno",
         mixerSoundEffectsOutputTitle: "Sons do sistema",
         mixerSoundEffectsOutputTooltip: "Escolher onde alertas e efeitos sonoros tocam",
@@ -3050,6 +3052,7 @@ extension Strings {
         switcherCurrentSpaceOnly: "Show only the current desktop",
         switcherCurrentSpaceOnlyCaption: "Lists only windows from the desktop you are on. Picking a window never moves you to another desktop.",
         shelfFileMissing: "The file no longer exists",
+        shelfDropFailed: "Could not add the dropped item to the shelf.",
         previewSizeSmall: "Small",
         mixerSoundEffectsOutputTitle: "System sounds",
         mixerSoundEffectsOutputTooltip: "Choose where alerts and sound effects play",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
@@ -935,6 +935,7 @@ extension Strings {
         switcherCurrentSpaceOnly: "仅显示当前桌面",
         switcherCurrentSpaceOnlyCaption: "切换器中只显示你所在桌面的窗口。选择窗口不会把你带到其他桌面。",
         shelfFileMissing: "文件已不存在",
+        shelfDropFailed: "无法将拖放的项目添加到暂存架。",
         previewSizeSmall: "小",
         mixerSoundEffectsOutputTitle: "系统声音",
         mixerSoundEffectsOutputTooltip: "选择提醒和音效的播放设备",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
@@ -936,6 +936,7 @@ extension Strings {
         switcherCurrentSpaceOnly: "僅顯示目前的桌面",
         switcherCurrentSpaceOnlyCaption: "切換器中只顯示你所在桌面的視窗。選擇視窗不會帶你前往其他桌面。",
         shelfFileMissing: "檔案已不存在",
+        shelfDropFailed: "無法將拖放的項目加入暫存架。",
         previewSizeSmall: "小",
         mixerSoundEffectsOutputTitle: "系統聲音",
         mixerSoundEffectsOutputTooltip: "選擇提示音和音效的播放裝置",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
@@ -936,6 +936,7 @@ extension Strings {
         switcherCurrentSpaceOnly: "僅顯示目前的桌面",
         switcherCurrentSpaceOnlyCaption: "切換器中只顯示你所在桌面的視窗。選擇視窗不會把你帶到其他桌面。",
         shelfFileMissing: "檔案已不存在",
+        shelfDropFailed: "無法將拖放的項目加入暫存架。",
         previewSizeSmall: "小",
         mixerSoundEffectsOutputTitle: "系統聲音",
         mixerSoundEffectsOutputTooltip: "選擇提示音與音效的播放裝置",

--- a/Sources/Vorssaint/Core/Localizations/Strings+French.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+French.swift
@@ -935,6 +935,7 @@ extension Strings {
         switcherCurrentSpaceOnly: "Afficher uniquement le bureau actuel",
         switcherCurrentSpaceOnlyCaption: "N'affiche dans le sélecteur que les fenêtres du bureau où vous êtes. Choisir une fenêtre ne vous emmène jamais sur un autre bureau.",
         shelfFileMissing: "Le fichier n'existe plus",
+        shelfDropFailed: "Impossible d’ajouter l’élément déposé à l’étagère.",
         previewSizeSmall: "Petite",
         mixerSoundEffectsOutputTitle: "Sons du système",
         mixerSoundEffectsOutputTooltip: "Choisir où sont diffusés les alertes et effets sonores",

--- a/Sources/Vorssaint/Core/Localizations/Strings+German.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+German.swift
@@ -935,6 +935,7 @@ extension Strings {
         switcherCurrentSpaceOnly: "Nur den aktuellen Schreibtisch anzeigen",
         switcherCurrentSpaceOnlyCaption: "Zeigt im Umschalter nur Fenster des Schreibtischs, auf dem du gerade bist. Die Auswahl eines Fensters wechselt nie zu einem anderen Schreibtisch.",
         shelfFileMissing: "Die Datei existiert nicht mehr",
+        shelfDropFailed: "Das abgelegte Element konnte nicht zur Ablage hinzugefügt werden.",
         previewSizeSmall: "Klein",
         mixerSoundEffectsOutputTitle: "Systemtöne",
         mixerSoundEffectsOutputTooltip: "Auswählen, wo Hinweise und Toneffekte wiedergegeben werden",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
@@ -935,6 +935,7 @@ extension Strings {
         switcherCurrentSpaceOnly: "Mostra solo la scrivania attuale",
         switcherCurrentSpaceOnlyCaption: "Mostra nel commutatore solo le finestre della scrivania in cui ti trovi. Scegliere una finestra non ti porta mai su un'altra scrivania.",
         shelfFileMissing: "Il file non esiste più",
+        shelfDropFailed: "Impossibile aggiungere l’elemento trascinato al ripiano.",
         previewSizeSmall: "Piccola",
         mixerSoundEffectsOutputTitle: "Suoni di sistema",
         mixerSoundEffectsOutputTooltip: "Scegli dove riprodurre avvisi ed effetti sonori",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
@@ -935,6 +935,7 @@ extension Strings {
         switcherCurrentSpaceOnly: "現在のデスクトップのみ表示",
         switcherCurrentSpaceOnlyCaption: "今いるデスクトップのウインドウだけをスイッチャーに表示します。ウインドウを選んでも別のデスクトップには移動しません。",
         shelfFileMissing: "ファイルはもう存在しません",
+        shelfDropFailed: "ドロップした項目をシェルフに追加できませんでした。",
         previewSizeSmall: "小",
         mixerSoundEffectsOutputTitle: "システムサウンド",
         mixerSoundEffectsOutputTooltip: "通知音とサウンドエフェクトの出力先を選択",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
@@ -936,6 +936,7 @@ extension Strings {
         switcherCurrentSpaceOnly: "현재 데스크탑만 표시",
         switcherCurrentSpaceOnlyCaption: "지금 있는 데스크탑의 윈도우만 전환기에 표시합니다. 윈도우를 선택해도 다른 데스크탑으로 이동하지 않습니다.",
         shelfFileMissing: "파일이 더 이상 존재하지 않습니다",
+        shelfDropFailed: "드롭한 항목을 선반에 추가할 수 없습니다.",
         previewSizeSmall: "작게",
         mixerSoundEffectsOutputTitle: "시스템 사운드",
         mixerSoundEffectsOutputTooltip: "알림 및 사운드 효과를 재생할 출력 선택",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
@@ -936,6 +936,7 @@ extension Strings {
         switcherCurrentSpaceOnly: "Показывать только текущий рабочий стол",
         switcherCurrentSpaceOnlyCaption: "В переключателе видны только окна рабочего стола, на котором вы находитесь. Выбор окна никогда не переносит вас на другой рабочий стол.",
         shelfFileMissing: "Файл больше не существует",
+        shelfDropFailed: "Не удалось добавить перетащенный элемент на полку.",
         previewSizeSmall: "Маленький",
         mixerSoundEffectsOutputTitle: "Системные звуки",
         mixerSoundEffectsOutputTooltip: "Выбрать устройство для оповещений и звуковых эффектов",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
@@ -935,6 +935,7 @@ extension Strings {
         switcherCurrentSpaceOnly: "Mostrar solo el escritorio actual",
         switcherCurrentSpaceOnlyCaption: "Muestra en el selector solo las ventanas del escritorio en el que estás. Elegir una ventana nunca te lleva a otro escritorio.",
         shelfFileMissing: "El archivo ya no existe",
+        shelfDropFailed: "No se pudo añadir el elemento arrastrado al estante.",
         previewSizeSmall: "Pequeño",
         mixerSoundEffectsOutputTitle: "Sonidos del sistema",
         mixerSoundEffectsOutputTooltip: "Elegir dónde se reproducen los avisos y efectos de sonido",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
@@ -935,6 +935,7 @@ extension Strings {
         switcherCurrentSpaceOnly: "Yalnızca geçerli masaüstünü göster",
         switcherCurrentSpaceOnlyCaption: "Değiştiricide yalnızca bulunduğunuz masaüstündeki pencereler listelenir. Bir pencere seçmek sizi asla başka bir masaüstüne taşımaz.",
         shelfFileMissing: "Dosya artık yok",
+        shelfDropFailed: "Bırakılan öğe rafa eklenemedi.",
         previewSizeSmall: "Küçük",
         mixerSoundEffectsOutputTitle: "Sistem sesleri",
         mixerSoundEffectsOutputTooltip: "Uyarıların ve ses efektlerinin çalacağı çıkışı seç",

--- a/Sources/Vorssaint/Services/Shelf/ShelfPromiseFallbackCoordinator.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfPromiseFallbackCoordinator.swift
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+/// Coordinates direct pasteboard fallback content while AppKit fulfills a
+/// batch of file promises. A receiver's reader callback is per promised file,
+/// not per receiver, so completion must be counted against the file names
+/// reported after each receiver is activated.
+final class ShelfPromiseFallbackCoordinator<Value> {
+    struct CallbackOutcome {
+        let discardFallback: [Value]?
+        let fallback: [Value]?
+        let reportFailure: Bool
+    }
+
+    let items: [Value]
+    private let lock = NSLock()
+    private let receiverCount: Int
+    private var registeredReceiverCount = 0
+    private var expectedFileCount = 0
+    private var completedFileCount = 0
+    private var hasSuccess = false
+    private var hasFailure = false
+    private var fallbackConsumed = false
+    private var failureReported = false
+    private var registrationFinished = false
+
+    init(items: [Value], receiverCount: Int) {
+        self.items = items
+        self.receiverCount = receiverCount
+    }
+
+    func registerReceiver(expectedFileCount: Int) {
+        lock.lock()
+        registeredReceiverCount += 1
+        // Keep one defensive slot for an unusual receiver that does not
+        // publish names, so a failed receiver cannot leave the batch waiting
+        // forever. Normal receivers use their exact fileNames.count.
+        self.expectedFileCount += max(expectedFileCount, 1)
+        lock.unlock()
+    }
+
+    func finishRegistration() -> CallbackOutcome? {
+        lock.lock()
+        defer { lock.unlock() }
+        registrationFinished = true
+        return completedOutcomeIfReady()
+    }
+
+    func recordSuccess() -> CallbackOutcome {
+        lock.lock()
+        defer { lock.unlock() }
+        completedFileCount += 1
+        hasSuccess = true
+        let discardFallback = consumeFallbackIfNeeded()
+        return CallbackOutcome(discardFallback: discardFallback,
+                               fallback: nil,
+                               reportFailure: reportFailureIfReady())
+    }
+
+    func recordFailure() -> CallbackOutcome {
+        lock.lock()
+        defer { lock.unlock() }
+        completedFileCount += 1
+        hasFailure = true
+        guard let outcome = completedOutcomeIfReady() else {
+            return CallbackOutcome(discardFallback: nil,
+                                   fallback: nil,
+                                   reportFailure: false)
+        }
+        return outcome
+    }
+
+    private func consumeFallbackIfNeeded() -> [Value]? {
+        guard !fallbackConsumed else { return nil }
+        fallbackConsumed = true
+        return items.isEmpty ? nil : items
+    }
+
+    private func completedOutcomeIfReady() -> CallbackOutcome? {
+        guard registrationFinished,
+              registeredReceiverCount == receiverCount,
+              completedFileCount >= expectedFileCount else { return nil }
+        if hasSuccess {
+            return CallbackOutcome(discardFallback: nil,
+                                   fallback: nil,
+                                   reportFailure: reportFailureIfReady())
+        }
+        guard !fallbackConsumed else {
+            return CallbackOutcome(discardFallback: nil,
+                                   fallback: nil,
+                                   reportFailure: reportFailureIfReady())
+        }
+        fallbackConsumed = true
+        if items.isEmpty {
+            return CallbackOutcome(discardFallback: nil,
+                                   fallback: nil,
+                                   reportFailure: reportFailureIfReady())
+        }
+        return CallbackOutcome(discardFallback: nil,
+                               fallback: items,
+                               reportFailure: false)
+    }
+
+    private func reportFailureIfReady() -> Bool {
+        guard registrationFinished,
+              registeredReceiverCount == receiverCount,
+              completedFileCount >= expectedFileCount,
+              hasFailure,
+              !failureReported else { return false }
+        failureReported = true
+        return true
+    }
+}

--- a/Sources/Vorssaint/Services/Shelf/ShelfPromiseFallbackCoordinator.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfPromiseFallbackCoordinator.swift
@@ -100,7 +100,9 @@ final class ShelfPromiseFallbackCoordinator<Value> {
                                reportFailure: reportFailureIfReady())
     }
 
-    func recordFailure(for receiverID: Int) -> CallbackOutcome {
+    /// Records an AppKit error that terminated a receiver before it could
+    /// deliver its remaining promised files.
+    func recordReceiverFailure(for receiverID: Int) -> CallbackOutcome {
         lock.lock()
         defer { lock.unlock() }
         guard var receiver = receivers[receiverID], !receiver.isWholesaleFailure else {
@@ -122,6 +124,41 @@ final class ShelfPromiseFallbackCoordinator<Value> {
         receiver.completedFileCount = receiver.expectedFileCount
         receiver.isTerminal = true
         receiver.isWholesaleFailure = true
+        receivers[receiverID] = receiver
+        hasFailure = true
+        guard let outcome = completedOutcomeIfReady() else {
+            return CallbackOutcome(acceptFile: false,
+                                   discardFallback: nil,
+                                   fallback: nil,
+                                   reportFailure: false)
+        }
+        return CallbackOutcome(acceptFile: false,
+                               discardFallback: outcome.discardFallback,
+                               fallback: outcome.fallback,
+                               reportFailure: outcome.reportFailure)
+    }
+
+    /// Records one file that arrived from an otherwise healthy receiver but
+    /// could not be copied into the Shelf store. This must not terminate the
+    /// receiver: AppKit can still deliver its later attachments.
+    func recordFileFailure(for receiverID: Int) -> CallbackOutcome {
+        lock.lock()
+        defer { lock.unlock() }
+        guard var receiver = receivers[receiverID], !receiver.isWholesaleFailure else {
+            return CallbackOutcome(acceptFile: false,
+                                   discardFallback: nil,
+                                   fallback: nil,
+                                   reportFailure: false)
+        }
+        if receiver.isTerminal {
+            receiver.expectedFileCount = receiver.completedFileCount + 1
+            receiver.isTerminal = false
+        }
+        receiver.completedFileCount += 1
+        if receiver.isExpectedFileCountFinal,
+           receiver.completedFileCount >= receiver.expectedFileCount {
+            receiver.isTerminal = true
+        }
         receivers[receiverID] = receiver
         hasFailure = true
         guard let outcome = completedOutcomeIfReady() else {

--- a/Sources/Vorssaint/Services/Shelf/ShelfPromiseFallbackCoordinator.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfPromiseFallbackCoordinator.swift
@@ -69,16 +69,16 @@ final class ShelfPromiseFallbackCoordinator<Value> {
     func recordSuccess(for receiverID: Int) -> CallbackOutcome {
         lock.lock()
         defer { lock.unlock() }
-        guard var receiver = receivers[receiverID], !receiver.isWholesaleFailure else {
-            // A prior error closes a receiver wholesale. Do not let a late
-            // success create a promised tile after the direct fallback was
-            // selected, but still let the caller clean a regular file safely.
+        guard var receiver = receivers[receiverID] else {
             return CallbackOutcome(acceptFile: false,
                                    discardFallback: nil,
                                    fallback: nil,
                                    reportFailure: false)
         }
-        if receiver.isTerminal {
+        // A wholesale error may be reported before the receiver's later
+        // promised files materialize. Keep those files instead of deleting
+        // them, even if direct fallback has already been queued.
+        if !receiver.isWholesaleFailure, receiver.isTerminal {
             // `fileNames` is normally authoritative, but the defensive
             // minimum of one cannot cap a provider that omits its names and
             // then delivers more than one file. Treat the extra callback as
@@ -87,7 +87,8 @@ final class ShelfPromiseFallbackCoordinator<Value> {
             receiver.isTerminal = false
         }
         receiver.completedFileCount += 1
-        if receiver.isExpectedFileCountFinal,
+        if !receiver.isWholesaleFailure,
+           receiver.isExpectedFileCountFinal,
            receiver.completedFileCount >= receiver.expectedFileCount {
             receiver.isTerminal = true
         }

--- a/Sources/Vorssaint/Services/Shelf/ShelfPromiseFallbackCoordinator.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfPromiseFallbackCoordinator.swift
@@ -69,7 +69,7 @@ final class ShelfPromiseFallbackCoordinator<Value> {
     func recordSuccess(for receiverID: Int) -> CallbackOutcome {
         lock.lock()
         defer { lock.unlock() }
-        guard var receiver = receivers[receiverID], !receiver.isTerminal else {
+        guard var receiver = receivers[receiverID], !receiver.isWholesaleFailure else {
             // A prior error closes a receiver wholesale. Do not let a late
             // success create a promised tile after the direct fallback was
             // selected, but still let the caller clean a regular file safely.
@@ -77,6 +77,14 @@ final class ShelfPromiseFallbackCoordinator<Value> {
                                    discardFallback: nil,
                                    fallback: nil,
                                    reportFailure: false)
+        }
+        if receiver.isTerminal {
+            // `fileNames` is normally authoritative, but the defensive
+            // minimum of one cannot cap a provider that omits its names and
+            // then delivers more than one file. Treat the extra callback as
+            // evidence that the expected count needs to grow.
+            receiver.expectedFileCount = receiver.completedFileCount + 1
+            receiver.isTerminal = false
         }
         receiver.completedFileCount += 1
         if receiver.isExpectedFileCountFinal,
@@ -94,11 +102,18 @@ final class ShelfPromiseFallbackCoordinator<Value> {
     func recordFailure(for receiverID: Int) -> CallbackOutcome {
         lock.lock()
         defer { lock.unlock() }
-        guard var receiver = receivers[receiverID], !receiver.isTerminal else {
+        guard var receiver = receivers[receiverID], !receiver.isWholesaleFailure else {
             return CallbackOutcome(acceptFile: false,
                                    discardFallback: nil,
                                    fallback: nil,
                                    reportFailure: false)
+        }
+        if receiver.isTerminal {
+            // Apply the same overflow rule to a late failure. An omitted or
+            // stale file count must not turn a real failed file into silent
+            // loss merely because an earlier callback reached the floor.
+            receiver.expectedFileCount = receiver.completedFileCount + 1
+            receiver.isTerminal = false
         }
         // An error callback may be the receiver's wholesale failure rather
         // than one failed file. Close the receiver and credit every remaining

--- a/Sources/Vorssaint/Services/Shelf/ShelfPromiseFallbackCoordinator.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfPromiseFallbackCoordinator.swift
@@ -165,6 +165,10 @@ final class ShelfPromiseFallbackCoordinator<Value> {
                                    fallback: nil,
                                    reportFailure: reportFailureIfReady())
         }
+        // Direct fallback is the user-visible recovery for a completely
+        // failed promise batch. Mark that failure handled so a later file
+        // from the same receiver cannot re-arm the suppressed notification.
+        failureReported = true
         return CallbackOutcome(acceptFile: false,
                                discardFallback: nil,
                                fallback: items,

--- a/Sources/Vorssaint/Services/Shelf/ShelfPromiseFallbackCoordinator.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfPromiseFallbackCoordinator.swift
@@ -4,22 +4,30 @@
 import Foundation
 
 /// Coordinates direct pasteboard fallback content while AppKit fulfills a
-/// batch of file promises. A receiver's reader callback is per promised file,
-/// not per receiver, so completion must be counted against the file names
-/// reported after each receiver is activated.
+/// batch of file promises. A receiver can represent several files, and its
+/// reader callback is normally per file. A receiver error is also allowed to
+/// terminate the receiver wholesale, so the remaining advertised files are
+/// credited as failed instead of leaving the batch waiting forever.
 final class ShelfPromiseFallbackCoordinator<Value> {
     struct CallbackOutcome {
+        let acceptFile: Bool
         let discardFallback: [Value]?
         let fallback: [Value]?
         let reportFailure: Bool
     }
 
+    private struct ReceiverState {
+        var expectedFileCount: Int
+        var completedFileCount = 0
+        var isTerminal = false
+        var isWholesaleFailure = false
+        var isExpectedFileCountFinal: Bool
+    }
+
     let items: [Value]
     private let lock = NSLock()
     private let receiverCount: Int
-    private var registeredReceiverCount = 0
-    private var expectedFileCount = 0
-    private var completedFileCount = 0
+    private var receivers: [Int: ReceiverState] = [:]
     private var hasSuccess = false
     private var hasFailure = false
     private var fallbackConsumed = false
@@ -31,14 +39,24 @@ final class ShelfPromiseFallbackCoordinator<Value> {
         self.receiverCount = receiverCount
     }
 
-    func registerReceiver(expectedFileCount: Int) {
+    func registerReceiver(_ receiverID: Int,
+                          expectedFileCount: Int,
+                          isExpectedFileCountFinal: Bool = true) {
         lock.lock()
-        registeredReceiverCount += 1
-        // Keep one defensive slot for an unusual receiver that does not
-        // publish names, so a failed receiver cannot leave the batch waiting
-        // forever. Normal receivers use their exact fileNames.count.
-        self.expectedFileCount += max(expectedFileCount, 1)
+        receivers[receiverID] = ReceiverState(
+            expectedFileCount: max(expectedFileCount, 1),
+            isExpectedFileCountFinal: isExpectedFileCountFinal)
         lock.unlock()
+    }
+
+    func updateExpectedFileCount(for receiverID: Int, to expectedFileCount: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard var receiver = receivers[receiverID], !receiver.isWholesaleFailure else { return }
+        receiver.expectedFileCount = max(expectedFileCount, 1)
+        receiver.isExpectedFileCountFinal = true
+        receiver.isTerminal = receiver.completedFileCount >= receiver.expectedFileCount
+        receivers[receiverID] = receiver
     }
 
     func finishRegistration() -> CallbackOutcome? {
@@ -48,28 +66,58 @@ final class ShelfPromiseFallbackCoordinator<Value> {
         return completedOutcomeIfReady()
     }
 
-    func recordSuccess() -> CallbackOutcome {
+    func recordSuccess(for receiverID: Int) -> CallbackOutcome {
         lock.lock()
         defer { lock.unlock() }
-        completedFileCount += 1
+        guard var receiver = receivers[receiverID], !receiver.isTerminal else {
+            // A prior error closes a receiver wholesale. Do not let a late
+            // success create a promised tile after the direct fallback was
+            // selected, but still let the caller clean a regular file safely.
+            return CallbackOutcome(acceptFile: false,
+                                   discardFallback: nil,
+                                   fallback: nil,
+                                   reportFailure: false)
+        }
+        receiver.completedFileCount += 1
+        if receiver.isExpectedFileCountFinal,
+           receiver.completedFileCount >= receiver.expectedFileCount {
+            receiver.isTerminal = true
+        }
+        receivers[receiverID] = receiver
         hasSuccess = true
-        let discardFallback = consumeFallbackIfNeeded()
-        return CallbackOutcome(discardFallback: discardFallback,
+        return CallbackOutcome(acceptFile: true,
+                               discardFallback: consumeFallbackIfNeeded(),
                                fallback: nil,
                                reportFailure: reportFailureIfReady())
     }
 
-    func recordFailure() -> CallbackOutcome {
+    func recordFailure(for receiverID: Int) -> CallbackOutcome {
         lock.lock()
         defer { lock.unlock() }
-        completedFileCount += 1
-        hasFailure = true
-        guard let outcome = completedOutcomeIfReady() else {
-            return CallbackOutcome(discardFallback: nil,
+        guard var receiver = receivers[receiverID], !receiver.isTerminal else {
+            return CallbackOutcome(acceptFile: false,
+                                   discardFallback: nil,
                                    fallback: nil,
                                    reportFailure: false)
         }
-        return outcome
+        // An error callback may be the receiver's wholesale failure rather
+        // than one failed file. Close the receiver and credit every remaining
+        // advertised file so the fallback cannot wait forever.
+        receiver.completedFileCount = receiver.expectedFileCount
+        receiver.isTerminal = true
+        receiver.isWholesaleFailure = true
+        receivers[receiverID] = receiver
+        hasFailure = true
+        guard let outcome = completedOutcomeIfReady() else {
+            return CallbackOutcome(acceptFile: false,
+                                   discardFallback: nil,
+                                   fallback: nil,
+                                   reportFailure: false)
+        }
+        return CallbackOutcome(acceptFile: false,
+                               discardFallback: outcome.discardFallback,
+                               fallback: outcome.fallback,
+                               reportFailure: outcome.reportFailure)
     }
 
     private func consumeFallbackIfNeeded() -> [Value]? {
@@ -80,33 +128,37 @@ final class ShelfPromiseFallbackCoordinator<Value> {
 
     private func completedOutcomeIfReady() -> CallbackOutcome? {
         guard registrationFinished,
-              registeredReceiverCount == receiverCount,
-              completedFileCount >= expectedFileCount else { return nil }
+              receivers.count == receiverCount,
+              receivers.values.allSatisfy(\.isTerminal) else { return nil }
         if hasSuccess {
-            return CallbackOutcome(discardFallback: nil,
+            return CallbackOutcome(acceptFile: false,
+                                   discardFallback: nil,
                                    fallback: nil,
                                    reportFailure: reportFailureIfReady())
         }
         guard !fallbackConsumed else {
-            return CallbackOutcome(discardFallback: nil,
+            return CallbackOutcome(acceptFile: false,
+                                   discardFallback: nil,
                                    fallback: nil,
                                    reportFailure: reportFailureIfReady())
         }
         fallbackConsumed = true
         if items.isEmpty {
-            return CallbackOutcome(discardFallback: nil,
+            return CallbackOutcome(acceptFile: false,
+                                   discardFallback: nil,
                                    fallback: nil,
                                    reportFailure: reportFailureIfReady())
         }
-        return CallbackOutcome(discardFallback: nil,
+        return CallbackOutcome(acceptFile: false,
+                               discardFallback: nil,
                                fallback: items,
                                reportFailure: false)
     }
 
     private func reportFailureIfReady() -> Bool {
         guard registrationFinished,
-              registeredReceiverCount == receiverCount,
-              completedFileCount >= expectedFileCount,
+              receivers.count == receiverCount,
+              receivers.values.allSatisfy(\.isTerminal),
               hasFailure,
               !failureReported else { return false }
         failureReported = true

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -103,6 +103,27 @@ final class ShelfService: ObservableObject {
         }
     }
 
+    /// Direct representations are held until a promise either succeeds or
+    /// fails. A lock makes the one-shot fallback safe when multiple promise
+    /// receivers complete on the operation queue at the same time.
+    private final class PromiseFallbackState {
+        let items: [Item]
+        private let lock = NSLock()
+        private var consumed = false
+
+        init(items: [Item]) {
+            self.items = items
+        }
+
+        func take() -> [Item]? {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !consumed else { return nil }
+            consumed = true
+            return items
+        }
+    }
+
     @Published private(set) var items: [Item] = [] {
         didSet {
             contentRevision &+= 1
@@ -1127,7 +1148,7 @@ final class ShelfService: ObservableObject {
                 guard let self else {
                     return DispatchQueue.main.async { completion(nil) }
                 }
-                guard error == nil, let url, self.isReadableFile(url),
+                guard error == nil, let url, self.isUsablePromiseFile(url),
                       let storedURL = self.storePromisedFile(url) else {
                     // Some providers register the promise UTI alongside a
                     // usable image, URL, or text representation. A failed or
@@ -1189,13 +1210,26 @@ final class ShelfService: ObservableObject {
         }
     }
 
-    private func isReadableFile(_ url: URL) -> Bool {
+    private func isUsablePromiseFile(_ url: URL) -> Bool {
         guard url.isFileURL,
               FileManager.default.fileExists(atPath: url.path),
               FileManager.default.isReadableFile(atPath: url.path),
               let values = try? url.resourceValues(forKeys: [.isRegularFileKey]),
               values.isRegularFile == true else { return false }
-        return true
+
+        // A provider can expose the promise UTI through this item-provider
+        // path. Foundation then writes that short identifier into a regular
+        // temporary file, which passes filesystem checks but is not the
+        // promised content. Reject that placeholder so direct loaders below
+        // get a chance to handle the same provider.
+        guard url.pathExtension.isEmpty,
+              let data = try? Data(contentsOf: url, options: .mappedIfSafe),
+              data.count <= 256,
+              let identifier = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              !identifier.isEmpty,
+              UTType(identifier) != nil else { return true }
+        return false
     }
 
     func removeItem(_ id: UUID) {
@@ -1475,7 +1509,9 @@ final class ShelfService: ObservableObject {
         }
         let promises = filePromises(from: pasteboard)
         if !promises.isEmpty {
-            return receivePromisedFiles(promises, mergingInto: targetID)
+            return receivePromisedFiles(promises,
+                                        mergingInto: targetID,
+                                        fallbackItems: items(from: pasteboard))
         }
         let additions = items(from: pasteboard)
         guard !additions.isEmpty else { return false }
@@ -1505,7 +1541,10 @@ final class ShelfService: ObservableObject {
             // Promise-backed drops may also advertise auxiliary text or URL
             // flavors, such as Outlook's subject. The promised file is the
             // authoritative Shelf item, so do not add those flavors twice.
-            return receivePromisedFiles(promises)
+            // Direct representations are kept only as a failure fallback,
+            // which preserves Chromium image drags without duplicating
+            // Outlook's promised message or attachment.
+            return receivePromisedFiles(promises, fallbackItems: items(from: pasteboard))
         }
         let fileURLs = fileURLs(from: pasteboard)
         if fileURLs.count > 1 {
@@ -1665,8 +1704,10 @@ final class ShelfService: ObservableObject {
     /// completion handler returns, so it is copied into the Shelf store before
     /// the item is built on the main thread.
     private func receivePromisedFiles(_ promises: [NSFilePromiseReceiver],
-                                      mergingInto targetID: UUID? = nil) -> Bool {
+                                      mergingInto targetID: UUID? = nil,
+                                      fallbackItems: [Item] = []) -> Bool {
         guard !promises.isEmpty else { return false }
+        let fallbackState = fallbackItems.isEmpty ? nil : PromiseFallbackState(items: fallbackItems)
         var scheduled = false
         for promise in promises {
             // A receiver can represent more than one file, so keep its
@@ -1679,7 +1720,9 @@ final class ShelfService: ObservableObject {
                 at: destination,
                 withIntermediateDirectories: true,
                 attributes: [.posixPermissions: 0o700])) != nil else {
-                reportPromiseFailure()
+                if !fallbackPromisedItems(fallbackState, mergingInto: targetID) {
+                    reportPromiseFailure()
+                }
                 continue
             }
             scheduled = true
@@ -1689,18 +1732,24 @@ final class ShelfService: ObservableObject {
                 guard let self else { return }
                 guard error == nil else {
                     try? FileManager.default.removeItem(at: url)
-                    self.reportPromiseFailure()
+                    if !self.fallbackPromisedItems(fallbackState, mergingInto: targetID) {
+                        self.reportPromiseFailure()
+                    }
                     return
                 }
                 guard let storedURL = self.storePromisedFile(url) else {
                     try? FileManager.default.removeItem(at: url)
-                    self.reportPromiseFailure()
+                    if !self.fallbackPromisedItems(fallbackState, mergingInto: targetID) {
+                        self.reportPromiseFailure()
+                    }
                     return
                 }
                 let title = url.lastPathComponent
                 try? FileManager.default.removeItem(at: url)
+                let fallback = fallbackState?.take()
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }
+                    if let fallback { self.discardOwnedPayloads(in: fallback) }
                     let item = self.fileItem(for: storedURL, title: title)
                     if let targetID {
                         if self.merge([item], into: targetID) {
@@ -1728,6 +1777,35 @@ final class ShelfService: ObservableObject {
             }
         }
         return scheduled
+    }
+
+    /// Uses direct representations only after promise fulfillment fails. A
+    /// Chromium image can advertise a promise flavor while still carrying a
+    /// usable image, whereas Outlook's subject flavor must not create a
+    /// duplicate tile while its promised file is still pending.
+    @discardableResult
+    private func fallbackPromisedItems(_ state: PromiseFallbackState?,
+                                       mergingInto targetID: UUID?) -> Bool {
+        guard let state, let fallbackItems = state.take() else { return false }
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if let targetID, self.merge(fallbackItems, into: targetID) {
+                self.startContentThumbnails(for: fallbackItems)
+                self.lastAddedID = self.dragItems(for: fallbackItems).last?.id
+                self.addSerial &+= 1
+                self.noteInteraction()
+                return
+            }
+
+            let fallback = fallbackItems.count == 1
+                ? fallbackItems[0]
+                : self.batchItem(children: fallbackItems)
+            guard self.append(fallback) else {
+                self.reportPromiseFailure()
+                return
+            }
+        }
+        return true
     }
 
     /// Promise materialization is asynchronous, so a drop cannot return a

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -103,24 +103,46 @@ final class ShelfService: ObservableObject {
         }
     }
 
-    /// Direct representations are held until a promise either succeeds or
-    /// fails. A lock makes the one-shot fallback safe when multiple promise
-    /// receivers complete on the operation queue at the same time.
+    /// Direct representations are held until every promise receiver has
+    /// reported. A successful receiver suppresses the fallback, so one failed
+    /// attachment cannot add a stray subject while another attachment lands.
     private final class PromiseFallbackState {
-        let items: [Item]
-        private let lock = NSLock()
-        private var consumed = false
-
-        init(items: [Item]) {
-            self.items = items
+        enum FailureAction {
+            case wait
+            case fallback([Item])
+            case report
         }
 
-        func take() -> [Item]? {
+        let items: [Item]
+        private let lock = NSLock()
+        private let receiverCount: Int
+        private var resolvedReceivers = Set<Int>()
+        private var hasSuccess = false
+        private var fallbackConsumed = false
+
+        init(items: [Item], receiverCount: Int) {
+            self.items = items
+            self.receiverCount = receiverCount
+        }
+
+        func recordSuccess(for receiverID: Int) -> [Item]? {
             lock.lock()
             defer { lock.unlock() }
-            guard !consumed else { return nil }
-            consumed = true
-            return items
+            guard resolvedReceivers.insert(receiverID).inserted else { return nil }
+            hasSuccess = true
+            guard !fallbackConsumed else { return nil }
+            fallbackConsumed = true
+            return items.isEmpty ? nil : items
+        }
+
+        func recordFailure(for receiverID: Int) -> FailureAction {
+            lock.lock()
+            defer { lock.unlock() }
+            guard resolvedReceivers.insert(receiverID).inserted else { return .wait }
+            guard resolvedReceivers.count == receiverCount else { return .wait }
+            guard !hasSuccess, !fallbackConsumed else { return .report }
+            fallbackConsumed = true
+            return items.isEmpty ? .report : .fallback(items)
         }
     }
 
@@ -1706,11 +1728,12 @@ final class ShelfService: ObservableObject {
     /// the item is built on the main thread.
     private func receivePromisedFiles(_ promises: [NSFilePromiseReceiver],
                                       mergingInto targetID: UUID? = nil,
-                                      fallbackItems: [Item] = []) -> Bool {
+        fallbackItems: [Item] = []) -> Bool {
         guard !promises.isEmpty else { return false }
-        let fallbackState = fallbackItems.isEmpty ? nil : PromiseFallbackState(items: fallbackItems)
+        let fallbackState = PromiseFallbackState(items: fallbackItems,
+                                                 receiverCount: promises.count)
         var scheduled = false
-        for promise in promises {
+        for (receiverID, promise) in promises.enumerated() {
             // A receiver can represent more than one file, so keep its
             // staging directory alive until the existing temp-file sweep.
             // Removing it from the first callback could delete a later file
@@ -1721,7 +1744,12 @@ final class ShelfService: ObservableObject {
                 at: destination,
                 withIntermediateDirectories: true,
                 attributes: [.posixPermissions: 0o700])) != nil else {
-                if !fallbackPromisedItems(fallbackState, mergingInto: targetID) {
+                switch fallbackState.recordFailure(for: receiverID) {
+                case .wait:
+                    continue
+                case let .fallback(items):
+                    fallbackPromisedItems(items, mergingInto: targetID)
+                case .report:
                     reportPromiseFailure()
                 }
                 continue
@@ -1733,21 +1761,31 @@ final class ShelfService: ObservableObject {
                 guard let self else { return }
                 guard error == nil else {
                     try? FileManager.default.removeItem(at: url)
-                    if !self.fallbackPromisedItems(fallbackState, mergingInto: targetID) {
+                    switch fallbackState.recordFailure(for: receiverID) {
+                    case .wait:
+                        return
+                    case let .fallback(items):
+                        self.fallbackPromisedItems(items, mergingInto: targetID)
+                    case .report:
                         self.reportPromiseFailure()
                     }
                     return
                 }
                 guard let storedURL = self.storePromisedFile(url) else {
                     try? FileManager.default.removeItem(at: url)
-                    if !self.fallbackPromisedItems(fallbackState, mergingInto: targetID) {
+                    switch fallbackState.recordFailure(for: receiverID) {
+                    case .wait:
+                        return
+                    case let .fallback(items):
+                        self.fallbackPromisedItems(items, mergingInto: targetID)
+                    case .report:
                         self.reportPromiseFailure()
                     }
                     return
                 }
                 let title = url.lastPathComponent
                 try? FileManager.default.removeItem(at: url)
-                let fallback = fallbackState?.take()
+                let fallback = fallbackState.recordSuccess(for: receiverID)
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }
                     if let fallback { self.discardOwnedPayloads(in: fallback) }
@@ -1785,9 +1823,8 @@ final class ShelfService: ObservableObject {
     /// usable image, whereas Outlook's subject flavor must not create a
     /// duplicate tile while its promised file is still pending.
     @discardableResult
-    private func fallbackPromisedItems(_ state: PromiseFallbackState?,
+    private func fallbackPromisedItems(_ fallbackItems: [Item],
                                        mergingInto targetID: UUID?) -> Bool {
-        guard let state, let fallbackItems = state.take() else { return false }
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             if let targetID, self.merge(fallbackItems, into: targetID) {

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -241,6 +241,15 @@ final class ShelfService: ObservableObject {
     private static let persistQueue = DispatchQueue(label: "com.vorssaint.utils.shelf-persist",
                                                     qos: .utility)
 
+    /// File promises may need to wait for Outlook to download or materialize
+    /// an attachment, so their callbacks must never occupy the main queue.
+    private let promiseOperationQueue: OperationQueue = {
+        let queue = OperationQueue()
+        queue.name = "com.vorssaint.utils.shelf-file-promises"
+        queue.qualityOfService = .utility
+        return queue
+    }()
+
     private var persistScheduled = false
     /// Gates persistence until the restore has landed, so an early mutation
     /// cannot overwrite the saved shelf with a partial list.
@@ -275,6 +284,21 @@ final class ShelfService: ObservableObject {
         }
     }
 
+    /// Outlook and Mail expose dragged messages and attachments as file
+    /// promises. The dynamic type is supplied by AppKit, so use the system's
+    /// readable list instead of hardcoding an Outlook-specific identifier.
+    private static let filePromiseTypeIdentifiers = Set(NSFilePromiseReceiver.readableDraggedTypes)
+    private static let filePromiseMetadataTypeIdentifier = "com.apple.NSFilePromiseItemMetaData"
+    private static let filePromiseDropTypes = NSFilePromiseReceiver.readableDraggedTypes
+        .map { NSPasteboard.PasteboardType($0) }
+
+    /// The SwiftUI drop surfaces need the same identifiers as their AppKit
+    /// counterparts. `UTType(importedAs:)` preserves custom pasteboard types
+    /// that do not have a public declaration in UniformTypeIdentifiers.
+    static let swiftUIDropTypes: [UTType] = [
+        .fileURL, .image, .url, .text, .plainText
+    ] + NSFilePromiseReceiver.readableDraggedTypes.map { UTType(importedAs: $0) }
+
     static let tileDropTypes: [NSPasteboard.PasteboardType] = [
         .fileURL,
         .URL,
@@ -289,7 +313,7 @@ final class ShelfService: ObservableObject {
         NSPasteboard.PasteboardType(UTType.url.identifier),
         NSPasteboard.PasteboardType(UTType.text.identifier),
         NSPasteboard.PasteboardType(UTType.plainText.identifier),
-    ]
+    ] + filePromiseDropTypes
 
     // MARK: - Lifecycle
 
@@ -540,6 +564,7 @@ final class ShelfService: ObservableObject {
         for item in items {
             for type in item.types {
                 if directTypes.contains(type.rawValue) { return true }
+                if Self.filePromiseTypeIdentifiers.contains(type.rawValue) { return true }
                 guard let utType = UTType(type.rawValue) else { continue }
                 if supportedUTTypes.contains(where: { utType.conforms(to: $0) }) { return true }
             }
@@ -1032,11 +1057,19 @@ final class ShelfService: ObservableObject {
     /// Kept in sync with `resolveItem`'s own branches by hand, since a
     /// provider load is async and cannot itself be probed synchronously.
     private func canResolveItem(from provider: NSItemProvider) -> Bool {
-        provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
+        promisedFileTypeIdentifier(for: provider) != nil
+            || provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
             || provider.hasItemConformingToTypeIdentifier(UTType.gif.identifier)
             || provider.canLoadObject(ofClass: NSImage.self)
             || provider.canLoadObject(ofClass: URL.self)
             || provider.canLoadObject(ofClass: NSString.self)
+    }
+
+    private func promisedFileTypeIdentifier(for provider: NSItemProvider) -> String? {
+        provider.registeredTypeIdentifiers.first {
+            Self.filePromiseTypeIdentifiers.contains($0)
+                && $0 != Self.filePromiseMetadataTypeIdentifier
+        }
     }
 
     /// Resolves every provider in a drop and adds them together: one pile
@@ -1069,7 +1102,18 @@ final class ShelfService: ObservableObject {
     /// image, then a URL (file or link), then text. Always calls back
     /// exactly once, on the main queue, so callers can mutate state from it.
     private func resolveItem(from provider: NSItemProvider, completion: @escaping (Item?) -> Void) {
-        if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+        if let promiseType = promisedFileTypeIdentifier(for: provider) {
+            _ = provider.loadFileRepresentation(forTypeIdentifier: promiseType) { [weak self] url, error in
+                guard error == nil, let self, let url,
+                      let storedURL = self.storePromisedFile(url) else {
+                    return DispatchQueue.main.async { completion(nil) }
+                }
+                let title = url.lastPathComponent
+                DispatchQueue.main.async {
+                    completion(self.fileItem(for: storedURL, title: title))
+                }
+            }
+        } else if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
             _ = provider.loadObject(ofClass: URL.self) { [weak self] url, _ in
                 DispatchQueue.main.async {
                     guard let url, url.isFileURL else { return completion(nil) }
@@ -1384,6 +1428,10 @@ final class ShelfService: ObservableObject {
         if !activeInternalDragIDs.isEmpty {
             return mergeInternalDrag(into: targetID)
         }
+        let promises = filePromises(from: pasteboard)
+        if !promises.isEmpty {
+            return receivePromisedFiles(promises, mergingInto: targetID)
+        }
         let additions = items(from: pasteboard)
         guard !additions.isEmpty else { return false }
         guard merge(additions, into: targetID) else {
@@ -1407,6 +1455,18 @@ final class ShelfService: ObservableObject {
     }
 
     func accept(pasteboard: NSPasteboard) -> Bool {
+        let promises = filePromises(from: pasteboard)
+        if !promises.isEmpty {
+            let directItems = items(from: pasteboard)
+            var accepted = false
+            if !directItems.isEmpty {
+                accepted = append(directItems)
+            }
+            if itemCount < ShelfPersistenceSupport.maxLeaves {
+                accepted = receivePromisedFiles(promises) || accepted
+            }
+            return accepted
+        }
         let fileURLs = fileURLs(from: pasteboard)
         if fileURLs.count > 1 {
             return addFileBatch(fileURLs)
@@ -1559,6 +1619,82 @@ final class ShelfService: ObservableObject {
         return Item(payload: .file(url), title: "GIF", icon: icon, isImage: true, hasContentThumbnail: true)
     }
 
+    /// Fulfills Outlook's file promise without blocking the drop callback.
+    /// Outlook may need to download an attachment or serialize an email first,
+    /// and the resulting temporary URL is only valid until the provider's
+    /// completion handler returns, so it is copied into the Shelf store before
+    /// the item is built on the main thread.
+    private func receivePromisedFiles(_ promises: [NSFilePromiseReceiver],
+                                      mergingInto targetID: UUID? = nil) -> Bool {
+        guard !promises.isEmpty else { return false }
+        let destination = tempDir.appendingPathComponent("Promise-\(UUID().uuidString)",
+                                                         isDirectory: true)
+        guard (try? FileManager.default.createDirectory(
+            at: destination,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])) != nil else {
+            return false
+        }
+
+        for promise in promises {
+            promise.receivePromisedFiles(atDestination: destination,
+                                         options: [:],
+                                         operationQueue: promiseOperationQueue) { [weak self] url, error in
+                guard error == nil, let self,
+                      let storedURL = self.storePromisedFile(url) else { return }
+                let title = url.lastPathComponent
+                if storedURL != url { try? FileManager.default.removeItem(at: url) }
+                try? FileManager.default.removeItem(at: destination)
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    let item = self.fileItem(for: storedURL, title: title)
+                    if let targetID {
+                        guard self.merge([item], into: targetID) else {
+                            self.discardOwnedPayloads(in: [item])
+                            return
+                        }
+                        self.startContentThumbnails(for: [item])
+                        self.lastAddedID = item.id
+                        self.addSerial &+= 1
+                        self.noteInteraction()
+                    } else {
+                        _ = self.append(item)
+                    }
+                }
+            }
+        }
+        return true
+    }
+
+    /// Copies one promised file into the same owner-only persistent store as
+    /// pasted images and GIFs. The original filename remains the tile title,
+    /// while a generated destination avoids collisions between repeated
+    /// Outlook drags with the same attachment name.
+    private func storePromisedFile(_ source: URL) -> URL? {
+        guard source.isFileURL else { return nil }
+        let directory: URL
+        if let store = Self.storeDirectory,
+           PrivateFileStore.createDirectory(at: store) {
+            directory = store
+        } else {
+            directory = tempDir
+            guard PrivateFileStore.createDirectory(at: directory) else { return nil }
+        }
+        var destination = directory.appendingPathComponent(UUID().uuidString)
+        if !source.pathExtension.isEmpty {
+            destination.appendPathExtension(source.pathExtension)
+        }
+        do {
+            try FileManager.default.copyItem(at: source, to: destination)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600],
+                                                  ofItemAtPath: destination.path)
+            return destination
+        } catch {
+            try? FileManager.default.removeItem(at: destination)
+            return nil
+        }
+    }
+
     /// Writes a pasted payload where it can outlive this run; only if the
     /// Application Support store is unavailable does it fall back to the temp
     /// dir (the item then works for this session, as it always did).
@@ -1657,6 +1793,16 @@ final class ShelfService: ObservableObject {
         return []
     }
 
+    private func filePromises(from pasteboard: NSPasteboard) -> [NSFilePromiseReceiver] {
+        (pasteboard.readObjects(forClasses: [NSFilePromiseReceiver.self], options: nil) as? [NSFilePromiseReceiver]) ?? []
+    }
+
+    private func pasteboardHasFilePromises(_ pasteboard: NSPasteboard) -> Bool {
+        (pasteboard.types ?? []).contains { type in
+            Self.filePromiseTypeIdentifiers.contains(type.rawValue)
+        }
+    }
+
     private func fileURLs(from pasteboard: NSPasteboard) -> [URL] {
         let fileOptions: [NSPasteboard.ReadingOptionKey: Any] = [.urlReadingFileURLsOnly: true]
         if let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: fileOptions) as? [NSURL],
@@ -1671,6 +1817,9 @@ final class ShelfService: ObservableObject {
     }
 
     private func pasteboardCanCreateItem(_ pasteboard: NSPasteboard) -> Bool {
+        if pasteboardHasFilePromises(pasteboard) {
+            return !filePromises(from: pasteboard).isEmpty
+        }
         if !fileURLs(from: pasteboard).isEmpty {
             return true
         }

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -303,7 +303,7 @@ final class ShelfService: ObservableObject {
     /// that do not have a public declaration in UniformTypeIdentifiers.
     static let swiftUIDropTypes: [UTType] = [
         .fileURL, .image, .url, .text, .plainText
-    ] + NSFilePromiseReceiver.readableDraggedTypes.map { UTType(importedAs: $0) }
+    ] + [UTType(importedAs: filePromiseContentTypeIdentifier)]
 
     static let tileDropTypes: [NSPasteboard.PasteboardType] = [
         .fileURL,

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -548,6 +548,7 @@ final class ShelfService: ObservableObject {
 
     private func pasteboardHasDroppableContent(_ pasteboard: NSPasteboard) -> Bool {
         guard let items = pasteboard.pasteboardItems, !items.isEmpty else { return false }
+        let hasReadablePromises = pasteboardHasReadableFilePromises(pasteboard)
         let directTypes: Set<String> = [
             NSPasteboard.PasteboardType.fileURL.rawValue,
             NSPasteboard.PasteboardType.string.rawValue,
@@ -567,7 +568,9 @@ final class ShelfService: ObservableObject {
         for item in items {
             for type in item.types {
                 if directTypes.contains(type.rawValue) { return true }
-                if Self.filePromiseTypeIdentifiers.contains(type.rawValue) { return true }
+                if Self.filePromiseTypeIdentifiers.contains(type.rawValue), hasReadablePromises {
+                    return true
+                }
                 guard let utType = UTType(type.rawValue) else { continue }
                 if supportedUTTypes.contains(where: { utType.conforms(to: $0) }) { return true }
             }
@@ -1110,9 +1113,10 @@ final class ShelfService: ObservableObject {
     }
 
     /// Turns one dropped provider into an item, preferring richer
-    /// representations first: a file on disk, then GIF data, then a plain
-    /// image, then a URL (file or link), then text. Always calls back
-    /// exactly once, on the main queue, so callers can mutate state from it.
+    /// representations first: a promised file when it produces a readable
+    /// file, then a file on disk, GIF data, a plain image, a URL (file or
+    /// link), and finally text. Always calls back exactly once, on the main
+    /// queue, so callers can mutate state from it.
     private func resolveItem(from provider: NSItemProvider, completion: @escaping (Item?) -> Void) {
         if let promiseType = promisedFileTypeIdentifier(for: provider) {
             // SwiftUI exposes item-based file promises as NSItemProvider file
@@ -1123,17 +1127,29 @@ final class ShelfService: ObservableObject {
                 guard let self else {
                     return DispatchQueue.main.async { completion(nil) }
                 }
-                guard error == nil, let url,
+                guard error == nil, let url, self.isReadableFile(url),
                       let storedURL = self.storePromisedFile(url) else {
-                    self.reportPromiseFailure()
-                    return DispatchQueue.main.async { completion(nil) }
+                    // Some providers register the promise UTI alongside a
+                    // usable image, URL, or text representation. A failed or
+                    // non-file promise must not hide that working fallback.
+                    return self.resolveStandardItem(from: provider) { item in
+                        if item == nil { self.reportPromiseFailure() }
+                        completion(item)
+                    }
                 }
                 let title = provider.suggestedName ?? url.lastPathComponent
                 DispatchQueue.main.async {
                     completion(self.fileItem(for: storedURL, title: title))
                 }
             }
-        } else if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+            return
+        }
+        resolveStandardItem(from: provider, completion: completion)
+    }
+
+    private func resolveStandardItem(from provider: NSItemProvider,
+                                     completion: @escaping (Item?) -> Void) {
+        if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
             _ = provider.loadObject(ofClass: URL.self) { [weak self] url, _ in
                 DispatchQueue.main.async {
                     guard let url, url.isFileURL else { return completion(nil) }
@@ -1171,6 +1187,15 @@ final class ShelfService: ObservableObject {
         } else {
             DispatchQueue.main.async { completion(nil) }
         }
+    }
+
+    private func isReadableFile(_ url: URL) -> Bool {
+        guard url.isFileURL,
+              FileManager.default.fileExists(atPath: url.path),
+              FileManager.default.isReadableFile(atPath: url.path),
+              let values = try? url.resourceValues(forKeys: [.isRegularFileKey]),
+              values.isRegularFile == true else { return false }
+        return true
     }
 
     func removeItem(_ id: UUID) {
@@ -1678,15 +1703,21 @@ final class ShelfService: ObservableObject {
                     guard let self else { return }
                     let item = self.fileItem(for: storedURL, title: title)
                     if let targetID {
-                        guard self.merge([item], into: targetID) else {
-                            self.discardOwnedPayloads(in: [item])
-                            self.reportPromiseFailure()
-                            return
+                        if self.merge([item], into: targetID) {
+                            self.startContentThumbnails(for: [item])
+                            self.lastAddedID = item.id
+                            self.addSerial &+= 1
+                            self.noteInteraction()
+                        } else {
+                            // The user may remove the pile while Outlook is
+                            // still fulfilling the promise. Keep the file at
+                            // top level instead of discarding a successful
+                            // materialization just because its target vanished.
+                            guard self.append(item) else {
+                                self.reportPromiseFailure()
+                                return
+                            }
                         }
-                        self.startContentThumbnails(for: [item])
-                        self.lastAddedID = item.id
-                        self.addSerial &+= 1
-                        self.noteInteraction()
                     } else {
                         guard self.append(item) else {
                             self.reportPromiseFailure()
@@ -1852,6 +1883,10 @@ final class ShelfService: ObservableObject {
         }
     }
 
+    private func pasteboardHasReadableFilePromises(_ pasteboard: NSPasteboard) -> Bool {
+        pasteboardHasFilePromises(pasteboard) && !filePromises(from: pasteboard).isEmpty
+    }
+
     private func fileURLs(from pasteboard: NSPasteboard) -> [URL] {
         let fileOptions: [NSPasteboard.ReadingOptionKey: Any] = [.urlReadingFileURLsOnly: true]
         if let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: fileOptions) as? [NSURL],
@@ -1866,10 +1901,7 @@ final class ShelfService: ObservableObject {
     }
 
     private func pasteboardCanCreateItem(_ pasteboard: NSPasteboard) -> Bool {
-        if pasteboardHasFilePromises(pasteboard),
-           !filePromises(from: pasteboard).isEmpty {
-            return true
-        }
+        if pasteboardHasReadableFilePromises(pasteboard) { return true }
         if !fileURLs(from: pasteboard).isEmpty {
             return true
         }

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -569,7 +569,6 @@ final class ShelfService: ObservableObject {
 
     private func pasteboardHasDroppableContent(_ pasteboard: NSPasteboard) -> Bool {
         guard let items = pasteboard.pasteboardItems, !items.isEmpty else { return false }
-        let hasReadablePromises = pasteboardHasReadableFilePromises(pasteboard)
         let directTypes: Set<String> = [
             NSPasteboard.PasteboardType.fileURL.rawValue,
             NSPasteboard.PasteboardType.string.rawValue,
@@ -585,18 +584,20 @@ final class ShelfService: ObservableObject {
             "NSURLPboardType"
         ]
         let supportedUTTypes: [UTType] = [.fileURL, .gif, .image, .url, .text, .plainText]
+        var hasPromiseType = false
 
         for item in items {
             for type in item.types {
                 if directTypes.contains(type.rawValue) { return true }
-                if Self.filePromiseTypeIdentifiers.contains(type.rawValue), hasReadablePromises {
-                    return true
+                if Self.filePromiseTypeIdentifiers.contains(type.rawValue) {
+                    hasPromiseType = true
+                    continue
                 }
                 guard let utType = UTType(type.rawValue) else { continue }
                 if supportedUTTypes.contains(where: { utType.conforms(to: $0) }) { return true }
             }
         }
-        return false
+        return hasPromiseType && pasteboardHasReadableFilePromises(pasteboard)
     }
 
     private func eventBelongsToDock(_ event: NSEvent) -> Bool {

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -293,7 +293,8 @@ final class ShelfService: ObservableObject {
     /// promises. The dynamic type is supplied by AppKit, so use the system's
     /// readable list instead of hardcoding an Outlook-specific identifier.
     private static let filePromiseTypeIdentifiers = Set(NSFilePromiseReceiver.readableDraggedTypes)
-    private static let filePromiseMetadataTypeIdentifier = "com.apple.NSFilePromiseItemMetaData"
+    private static let filePromiseContentTypeIdentifier =
+        "com.apple.pasteboard.promised-file-content-type"
     private static let filePromiseDropTypes = NSFilePromiseReceiver.readableDraggedTypes
         .map { NSPasteboard.PasteboardType($0) }
 
@@ -1080,10 +1081,9 @@ final class ShelfService: ObservableObject {
     }
 
     private func promisedFileTypeIdentifier(for provider: NSItemProvider) -> String? {
-        provider.registeredTypeIdentifiers.first {
-            Self.filePromiseTypeIdentifiers.contains($0)
-                && $0 != Self.filePromiseMetadataTypeIdentifier
-        }
+        guard provider.registeredTypeIdentifiers.contains(Self.filePromiseContentTypeIdentifier)
+        else { return nil }
+        return Self.filePromiseContentTypeIdentifier
     }
 
     /// Resolves every provider in a drop and adds them together: one pile

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -103,48 +103,7 @@ final class ShelfService: ObservableObject {
         }
     }
 
-    /// Direct representations are held until every promise receiver has
-    /// reported. A successful receiver suppresses the fallback, so one failed
-    /// attachment cannot add a stray subject while another attachment lands.
-    private final class PromiseFallbackState {
-        enum FailureAction {
-            case wait
-            case fallback([Item])
-            case report
-        }
-
-        let items: [Item]
-        private let lock = NSLock()
-        private let receiverCount: Int
-        private var resolvedReceivers = Set<Int>()
-        private var hasSuccess = false
-        private var fallbackConsumed = false
-
-        init(items: [Item], receiverCount: Int) {
-            self.items = items
-            self.receiverCount = receiverCount
-        }
-
-        func recordSuccess(for receiverID: Int) -> [Item]? {
-            lock.lock()
-            defer { lock.unlock() }
-            guard resolvedReceivers.insert(receiverID).inserted else { return nil }
-            hasSuccess = true
-            guard !fallbackConsumed else { return nil }
-            fallbackConsumed = true
-            return items.isEmpty ? nil : items
-        }
-
-        func recordFailure(for receiverID: Int) -> FailureAction {
-            lock.lock()
-            defer { lock.unlock() }
-            guard resolvedReceivers.insert(receiverID).inserted else { return .wait }
-            guard resolvedReceivers.count == receiverCount else { return .wait }
-            guard !hasSuccess, !fallbackConsumed else { return .report }
-            fallbackConsumed = true
-            return items.isEmpty ? .report : .fallback(items)
-        }
-    }
+    private typealias PromiseFallbackState = ShelfPromiseFallbackCoordinator<Item>
 
     @Published private(set) var items: [Item] = [] {
         didSet {
@@ -1732,63 +1691,48 @@ final class ShelfService: ObservableObject {
         guard !promises.isEmpty else { return false }
         let fallbackState = PromiseFallbackState(items: fallbackItems,
                                                  receiverCount: promises.count)
-        var scheduled = false
-        for (receiverID, promise) in promises.enumerated() {
-            // A receiver can represent more than one file, so keep its
-            // staging directory alive until the existing temp-file sweep.
-            // Removing it from the first callback could delete a later file
-            // that is still being materialized by the same receiver.
-            let destination = tempDir.appendingPathComponent("Promise-\(UUID().uuidString)",
-                                                             isDirectory: true)
-            guard (try? FileManager.default.createDirectory(
-                at: destination,
-                withIntermediateDirectories: true,
-                attributes: [.posixPermissions: 0o700])) != nil else {
-                switch fallbackState.recordFailure(for: receiverID) {
-                case .wait:
-                    continue
-                case let .fallback(items):
-                    fallbackPromisedItems(items, mergingInto: targetID)
-                case .report:
-                    reportPromiseFailure()
-                }
-                continue
+        // Apple requires all receivers from one drag to use the same
+        // destination. The reader still runs once per promised file, so the
+        // fallback barrier counts the fileNames reported after each receiver
+        // is activated rather than counting receivers themselves.
+        let destination = tempDir.appendingPathComponent("Promise-\(UUID().uuidString)",
+                                                         isDirectory: true)
+        guard (try? FileManager.default.createDirectory(
+            at: destination,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])) != nil else {
+            if fallbackItems.isEmpty {
+                reportPromiseFailure()
+                return false
             }
-            scheduled = true
+            return fallbackPromisedItems(fallbackItems, mergingInto: targetID)
+        }
+
+        for promise in promises {
             promise.receivePromisedFiles(atDestination: destination,
                                          options: [:],
                                          operationQueue: promiseOperationQueue) { [weak self] url, error in
                 guard let self else { return }
                 guard error == nil else {
                     try? FileManager.default.removeItem(at: url)
-                    switch fallbackState.recordFailure(for: receiverID) {
-                    case .wait:
-                        return
-                    case let .fallback(items):
-                        self.fallbackPromisedItems(items, mergingInto: targetID)
-                    case .report:
-                        self.reportPromiseFailure()
-                    }
+                    let outcome = fallbackState.recordFailure()
+                    self.applyPromiseFallback(outcome, mergingInto: targetID)
                     return
                 }
                 guard let storedURL = self.storePromisedFile(url) else {
                     try? FileManager.default.removeItem(at: url)
-                    switch fallbackState.recordFailure(for: receiverID) {
-                    case .wait:
-                        return
-                    case let .fallback(items):
-                        self.fallbackPromisedItems(items, mergingInto: targetID)
-                    case .report:
-                        self.reportPromiseFailure()
-                    }
+                    let outcome = fallbackState.recordFailure()
+                    self.applyPromiseFallback(outcome, mergingInto: targetID)
                     return
                 }
                 let title = url.lastPathComponent
                 try? FileManager.default.removeItem(at: url)
-                let fallback = fallbackState.recordSuccess(for: receiverID)
+                let outcome = fallbackState.recordSuccess()
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }
-                    if let fallback { self.discardOwnedPayloads(in: fallback) }
+                    if let fallback = outcome.discardFallback {
+                        self.discardOwnedPayloads(in: fallback)
+                    }
                     let item = self.fileItem(for: storedURL, title: title)
                     if let targetID {
                         if self.merge([item], into: targetID) {
@@ -1812,10 +1756,32 @@ final class ShelfService: ObservableObject {
                             return
                         }
                     }
+                    if outcome.reportFailure {
+                        self.reportPromiseFailure()
+                    }
                 }
             }
+            // `fileNames` is populated by AppKit when the receiver is
+            // activated. Keep one defensive slot for an unusual receiver that
+            // does not publish names, so a receiver failure still resolves the
+            // batch instead of waiting forever.
+            fallbackState.registerReceiver(expectedFileCount: promise.fileNames.count)
         }
-        return scheduled
+
+        if let outcome = fallbackState.finishRegistration() {
+            applyPromiseFallback(outcome, mergingInto: targetID)
+        }
+        return true
+    }
+
+    private func applyPromiseFallback(_ outcome: PromiseFallbackState.CallbackOutcome,
+                                      mergingInto targetID: UUID?) {
+        if let fallback = outcome.fallback {
+            fallbackPromisedItems(fallback, mergingInto: targetID)
+        }
+        if outcome.reportFailure {
+            reportPromiseFailure()
+        }
     }
 
     /// Uses direct representations only after promise fulfillment fails. A

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -293,17 +293,8 @@ final class ShelfService: ObservableObject {
     /// promises. The dynamic type is supplied by AppKit, so use the system's
     /// readable list instead of hardcoding an Outlook-specific identifier.
     private static let filePromiseTypeIdentifiers = Set(NSFilePromiseReceiver.readableDraggedTypes)
-    private static let filePromiseContentTypeIdentifier =
-        "com.apple.pasteboard.promised-file-content-type"
     private static let filePromiseDropTypes = NSFilePromiseReceiver.readableDraggedTypes
         .map { NSPasteboard.PasteboardType($0) }
-
-    /// The SwiftUI drop surfaces need the same identifiers as their AppKit
-    /// counterparts. `UTType(importedAs:)` preserves custom pasteboard types
-    /// that do not have a public declaration in UniformTypeIdentifiers.
-    static let swiftUIDropTypes: [UTType] = [
-        .fileURL, .image, .url, .text, .plainText
-    ] + [UTType(importedAs: filePromiseContentTypeIdentifier)]
 
     static let tileDropTypes: [NSPasteboard.PasteboardType] = [
         .fileURL,
@@ -1050,170 +1041,6 @@ final class ShelfService: ObservableObject {
 
     // MARK: - Items
 
-    /// Order matters for fidelity: a file is always a file, but a web image
-    /// drag carries both an image and its page URL — prefer the image, and
-    /// only fall back to treating a URL as a link when nothing richer exists.
-    func accept(providers: [NSItemProvider]) -> Bool {
-        let candidateLeaves = providers.reduce(0) { count, provider in
-            count + (canResolveItem(from: provider) ? 1 : 0)
-        }
-        guard ShelfPersistenceSupport.canAdd(existingLeaves: itemCount,
-                                             newLeaves: candidateLeaves) else {
-            if providers.contains(where: { promisedFileTypeIdentifier(for: $0) != nil }) {
-                reportPromiseFailure()
-            }
-            return false
-        }
-        acceptMixedBatch(providers: providers)
-        return true
-    }
-
-    /// Whether `resolveItem` has any representation it can turn into an item.
-    /// Kept in sync with `resolveItem`'s own branches by hand, since a
-    /// provider load is async and cannot itself be probed synchronously.
-    private func canResolveItem(from provider: NSItemProvider) -> Bool {
-        promisedFileTypeIdentifier(for: provider) != nil
-            || provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
-            || provider.hasItemConformingToTypeIdentifier(UTType.gif.identifier)
-            || provider.canLoadObject(ofClass: NSImage.self)
-            || provider.canLoadObject(ofClass: URL.self)
-            || provider.canLoadObject(ofClass: NSString.self)
-    }
-
-    private func promisedFileTypeIdentifier(for provider: NSItemProvider) -> String? {
-        guard provider.registeredTypeIdentifiers.contains(Self.filePromiseContentTypeIdentifier)
-        else { return nil }
-        return Self.filePromiseContentTypeIdentifier
-    }
-
-    /// Resolves every provider in a drop and adds them together: one pile
-    /// when more than one item survives, a single plain item otherwise. A
-    /// drop is one gesture, so whatever arrives with it belongs together,
-    /// whether it's files, images, GIFs, links or text: the same rule
-    /// `accept(pasteboard:)` already applies to files.
-    private func acceptMixedBatch(providers: [NSItemProvider]) {
-        let group = DispatchGroup()
-        var resolved: [(Int, Item)] = []
-        let containsPromise = providers.contains {
-            promisedFileTypeIdentifier(for: $0) != nil
-        }
-
-        for (index, provider) in providers.enumerated() {
-            group.enter()
-            resolveItem(from: provider) { item in
-                if let item { resolved.append((index, item)) }
-                group.leave()
-            }
-        }
-
-        group.notify(queue: .main) { [weak self] in
-            guard let self else { return }
-            let items = ShelfBatchSupport.orderedItems(from: resolved)
-            guard !items.isEmpty else { return }
-            let accepted = self.append(items.count == 1 ? items[0] : self.batchItem(children: items))
-            if !accepted, containsPromise { self.reportPromiseFailure() }
-        }
-    }
-
-    /// Turns one dropped provider into an item, preferring richer
-    /// representations first: a promised file when it produces a readable
-    /// file, then a file on disk, GIF data, a plain image, a URL (file or
-    /// link), and finally text. Always calls back exactly once, on the main
-    /// queue, so callers can mutate state from it.
-    private func resolveItem(from provider: NSItemProvider, completion: @escaping (Item?) -> Void) {
-        if let promiseType = promisedFileTypeIdentifier(for: provider) {
-            // SwiftUI exposes item-based file promises as NSItemProvider file
-            // representations. Foundation writes that representation to a
-            // temporary URL before this callback returns, so copy it just as
-            // promptly as the AppKit NSFilePromiseReceiver path below.
-            _ = provider.loadFileRepresentation(forTypeIdentifier: promiseType) { [weak self] url, error in
-                guard let self else {
-                    return DispatchQueue.main.async { completion(nil) }
-                }
-                guard error == nil, let url, self.isUsablePromiseFile(url),
-                      let storedURL = self.storePromisedFile(url) else {
-                    // Some providers register the promise UTI alongside a
-                    // usable image, URL, or text representation. A failed or
-                    // non-file promise must not hide that working fallback.
-                    return self.resolveStandardItem(from: provider) { item in
-                        if item == nil { self.reportPromiseFailure() }
-                        completion(item)
-                    }
-                }
-                let title = provider.suggestedName ?? url.lastPathComponent
-                DispatchQueue.main.async {
-                    completion(self.fileItem(for: storedURL, title: title))
-                }
-            }
-            return
-        }
-        resolveStandardItem(from: provider, completion: completion)
-    }
-
-    private func resolveStandardItem(from provider: NSItemProvider,
-                                     completion: @escaping (Item?) -> Void) {
-        if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
-            _ = provider.loadObject(ofClass: URL.self) { [weak self] url, _ in
-                DispatchQueue.main.async {
-                    guard let url, url.isFileURL else { return completion(nil) }
-                    completion(self?.fileItem(for: url))
-                }
-            }
-        } else if provider.hasItemConformingToTypeIdentifier(UTType.gif.identifier) {
-            _ = provider.loadDataRepresentation(forTypeIdentifier: UTType.gif.identifier) { [weak self] data, _ in
-                DispatchQueue.main.async {
-                    guard let data, !data.isEmpty else { return completion(nil) }
-                    completion(self?.gifItem(for: data))
-                }
-            }
-        } else if provider.canLoadObject(ofClass: NSImage.self) {
-            _ = provider.loadObject(ofClass: NSImage.self) { [weak self] image, _ in
-                DispatchQueue.main.async {
-                    let item = (image as? NSImage).flatMap { self?.imageItem(for: $0) }
-                    completion(item)
-                }
-            }
-        } else if provider.canLoadObject(ofClass: URL.self) {
-            _ = provider.loadObject(ofClass: URL.self) { [weak self] url, _ in
-                DispatchQueue.main.async {
-                    let item = url.flatMap { url in url.isFileURL ? self?.fileItem(for: url) : self?.linkItem(for: url) }
-                    completion(item)
-                }
-            }
-        } else if provider.canLoadObject(ofClass: NSString.self) {
-            _ = provider.loadObject(ofClass: NSString.self) { [weak self] string, _ in
-                DispatchQueue.main.async {
-                    let item = (string as? String).flatMap { self?.textItem(for: $0) }
-                    completion(item)
-                }
-            }
-        } else {
-            DispatchQueue.main.async { completion(nil) }
-        }
-    }
-
-    private func isUsablePromiseFile(_ url: URL) -> Bool {
-        guard url.isFileURL,
-              FileManager.default.fileExists(atPath: url.path),
-              FileManager.default.isReadableFile(atPath: url.path),
-              let values = try? url.resourceValues(forKeys: [.isRegularFileKey]),
-              values.isRegularFile == true else { return false }
-
-        // A provider can expose the promise UTI through this item-provider
-        // path. Foundation then writes that short identifier into a regular
-        // temporary file, which passes filesystem checks but is not the
-        // promised content. Reject that placeholder so direct loaders below
-        // get a chance to handle the same provider.
-        guard url.pathExtension.isEmpty,
-              let data = try? Data(contentsOf: url, options: .mappedIfSafe),
-              data.count <= 256,
-              let identifier = String(data: data, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-              !identifier.isEmpty,
-              UTType(identifier) != nil else { return true }
-        return false
-    }
-
     func removeItem(_ id: UUID) {
         var removed: [Item] = []
         removeItems(Set([id]), from: &items, removed: &removed)
@@ -1724,13 +1551,13 @@ final class ShelfService: ObservableObject {
                     // AppKit may pass the destination directory, no URL, or
                     // a partial path on failure. It was not written by this
                     // reader, so leave it for the temporary-file sweep.
-                    let outcome = fallbackState.recordFailure(for: receiverID)
+                    let outcome = fallbackState.recordReceiverFailure(for: receiverID)
                     self.applyPromiseFallback(outcome, mergingInto: targetID)
                     return
                 }
                 guard let storedURL = self.storePromisedFile(url) else {
                     self.removePromisedFileIfRegular(url, inside: destination)
-                    let outcome = fallbackState.recordFailure(for: receiverID)
+                    let outcome = fallbackState.recordFileFailure(for: receiverID)
                     self.applyPromiseFallback(outcome, mergingInto: targetID)
                     return
                 }

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -1692,9 +1692,9 @@ final class ShelfService: ObservableObject {
         let fallbackState = PromiseFallbackState(items: fallbackItems,
                                                  receiverCount: promises.count)
         // Apple requires all receivers from one drag to use the same
-        // destination. The reader still runs once per promised file, so the
-        // fallback barrier counts the fileNames reported after each receiver
-        // is activated rather than counting receivers themselves.
+        // destination. A successful reader callback represents one file, but
+        // an error can terminate a receiver wholesale, so the coordinator
+        // tracks both per-file success and per-receiver failure terminality.
         let destination = tempDir.appendingPathComponent("Promise-\(UUID().uuidString)",
                                                          isDirectory: true)
         guard (try? FileManager.default.createDirectory(
@@ -1708,28 +1708,42 @@ final class ShelfService: ObservableObject {
             return fallbackPromisedItems(fallbackItems, mergingInto: targetID)
         }
 
-        for promise in promises {
+        for (receiverID, promise) in promises.enumerated() {
+            // Register a provisional slot before activation in case AppKit
+            // dispatches a reader operation immediately. Replace it with the
+            // receiver's advertised fileNames count as soon as activation
+            // returns.
+            fallbackState.registerReceiver(receiverID,
+                                            expectedFileCount: 1,
+                                            isExpectedFileCountFinal: false)
             promise.receivePromisedFiles(atDestination: destination,
                                          options: [:],
                                          operationQueue: promiseOperationQueue) { [weak self] url, error in
                 guard let self else { return }
                 guard error == nil else {
-                    try? FileManager.default.removeItem(at: url)
-                    let outcome = fallbackState.recordFailure()
+                    // AppKit may pass the destination directory, no URL, or
+                    // a partial path on failure. It was not written by this
+                    // reader, so leave it for the temporary-file sweep.
+                    let outcome = fallbackState.recordFailure(for: receiverID)
                     self.applyPromiseFallback(outcome, mergingInto: targetID)
                     return
                 }
                 guard let storedURL = self.storePromisedFile(url) else {
-                    try? FileManager.default.removeItem(at: url)
-                    let outcome = fallbackState.recordFailure()
+                    self.removePromisedFileIfRegular(url, inside: destination)
+                    let outcome = fallbackState.recordFailure(for: receiverID)
                     self.applyPromiseFallback(outcome, mergingInto: targetID)
                     return
                 }
                 let title = url.lastPathComponent
-                try? FileManager.default.removeItem(at: url)
-                let outcome = fallbackState.recordSuccess()
+                self.removePromisedFileIfRegular(url, inside: destination)
+                let outcome = fallbackState.recordSuccess(for: receiverID)
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }
+                    guard outcome.acceptFile else {
+                        self.removePromisedFileIfRegular(storedURL)
+                        self.applyPromiseFallback(outcome, mergingInto: targetID)
+                        return
+                    }
                     if let fallback = outcome.discardFallback {
                         self.discardOwnedPayloads(in: fallback)
                     }
@@ -1765,7 +1779,8 @@ final class ShelfService: ObservableObject {
             // activated. Keep one defensive slot for an unusual receiver that
             // does not publish names, so a receiver failure still resolves the
             // batch instead of waiting forever.
-            fallbackState.registerReceiver(expectedFileCount: promise.fileNames.count)
+            fallbackState.updateExpectedFileCount(for: receiverID,
+                                                  to: promise.fileNames.count)
         }
 
         if let outcome = fallbackState.finishRegistration() {
@@ -1782,6 +1797,18 @@ final class ShelfService: ObservableObject {
         if outcome.reportFailure {
             reportPromiseFailure()
         }
+    }
+
+    private func removePromisedFileIfRegular(_ url: URL, inside destination: URL? = nil) {
+        guard url.isFileURL,
+              let values = try? url.resourceValues(forKeys: [.isRegularFileKey]),
+              values.isRegularFile == true else { return }
+        if let destination,
+           url.standardizedFileURL.deletingLastPathComponent()
+                != destination.standardizedFileURL {
+            return
+        }
+        try? FileManager.default.removeItem(at: url)
     }
 
     /// Uses direct representations only after promise fulfillment fails. A

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -249,6 +249,9 @@ final class ShelfService: ObservableObject {
         queue.qualityOfService = .utility
         return queue
     }()
+    /// Promise callbacks can fail independently during one multi-file drop.
+    /// Keep the failure feedback useful without beeping once per attachment.
+    private var promiseFailureFeedbackScheduled = false
 
     private var persistScheduled = false
     /// Gates persistence until the restore has landed, so an early mutation
@@ -1048,7 +1051,12 @@ final class ShelfService: ObservableObject {
             count + (canResolveItem(from: provider) ? 1 : 0)
         }
         guard ShelfPersistenceSupport.canAdd(existingLeaves: itemCount,
-                                             newLeaves: candidateLeaves) else { return false }
+                                             newLeaves: candidateLeaves) else {
+            if providers.contains(where: { promisedFileTypeIdentifier(for: $0) != nil }) {
+                reportPromiseFailure()
+            }
+            return false
+        }
         acceptMixedBatch(providers: providers)
         return true
     }
@@ -1080,6 +1088,9 @@ final class ShelfService: ObservableObject {
     private func acceptMixedBatch(providers: [NSItemProvider]) {
         let group = DispatchGroup()
         var resolved: [(Int, Item)] = []
+        let containsPromise = providers.contains {
+            promisedFileTypeIdentifier(for: $0) != nil
+        }
 
         for (index, provider) in providers.enumerated() {
             group.enter()
@@ -1093,7 +1104,8 @@ final class ShelfService: ObservableObject {
             guard let self else { return }
             let items = ShelfBatchSupport.orderedItems(from: resolved)
             guard !items.isEmpty else { return }
-            _ = self.append(items.count == 1 ? items[0] : self.batchItem(children: items))
+            let accepted = self.append(items.count == 1 ? items[0] : self.batchItem(children: items))
+            if !accepted, containsPromise { self.reportPromiseFailure() }
         }
     }
 
@@ -1103,12 +1115,20 @@ final class ShelfService: ObservableObject {
     /// exactly once, on the main queue, so callers can mutate state from it.
     private func resolveItem(from provider: NSItemProvider, completion: @escaping (Item?) -> Void) {
         if let promiseType = promisedFileTypeIdentifier(for: provider) {
+            // SwiftUI exposes item-based file promises as NSItemProvider file
+            // representations. Foundation writes that representation to a
+            // temporary URL before this callback returns, so copy it just as
+            // promptly as the AppKit NSFilePromiseReceiver path below.
             _ = provider.loadFileRepresentation(forTypeIdentifier: promiseType) { [weak self] url, error in
-                guard error == nil, let self, let url,
-                      let storedURL = self.storePromisedFile(url) else {
+                guard let self else {
                     return DispatchQueue.main.async { completion(nil) }
                 }
-                let title = url.lastPathComponent
+                guard error == nil, let url,
+                      let storedURL = self.storePromisedFile(url) else {
+                    self.reportPromiseFailure()
+                    return DispatchQueue.main.async { completion(nil) }
+                }
+                let title = provider.suggestedName ?? url.lastPathComponent
                 DispatchQueue.main.async {
                     completion(self.fileItem(for: storedURL, title: title))
                 }
@@ -1457,15 +1477,10 @@ final class ShelfService: ObservableObject {
     func accept(pasteboard: NSPasteboard) -> Bool {
         let promises = filePromises(from: pasteboard)
         if !promises.isEmpty {
-            let directItems = items(from: pasteboard)
-            var accepted = false
-            if !directItems.isEmpty {
-                accepted = append(directItems)
-            }
-            if itemCount < ShelfPersistenceSupport.maxLeaves {
-                accepted = receivePromisedFiles(promises) || accepted
-            }
-            return accepted
+            // Promise-backed drops may also advertise auxiliary text or URL
+            // flavors, such as Outlook's subject. The promised file is the
+            // authoritative Shelf item, so do not add those flavors twice.
+            return receivePromisedFiles(promises)
         }
         let fileURLs = fileURLs(from: pasteboard)
         if fileURLs.count > 1 {
@@ -1627,30 +1642,45 @@ final class ShelfService: ObservableObject {
     private func receivePromisedFiles(_ promises: [NSFilePromiseReceiver],
                                       mergingInto targetID: UUID? = nil) -> Bool {
         guard !promises.isEmpty else { return false }
-        let destination = tempDir.appendingPathComponent("Promise-\(UUID().uuidString)",
-                                                         isDirectory: true)
-        guard (try? FileManager.default.createDirectory(
-            at: destination,
-            withIntermediateDirectories: true,
-            attributes: [.posixPermissions: 0o700])) != nil else {
-            return false
-        }
-
+        var scheduled = false
         for promise in promises {
+            // A receiver can represent more than one file, so keep its
+            // staging directory alive until the existing temp-file sweep.
+            // Removing it from the first callback could delete a later file
+            // that is still being materialized by the same receiver.
+            let destination = tempDir.appendingPathComponent("Promise-\(UUID().uuidString)",
+                                                             isDirectory: true)
+            guard (try? FileManager.default.createDirectory(
+                at: destination,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700])) != nil else {
+                reportPromiseFailure()
+                continue
+            }
+            scheduled = true
             promise.receivePromisedFiles(atDestination: destination,
                                          options: [:],
                                          operationQueue: promiseOperationQueue) { [weak self] url, error in
-                guard error == nil, let self,
-                      let storedURL = self.storePromisedFile(url) else { return }
+                guard let self else { return }
+                guard error == nil else {
+                    try? FileManager.default.removeItem(at: url)
+                    self.reportPromiseFailure()
+                    return
+                }
+                guard let storedURL = self.storePromisedFile(url) else {
+                    try? FileManager.default.removeItem(at: url)
+                    self.reportPromiseFailure()
+                    return
+                }
                 let title = url.lastPathComponent
-                if storedURL != url { try? FileManager.default.removeItem(at: url) }
-                try? FileManager.default.removeItem(at: destination)
+                try? FileManager.default.removeItem(at: url)
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }
                     let item = self.fileItem(for: storedURL, title: title)
                     if let targetID {
                         guard self.merge([item], into: targetID) else {
                             self.discardOwnedPayloads(in: [item])
+                            self.reportPromiseFailure()
                             return
                         }
                         self.startContentThumbnails(for: [item])
@@ -1658,12 +1688,31 @@ final class ShelfService: ObservableObject {
                         self.addSerial &+= 1
                         self.noteInteraction()
                     } else {
-                        _ = self.append(item)
+                        guard self.append(item) else {
+                            self.reportPromiseFailure()
+                            return
+                        }
                     }
                 }
             }
         }
-        return true
+        return scheduled
+    }
+
+    /// Promise materialization is asynchronous, so a drop cannot return a
+    /// later failure through AppKit's synchronous operation result. Keep the
+    /// existing beep convention and add a localized HUD when a promise fails.
+    private func reportPromiseFailure() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, !self.promiseFailureFeedbackScheduled else { return }
+            self.promiseFailureFeedbackScheduled = true
+            NSSound.beep()
+            QuickToolHUD.show(icon: "exclamationmark.triangle",
+                              message: L10n.shared.s.shelfDropFailed)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
+                self?.promiseFailureFeedbackScheduled = false
+            }
+        }
     }
 
     /// Copies one promised file into the same owner-only persistent store as
@@ -1817,8 +1866,9 @@ final class ShelfService: ObservableObject {
     }
 
     private func pasteboardCanCreateItem(_ pasteboard: NSPasteboard) -> Bool {
-        if pasteboardHasFilePromises(pasteboard) {
-            return !filePromises(from: pasteboard).isEmpty
+        if pasteboardHasFilePromises(pasteboard),
+           !filePromises(from: pasteboard).isEmpty {
+            return true
         }
         if !fileURLs(from: pasteboard).isEmpty {
             return true

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -1687,7 +1687,7 @@ final class ShelfService: ObservableObject {
     /// the item is built on the main thread.
     private func receivePromisedFiles(_ promises: [NSFilePromiseReceiver],
                                       mergingInto targetID: UUID? = nil,
-        fallbackItems: [Item] = []) -> Bool {
+                                      fallbackItems: [Item] = []) -> Bool {
         guard !promises.isEmpty else { return false }
         let fallbackState = PromiseFallbackState(items: fallbackItems,
                                                  receiverCount: promises.count)

--- a/Sources/Vorssaint/Services/Shelf/ShelfSupport.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfSupport.swift
@@ -565,12 +565,3 @@ enum ShelfPersistenceSupport {
         return result
     }
 }
-
-enum ShelfBatchSupport {
-    /// Restores original drop order after resolving every provider in a
-    /// multi-item drop in parallel, which completes out of order, and
-    /// drops any provider that failed to resolve to anything.
-    static func orderedItems<Item>(from resolved: [(index: Int, item: Item)]) -> [Item] {
-        resolved.sorted { $0.index < $1.index }.map(\.item)
-    }
-}

--- a/Sources/Vorssaint/UI/Shelf/ShelfDropZoneView.swift
+++ b/Sources/Vorssaint/UI/Shelf/ShelfDropZoneView.swift
@@ -2,7 +2,6 @@
 // Copyright (C) 2026 Vorssaint
 
 import SwiftUI
-import UniformTypeIdentifiers
 
 /// The shelf docked under the menu bar icon. It is a single thing in one place:
 /// a small pill when idle, the full shelf card when opened or when a drag needs
@@ -20,7 +19,7 @@ struct DockedShelfView: View {
                 ShelfView(dismissSystemImage: "chevron.up",
                           dismissHelp: l10n.s.shelfCollapse,
                           onDismiss: { shelf.collapseDocked() },
-                          onAccept: { _ in shelf.dockDidAccept() },
+                          onAccept: { shelf.dockDidAccept() },
                           brandWatermark: true)
             } else {
                 ShelfPill()
@@ -36,10 +35,7 @@ private struct ShelfPill: View {
     @EnvironmentObject private var shelf: ShelfService
     @ObservedObject private var l10n = L10n.shared
     @Environment(\.colorScheme) private var colorScheme
-    @State private var targeted = false
     @State private var hovered = false
-
-    private static let dropTypes = ShelfService.swiftUIDropTypes
 
     var body: some View {
         HStack(spacing: 7) {
@@ -53,32 +49,32 @@ private struct ShelfPill: View {
             Image(systemName: "chevron.down")
                 .font(.system(size: 9, weight: .bold))
                 .foregroundStyle(.secondary)
-                .opacity(hovered || targeted ? 1 : 0.55)
+                .opacity(hovered || shelf.dropTargeted ? 1 : 0.55)
         }
         .padding(.horizontal, shelf.itemCount > 0 ? 12 : 11)
         .padding(.vertical, 8)
-        .background(HUDBackdrop(cornerRadius: 13))
+        .background(
+            ZStack {
+                HUDBackdrop(cornerRadius: 13)
+                WindowMoveHandle(acceptsDrops: true) { shelf.dockDidAccept() }
+            }
+        )
         .clipShape(RoundedRectangle(cornerRadius: 13, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 13, style: .continuous)
-                .strokeBorder(targeted ? Color.accentColor : Color.white.opacity(0.12),
-                              lineWidth: targeted ? 2 : 1)
+                .strokeBorder(shelf.dropTargeted ? Color.accentColor : Color.white.opacity(0.12),
+                              lineWidth: shelf.dropTargeted ? 2 : 1)
         )
-        .scaleEffect(targeted ? 1.06 : 1)
-        .shadow(color: targeted ? Color.accentColor.opacity(0.32) : Color.black.opacity(0.16),
-                radius: targeted ? 12 : 7, x: 0, y: 3)
+        .scaleEffect(shelf.dropTargeted ? 1.06 : 1)
+        .shadow(color: shelf.dropTargeted ? Color.accentColor.opacity(0.32) : Color.black.opacity(0.16),
+                radius: shelf.dropTargeted ? 12 : 7, x: 0, y: 3)
         .contentShape(RoundedRectangle(cornerRadius: 13, style: .continuous))
         .onHover { hovered = $0 }
         .onTapGesture { shelf.expandDocked() }
         .help(l10n.s.shelfOpenNow)
-        .animation(.easeOut(duration: 0.13), value: targeted)
+        .animation(.easeOut(duration: 0.13), value: shelf.dropTargeted)
         .animation(.easeOut(duration: 0.15), value: shelf.dockedJustCaught)
         .padding(8)
-        .onDrop(of: Self.dropTypes, isTargeted: $targeted) { providers in
-            let accepted = shelf.accept(providers: providers)
-            if accepted { shelf.dockDidAccept() }
-            return accepted
-        }
     }
 
     /// The Vorssaint mark, quiet, so the pill is unmistakably the app's; it

--- a/Sources/Vorssaint/UI/Shelf/ShelfDropZoneView.swift
+++ b/Sources/Vorssaint/UI/Shelf/ShelfDropZoneView.swift
@@ -39,7 +39,7 @@ private struct ShelfPill: View {
     @State private var targeted = false
     @State private var hovered = false
 
-    private static let dropTypes: [UTType] = [.fileURL, .image, .url, .text, .plainText]
+    private static let dropTypes = ShelfService.swiftUIDropTypes
 
     var body: some View {
         HStack(spacing: 7) {

--- a/Sources/Vorssaint/UI/Shelf/ShelfTilesView.swift
+++ b/Sources/Vorssaint/UI/Shelf/ShelfTilesView.swift
@@ -8,15 +8,18 @@ import SwiftUI
 /// header and empty shelf space; tiles stay free to start item drags.
 struct WindowMoveHandle: NSViewRepresentable {
     var acceptsDrops = false
+    var onDropAccepted: (() -> Void)?
 
     func makeNSView(context: Context) -> ShelfPanelMoveView {
         let view = ShelfPanelMoveView()
         view.acceptsDrops = acceptsDrops
+        view.onDropAccepted = onDropAccepted
         return view
     }
 
     func updateNSView(_ nsView: ShelfPanelMoveView, context: Context) {
         nsView.acceptsDrops = acceptsDrops
+        nsView.onDropAccepted = onDropAccepted
     }
 }
 
@@ -24,6 +27,7 @@ class ShelfPanelMoveView: NSView {
     var acceptsDrops = false {
         didSet { syncDraggedTypes() }
     }
+    var onDropAccepted: (() -> Void)?
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -58,6 +62,7 @@ class ShelfPanelMoveView: NSView {
 
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
         let accepted = acceptsDrops && ShelfService.shared.accept(pasteboard: sender.draggingPasteboard)
+        if accepted { onDropAccepted?() }
         ShelfService.shared.setDropTargeted(false)
         return accepted
     }

--- a/Sources/Vorssaint/UI/Shelf/ShelfView.swift
+++ b/Sources/Vorssaint/UI/Shelf/ShelfView.swift
@@ -2,7 +2,6 @@
 // Copyright (C) 2026 Vorssaint
 
 import SwiftUI
-import UniformTypeIdentifiers
 
 /// Contents of the floating shelf panel: a header (a move handle plus actions)
 /// and the item tiles. Dropping onto the card adds items; the tiles themselves
@@ -13,9 +12,9 @@ struct ShelfView: View {
     var dismissSystemImage: String = "xmark"
     var dismissHelp: String? = nil
     var onDismiss: (() -> Void)? = nil
-    /// Called with the provider count after a drop is accepted, so the docked
-    /// shelf can flash and settle back to its pill.
-    var onAccept: ((Int) -> Void)? = nil
+    /// Called after a drop is accepted, so the docked shelf can flash and
+    /// settle back to its pill.
+    var onAccept: (() -> Void)? = nil
     /// The docked shelf shows the brand mark as a quiet watermark, so it reads
     /// as the app's own tray rather than a plain floating card.
     var brandWatermark: Bool = false
@@ -23,12 +22,10 @@ struct ShelfView: View {
     @EnvironmentObject private var shelf: ShelfService
     @ObservedObject private var l10n = L10n.shared
     @Environment(\.colorScheme) private var colorScheme
-    @State private var targeted = false
     @State private var clearButtonHovered = false
     @State private var pinButtonHovered = false
     @State private var closeButtonHovered = false
 
-    private static let dropTypes = ShelfService.swiftUIDropTypes
     private static let panelWidth: CGFloat = 304
     private static let tileAreaHeight: CGFloat = 188
 
@@ -46,6 +43,13 @@ struct ShelfView: View {
             ZStack {
                 HUDBackdrop(cornerRadius: 18)
                 if brandWatermark { brandWatermarkLayer }
+                // This stays above the material view, but below the panel's
+                // controls, so the entire card receives the original AppKit
+                // dragging pasteboard without changing normal button clicks.
+                WindowMoveHandle(acceptsDrops: true) {
+                    shelf.noteInteraction()
+                    onAccept?()
+                }
             }
         )
         .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
@@ -62,21 +66,10 @@ struct ShelfView: View {
         .onHover { inside in
             shelf.setPointerInsidePanel(inside)
         }
-        .onChange(of: targeted) { _, isTargeted in
-            shelf.setDropTargeted(isTargeted)
-        }
-        .onDrop(of: Self.dropTypes, isTargeted: $targeted) { providers in
-            let accepted = shelf.accept(providers: providers)
-            if accepted {
-                shelf.noteInteraction()
-                onAccept?(providers.count)
-            }
-            return accepted
-        }
     }
 
     private var isDropTargeted: Bool {
-        targeted || shelf.dropTargeted
+        shelf.dropTargeted
     }
 
     /// The official mark, large and faint in the corner: unmistakably ours,

--- a/Sources/Vorssaint/UI/Shelf/ShelfView.swift
+++ b/Sources/Vorssaint/UI/Shelf/ShelfView.swift
@@ -28,7 +28,7 @@ struct ShelfView: View {
     @State private var pinButtonHovered = false
     @State private var closeButtonHovered = false
 
-    private static let dropTypes: [UTType] = [.fileURL, .image, .url, .text, .plainText]
+    private static let dropTypes = ShelfService.swiftUIDropTypes
     private static let panelWidth: CGFloat = 304
     private static let tileAreaHeight: CGFloat = 188
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21337,57 +21337,82 @@ struct MetricsTests {
 
         // MARK: File-promise fallback coordination
 
-        // A non-item-based receiver can report several files through one
-        // reader callback sequence. A first failure must wait for the later
-        // success, and the successful promise must discard the direct
-        // fallback while still reporting the partial failure once the batch
-        // is complete.
-        let multiFileFallback = ShelfPromiseFallbackCoordinator(
+        // A receiver error can close a multi-file receiver wholesale. The
+        // coordinator must credit its remaining advertised files so a batch
+        // with no successful promises reaches fallback instead of waiting.
+        let wholesaleFailure = ShelfPromiseFallbackCoordinator(
             items: ["subject"], receiverCount: 1)
-        multiFileFallback.registerReceiver(expectedFileCount: 2)
-        let firstFailure = multiFileFallback.recordFailure()
-        expect(firstFailure.fallback == nil && !firstFailure.reportFailure,
-               "a failed file waits for the remaining callbacks")
-        let laterSuccess = multiFileFallback.recordSuccess()
-        expect(laterSuccess.discardFallback == ["subject"]
-                && laterSuccess.fallback == nil
-                && !laterSuccess.reportFailure,
-               "a later success consumes the direct fallback without early feedback")
-        let multiFileCompletion = multiFileFallback.finishRegistration()
-        expect(multiFileCompletion?.reportFailure == true,
-               "a completed partial promise reports the failed file once")
+        wholesaleFailure.registerReceiver(0, expectedFileCount: 2)
+        let receiverFailure = wholesaleFailure.recordFailure(for: 0)
+        expect(receiverFailure.fallback == nil && !receiverFailure.reportFailure,
+               "a wholesale receiver failure waits for registration to finish")
+        let wholesaleCompletion = wholesaleFailure.finishRegistration()
+        expect(wholesaleCompletion?.fallback == ["subject"]
+                && wholesaleCompletion?.reportFailure == false,
+               "a wholesale failure credits every remaining file for fallback")
 
-        // The reverse order must have the same result: success suppresses the
-        // fallback, but a later failed file still produces feedback instead of
-        // disappearing behind the already-consumed success.
-        let reverseOrderFallback = ShelfPromiseFallbackCoordinator(
+        // Registration begins before activation, so an immediately dispatched
+        // callback is not mistaken for an unknown receiver. The provisional
+        // slot expands to the advertised count when activation returns.
+        let earlyCallback = ShelfPromiseFallbackCoordinator(
             items: ["subject"], receiverCount: 1)
-        reverseOrderFallback.registerReceiver(expectedFileCount: 2)
-        let firstSuccess = reverseOrderFallback.recordSuccess()
-        expect(firstSuccess.discardFallback == ["subject"]
-                && !firstSuccess.reportFailure,
-               "an early success suppresses fallback without early feedback")
-        let laterFailure = reverseOrderFallback.recordFailure()
-        expect(!laterFailure.reportFailure,
-               "a later failure waits until registration is complete")
-        let reverseCompletion = reverseOrderFallback.finishRegistration()
-        expect(reverseCompletion?.fallback == nil
-                && reverseCompletion?.reportFailure == true,
-               "a later failure after success is reported at batch completion")
+        earlyCallback.registerReceiver(0,
+                                       expectedFileCount: 1,
+                                       isExpectedFileCountFinal: false)
+        let earlySuccess = earlyCallback.recordSuccess(for: 0)
+        earlyCallback.updateExpectedFileCount(for: 0, to: 2)
+        let finalEarlySuccess = earlyCallback.recordSuccess(for: 0)
+        let earlyCompletion = earlyCallback.finishRegistration()
+        expect(earlySuccess.acceptFile && finalEarlySuccess.acceptFile
+                && earlyCompletion?.fallback == nil
+                && earlyCompletion?.reportFailure == false,
+               "an early callback remains part of the expanded multi-file receiver")
+
+        // With two receivers, a failure in one must wait for the other
+        // receiver's success. The successful promise suppresses the direct
+        // subject fallback, while the partial failure is reported once.
+        let partialFailure = ShelfPromiseFallbackCoordinator(
+            items: ["subject"], receiverCount: 2)
+        partialFailure.registerReceiver(0, expectedFileCount: 1)
+        partialFailure.registerReceiver(1, expectedFileCount: 1)
+        let firstReceiverFailure = partialFailure.recordFailure(for: 0)
+        expect(firstReceiverFailure.fallback == nil && !firstReceiverFailure.reportFailure,
+               "one receiver failure waits for the other receiver")
+        let secondReceiverSuccess = partialFailure.recordSuccess(for: 1)
+        expect(secondReceiverSuccess.acceptFile
+                && secondReceiverSuccess.discardFallback == ["subject"]
+                && !secondReceiverSuccess.reportFailure,
+               "a successful receiver suppresses fallback during partial failure")
+        let partialCompletion = partialFailure.finishRegistration()
+        expect(partialCompletion?.fallback == nil
+                && partialCompletion?.reportFailure == true,
+               "a partial receiver failure is reported after the batch completes")
+
+        // If an error closes a receiver, a late success from that receiver
+        // must not create a promised tile after fallback has been selected.
+        let lateSuccess = ShelfPromiseFallbackCoordinator(
+            items: ["subject"], receiverCount: 1)
+        lateSuccess.registerReceiver(0, expectedFileCount: 2)
+        _ = lateSuccess.recordFailure(for: 0)
+        let lateFailureCompletion = lateSuccess.finishRegistration()
+        let ignoredLateSuccess = lateSuccess.recordSuccess(for: 0)
+        expect(lateFailureCompletion?.fallback == ["subject"]
+                && !ignoredLateSuccess.acceptFile
+                && ignoredLateSuccess.fallback == nil,
+               "a late callback after wholesale failure cannot duplicate fallback")
 
         // A completely failed multi-receiver batch still uses the direct
-        // representation, but only after every expected file callback fails.
+        // representation, but only after every receiver has failed.
         let allFailureFallback = ShelfPromiseFallbackCoordinator(
             items: ["image"], receiverCount: 2)
-        allFailureFallback.registerReceiver(expectedFileCount: 2)
-        allFailureFallback.registerReceiver(expectedFileCount: 1)
-        _ = allFailureFallback.recordFailure()
-        _ = allFailureFallback.recordFailure()
-        let finalFailure = allFailureFallback.recordFailure()
-        let allFailureCompletion = allFailureFallback.finishRegistration()
-        expect(finalFailure.fallback == nil && allFailureCompletion?.fallback == ["image"]
-                && allFailureCompletion?.reportFailure == false,
-               "the direct fallback is deferred until every promised file fails")
+        allFailureFallback.registerReceiver(0, expectedFileCount: 2)
+        allFailureFallback.registerReceiver(1, expectedFileCount: 1)
+        _ = allFailureFallback.recordFailure(for: 0)
+        let finalReceiverFailure = allFailureFallback.recordFailure(for: 1)
+        expect(finalReceiverFailure.fallback == nil
+                && allFailureFallback.finishRegistration()?.fallback == ["image"]
+                && !finalReceiverFailure.reportFailure,
+               "fallback waits for every receiver in an all-failure batch")
 
         // MARK: Result
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21368,6 +21368,19 @@ struct MetricsTests {
                 && earlyCompletion?.reportFailure == false,
                "an early callback remains part of the expanded multi-file receiver")
 
+        // The defensive minimum must not cap a receiver that reports its
+        // filenames late and then delivers an additional failed file.
+        let overflowFailure = ShelfPromiseFallbackCoordinator(
+            items: ["subject"], receiverCount: 1)
+        overflowFailure.registerReceiver(0, expectedFileCount: 1)
+        let firstOverflowSuccess = overflowFailure.recordSuccess(for: 0)
+        let secondOverflowFailure = overflowFailure.recordFailure(for: 0)
+        let overflowCompletion = overflowFailure.finishRegistration()
+        expect(firstOverflowSuccess.acceptFile && !secondOverflowFailure.acceptFile
+                && overflowCompletion?.fallback == nil
+                && overflowCompletion?.reportFailure == true,
+               "an extra callback after the defensive floor is still reported")
+
         // With two receivers, a failure in one must wait for the other
         // receiver's success. The successful promise suppresses the direct
         // subject fallback, while the partial failure is reported once.
@@ -21413,6 +21426,20 @@ struct MetricsTests {
                 && allFailureFallback.finishRegistration()?.fallback == ["image"]
                 && !finalReceiverFailure.reportFailure,
                "fallback waits for every receiver in an all-failure batch")
+
+        // SwiftUI must request the content promise explicitly. Selecting the
+        // first registered promise flavor could load a URL string as a file.
+        let shelfServiceSource = (try? String(contentsOfFile:
+            "Sources/Vorssaint/Services/Shelf/ShelfService.swift", encoding: .utf8)) ?? ""
+        expect(shelfServiceSource.contains(
+            "com.apple.pasteboard.promised-file-content-type"),
+               "the SwiftUI promise loader names the content representation explicitly")
+        expect(shelfServiceSource.contains(
+            "return Self.filePromiseContentTypeIdentifier"),
+               "provider ordering cannot select the promised URL representation")
+        expect(!shelfServiceSource.contains(
+            "provider.registeredTypeIdentifiers.first"),
+               "the promise loader no longer trusts provider type ordering")
 
         // MARK: Result
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -8019,15 +8019,6 @@ struct MetricsTests {
                     restoredIsEmpty: false, liveItemCount: 0),
                "shelf additions made during restore schedule the merged state for persistence")
 
-        expect(ShelfBatchSupport.orderedItems(from: [(Int, String)]()).isEmpty,
-               "shelf batch resolve with nothing resolved produces nothing")
-        expect(ShelfBatchSupport.orderedItems(from: [(0, "a"), (1, "b"), (2, "c")]) == ["a", "b", "c"],
-               "shelf batch resolve keeps drop order when providers finish in order")
-        expect(ShelfBatchSupport.orderedItems(from: [(2, "c"), (0, "a"), (1, "b")]) == ["a", "b", "c"],
-               "shelf batch resolve restores drop order when providers finish out of order")
-        expect(ShelfBatchSupport.orderedItems(from: [(3, "z")]) == ["z"],
-               "shelf batch resolve with a single provider produces that one item")
-
         expect(ClipboardHistoryBatch.listOwnsCopyShortcut(batchCount: 2)
                    && !ClipboardHistoryBatch.listOwnsCopyShortcut(batchCount: 0),
                "the list only claims command-C over an explicit selection")
@@ -21343,7 +21334,7 @@ struct MetricsTests {
         let wholesaleFailure = ShelfPromiseFallbackCoordinator(
             items: ["subject"], receiverCount: 1)
         wholesaleFailure.registerReceiver(0, expectedFileCount: 2)
-        let receiverFailure = wholesaleFailure.recordFailure(for: 0)
+        let receiverFailure = wholesaleFailure.recordReceiverFailure(for: 0)
         expect(receiverFailure.fallback == nil && !receiverFailure.reportFailure,
                "a wholesale receiver failure waits for registration to finish")
         let wholesaleCompletion = wholesaleFailure.finishRegistration()
@@ -21374,7 +21365,7 @@ struct MetricsTests {
             items: ["subject"], receiverCount: 1)
         overflowFailure.registerReceiver(0, expectedFileCount: 1)
         let firstOverflowSuccess = overflowFailure.recordSuccess(for: 0)
-        let secondOverflowFailure = overflowFailure.recordFailure(for: 0)
+        let secondOverflowFailure = overflowFailure.recordFileFailure(for: 0)
         let overflowCompletion = overflowFailure.finishRegistration()
         expect(firstOverflowSuccess.acceptFile && !secondOverflowFailure.acceptFile
                 && overflowCompletion?.fallback == nil
@@ -21388,7 +21379,7 @@ struct MetricsTests {
             items: ["subject"], receiverCount: 2)
         partialFailure.registerReceiver(0, expectedFileCount: 1)
         partialFailure.registerReceiver(1, expectedFileCount: 1)
-        let firstReceiverFailure = partialFailure.recordFailure(for: 0)
+        let firstReceiverFailure = partialFailure.recordReceiverFailure(for: 0)
         expect(firstReceiverFailure.fallback == nil && !firstReceiverFailure.reportFailure,
                "one receiver failure waits for the other receiver")
         let secondReceiverSuccess = partialFailure.recordSuccess(for: 1)
@@ -21406,7 +21397,7 @@ struct MetricsTests {
         let lateSuccess = ShelfPromiseFallbackCoordinator(
             items: ["subject"], receiverCount: 1)
         lateSuccess.registerReceiver(0, expectedFileCount: 2)
-        _ = lateSuccess.recordFailure(for: 0)
+        _ = lateSuccess.recordReceiverFailure(for: 0)
         let lateFailureCompletion = lateSuccess.finishRegistration()
         let ignoredLateSuccess = lateSuccess.recordSuccess(for: 0)
         expect(lateFailureCompletion?.fallback == ["subject"]
@@ -21421,32 +21412,57 @@ struct MetricsTests {
             items: ["image"], receiverCount: 2)
         allFailureFallback.registerReceiver(0, expectedFileCount: 2)
         allFailureFallback.registerReceiver(1, expectedFileCount: 1)
-        _ = allFailureFallback.recordFailure(for: 0)
-        let finalReceiverFailure = allFailureFallback.recordFailure(for: 1)
+        _ = allFailureFallback.recordReceiverFailure(for: 0)
+        let finalReceiverFailure = allFailureFallback.recordReceiverFailure(for: 1)
         expect(finalReceiverFailure.fallback == nil
                 && allFailureFallback.finishRegistration()?.fallback == ["image"]
                 && !finalReceiverFailure.reportFailure,
                "fallback waits for every receiver in an all-failure batch")
 
-        // SwiftUI must request the content promise explicitly. Selecting the
-        // first registered promise flavor could load a URL string as a file.
-        let shelfServiceSource = (try? String(contentsOfFile:
+        // A failed local copy counts only the callback that failed. Outlook
+        // can keep delivering later attachments from the same receiver, and
+        // those files must not be accompanied by the message-subject fallback.
+        let partialCopyFailure = ShelfPromiseFallbackCoordinator(
+            items: ["subject"], receiverCount: 1)
+        partialCopyFailure.registerReceiver(0, expectedFileCount: 3)
+        let failedFirstCopy = partialCopyFailure.recordFileFailure(for: 0)
+        let secondAttachment = partialCopyFailure.recordSuccess(for: 0)
+        let thirdAttachment = partialCopyFailure.recordSuccess(for: 0)
+        let partialCopyCompletion = partialCopyFailure.finishRegistration()
+        expect(failedFirstCopy.fallback == nil
+                && secondAttachment.acceptFile
+                && secondAttachment.discardFallback == ["subject"]
+                && thirdAttachment.acceptFile
+                && partialCopyCompletion?.fallback == nil
+                && partialCopyCompletion?.reportFailure == true,
+               "a failed promised-file copy does not close its receiver or append subject fallback")
+
+        // Panel and pill drops must preserve the AppKit dragging pasteboard.
+        // Loading an NSItemProvider representation cannot construct the
+        // NSFilePromiseReceiver that Outlook and Mail require.
+        let shelfPromiseServiceSource = (try? String(contentsOfFile:
             "Sources/Vorssaint/Services/Shelf/ShelfService.swift", encoding: .utf8)) ?? ""
-        expect(shelfServiceSource.contains(
-            "com.apple.pasteboard.promised-file-content-type"),
-               "the SwiftUI promise loader names the content representation explicitly")
-        expect(shelfServiceSource.contains(
-            "return Self.filePromiseContentTypeIdentifier"),
-               "provider ordering cannot select the promised URL representation")
-        expect(!shelfServiceSource.contains(
-            "provider.registeredTypeIdentifiers.first"),
-               "the promise loader no longer trusts provider type ordering")
-        expect(shelfServiceSource.contains(
-            "] + [UTType(importedAs: filePromiseContentTypeIdentifier)]"),
-               "SwiftUI registers only the promise flavor its loader resolves")
-        expect(!shelfServiceSource.contains(
-            "] + NSFilePromiseReceiver.readableDraggedTypes.map { UTType(importedAs: $0) }"),
-               "SwiftUI does not advertise unresolved promise URL flavors")
+        let shelfViewSource = (try? String(contentsOfFile:
+            "Sources/Vorssaint/UI/Shelf/ShelfView.swift", encoding: .utf8)) ?? ""
+        let shelfDropZoneSource = (try? String(contentsOfFile:
+            "Sources/Vorssaint/UI/Shelf/ShelfDropZoneView.swift", encoding: .utf8)) ?? ""
+        let shelfTilesSource = (try? String(contentsOfFile:
+            "Sources/Vorssaint/UI/Shelf/ShelfTilesView.swift", encoding: .utf8)) ?? ""
+        expect(shelfPromiseServiceSource.contains("recordReceiverFailure(for: receiverID)")
+                && shelfPromiseServiceSource.contains("recordFileFailure(for: receiverID)"),
+               "AppKit receiver errors and local copy failures use distinct promise accounting")
+        expect(!shelfPromiseServiceSource.contains("loadFileRepresentation(forTypeIdentifier:"),
+               "Shelf no longer resolves promised files through NSItemProvider placeholders")
+        expect(shelfViewSource.contains("WindowMoveHandle(acceptsDrops: true)")
+                && shelfDropZoneSource.contains("WindowMoveHandle(acceptsDrops: true)"),
+               "both Shelf panel surfaces receive drops through the AppKit promise route")
+        expect(shelfTilesSource.contains("registerForDraggedTypes(ShelfService.tileDropTypes)")
+                && shelfTilesSource.contains(
+                    "ShelfService.shared.accept(pasteboard: sender.draggingPasteboard)"),
+               "the shared AppKit destination registers promise types and forwards its original pasteboard")
+        expect(!shelfViewSource.contains(".onDrop(")
+                && !shelfDropZoneSource.contains(".onDrop("),
+               "SwiftUI provider drops cannot bypass the file-promise receiver")
 
         // MARK: Result
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21335,6 +21335,60 @@ struct MetricsTests {
                "a container an earlier version left world readable is tightened on the next write")
         try? FileManager.default.removeItem(at: privateRoot)
 
+        // MARK: File-promise fallback coordination
+
+        // A non-item-based receiver can report several files through one
+        // reader callback sequence. A first failure must wait for the later
+        // success, and the successful promise must discard the direct
+        // fallback while still reporting the partial failure once the batch
+        // is complete.
+        let multiFileFallback = ShelfPromiseFallbackCoordinator(
+            items: ["subject"], receiverCount: 1)
+        multiFileFallback.registerReceiver(expectedFileCount: 2)
+        let firstFailure = multiFileFallback.recordFailure()
+        expect(firstFailure.fallback == nil && !firstFailure.reportFailure,
+               "a failed file waits for the remaining callbacks")
+        let laterSuccess = multiFileFallback.recordSuccess()
+        expect(laterSuccess.discardFallback == ["subject"]
+                && laterSuccess.fallback == nil
+                && !laterSuccess.reportFailure,
+               "a later success consumes the direct fallback without early feedback")
+        let multiFileCompletion = multiFileFallback.finishRegistration()
+        expect(multiFileCompletion?.reportFailure == true,
+               "a completed partial promise reports the failed file once")
+
+        // The reverse order must have the same result: success suppresses the
+        // fallback, but a later failed file still produces feedback instead of
+        // disappearing behind the already-consumed success.
+        let reverseOrderFallback = ShelfPromiseFallbackCoordinator(
+            items: ["subject"], receiverCount: 1)
+        reverseOrderFallback.registerReceiver(expectedFileCount: 2)
+        let firstSuccess = reverseOrderFallback.recordSuccess()
+        expect(firstSuccess.discardFallback == ["subject"]
+                && !firstSuccess.reportFailure,
+               "an early success suppresses fallback without early feedback")
+        let laterFailure = reverseOrderFallback.recordFailure()
+        expect(!laterFailure.reportFailure,
+               "a later failure waits until registration is complete")
+        let reverseCompletion = reverseOrderFallback.finishRegistration()
+        expect(reverseCompletion?.fallback == nil
+                && reverseCompletion?.reportFailure == true,
+               "a later failure after success is reported at batch completion")
+
+        // A completely failed multi-receiver batch still uses the direct
+        // representation, but only after every expected file callback fails.
+        let allFailureFallback = ShelfPromiseFallbackCoordinator(
+            items: ["image"], receiverCount: 2)
+        allFailureFallback.registerReceiver(expectedFileCount: 2)
+        allFailureFallback.registerReceiver(expectedFileCount: 1)
+        _ = allFailureFallback.recordFailure()
+        _ = allFailureFallback.recordFailure()
+        let finalFailure = allFailureFallback.recordFailure()
+        let allFailureCompletion = allFailureFallback.finishRegistration()
+        expect(finalFailure.fallback == nil && allFailureCompletion?.fallback == ["image"]
+                && allFailureCompletion?.reportFailure == false,
+               "the direct fallback is deferred until every promised file fails")
+
         // MARK: Result
 
         // MARK: Every defaults suite stays inside a namespace build.sh sweeps

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21411,8 +21411,9 @@ struct MetricsTests {
         let ignoredLateSuccess = lateSuccess.recordSuccess(for: 0)
         expect(lateFailureCompletion?.fallback == ["subject"]
                 && ignoredLateSuccess.acceptFile
-                && ignoredLateSuccess.discardFallback == nil,
-               "a late callback after wholesale failure is preserved beside fallback")
+                && ignoredLateSuccess.discardFallback == nil
+                && !ignoredLateSuccess.reportFailure,
+               "a late callback after wholesale failure is preserved without rearming failure feedback")
 
         // A completely failed multi-receiver batch still uses the direct
         // representation, but only after every receiver has failed.

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21402,7 +21402,7 @@ struct MetricsTests {
                "a partial receiver failure is reported after the batch completes")
 
         // If an error closes a receiver, a late success from that receiver
-        // must not create a promised tile after fallback has been selected.
+        // must be kept even when fallback has already been selected.
         let lateSuccess = ShelfPromiseFallbackCoordinator(
             items: ["subject"], receiverCount: 1)
         lateSuccess.registerReceiver(0, expectedFileCount: 2)
@@ -21410,9 +21410,9 @@ struct MetricsTests {
         let lateFailureCompletion = lateSuccess.finishRegistration()
         let ignoredLateSuccess = lateSuccess.recordSuccess(for: 0)
         expect(lateFailureCompletion?.fallback == ["subject"]
-                && !ignoredLateSuccess.acceptFile
-                && ignoredLateSuccess.fallback == nil,
-               "a late callback after wholesale failure cannot duplicate fallback")
+                && ignoredLateSuccess.acceptFile
+                && ignoredLateSuccess.discardFallback == nil,
+               "a late callback after wholesale failure is preserved beside fallback")
 
         // A completely failed multi-receiver batch still uses the direct
         // representation, but only after every receiver has failed.
@@ -21440,6 +21440,12 @@ struct MetricsTests {
         expect(!shelfServiceSource.contains(
             "provider.registeredTypeIdentifiers.first"),
                "the promise loader no longer trusts provider type ordering")
+        expect(shelfServiceSource.contains(
+            "] + [UTType(importedAs: filePromiseContentTypeIdentifier)]"),
+               "SwiftUI registers only the promise flavor its loader resolves")
+        expect(!shelfServiceSource.contains(
+            "] + NSFilePromiseReceiver.readableDraggedTypes.map { UTType(importedAs: $0) }"),
+               "SwiftUI does not advertise unresolved promise URL flavors")
 
         // MARK: Result
 

--- a/build.sh
+++ b/build.sh
@@ -373,6 +373,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/Cleaner/CleanerSchedule.swift \
         Sources/Vorssaint/Services/Uninstall/UninstallerSupport.swift \
         Sources/Vorssaint/Services/ManagedDownloads/WhatsAppDownloadSupport.swift \
+        Sources/Vorssaint/Services/Shelf/ShelfPromiseFallbackCoordinator.swift \
         Tests/MetricsTests.swift \
         -o build/metrics-tests
     # `set -e` would end the script on a failing run before the sweep below.


### PR DESCRIPTION
## Summary

- Add Shelf support for AppKit file promises exposed by Outlook and Mail.
- Materialize promised `.eml` messages and attachments asynchronously, then copy them into Shelf's owner-only file store as normal file items.
- Preserve original filenames as Shelf tile titles and support dropping promised files onto existing Shelf piles.

## Review follow-up

- All `NSFilePromiseReceiver` instances from one drag use AppKit's required shared staging destination. The fallback coordinator tracks the advertised callback count, handles callbacks that arrive during registration, and keeps direct representations pending until the promise batch reaches a terminal outcome.
- AppKit receiver errors and Shelf copy errors now have different accounting. An AppKit error closes the affected receiver wholesale so an unavailable receiver cannot wedge the batch. A `storePromisedFile` failure credits only that callback, allowing Outlook's later attachments from the same receiver to arrive normally. This prevents a message-subject fallback tile from appearing beside attachments that did succeed.
- A late materialized file remains accepted after a wholesale receiver failure or after direct fallback was selected. Direct fallback also marks the failure handled, so that late success cannot re-arm the failure HUD.
- The Shelf panel and docked pill now use the shared AppKit `WindowMoveHandle` drop destination. Both preserve the original dragging pasteboard and reach `accept(pasteboard:)`, which constructs `NSFilePromiseReceiver`. The former SwiftUI `NSItemProvider.loadFileRepresentation` route, including its placeholder fallback behavior, has been removed so Outlook's subject text cannot be accepted as a substitute tile on those surfaces.
- Promise-backed drops treat promised files as authoritative. Auxiliary text and URL flavors are held as a fallback only, and are discarded when any promised file succeeds. Ordinary file, image, URL, text, GIF, and pile-merge drops continue to use the same AppKit pasteboard path.
- Promise-copy cleanup remains limited to regular files inside the staging directory. Error callbacks never remove an AppKit-supplied directory, absent URL, or partial path.
- Removed the obsolete provider-batch helper and its tests with the retired SwiftUI route, leaving one canonical promise implementation.

## Verification

- Rebased onto current `main` at `ed882cd` and verified GitHub reports `behind_by: 0`.
- `./build.sh` passed after the rebase, including protected fan-helper compilation, app bundle assembly, and ad-hoc signing.
- `./build.sh --test` compiled and ran 9,498 checks. The new promise-coordinator and drop-route regressions passed. Eight existing host-dependent checks remain unavailable in this environment: WhatsApp bucketing, non-PNG image conversion, in-process AppleScript, JPEG/movie tool routing, and external-media staging and byte-preservation tests.
- `git diff --check` passed. The final diff contains no credentials or generated artifacts.

Live Outlook or Mail drags were not available in this environment. A maintainer should perform one drag with multiple attachments onto both the expanded Shelf panel and docked pill before merge. That provider-specific manual check is distinct from the successful local build and regression coverage above.

Refs #1083
