### PR TITLE
fix(dock-preview): cap how long a hover waits for the Dock

### DIFF
--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
@@ -1118,7 +1118,7 @@ final class DockPreviewService: ObservableObject {
         let system = AXUIElementCreateSystemWide()
         var rawElement: AXUIElement?
         guard AXUIElementCopyElementAtPosition(system, Float(axPoint.x), Float(axPoint.y), &rawElement) == .success,
-              let element = rawElement
+              let element = bounded(rawElement)
         else { return nil }
 
         for candidate in elementAndParents(from: element) {
@@ -1314,7 +1314,39 @@ final class DockPreviewService: ObservableObject {
               let value,
               CFGetTypeID(value) == AXUIElementGetTypeID()
         else { return nil }
-        return (value as! AXUIElement)
+        let child = value as! AXUIElement
+        return bounded(child)
+    }
+
+    /// Caps how long one Accessibility question about the Dock may take.
+    ///
+    /// These reads run on the main thread — the event tap's run-loop source is
+    /// on the main run loop and `handleOnMain` stays there — and they fire on
+    /// every mouse-move sample along the Dock's edge. The process they question
+    /// is the Dock, which is the one that stops answering (#971). The walk gives
+    /// up on its first failure, so a Dock that has stopped answering costs a few
+    /// of these per sample rather than the whole chain.
+    ///
+    /// Per element on purpose. Setting a timeout on the system-wide object sets
+    /// the process-wide default, and five features here already write that
+    /// global with three different values; hovering the Dock must not change how
+    /// long window layout or focus-follows-mouse wait. Measured on 26.6.2: a
+    /// value written to an element survives a later write to the global, and a
+    /// new element inherits whichever global was written last.
+    ///
+    /// The value matches what `AppDelegate` writes to the global at launch, so
+    /// a read here answers or gives up exactly when it does today. Tightening it
+    /// is a separate question: a read that gives up sooner is a hover that opens
+    /// no preview, and one that lands in the classifier reads as a pointer that
+    /// left the Dock, which closes a preview already open. That trade wants the
+    /// timeout signal in #1086 first, so a read that ran out is no longer
+    /// indistinguishable from an answer.
+    private static let messagingTimeout: Float = 0.35
+
+    private func bounded(_ element: AXUIElement?) -> AXUIElement? {
+        guard let element else { return nil }
+        AXUIElementSetMessagingTimeout(element, Self.messagingTimeout)
+        return element
     }
 
     private func stringAttribute(_ element: AXUIElement, _ attribute: String) -> String? {

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
@@ -1115,9 +1115,16 @@ final class DockPreviewService: ObservableObject {
             ownProcessID: getpid()
         ) else { return nil }
 
-        let system = AXUIElementCreateSystemWide()
+        // Hit-tested through the Dock's own application element rather than the
+        // system-wide one, so this read carries the cap below like every other
+        // read here; a timeout written on the system-wide object would be the
+        // process-wide default. The guard above has already established that the
+        // Dock owns this point and the loop below drops any candidate that is
+        // not the Dock's, so narrowing the search to its hierarchy removes no
+        // case that reaches here.
         var rawElement: AXUIElement?
-        guard AXUIElementCopyElementAtPosition(system, Float(axPoint.x), Float(axPoint.y), &rawElement) == .success,
+        guard let dock = bounded(AXUIElementCreateApplication(dockPID)),
+              AXUIElementCopyElementAtPosition(dock, Float(axPoint.x), Float(axPoint.y), &rawElement) == .success,
               let element = bounded(rawElement)
         else { return nil }
 
@@ -1323,9 +1330,9 @@ final class DockPreviewService: ObservableObject {
     /// These reads run on the main thread — the event tap's run-loop source is
     /// on the main run loop and `handleOnMain` stays there — and they fire on
     /// every mouse-move sample along the Dock's edge. The process they question
-    /// is the Dock, which is the one that stops answering (#971). The walk gives
-    /// up on its first failure, so a Dock that has stopped answering costs a few
-    /// of these per sample rather than the whole chain.
+    /// is the Dock, which is the one that stops answering (#971). Each step is a
+    /// guard, so a Dock that has stopped answering costs the hit test alone and
+    /// a Dock that answers it and then stops costs three.
     ///
     /// Per element on purpose. Setting a timeout on the system-wide object sets
     /// the process-wide default, and six features here already write that

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
@@ -1328,7 +1328,7 @@ final class DockPreviewService: ObservableObject {
     /// of these per sample rather than the whole chain.
     ///
     /// Per element on purpose. Setting a timeout on the system-wide object sets
-    /// the process-wide default, and five features here already write that
+    /// the process-wide default, and six features here already write that
     /// global with three different values; hovering the Dock must not change how
     /// long window layout or focus-follows-mouse wait. Measured on 26.6.2: a
     /// value written to an element survives a later write to the global, and a

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15192,6 +15192,25 @@ struct MetricsTests {
         expect(!appSources.isEmpty && unboundedOperationWaits.isEmpty,
                "no operation queue is waited on without a deadline: \(unboundedOperationWaits)")
 
+        // The Dock preview hit test reads Accessibility on the main thread on
+        // every mouse-move sample along the Dock's edge, and the process it
+        // questions is the Dock — the one that stops answering (issue #971).
+        // Its cap has to be written on the elements it holds: written on the
+        // system-wide object it is the process-wide default, which five other
+        // features already write with three different values, so hovering the
+        // Dock would change how long window layout and focus-follows-mouse
+        // wait. Comment lines are dropped first, since both spellings appear in
+        // the reasoning right above the code.
+        let dockPreviewLines = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift",
+            encoding: .utf8)) ?? "")
+            .components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+        expect(dockPreviewLines.contains { $0.contains("AXUIElementSetMessagingTimeout") },
+               "dock preview caps how long it waits for the Dock to answer")
+        expect(!dockPreviewLines.contains { $0.contains("AXUIElementSetMessagingTimeout(system") },
+               "dock preview caps its own elements, never the process-wide default")
+
         // Asking an application element for its role switches a Chromium app's
         // renderers into full accessibility mode for the rest of the process's
         // life (issue #953). It was fixed at the liveness probe, then found

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15196,7 +15196,7 @@ struct MetricsTests {
         // every mouse-move sample along the Dock's edge, and the process it
         // questions is the Dock — the one that stops answering (issue #971).
         // Its cap has to be written on the elements it holds: written on the
-        // system-wide object it is the process-wide default, which five other
+        // system-wide object it is the process-wide default, which six other
         // features already write with three different values, so hovering the
         // Dock would change how long window layout and focus-follows-mouse
         // wait. Comment lines are dropped first, since both spellings appear in
@@ -15208,7 +15208,8 @@ struct MetricsTests {
             .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
         expect(dockPreviewLines.contains { $0.contains("AXUIElementSetMessagingTimeout") },
                "dock preview caps how long it waits for the Dock to answer")
-        expect(!dockPreviewLines.contains { $0.contains("AXUIElementSetMessagingTimeout(system") },
+        expect(!dockPreviewLines.contains { $0.contains("AXUIElementSetMessagingTimeout(system")
+                                            || $0.contains("bounded(system") },
                "dock preview caps its own elements, never the process-wide default")
 
         // Asking an application element for its role switches a Chromium app's

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15199,8 +15199,10 @@ struct MetricsTests {
         // system-wide object it is the process-wide default, which six other
         // features already write with three different values, so hovering the
         // Dock would change how long window layout and focus-follows-mouse
-        // wait. Comment lines are dropped first, since both spellings appear in
-        // the reasoning right above the code.
+        // wait. The rule is the absence of that element here rather than of one
+        // spelling of the write, since the write can be reached through any
+        // name the element is given. Comment lines are dropped first, since the
+        // symbol appears in the reasoning right above the code.
         let dockPreviewLines = ((try? String(
             contentsOfFile: "Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift",
             encoding: .utf8)) ?? "")
@@ -15208,9 +15210,8 @@ struct MetricsTests {
             .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
         expect(dockPreviewLines.contains { $0.contains("AXUIElementSetMessagingTimeout") },
                "dock preview caps how long it waits for the Dock to answer")
-        expect(!dockPreviewLines.contains { $0.contains("AXUIElementSetMessagingTimeout(system")
-                                            || $0.contains("bounded(system") },
-               "dock preview caps its own elements, never the process-wide default")
+        expect(!dockPreviewLines.contains { $0.contains("AXUIElementCreateSystemWide") },
+               "dock preview never holds the element whose timeout is the process-wide default")
 
         // Asking an application element for its role switches a Chromium app's
         // renderers into full accessibility mode for the rest of the process's


### PR DESCRIPTION
## Summary

The hit test behind a Dock hover — `dockHit(at:)` — reads Accessibility on the
main thread, on every mouse-move sample along the Dock's edge, and the process
it questions is the Dock: the one that stops answering in #971. It set no
messaging timeout of its own, so every read waited for whatever the
process-wide default happened to be at that moment. Six features here write
that global with three different values (`AppDelegate` 0.35 at launch,
`WindowLayoutService` and `FocusFollowsMouseService` 0.25, `AutoQuitService`
and `FinderCutPaste` 0.15, `WindowMaximizer` 0.35), and the last write wins for the whole process, so how
long a Dock hover waits depended on which unrelated feature you used last.

Every element this file obtains now carries its own 0.35s cap, written at the
doors an element comes through rather than at the call sites, so a read added
later is capped without anyone remembering to. The hit test is one of them: it
went through the system-wide element, which is the one handle a timeout cannot
be written on without writing the global, and it takes an application element
just as well — the Dock's pid is in hand two lines above.

**Why per element rather than the global.** Setting the timeout on the
system-wide object *is* the process-wide default; hovering the Dock would then
change how long window layout and focus-follows-mouse wait. Measured on 26.6.2
against a synthetic Accessibility target: a value written to an element
survives a later write to the global, and a new element inherits whichever
global was written last. A per-element cap is the only way this path can hold
its own value without moving anyone else's.

**Why 0.35 and not tighter.** It is the value `AppDelegate` writes at launch, so
with the global untouched every read answers or gives up exactly when it does
today. Tightening it is a real question but not this one: a read that gives up
sooner is a hover that opens no preview, and a read that gives up inside the
pointer classifier reads as a pointer that left the Dock, which closes a preview
already open. #1086 reports that the 0.35 timeout already fires on this path
under contention, so that trade wants its timeout signal landed first, where a
read that ran out stops being indistinguishable from an answer.

**Effect. This is not a shorter wait.** Every step is a guard, so what a bad
Dock costs depends on which kind of bad it is. Per mouse-move sample, on the
main thread:

A Dock that has stopped answering fails the hit test and nothing after it runs —
one read:

| global at that moment | before | after |
|---|---|---|
| 0.35 — launch default, nobody moved it | 0.35s | 0.35s |
| 0.25 — after a window-layout gesture or focus-follows-mouse | 0.25s | 0.35s |
| 0.15 — after Finder cut/paste or auto-quit | 0.15s | 0.35s |

A Dock that answers the hit test and then stops costs three — hit test, one
parent read, then the candidate's position; `appKitFrame` is one guard chain, so
a position read that runs out short-circuits before the size read:

| global at that moment | before | after |
|---|---|---|
| 0.35 | 1.05s | 1.05s |
| 0.25 | 0.75s | 1.05s |
| 0.15 | 0.45s | 1.05s |

So in the two states where another feature has left the global tighter than
launch, this path now stalls longer than it did, by up to 0.6s. What it buys is
that the number is this path's own: a Dock hover no longer waits longer or
shorter because of a feature that has nothing to do with it, and the reads those
tighter globals were abandoning early — a Dock that is slow rather than stopped
— now answer. Whether 0.35 is the right number for a hover is a separate
question and now a one-constant one, since every read on the path reads it.

**Not changed.** The six writers of the global. The hit test now searches the
Dock's hierarchy rather than every process's, which removes no case that reaches
it: `dockOwnsPoint` walks the on-screen window list front to back and returns
false when anything else covers the point, and the loop below already dropped
every candidate whose pid was not the Dock's.

The comments in `WindowMaximizer`, `AutoQuitService`, `WindowEnumerator` and
`WindowLayoutService` all cite a "6 second default"; against a synthetic
Accessibility target on 26.6.2 the unset default measured 1.5s, not 6s. Not
checked against a bundled application, so those comments are left alone and the
number is offered here rather than corrected in five files.

## Verification

MacBook (Apple silicon), macOS 26.6.2, my own `./build.sh` release build, single
display.

```sh
./build.sh                     # no warnings
./build/Vorssaint --selftest   # SELFTEST OK
./build.sh --test              # TESTS OK (8939 checks)
```

Hit-testing through the Dock's application element was measured against the
running Dock: an icon's centre resolves to the element the system-wide call
returns, `CFEqual`, same frame, same pid.

Two assertions added, both verified in both directions: reverting the source
change reddens "caps how long it waits for the Dock to answer", and putting
`AXUIElementCreateSystemWide` back in the file reddens "never holds the element
whose timeout is the process-wide default". The second is green on unmodified
`main` by design — it pins the shape of the fix rather than restating it. It
keys on the absence of that public symbol rather than on one spelling of the
write, so renaming a local does not retire it. Comment lines are stripped before
the scan, since the symbol appears in the reasoning above the code.

`#938` states the writer count in its title and carries the same correction.

**What I could not test.** A genuinely hung Dock. The timings above are the
arithmetic of four reads at a known cap; the cap behaviour was measured against
a synthetic target — a second process holding its main thread — not against the
Dock. The global's reach was measured with elements from
`AXUIElementCreateApplication`; that elements from
`AXUIElementCopyElementAtPosition` inherit the same default is taken from it
being process-wide, not separately measured. Under a healthy Dock nothing
changes: a Dock that answers in microseconds never reaches any of these caps.

## Anything else

#971 carries more than one report. This covers only the Dock preview path named
in its title; the dispatch-pool exhaustion and the unbounded window walk were
fixed in #989. It does not conflict with #1086, which is the other half of the
same timeout — what a read that ran out is allowed to mean — in shared code this
path reaches by pid rather than by element.

This is #938's third question — whether `DockPreviewService` needs its own cap
— and it arrives with the fact that issue was missing. #938 holds a patch of
this shape back because capping the hit test looked like it required becoming
the sixth writer of the global: "the first question it asks goes to the
system-wide object". It does not have to. `AXUIElementCopyElementAtPosition`
takes an application element, and against the running Dock it returns the same
element the system-wide call returns, so all three reads on this path are capped
without a global write and without the half-measure that issue declines.

Questions 1 and 2 there — whether anything should write the process-global value
at all, and what it should be — are untouched. This adds no writer and moves no
existing one; if the answer to 1 is that every one of the six becomes
element-scoped, this path is already in that shape. The guard added here is
question 4's assertion, scoped to the one file rather than the repository.

Refs #971
Refs #938
