### PR TITLE
fix(clipboard): keep a long entry inside its row in the menu panel

### DIFF
--- a/Sources/Vorssaint/UI/MenuPanel/PanelClipboardView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/PanelClipboardView.swift
@@ -138,11 +138,15 @@ struct PanelClipboardView: View {
     private func entryPreview(_ entry: ClipboardHistoryEntry) -> some View {
         switch entry.kind {
         case .text:
+            // Deliberately not selectable: clicking a selectable Text swaps in
+            // the selection renderer, which lays the whole preview out and
+            // ignores the line limit, so a long entry paints over the rows
+            // below it. The history window shows the full, selectable text.
             Text(entry.preview)
                 .font(.system(size: 10.5))
                 .lineLimit(3)
                 .truncationMode(.tail)
-                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
         case .image:
             HStack(alignment: .center, spacing: 7) {
                 if let name = entry.imageFile,


### PR DESCRIPTION
## Summary

Clicking a long text entry in the menu panel's Clipboard utility painted its whole text over the entries below it, and the panel only recovered on reopen.

The row preview was a `Text` with `.textSelection(.enabled)` and `.lineLimit(3)`. A click on a selectable `Text` swaps in the selection renderer, which lays the whole string out and ignores the line limit, so the row grew under the rows after it. Reproduced in an isolated SwiftUI harness with the panel's row and nested-scroll shape: same overflow with selection on, correct truncation with it off.

The row no longer offers inline selection. The full, selectable text is in the clipboard window, which the panel already opens. The other clipboard previews (quick window rows, preview sidebar) were checked: the quick window rows never had selection, and the sidebar shows the full text without a line limit, so neither has this defect.

What a user notices: expanding the Clipboard utility and clicking or dragging across a long entry keeps the list intact.

## Verification

MacBook Pro 14" (MacBookPro18,3, M1 Pro), macOS 15.7.7 (24G720), one built-in Retina display, one Space, English (US). Own build: `./build.sh --dev --install` for hands-on checks, `./build.sh` (release) finishes without warnings, `./build/Vorssaint --selftest` passes, `./build.sh --test` passes.
Checked by hand in the developer build: drag across a long entry in the panel, the list stays laid out.
