### PR TITLE
fix: stop features setting each other's Accessibility timeout

### DIFF
--- a/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
+++ b/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
@@ -489,8 +489,7 @@ final class AutoQuitService: ObservableObject {
             }
         }
         for attribute in [kAXMainWindowAttribute, kAXFocusedWindowAttribute] {
-            if let window = Self.windowAttribute(appElement, attribute as String) {
-                AXUIElementSetMessagingTimeout(window, 0.35)
+            if let window = Self.windowAttribute(appElement, attribute as String, cappedAt: 0.35) {
                 if Self.isStandardWindow(window) { Self.appendUnique(window, to: &result) }
             }
         }
@@ -524,12 +523,21 @@ final class AutoQuitService: ObservableObject {
         windows.append(window)
     }
 
-    private static func windowAttribute(_ appElement: AXUIElement, _ attribute: String) -> AXUIElement? {
+    /// The cap travels with the caller because this is the door elements come
+    /// through on two paths that wait different lengths — the observer walk at
+    /// 0.35 and the click tap at 0.15. An element produced here is a fresh one:
+    /// it takes the process-wide default, not the cap on the element it was
+    /// read from, so leaving it uncapped puts it on whatever the global says.
+    private static func windowAttribute(_ appElement: AXUIElement,
+                                        _ attribute: String,
+                                        cappedAt timeout: Float) -> AXUIElement? {
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(appElement, attribute as CFString, &value) == .success,
               let value,
               CFGetTypeID(value) == AXUIElementGetTypeID() else { return nil }
-        return (value as! AXUIElement)
+        let element = value as! AXUIElement
+        AXUIElementSetMessagingTimeout(element, timeout)
+        return element
     }
 
     private static func boolAttribute(_ element: AXUIElement, _ attribute: String, default defaultValue: Bool = false) -> Bool {
@@ -765,7 +773,7 @@ final class AutoQuitService: ObservableObject {
     private func closeButtonPID(at point: CGPoint, candidate: TrafficLightCandidate) -> pid_t? {
         guard candidate.pid != getpid(), observers[candidate.pid] != nil else { return nil }
         guard let element = elementAt(point: point, in: candidate.pid),
-              let window = Self.topLevelWindow(from: element)
+              let window = Self.topLevelWindow(from: element, cappedAt: 0.15)
         else { return candidate.pid }
 
         var pid: pid_t = 0
@@ -774,7 +782,7 @@ final class AutoQuitService: ObservableObject {
         guard pid == candidate.pid else { return nil }
 
         guard Self.isStandardWindow(window),
-              let closeButton = Self.windowAttribute(window, kAXCloseButtonAttribute as String),
+              let closeButton = Self.windowAttribute(window, kAXCloseButtonAttribute as String, cappedAt: 0.15),
               Self.boolAttribute(closeButton, kAXEnabledAttribute as String, default: true),
               let buttonFrame = Self.frame(of: closeButton)
         else { return candidate.pid }
@@ -817,14 +825,15 @@ final class AutoQuitService: ObservableObject {
         return CFEqual(element, AXUIElementCreateApplication(pid))
     }
 
-    private static func topLevelWindow(from element: AXUIElement) -> AXUIElement? {
+    private static func topLevelWindow(from element: AXUIElement,
+                                       cappedAt timeout: Float) -> AXUIElement? {
         guard !isApplicationElement(element) else { return nil }
         if role(of: element) == (kAXWindowRole as String) { return element }
-        if let window = windowAttribute(element, kAXWindowAttribute as String),
+        if let window = windowAttribute(element, kAXWindowAttribute as String, cappedAt: timeout),
            role(of: window) == (kAXWindowRole as String) {
             return window
         }
-        if let window = windowAttribute(element, kAXTopLevelUIElementAttribute as String),
+        if let window = windowAttribute(element, kAXTopLevelUIElementAttribute as String, cappedAt: timeout),
            role(of: window) == (kAXWindowRole as String) {
             return window
         }
@@ -837,7 +846,7 @@ final class AutoQuitService: ObservableObject {
         // already ends with no window in that case.
         var current = element
         for _ in 0..<8 {
-            guard let parent = windowAttribute(current, kAXParentAttribute as String) else { return nil }
+            guard let parent = windowAttribute(current, kAXParentAttribute as String, cappedAt: timeout) else { return nil }
             if isApplicationElement(parent) { return nil }
             if role(of: parent) == (kAXWindowRole as String) { return parent }
             current = parent

--- a/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
+++ b/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
@@ -764,7 +764,7 @@ final class AutoQuitService: ObservableObject {
 
     private func closeButtonPID(at point: CGPoint, candidate: TrafficLightCandidate) -> pid_t? {
         guard candidate.pid != getpid(), observers[candidate.pid] != nil else { return nil }
-        guard let element = elementAt(point: point),
+        guard let element = elementAt(point: point, in: candidate.pid),
               let window = Self.topLevelWindow(from: element)
         else { return candidate.pid }
 
@@ -782,15 +782,21 @@ final class AutoQuitService: ObservableObject {
         return buttonFrame.insetBy(dx: -4, dy: -4).contains(point) ? pid : nil
     }
 
-    private func elementAt(point: CGPoint) -> AXUIElement? {
-        let system = AXUIElementCreateSystemWide()
-        // This runs while a click is being handled, and the app being asked is
-        // the one that was just told to close, which is exactly when an app
-        // stops answering. A short limit here means a slow answer is dropped
-        // rather than holding this app, and every tap it runs, still.
-        AXUIElementSetMessagingTimeout(system, 0.15)
+    /// This runs while a click is being handled, and the app being asked is the
+    /// one that was just told to close, which is exactly when an app stops
+    /// answering. A short limit here means a slow answer is dropped rather than
+    /// holding this app, and every tap it runs, still.
+    ///
+    /// Hit-tested through that app's own element rather than the system-wide
+    /// one, so the limit belongs to this call; written on the system-wide
+    /// object it would be the process-wide default (#938). The caller has the
+    /// pid from the window list already and rejects any window that does not
+    /// match it.
+    private func elementAt(point: CGPoint, in pid: pid_t) -> AXUIElement? {
+        let app = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(app, 0.15)
         var element: AXUIElement?
-        guard AXUIElementCopyElementAtPosition(system, Float(point.x), Float(point.y), &element) == .success
+        guard AXUIElementCopyElementAtPosition(app, Float(point.x), Float(point.y), &element) == .success
         else { return nil }
         if let element { AXUIElementSetMessagingTimeout(element, 0.15) }
         return element

--- a/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
+++ b/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
@@ -480,12 +480,9 @@ final class AutoQuitService: ObservableObject {
 
     private func standardWindows(of appElement: AXUIElement) -> [AXUIElement] {
         var result: [AXUIElement] = []
-        var value: CFTypeRef?
-        if AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &value) == .success,
-           let windows = value as? [AXUIElement] {
-            for window in windows {
-                AXUIElementSetMessagingTimeout(window, 0.35)
-                if Self.isStandardWindow(window) { Self.appendUnique(window, to: &result) }
+        if let windows = Self.windowsAttribute(appElement, cappedAt: 0.35) {
+            for window in windows where Self.isStandardWindow(window) {
+                Self.appendUnique(window, to: &result)
             }
         }
         for attribute in [kAXMainWindowAttribute, kAXFocusedWindowAttribute] {
@@ -528,6 +525,18 @@ final class AutoQuitService: ObservableObject {
     /// 0.35 and the click tap at 0.15. An element produced here is a fresh one:
     /// it takes the process-wide default, not the cap on the element it was
     /// read from, so leaving it uncapped puts it on whatever the global says.
+    /// Every element in the list, for the same reason as the one above: a
+    /// caller that picks one of them still asked the others something first.
+    private static func windowsAttribute(_ appElement: AXUIElement,
+                                         cappedAt timeout: Float) -> [AXUIElement]? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &value) == .success,
+              let windows = value as? [AXUIElement]
+        else { return nil }
+        for window in windows { AXUIElementSetMessagingTimeout(window, timeout) }
+        return windows
+    }
+
     private static func windowAttribute(_ appElement: AXUIElement,
                                         _ attribute: String,
                                         cappedAt timeout: Float) -> AXUIElement? {

--- a/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
+++ b/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
@@ -772,7 +772,7 @@ final class AutoQuitService: ObservableObject {
 
     private func closeButtonPID(at point: CGPoint, candidate: TrafficLightCandidate) -> pid_t? {
         guard candidate.pid != getpid(), observers[candidate.pid] != nil else { return nil }
-        guard let element = elementAt(point: point, in: candidate.pid),
+        guard let element = elementAt(point: point),
               let window = Self.topLevelWindow(from: element, cappedAt: 0.15)
         else { return candidate.pid }
 
@@ -795,16 +795,18 @@ final class AutoQuitService: ObservableObject {
     /// answering. A short limit here means a slow answer is dropped rather than
     /// holding this app, and every tap it runs, still.
     ///
-    /// Hit-tested through that app's own element rather than the system-wide
-    /// one, so the limit belongs to this call; written on the system-wide
-    /// object it would be the process-wide default (#938). The caller has the
-    /// pid from the window list already and rejects any window that does not
-    /// match it.
-    private func elementAt(point: CGPoint, in pid: pid_t) -> AXUIElement? {
-        let app = AXUIElementCreateApplication(pid)
-        AXUIElementSetMessagingTimeout(app, 0.15)
+    /// No cap is written on the system-wide object here — that is the
+    /// process-wide default (#938) — so this one read inherits the launch
+    /// default and everything reached through it carries the limit above.
+    /// Asking the app's own element would let this read carry it too, but that
+    /// hit test ignores occlusion, and the `pid` comparison in the caller is
+    /// what rejects a click that landed on another process's panel over this
+    /// window: `candidate` skips every window that is not layer 0, so the panel
+    /// is never the candidate.
+    private func elementAt(point: CGPoint) -> AXUIElement? {
+        let system = AXUIElementCreateSystemWide()
         var element: AXUIElement?
-        guard AXUIElementCopyElementAtPosition(app, Float(point.x), Float(point.y), &element) == .success
+        guard AXUIElementCopyElementAtPosition(system, Float(point.x), Float(point.y), &element) == .success
         else { return nil }
         if let element { AXUIElementSetMessagingTimeout(element, 0.15) }
         return element

--- a/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
+++ b/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
@@ -172,7 +172,7 @@ final class AutoQuitService: ObservableObject {
 
         let appElement = AXUIElementCreateApplication(pid)
         // A launching app that is busy (say, blocked on a Keychain prompt)
-        // would hold every synchronous AX call below for the 6 second default
+        // would hold every synchronous AX call below for the default
         // timeout apiece, freezing the main thread and every event tap with
         // it: typing dies system wide (issue #189). Give up fast and retry
         // with growing spacing until the app services its run loop again.
@@ -335,7 +335,7 @@ final class AutoQuitService: ObservableObject {
 
         let appElement = AXUIElementCreateApplication(pid)
         // Bounded AX: an unresponsive app must not hold the main thread
-        // (and with it every event tap) for the 6 second default timeout.
+        // (and with it every event tap) for the default timeout.
         AXUIElementSetMessagingTimeout(appElement, 0.35)
         let hasMinimizedWindow = hasKnownMinimizedWindow(pid: pid, appElement: appElement)
         let hasVisibleWindow = hasUserFacingWindow(pid: pid, appElement: appElement)

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
@@ -1115,16 +1115,17 @@ final class DockPreviewService: ObservableObject {
             ownProcessID: getpid()
         ) else { return nil }
 
-        // Hit-tested through the Dock's own application element rather than the
-        // system-wide one, so this read carries the cap below like every other
-        // read here; a timeout written on the system-wide object would be the
-        // process-wide default. The guard above has already established that the
-        // Dock owns this point and the loop below drops any candidate that is
-        // not the Dock's, so narrowing the search to its hierarchy removes no
-        // case that reaches here.
+        // Asked of the system-wide element, so this read alone runs on the
+        // launch default: a timeout written on that object is the process-wide
+        // one (#938), and the application element that could carry a cap
+        // answers for its own hierarchy whatever is drawn over it.
+        // `dockOwnsPoint` above skips a window of ours on the point rather than
+        // rejecting it, so a pinned preview panel over the strip reaches here,
+        // and the `pid` comparison below is what keeps it from opening a
+        // preview for the icon underneath.
+        let system = AXUIElementCreateSystemWide()
         var rawElement: AXUIElement?
-        guard let dock = bounded(AXUIElementCreateApplication(dockPID)),
-              AXUIElementCopyElementAtPosition(dock, Float(axPoint.x), Float(axPoint.y), &rawElement) == .success,
+        guard AXUIElementCopyElementAtPosition(system, Float(axPoint.x), Float(axPoint.y), &rawElement) == .success,
               let element = bounded(rawElement)
         else { return nil }
 

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
@@ -1335,19 +1335,20 @@ final class DockPreviewService: ObservableObject {
     /// a Dock that answers it and then stops costs three.
     ///
     /// Per element on purpose. Setting a timeout on the system-wide object sets
-    /// the process-wide default, and six features here already write that
-    /// global with three different values; hovering the Dock must not change how
-    /// long window layout or focus-follows-mouse wait. Measured on 26.6.2: a
-    /// value written to an element survives a later write to the global, and a
-    /// new element inherits whichever global was written last.
+    /// the process-wide default for every question this process asks, whoever
+    /// asks it, so hovering the Dock would change how long the other
+    /// Accessibility features wait. Measured on 26.6.2: a value written to an
+    /// element survives a later write to the global, and a fresh element takes
+    /// whichever global was written last rather than the cap on the element it
+    /// came from — which is why the two doors above carry it rather than the
+    /// call sites.
     ///
-    /// The value matches what `AppDelegate` writes to the global at launch, so
-    /// a read here answers or gives up exactly when it does today. Tightening it
-    /// is a separate question: a read that gives up sooner is a hover that opens
-    /// no preview, and one that lands in the classifier reads as a pointer that
-    /// left the Dock, which closes a preview already open. That trade wants the
-    /// timeout signal in #1086 first, so a read that ran out is no longer
-    /// indistinguishable from an answer.
+    /// This number is this path's alone. Tightening it is a separate question:
+    /// a read that gives up sooner is a hover that opens no preview, and one
+    /// that lands in the classifier reads as a pointer that left the Dock,
+    /// which closes a preview already open. That trade wants the timeout signal
+    /// in #1086 first, so a read that ran out is no longer indistinguishable
+    /// from an answer.
     private static let messagingTimeout: Float = 0.35
 
     private func bounded(_ element: AXUIElement?) -> AXUIElement? {

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
@@ -1115,10 +1115,17 @@ final class DockPreviewService: ObservableObject {
             ownProcessID: getpid()
         ) else { return nil }
 
-        let system = AXUIElementCreateSystemWide()
+        // Hit-tested through the Dock's own application element rather than the
+        // system-wide one, so this read carries the cap below like every other
+        // read here; a timeout written on the system-wide object would be the
+        // process-wide default. The guard above has already established that the
+        // Dock owns this point and the loop below drops any candidate that is
+        // not the Dock's, so narrowing the search to its hierarchy removes no
+        // case that reaches here.
         var rawElement: AXUIElement?
-        guard AXUIElementCopyElementAtPosition(system, Float(axPoint.x), Float(axPoint.y), &rawElement) == .success,
-              let element = rawElement
+        guard let dock = bounded(AXUIElementCreateApplication(dockPID)),
+              AXUIElementCopyElementAtPosition(dock, Float(axPoint.x), Float(axPoint.y), &rawElement) == .success,
+              let element = bounded(rawElement)
         else { return nil }
 
         for candidate in elementAndParents(from: element) {
@@ -1314,7 +1321,39 @@ final class DockPreviewService: ObservableObject {
               let value,
               CFGetTypeID(value) == AXUIElementGetTypeID()
         else { return nil }
-        return (value as! AXUIElement)
+        let child = value as! AXUIElement
+        return bounded(child)
+    }
+
+    /// Caps how long one Accessibility question about the Dock may take.
+    ///
+    /// These reads run on the main thread — the event tap's run-loop source is
+    /// on the main run loop and `handleOnMain` stays there — and they fire on
+    /// every mouse-move sample along the Dock's edge. The process they question
+    /// is the Dock, which is the one that stops answering (#971). Each step is a
+    /// guard, so a Dock that has stopped answering costs the hit test alone and
+    /// a Dock that answers it and then stops costs three.
+    ///
+    /// Per element on purpose. Setting a timeout on the system-wide object sets
+    /// the process-wide default, and six features here already write that
+    /// global with three different values; hovering the Dock must not change how
+    /// long window layout or focus-follows-mouse wait. Measured on 26.6.2: a
+    /// value written to an element survives a later write to the global, and a
+    /// new element inherits whichever global was written last.
+    ///
+    /// The value matches what `AppDelegate` writes to the global at launch, so
+    /// a read here answers or gives up exactly when it does today. Tightening it
+    /// is a separate question: a read that gives up sooner is a hover that opens
+    /// no preview, and one that lands in the classifier reads as a pointer that
+    /// left the Dock, which closes a preview already open. That trade wants the
+    /// timeout signal in #1086 first, so a read that ran out is no longer
+    /// indistinguishable from an answer.
+    private static let messagingTimeout: Float = 0.35
+
+    private func bounded(_ element: AXUIElement?) -> AXUIElement? {
+        guard let element else { return nil }
+        AXUIElementSetMessagingTimeout(element, Self.messagingTimeout)
+        return element
     }
 
     private func stringAttribute(_ element: AXUIElement, _ attribute: String) -> String? {

--- a/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
@@ -445,7 +445,11 @@ final class FinderCutPaste: ObservableObject {
               // Type-check before casting: this runs inside the event tap, so
               // an unexpected CF type must degrade gracefully, never crash.
               CFGetTypeID(focused) == AXUIElementGetTypeID() else { return false }
+        // The focused element is a fresh element, and a fresh one takes the
+        // process-wide default rather than the cap on the element it came from,
+        // so the role read below needs its own or it waits the default here.
         let element = focused as! AXUIElement
+        AXUIElementSetMessagingTimeout(element, 0.15)
         var roleRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(element, "AXRole" as CFString, &roleRef) == .success,
               let role = roleRef as? String else { return false }

--- a/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
@@ -287,9 +287,10 @@ final class FinderCutPaste: ObservableObject {
         let flags = event.flags
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
 
-        guard NSWorkspace.shared.frontmostApplication?.bundleIdentifier == Self.finderBundleID,
+        guard let finder = NSWorkspace.shared.frontmostApplication,
+              finder.bundleIdentifier == Self.finderBundleID,
               AXIsProcessTrusted(),
-              !isEditingText()
+              !isEditingText(in: finder.processIdentifier)
         else { return Unmanaged.passUnretained(event) }
 
         switch keyCode {
@@ -425,15 +426,21 @@ final class FinderCutPaste: ObservableObject {
 
     /// True when the keyboard focus is in an editable text control, so cut/copy/
     /// paste shortcuts must be left to the system (e.g. renaming a file).
-    private func isEditingText() -> Bool {
-        let system = AXUIElementCreateSystemWide()
-        // The whole session's typing waits for this tap to answer, and this
-        // question goes to whichever app is in front. A file browser reading a
-        // share that went away is exactly the app that stops answering, so the
-        // wait is kept short enough not to be felt.
-        AXUIElementSetMessagingTimeout(system, 0.15)
+    ///
+    /// Asked of Finder's own element rather than the system-wide one. The whole
+    /// session's typing waits for this tap to answer, and Finder reading a share
+    /// that went away is exactly the app that stops answering, so the wait is
+    /// kept short enough not to be felt — but a timeout written on the
+    /// system-wide object is the process-wide default, and this feature was
+    /// setting it for every other one (#938). The caller has already established
+    /// that Finder is frontmost, and the two questions return the same element:
+    /// measured on 26.6.2 with the file list focused and with the Go to Folder
+    /// field focused, both reads gave the same role.
+    private func isEditingText(in pid: pid_t) -> Bool {
+        let finder = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(finder, 0.15)
         var focused: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(system, "AXFocusedUIElement" as CFString, &focused) == .success,
+        guard AXUIElementCopyAttributeValue(finder, "AXFocusedUIElement" as CFString, &focused) == .success,
               let focused,
               // Type-check before casting: this runs inside the event tap, so
               // an unexpected CF type must degrade gracefully, never crash.

--- a/Sources/Vorssaint/Services/Finder/FinderRenameService.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderRenameService.swift
@@ -183,7 +183,11 @@ final class FinderRenameService {
                                             &focused) == .success,
               let focused, CFGetTypeID(focused) == AXUIElementGetTypeID()
         else { return nil }
+        // A fresh element takes the process-wide default rather than the cap on
+        // the element it was read from, so the role read below needs its own or
+        // it waits the default on the rename shortcut's tap.
         let element = focused as! AXUIElement
+        AXUIElementSetMessagingTimeout(element, 0.15)
         var role: CFTypeRef?
         guard AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString,
                                             &role) == .success,

--- a/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
+++ b/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
@@ -8,11 +8,14 @@ import CoreGraphics
 final class FocusFollowsMouseService {
     static let shared = FocusFollowsMouseService()
 
-    private let systemElement: AXUIElement = {
-        let element = AXUIElementCreateSystemWide()
-        AXUIElementSetMessagingTimeout(element, 0.25)
-        return element
-    }()
+    /// No cap is written on this element: it is the system-wide object, and a
+    /// timeout there is the process-wide default (#938). This service is the
+    /// one that can least afford to set it — its queries run on `queryQueue`,
+    /// so a slow answer costs it nothing but a focus change deferred to the
+    /// next tick, while three features that stall the main thread inside an
+    /// event tap were inheriting whatever it wrote. The elements this hit test
+    /// returns are capped below.
+    private let systemElement = AXUIElementCreateSystemWide()
     private let queryQueue = DispatchQueue(label: "com.vorssaint.focus-follows-mouse")
     private var timer: Timer?
     private var mouseMonitor: Any?

--- a/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
+++ b/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
@@ -133,8 +133,7 @@ final class FocusFollowsMouseService {
               let rawElement
         else { return nil }
         AXUIElementSetMessagingTimeout(rawElement, 0.25)
-        guard let window = topLevelWindow(from: rawElement) else { return nil }
-        AXUIElementSetMessagingTimeout(window, 0.25)
+        guard let window = topLevelWindow(from: rawElement, cappedAt: 0.25) else { return nil }
         guard stringAttribute(window, kAXRoleAttribute as String) == (kAXWindowRole as String),
               let windowID = AXWindowResolver.windowID(for: window)
         else { return nil }
@@ -148,7 +147,11 @@ final class FocusFollowsMouseService {
                       isFocused: boolAttribute(window, kAXFocusedAttribute as String))
     }
 
-    private func topLevelWindow(from element: AXUIElement) -> AXUIElement? {
+    /// The cap is the caller's, and written here rather than where the result
+    /// is used: an element read out of another one is a fresh element and takes
+    /// the process-wide default, so a caller that forgets puts every read off it
+    /// on the global.
+    private func topLevelWindow(from element: AXUIElement, cappedAt timeout: Float) -> AXUIElement? {
         if stringAttribute(element, kAXRoleAttribute as String) == (kAXWindowRole as String) {
             return element
         }
@@ -156,7 +159,9 @@ final class FocusFollowsMouseService {
         guard AXUIElementCopyAttributeValue(element, kAXWindowAttribute as CFString, &value) == .success,
               let value, CFGetTypeID(value) == AXUIElementGetTypeID()
         else { return nil }
-        return (value as! AXUIElement)
+        let window = value as! AXUIElement
+        AXUIElementSetMessagingTimeout(window, timeout)
+        return window
     }
 
     private func stringAttribute(_ element: AXUIElement, _ name: String) -> String? {

--- a/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
@@ -501,7 +501,7 @@ enum WindowEnumerator {
         let app = AXUIElementCreateApplication(pid)
         // This runs on the main thread (tap callback and activation warm-ups):
         // an app that is not servicing its run loop would hold every AX call
-        // for the 6 second default timeout, and a blocked main thread stalls
+        // for the default timeout, and a blocked main thread stalls
         // the event taps with it, freezing typing system wide (issue #189).
         AXUIElementSetMessagingTimeout(app, messagingTimeout)
         var axWindows: [AXUIElement] = []

--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
@@ -294,7 +294,7 @@ final class WindowLayoutService: ObservableObject {
             else { continue }
             let axApp = AXUIElementCreateApplication(pid)
             // Bounded AX: a hung app in the MRU list must not stall the main
-            // thread (and every event tap) for the 6 second default timeout.
+            // thread (and every event tap) for the default timeout.
             AXUIElementSetMessagingTimeout(axApp, 0.35)
             for attribute in [kAXFocusedWindowAttribute, kAXMainWindowAttribute] {
                 if let window = windowAttribute(axApp, attribute as String),

--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
@@ -1715,8 +1715,12 @@ final class WindowLayoutService: ObservableObject {
 
     private func gestureTarget(at point: CGPoint,
                                requiresResize: Bool) -> WindowGestureTarget? {
+        // No cap is written here: the only handle this hit test has is the
+        // system-wide object, and a timeout on that is the process-wide default
+        // (#938). The gesture fires on a press rather than on movement, so this
+        // is one read per drag and it inherits the launch default. Everything
+        // after it is capped on the element itself.
         let system = AXUIElementCreateSystemWide()
-        AXUIElementSetMessagingTimeout(system, 0.25)
         var rawElement: AXUIElement?
         guard AXUIElementCopyElementAtPosition(system, Float(point.x), Float(point.y), &rawElement) == .success,
               let element = rawElement

--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
@@ -297,7 +297,7 @@ final class WindowLayoutService: ObservableObject {
             // thread (and every event tap) for the default timeout.
             AXUIElementSetMessagingTimeout(axApp, 0.35)
             for attribute in [kAXFocusedWindowAttribute, kAXMainWindowAttribute] {
-                if let window = windowAttribute(axApp, attribute as String),
+                if let window = windowAttribute(axApp, attribute as String, cappedAt: 0.35),
                    let target = target(from: window,
                                        app: app,
                                        onScreenWindowIDs: onScreenWindowIDs,
@@ -305,7 +305,7 @@ final class WindowLayoutService: ObservableObject {
                     return target
                 }
             }
-            if let windows = windowsAttribute(axApp),
+            if let windows = windowsAttribute(axApp, cappedAt: 0.35),
                let first = windows.compactMap({ target(from: $0,
                                                         app: app,
                                                         onScreenWindowIDs: onScreenWindowIDs,
@@ -1183,10 +1183,9 @@ final class WindowLayoutService: ObservableObject {
               !app.isTerminated, app.activationPolicy == .regular else { return nil }
         let axApp = AXUIElementCreateApplication(pressCandidate.pid)
         AXUIElementSetMessagingTimeout(axApp, 0.25)
-        guard let window = windowsAttribute(axApp)?.first(where: {
+        guard let window = windowsAttribute(axApp, cappedAt: 0.25)?.first(where: {
                   AXWindowResolver.windowID(for: $0) == pressCandidate.windowID
               }) else { return nil }
-        AXUIElementSetMessagingTimeout(window, 0.25)
         guard let onScreenWindowIDs = onScreenWindowIDs(),
               let target = target(from: window,
                                   app: app,
@@ -1731,11 +1730,10 @@ final class WindowLayoutService: ObservableObject {
         if role(of: element) == (kAXWindowRole as String) {
             window = element
         } else {
-            window = windowAttribute(element, kAXWindowAttribute as String)
-                ?? windowAttribute(element, kAXTopLevelUIElementAttribute as String)
+            window = windowAttribute(element, kAXWindowAttribute as String, cappedAt: 0.25)
+                ?? windowAttribute(element, kAXTopLevelUIElementAttribute as String, cappedAt: 0.25)
         }
         guard let window else { return nil }
-        AXUIElementSetMessagingTimeout(window, 0.25)
 
         var pid = pid_t(0)
         guard role(of: window) == (kAXWindowRole as String),
@@ -1865,20 +1863,32 @@ final class WindowLayoutService: ObservableObject {
         return value as? String
     }
 
-    private func windowAttribute(_ element: AXUIElement, _ attribute: String) -> AXUIElement? {
+    /// The cap is the caller's: an element read out of another one is a fresh
+    /// element and takes the process-wide default, not the cap on the element it
+    /// came from, so every read off it would run on the global instead.
+    private func windowAttribute(_ element: AXUIElement,
+                                 _ attribute: String,
+                                 cappedAt timeout: Float) -> AXUIElement? {
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success,
               let value,
               CFGetTypeID(value) == AXUIElementGetTypeID()
         else { return nil }
-        return (value as! AXUIElement)
+        let child = value as! AXUIElement
+        AXUIElementSetMessagingTimeout(child, timeout)
+        return child
     }
 
-    private func windowsAttribute(_ element: AXUIElement) -> [AXUIElement]? {
+    /// Every element in the list, not only the one a caller keeps: the search
+    /// that picks one asks each of them for its window id, and that question
+    /// reaches the other process.
+    private func windowsAttribute(_ element: AXUIElement,
+                                  cappedAt timeout: Float) -> [AXUIElement]? {
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(element, kAXWindowsAttribute as CFString, &value) == .success,
               let values = value as? [AXUIElement]
         else { return nil }
+        for value in values { AXUIElementSetMessagingTimeout(value, timeout) }
         return values
     }
 

--- a/Sources/Vorssaint/Services/WindowMaximizer.swift
+++ b/Sources/Vorssaint/Services/WindowMaximizer.swift
@@ -280,12 +280,10 @@ final class WindowMaximizer: ObservableObject {
         guard !isApplicationElement(element) else { return nil }
         if role(of: element) == (kAXWindowRole as String) { return element }
 
-        if let window = elementAttribute(element, kAXWindowAttribute as String) {
-            AXUIElementSetMessagingTimeout(window, 0.35)
+        if let window = elementAttribute(element, kAXWindowAttribute as String, cappedAt: 0.35) {
             if role(of: window) == (kAXWindowRole as String) { return window }
         }
-        if let window = elementAttribute(element, kAXTopLevelUIElementAttribute as String) {
-            AXUIElementSetMessagingTimeout(window, 0.35)
+        if let window = elementAttribute(element, kAXTopLevelUIElementAttribute as String, cappedAt: 0.35) {
             if role(of: window) == (kAXWindowRole as String) { return window }
         }
 
@@ -297,7 +295,7 @@ final class WindowMaximizer: ObservableObject {
         // already ends with no window in that case.
         var current = element
         for _ in 0..<8 {
-            guard let parent = elementAttribute(current, kAXParentAttribute as String) else { return nil }
+            guard let parent = elementAttribute(current, kAXParentAttribute as String, cappedAt: 0.35) else { return nil }
             if isApplicationElement(parent) { return nil }
             if role(of: parent) == (kAXWindowRole as String) { return parent }
             current = parent
@@ -310,7 +308,7 @@ final class WindowMaximizer: ObservableObject {
             (attribute: kAXZoomButtonAttribute as String, allowsNativeFallback: true),
             (attribute: kAXFullScreenButtonAttribute as String, allowsNativeFallback: false)
         ] {
-            guard let button = elementAttribute(window, entry.attribute),
+            guard let button = elementAttribute(window, entry.attribute, cappedAt: 0.35),
                   boolAttribute(button, kAXEnabledAttribute as String, default: true),
                   let frame = frame(of: button),
                   frame.insetBy(dx: -3, dy: -3).contains(point)
@@ -431,13 +429,21 @@ final class WindowMaximizer: ObservableObject {
         return size
     }
 
-    private func elementAttribute(_ element: AXUIElement, _ attribute: String) -> AXUIElement? {
+    /// The cap is the caller's because an element read out of another one is a
+    /// fresh element: it takes the process-wide default rather than the cap on
+    /// the element it came from, so leaving it uncapped puts the walk above and
+    /// every read off it on whatever the global says.
+    private func elementAttribute(_ element: AXUIElement,
+                                  _ attribute: String,
+                                  cappedAt timeout: Float) -> AXUIElement? {
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success,
               let value,
               CFGetTypeID(value) == AXUIElementGetTypeID()
         else { return nil }
-        return (value as! AXUIElement)
+        let child = value as! AXUIElement
+        AXUIElementSetMessagingTimeout(child, timeout)
+        return child
     }
 
     private func pid(of element: AXUIElement) -> pid_t? {

--- a/Sources/Vorssaint/Services/WindowMaximizer.swift
+++ b/Sources/Vorssaint/Services/WindowMaximizer.swift
@@ -129,7 +129,7 @@ final class WindowMaximizer: ObservableObject {
 
     private func target(at point: CGPoint) -> ClickTarget? {
         guard let candidate = WindowServerTrafficLightHitTest.candidate(at: point, button: .zoom),
-              let element = elementAt(point: point, in: candidate.pid),
+              let element = elementAt(point: point),
               let window = topLevelWindow(from: element),
               role(of: window) == (kAXWindowRole as String),
               pid(of: window) == candidate.pid,
@@ -239,17 +239,22 @@ final class WindowMaximizer: ObservableObject {
 
     /// Bounded AX inside the mouse tap: a hung app under the cursor must not
     /// stall the main thread, and with it every event tap, for the system
-    /// default. Hit-tested through the owning application's element rather than
-    /// the system-wide one, so the cap is this call's own — written on the
-    /// system-wide object it would be the process-wide default, which is what
-    /// #938 is about. The caller has already established from the window list
-    /// that this point belongs to `pid`, and drops any window that turns out
-    /// not to.
-    private func elementAt(point: CGPoint, in pid: pid_t) -> AXUIElement? {
-        let app = AXUIElementCreateApplication(pid)
-        AXUIElementSetMessagingTimeout(app, 0.35)
+    /// default.
+    ///
+    /// No cap is written on the system-wide object here — that is the
+    /// process-wide default (#938) — so this one read inherits the launch
+    /// default, and everything reached through it is capped below. Asking the
+    /// owning application's element instead would let the cap be this call's
+    /// own, but that hit test ignores occlusion: it returns that app's element
+    /// even where another process's floating panel covers the point, and the
+    /// `pid` comparison in the caller is what rejects a click that landed on
+    /// something else. `candidate` skips every window that is not layer 0, so
+    /// the panel is never the candidate and the comparison is the only thing
+    /// carrying it.
+    private func elementAt(point: CGPoint) -> AXUIElement? {
+        let system = AXUIElementCreateSystemWide()
         var element: AXUIElement?
-        guard AXUIElementCopyElementAtPosition(app, Float(point.x), Float(point.y), &element) == .success,
+        guard AXUIElementCopyElementAtPosition(system, Float(point.x), Float(point.y), &element) == .success,
               let element
         else { return nil }
         AXUIElementSetMessagingTimeout(element, 0.35)

--- a/Sources/Vorssaint/Services/WindowMaximizer.swift
+++ b/Sources/Vorssaint/Services/WindowMaximizer.swift
@@ -129,7 +129,7 @@ final class WindowMaximizer: ObservableObject {
 
     private func target(at point: CGPoint) -> ClickTarget? {
         guard let candidate = WindowServerTrafficLightHitTest.candidate(at: point, button: .zoom),
-              let element = elementAt(point: point),
+              let element = elementAt(point: point, in: candidate.pid),
               let window = topLevelWindow(from: element),
               role(of: window) == (kAXWindowRole as String),
               pid(of: window) == candidate.pid,
@@ -237,14 +237,19 @@ final class WindowMaximizer: ObservableObject {
             && sizeSettable.boolValue
     }
 
-    private func elementAt(point: CGPoint) -> AXUIElement? {
-        let system = AXUIElementCreateSystemWide()
-        // Bounded AX inside the mouse tap: a hung app under the cursor must
-        // not stall the main thread (and with it every event tap) for the
-        // 6 second default timeout.
-        AXUIElementSetMessagingTimeout(system, 0.35)
+    /// Bounded AX inside the mouse tap: a hung app under the cursor must not
+    /// stall the main thread, and with it every event tap, for the system
+    /// default. Hit-tested through the owning application's element rather than
+    /// the system-wide one, so the cap is this call's own — written on the
+    /// system-wide object it would be the process-wide default, which is what
+    /// #938 is about. The caller has already established from the window list
+    /// that this point belongs to `pid`, and drops any window that turns out
+    /// not to.
+    private func elementAt(point: CGPoint, in pid: pid_t) -> AXUIElement? {
+        let app = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(app, 0.35)
         var element: AXUIElement?
-        guard AXUIElementCopyElementAtPosition(system, Float(point.x), Float(point.y), &element) == .success,
+        guard AXUIElementCopyElementAtPosition(app, Float(point.x), Float(point.y), &element) == .success,
               let element
         else { return nil }
         AXUIElementSetMessagingTimeout(element, 0.35)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15368,11 +15368,19 @@ struct MetricsTests {
         let holders = mayHoldSystemWide.filter { code($0).contains("AXUIElementCreateSystemWide") }
         expect(holders.count == mayHoldSystemWide.count,
                "every file allowed to hold the system-wide element still does: \(holders)")
-        // And the floor itself is still written, since the four that hold the
-        // element without capping it are relying on there being one.
-        expect(code("App/AppDelegate.swift")
+        // And the floor itself is still set, since every hit test listed above
+        // runs on it. Both halves are checked: a write nobody calls is not a
+        // floor, and the string outlives the call that reaches it.
+        let launchSource = code("App/AppDelegate.swift")
+        expect(launchSource
                    .contains("AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide()"),
                "the launch default that every uncapped read falls back to is still set")
+        // Excluding the declaration, or deleting the call leaves the function
+        // matching its own name and the rule passes on dead code.
+        expect(launchSource.components(separatedBy: "\n").contains {
+                   $0.contains("boundAccessibilityWaits()") && !$0.contains("func ")
+               },
+               "the launch default is still reached from startup")
         // The Dock preview hit test reads Accessibility on the main thread on
         // every mouse-move sample along the Dock's edge, and the process it
         // questions is the Dock — the one that stops answering (issue #971).
@@ -15381,7 +15389,7 @@ struct MetricsTests {
         // an element comes through carry it, and a read added later is covered
         // without anyone remembering to. Which element may hold the
         // process-wide default is the rule above, and this file is on that list
-        // for its hit test like the other four.
+        // for its hit test like the other holders.
         let dockPreviewLines = ((try? String(
             contentsOfFile: "Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift",
             encoding: .utf8)) ?? "")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15226,15 +15226,7 @@ struct MetricsTests {
         //
         //   AppDelegate — the deliberate floor, set once at launch, so a path
         //   that caps nothing of its own still waits a bounded time.
-        //
-        //   FinderCutPaste — open. It asks the system-wide element for
-        //   `AXFocusedUIElement`, and asking the frontmost application's
-        //   element instead is not the same question: measured on 26.6.2 the
-        //   system-wide read failed where the application read answered. That
-        //   is a behaviour change and wants its own reasoning, not a rider on
-        //   this one.
-        let allowedSystemWideTimeoutWriters = ["App/AppDelegate.swift",
-                                               "Services/Finder/FinderCutPaste.swift"]
+        let allowedSystemWideTimeoutWriters = ["App/AppDelegate.swift"]
         let unexpectedWriters = systemWideTimeoutWriters.filter { entry in
             !allowedSystemWideTimeoutWriters.contains { entry.hasPrefix($0 + ":") }
         }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15192,6 +15192,57 @@ struct MetricsTests {
         expect(!appSources.isEmpty && unboundedOperationWaits.isEmpty,
                "no operation queue is waited on without a deadline: \(unboundedOperationWaits)")
 
+        // A messaging timeout written on the system-wide element is the default
+        // for every Accessibility question this process asks, whoever asks it
+        // (`AXUIElement.h`). Five features wrote it believing it was their own,
+        // three different values, last writer wins, so how long a frozen app
+        // held the cursor depended on which unrelated feature ran last (#938).
+        // The rule is who may write it, matched on Apple's symbols rather than
+        // our own names: a file is only judged to hold the system-wide element
+        // when it says so itself, in `AXUIElementCreateSystemWide()`.
+        var systemWideTimeoutWriters: [String] = []
+        for file in appSources.sorted() {
+            guard let source = try? String(contentsOfFile: "Sources/Vorssaint/\(file)",
+                                           encoding: .utf8) else { continue }
+            let lines = source.components(separatedBy: "\n")
+                .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            var systemWideNames: Set<String> = []
+            for line in lines {
+                guard line.contains("= AXUIElementCreateSystemWide()"),
+                      let name = line.components(separatedBy: "=").first?
+                          .components(separatedBy: .whitespaces)
+                          .last(where: { !$0.isEmpty })
+                else { continue }
+                systemWideNames.insert(name)
+            }
+            for (index, line) in lines.enumerated()
+            where line.contains("AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide()")
+                || systemWideNames.contains(where: { line.contains("AXUIElementSetMessagingTimeout(\($0)") }) {
+                systemWideTimeoutWriters.append("\(file):\(index + 1)")
+            }
+        }
+        // Every entry states why that one write is right, and stops being right
+        // when the reason expires.
+        //
+        //   AppDelegate — the deliberate floor, set once at launch, so a path
+        //   that caps nothing of its own still waits a bounded time.
+        //
+        //   FinderCutPaste — open. It asks the system-wide element for
+        //   `AXFocusedUIElement`, and asking the frontmost application's
+        //   element instead is not the same question: measured on 26.6.2 the
+        //   system-wide read failed where the application read answered. That
+        //   is a behaviour change and wants its own reasoning, not a rider on
+        //   this one.
+        let allowedSystemWideTimeoutWriters = ["App/AppDelegate.swift",
+                                               "Services/Finder/FinderCutPaste.swift"]
+        let unexpectedWriters = systemWideTimeoutWriters.filter { entry in
+            !allowedSystemWideTimeoutWriters.contains { entry.hasPrefix($0 + ":") }
+        }
+        expect(!appSources.isEmpty && unexpectedWriters.isEmpty,
+               "only the listed files set the process-wide Accessibility timeout: \(unexpectedWriters)")
+        expect(systemWideTimeoutWriters.count == allowedSystemWideTimeoutWriters.count,
+               "every allowed process-wide timeout writer is still there: \(systemWideTimeoutWriters)")
+
         // Asking an application element for its role switches a Chromium app's
         // renderers into full accessibility mode for the rest of the process's
         // life (issue #953). It was fixed at the liveness probe, then found

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15205,19 +15205,29 @@ struct MetricsTests {
             guard let source = try? String(contentsOfFile: "Sources/Vorssaint/\(file)",
                                            encoding: .utf8) else { continue }
             let lines = source.components(separatedBy: "\n")
-                .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            func isComment(_ line: String) -> Bool {
+                line.trimmingCharacters(in: .whitespaces).hasPrefix("//")
+            }
             var systemWideNames: Set<String> = []
-            for line in lines {
+            for line in lines where !isComment(line) {
+                // The name is whatever the declaration binds, which is the last
+                // word before the `=` and before any type annotation: both
+                // `let system = …` and `let system: AXUIElement = …` bind
+                // `system`, and a rule that reads the second one as
+                // `AXUIElement` is walked past by an ordinary spelling.
                 guard line.contains("= AXUIElementCreateSystemWide()"),
                       let name = line.components(separatedBy: "=").first?
+                          .components(separatedBy: ":").first?
                           .components(separatedBy: .whitespaces)
                           .last(where: { !$0.isEmpty })
                 else { continue }
                 systemWideNames.insert(name)
             }
-            for (index, line) in lines.enumerated()
-            where line.contains("AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide()")
-                || systemWideNames.contains(where: { line.contains("AXUIElementSetMessagingTimeout(\($0)") }) {
+            // Enumerated unfiltered, so the line number reported is the line in
+            // the file rather than a position in a filtered copy of it.
+            for (index, line) in lines.enumerated() where !isComment(line)
+                && (line.contains("AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide()")
+                    || systemWideNames.contains(where: { line.contains("AXUIElementSetMessagingTimeout(\($0)") })) {
                 systemWideTimeoutWriters.append("\(file):\(index + 1)")
             }
         }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15272,18 +15272,21 @@ struct MetricsTests {
         }
         expect(!appSources.isEmpty && systemWideViolations.isEmpty,
                "the process-wide Accessibility timeout has one writer: \(systemWideViolations)")
-        let holders = mayHoldSystemWide.filter { file in
-            guard let source = try? String(contentsOfFile: "Sources/Vorssaint/\(file)",
-                                           encoding: .utf8) else { return false }
-            return source.contains("AXUIElementCreateSystemWide")
+        // Read the same way the violation scan reads: commenting a line out is
+        // how a rule stops being enforced without anyone deleting it.
+        func code(_ file: String) -> String {
+            ((try? String(contentsOfFile: "Sources/Vorssaint/\(file)", encoding: .utf8)) ?? "")
+                .components(separatedBy: "\n")
+                .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+                .joined(separator: "\n")
         }
+        let holders = mayHoldSystemWide.filter { code($0).contains("AXUIElementCreateSystemWide") }
         expect(holders.count == mayHoldSystemWide.count,
                "every file allowed to hold the system-wide element still does: \(holders)")
         // And the floor itself is still written, since the four that hold the
         // element without capping it are relying on there being one.
-        let launchFloor = (try? String(contentsOfFile: "Sources/Vorssaint/App/AppDelegate.swift",
-                                       encoding: .utf8)) ?? ""
-        expect(launchFloor.contains("AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide()"),
+        expect(code("App/AppDelegate.swift")
+                   .contains("AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide()"),
                "the launch default that every uncapped read falls back to is still set")
         // The Dock preview hit test reads Accessibility on the main thread on
         // every mouse-move sample along the Dock's edge, and the process it

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15194,9 +15194,12 @@ struct MetricsTests {
 
         // A messaging timeout written on the system-wide element is the default
         // for every Accessibility question this process asks, whoever asks it
-        // (`AXUIElement.h`). Six features wrote it believing it was their own,
-        // three different values, last writer wins, so how long a frozen app
-        // held the cursor depended on which unrelated feature ran last (#938).
+        // (`AXUIElement.h`). Several features wrote it believing it was their
+        // own, last writer wins, so how long a frozen app held the cursor
+        // depended on which unrelated feature had run most recently (#938).
+        // A count belongs in that issue, not here: this rule is what keeps the
+        // number at one, so a comment restating it is a comment waiting to be
+        // wrong.
         //
         // Two rules, both matched on Apple's symbol rather than our own names.
         //

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15225,9 +15225,10 @@ struct MetricsTests {
             }
             // Enumerated unfiltered, so the line number reported is the line in
             // the file rather than a position in a filtered copy of it.
-            for (index, line) in lines.enumerated() where !isComment(line)
-                && (line.contains("AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide()")
-                    || systemWideNames.contains(where: { line.contains("AXUIElementSetMessagingTimeout(\($0)") })) {
+            for (index, rawLine) in lines.enumerated() where !isComment(rawLine)
+                && { let line = rawLine.replacingOccurrences(of: "self.", with: "")
+                     return line.contains("AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide()")
+                         || systemWideNames.contains(where: { line.contains("AXUIElementSetMessagingTimeout(\($0)") }) }() {
                 systemWideTimeoutWriters.append("\(file):\(index + 1)")
             }
         }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15212,15 +15212,18 @@ struct MetricsTests {
         //   every path that caps nothing of its own.
         //
         //   WindowMaximizer, AutoQuitService, WindowLayoutService,
-        //   FocusFollowsMouseService — hold it for a hit test and must not
-        //   write on it. A hit test through an application element ignores
-        //   occlusion, so these four ask the system what is actually on top;
-        //   the elements they get back carry their own caps.
+        //   FocusFollowsMouseService, DockPreviewService — hold it for a hit
+        //   test and must not write on it. A hit test through an application
+        //   element answers for that app's hierarchy whatever is drawn over
+        //   the point, and each of these has a caller that relies on the
+        //   answer being what is actually on top; the elements they get back
+        //   carry their own caps.
         let mayHoldSystemWide = ["App/AppDelegate.swift",
                                  "Services/WindowMaximizer.swift",
                                  "Services/AutoQuit/AutoQuitService.swift",
                                  "Services/WindowLayout/WindowLayoutService.swift",
-                                 "Services/FocusFollowsMouse/FocusFollowsMouseService.swift"]
+                                 "Services/FocusFollowsMouse/FocusFollowsMouseService.swift",
+                                 "Services/DockPreview/DockPreviewService.swift"]
         // The second is what may be done with it there. Outside `AppDelegate`
         // the element may be bound to a name and asked to hit-test a point, and
         // nothing else. Anything further is a hand-off: a helper that caps what
@@ -15303,14 +15306,12 @@ struct MetricsTests {
         // The Dock preview hit test reads Accessibility on the main thread on
         // every mouse-move sample along the Dock's edge, and the process it
         // questions is the Dock — the one that stops answering (issue #971).
-        // Its cap has to be written on the elements it holds: written on the
-        // system-wide object it is the process-wide default, which six other
-        // features already write with three different values, so hovering the
-        // Dock would change how long window layout and focus-follows-mouse
-        // wait. The rule is the absence of that element here rather than of one
-        // spelling of the write, since the write can be reached through any
-        // name the element is given. Comment lines are dropped first, since the
-        // symbol appears in the reasoning right above the code.
+        // #938 counts it as the file that queried Accessibility and capped
+        // nothing at all, so the rule is that it caps something: the two doors
+        // an element comes through carry it, and a read added later is covered
+        // without anyone remembering to. Which element may hold the
+        // process-wide default is the rule above, and this file is on that list
+        // for its hit test like the other four.
         let dockPreviewLines = ((try? String(
             contentsOfFile: "Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift",
             encoding: .utf8)) ?? "")
@@ -15318,8 +15319,6 @@ struct MetricsTests {
             .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
         expect(dockPreviewLines.contains { $0.contains("AXUIElementSetMessagingTimeout") },
                "dock preview caps how long it waits for the Dock to answer")
-        expect(!dockPreviewLines.contains { $0.contains("AXUIElementCreateSystemWide") },
-               "dock preview never holds the element whose timeout is the process-wide default")
 
         // Asking an application element for its role switches a Chromium app's
         // renderers into full accessibility mode for the rest of the process's

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15219,11 +15219,12 @@ struct MetricsTests {
                                  "Services/WindowLayout/WindowLayoutService.swift",
                                  "Services/FocusFollowsMouse/FocusFollowsMouseService.swift"]
         // The second is what may be done with it there. Outside `AppDelegate`
-        // the element may only be bound to a name — never handed to another
-        // function, since a helper that caps what it is given turns one
-        // argument into a global write with no `SetMessagingTimeout` on the
-        // line to find. `bounded(AXUIElementCreateSystemWide())` is exactly
-        // that shape, and it is the shape this code recommends elsewhere.
+        // the element may be bound to a name and asked to hit-test a point, and
+        // nothing else. Anything further is a hand-off: a helper that caps what
+        // it is given turns one argument into a global write with no
+        // `AXUIElementSetMessagingTimeout` anywhere near it, and splitting that
+        // across two lines hides it from any rule that reads only the line the
+        // symbol appears on.
         var systemWideViolations: [String] = []
         for file in appSources.sorted() {
             guard let source = try? String(contentsOfFile: "Sources/Vorssaint/\(file)",
@@ -15232,41 +15233,49 @@ struct MetricsTests {
             func isComment(_ line: String) -> Bool {
                 line.trimmingCharacters(in: .whitespaces).hasPrefix("//")
             }
-            var systemWideNames: Set<String> = []
-            for (index, raw) in lines.enumerated() where !isComment(raw) {
-                let line = raw.replacingOccurrences(of: "self.", with: "")
-                    .replacingOccurrences(of: "Self.", with: "")
+            // Whole-identifier matching, so a name is not found inside a longer
+            // one and a receiver in front of it does not hide it.
+            func mentions(_ line: String, _ name: String) -> Bool {
+                var searched = line[line.startIndex...]
+                while let found = searched.range(of: name) {
+                    let before = found.lowerBound == line.startIndex
+                        ? nil : line[line.index(before: found.lowerBound)]
+                    let after = found.upperBound == line.endIndex ? nil : line[found.upperBound]
+                    func isIdentifier(_ c: Character?) -> Bool {
+                        guard let c else { return false }
+                        return c.isLetter || c.isNumber || c == "_"
+                    }
+                    if !isIdentifier(before) && !isIdentifier(after) { return true }
+                    searched = line[found.upperBound...]
+                }
+                return false
+            }
+            var bindings: [String: Int] = [:]
+            for (index, line) in lines.enumerated() where !isComment(line) {
                 guard line.contains("AXUIElementCreateSystemWide") else { continue }
                 guard mayHoldSystemWide.contains(file) else {
                     systemWideViolations.append("\(file):\(index + 1) holds the system-wide element")
                     continue
                 }
                 guard file != "App/AppDelegate.swift" else { continue }
-                // A binding and nothing else: `… = AXUIElementCreateSystemWide()`
-                // ends the statement, so anything after it is a hand-off.
                 if line.trimmingCharacters(in: .whitespaces)
                     .hasSuffix("= AXUIElementCreateSystemWide()"),
                    let name = line.components(separatedBy: "=").first?
                        .components(separatedBy: ":").first?
                        .components(separatedBy: .whitespaces)
                        .last(where: { !$0.isEmpty }) {
-                    systemWideNames.insert(name)
+                    bindings[name] = index
                 } else {
                     systemWideViolations.append("\(file):\(index + 1) passes the system-wide element on")
                 }
             }
-            // Matched on the argument rather than on the spelling of the line:
-            // the receiver in front of the name is whatever the call site felt
-            // like writing — `systemElement`, `self.systemElement`,
-            // `Self.shared.systemElement` — and a rule that reads the line
-            // instead of the argument is retired by any of them.
-            for (index, raw) in lines.enumerated() where !isComment(raw) {
-                guard let call = raw.range(of: "AXUIElementSetMessagingTimeout(") else { continue }
-                let argument = raw[call.upperBound...]
-                    .components(separatedBy: ",").first?
-                    .trimmingCharacters(in: .whitespaces) ?? ""
-                if systemWideNames.contains(where: { argument == $0 || argument.hasSuffix(".\($0)") }) {
-                    systemWideViolations.append("\(file):\(index + 1) writes the process-wide default")
+            for (name, boundAt) in bindings {
+                for (index, line) in lines.enumerated()
+                where index != boundAt && !isComment(line) && mentions(line, name) {
+                    guard line.contains("AXUIElementCopyElementAtPosition(\(name),") else {
+                        systemWideViolations.append("\(file):\(index + 1) uses the system-wide element for something other than a hit test")
+                        continue
+                    }
                 }
             }
         }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15242,6 +15242,26 @@ struct MetricsTests {
                "only the listed files set the process-wide Accessibility timeout: \(unexpectedWriters)")
         expect(systemWideTimeoutWriters.count == allowedSystemWideTimeoutWriters.count,
                "every allowed process-wide timeout writer is still there: \(systemWideTimeoutWriters)")
+        // The Dock preview hit test reads Accessibility on the main thread on
+        // every mouse-move sample along the Dock's edge, and the process it
+        // questions is the Dock — the one that stops answering (issue #971).
+        // Its cap has to be written on the elements it holds: written on the
+        // system-wide object it is the process-wide default, which six other
+        // features already write with three different values, so hovering the
+        // Dock would change how long window layout and focus-follows-mouse
+        // wait. The rule is the absence of that element here rather than of one
+        // spelling of the write, since the write can be reached through any
+        // name the element is given. Comment lines are dropped first, since the
+        // symbol appears in the reasoning right above the code.
+        let dockPreviewLines = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift",
+            encoding: .utf8)) ?? "")
+            .components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+        expect(dockPreviewLines.contains { $0.contains("AXUIElementSetMessagingTimeout") },
+               "dock preview caps how long it waits for the Dock to answer")
+        expect(!dockPreviewLines.contains { $0.contains("AXUIElementCreateSystemWide") },
+               "dock preview never holds the element whose timeout is the process-wide default")
 
         // Asking an application element for its role switches a Chromium app's
         // renderers into full accessibility mode for the rest of the process's

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15194,13 +15194,37 @@ struct MetricsTests {
 
         // A messaging timeout written on the system-wide element is the default
         // for every Accessibility question this process asks, whoever asks it
-        // (`AXUIElement.h`). Five features wrote it believing it was their own,
+        // (`AXUIElement.h`). Six features wrote it believing it was their own,
         // three different values, last writer wins, so how long a frozen app
         // held the cursor depended on which unrelated feature ran last (#938).
-        // The rule is who may write it, matched on Apple's symbols rather than
-        // our own names: a file is only judged to hold the system-wide element
-        // when it says so itself, in `AXUIElementCreateSystemWide()`.
-        var systemWideTimeoutWriters: [String] = []
+        //
+        // Two rules, both matched on Apple's symbol rather than our own names.
+        //
+        // The first is who may hold that element at all. A file that never
+        // names `AXUIElementCreateSystemWide` cannot write the global whatever
+        // it calls its variables, so the list below is the whole surface, and a
+        // new file joining it is a decision rather than an accident.
+        //
+        //   AppDelegate — writes it, once at launch, on purpose: the floor for
+        //   every path that caps nothing of its own.
+        //
+        //   WindowMaximizer, AutoQuitService, WindowLayoutService,
+        //   FocusFollowsMouseService — hold it for a hit test and must not
+        //   write on it. A hit test through an application element ignores
+        //   occlusion, so these four ask the system what is actually on top;
+        //   the elements they get back carry their own caps.
+        let mayHoldSystemWide = ["App/AppDelegate.swift",
+                                 "Services/WindowMaximizer.swift",
+                                 "Services/AutoQuit/AutoQuitService.swift",
+                                 "Services/WindowLayout/WindowLayoutService.swift",
+                                 "Services/FocusFollowsMouse/FocusFollowsMouseService.swift"]
+        // The second is what may be done with it there. Outside `AppDelegate`
+        // the element may only be bound to a name — never handed to another
+        // function, since a helper that caps what it is given turns one
+        // argument into a global write with no `SetMessagingTimeout` on the
+        // line to find. `bounded(AXUIElementCreateSystemWide())` is exactly
+        // that shape, and it is the shape this code recommends elsewhere.
+        var systemWideViolations: [String] = []
         for file in appSources.sorted() {
             guard let source = try? String(contentsOfFile: "Sources/Vorssaint/\(file)",
                                            encoding: .utf8) else { continue }
@@ -15209,42 +15233,58 @@ struct MetricsTests {
                 line.trimmingCharacters(in: .whitespaces).hasPrefix("//")
             }
             var systemWideNames: Set<String> = []
-            for line in lines where !isComment(line) {
-                // The name is whatever the declaration binds, which is the last
-                // word before the `=` and before any type annotation: both
-                // `let system = …` and `let system: AXUIElement = …` bind
-                // `system`, and a rule that reads the second one as
-                // `AXUIElement` is walked past by an ordinary spelling.
-                guard line.contains("= AXUIElementCreateSystemWide()"),
-                      let name = line.components(separatedBy: "=").first?
-                          .components(separatedBy: ":").first?
-                          .components(separatedBy: .whitespaces)
-                          .last(where: { !$0.isEmpty })
-                else { continue }
-                systemWideNames.insert(name)
+            for (index, raw) in lines.enumerated() where !isComment(raw) {
+                let line = raw.replacingOccurrences(of: "self.", with: "")
+                    .replacingOccurrences(of: "Self.", with: "")
+                guard line.contains("AXUIElementCreateSystemWide") else { continue }
+                guard mayHoldSystemWide.contains(file) else {
+                    systemWideViolations.append("\(file):\(index + 1) holds the system-wide element")
+                    continue
+                }
+                guard file != "App/AppDelegate.swift" else { continue }
+                // A binding and nothing else: `… = AXUIElementCreateSystemWide()`
+                // ends the statement, so anything after it is a hand-off.
+                if line.trimmingCharacters(in: .whitespaces)
+                    .hasSuffix("= AXUIElementCreateSystemWide()"),
+                   let name = line.components(separatedBy: "=").first?
+                       .components(separatedBy: ":").first?
+                       .components(separatedBy: .whitespaces)
+                       .last(where: { !$0.isEmpty }) {
+                    systemWideNames.insert(name)
+                } else {
+                    systemWideViolations.append("\(file):\(index + 1) passes the system-wide element on")
+                }
             }
-            // Enumerated unfiltered, so the line number reported is the line in
-            // the file rather than a position in a filtered copy of it.
-            for (index, rawLine) in lines.enumerated() where !isComment(rawLine)
-                && { let line = rawLine.replacingOccurrences(of: "self.", with: "")
-                     return line.contains("AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide()")
-                         || systemWideNames.contains(where: { line.contains("AXUIElementSetMessagingTimeout(\($0)") }) }() {
-                systemWideTimeoutWriters.append("\(file):\(index + 1)")
+            // Matched on the argument rather than on the spelling of the line:
+            // the receiver in front of the name is whatever the call site felt
+            // like writing — `systemElement`, `self.systemElement`,
+            // `Self.shared.systemElement` — and a rule that reads the line
+            // instead of the argument is retired by any of them.
+            for (index, raw) in lines.enumerated() where !isComment(raw) {
+                guard let call = raw.range(of: "AXUIElementSetMessagingTimeout(") else { continue }
+                let argument = raw[call.upperBound...]
+                    .components(separatedBy: ",").first?
+                    .trimmingCharacters(in: .whitespaces) ?? ""
+                if systemWideNames.contains(where: { argument == $0 || argument.hasSuffix(".\($0)") }) {
+                    systemWideViolations.append("\(file):\(index + 1) writes the process-wide default")
+                }
             }
         }
-        // Every entry states why that one write is right, and stops being right
-        // when the reason expires.
-        //
-        //   AppDelegate — the deliberate floor, set once at launch, so a path
-        //   that caps nothing of its own still waits a bounded time.
-        let allowedSystemWideTimeoutWriters = ["App/AppDelegate.swift"]
-        let unexpectedWriters = systemWideTimeoutWriters.filter { entry in
-            !allowedSystemWideTimeoutWriters.contains { entry.hasPrefix($0 + ":") }
+        expect(!appSources.isEmpty && systemWideViolations.isEmpty,
+               "the process-wide Accessibility timeout has one writer: \(systemWideViolations)")
+        let holders = mayHoldSystemWide.filter { file in
+            guard let source = try? String(contentsOfFile: "Sources/Vorssaint/\(file)",
+                                           encoding: .utf8) else { return false }
+            return source.contains("AXUIElementCreateSystemWide")
         }
-        expect(!appSources.isEmpty && unexpectedWriters.isEmpty,
-               "only the listed files set the process-wide Accessibility timeout: \(unexpectedWriters)")
-        expect(systemWideTimeoutWriters.count == allowedSystemWideTimeoutWriters.count,
-               "every allowed process-wide timeout writer is still there: \(systemWideTimeoutWriters)")
+        expect(holders.count == mayHoldSystemWide.count,
+               "every file allowed to hold the system-wide element still does: \(holders)")
+        // And the floor itself is still written, since the four that hold the
+        // element without capping it are relying on there being one.
+        let launchFloor = (try? String(contentsOfFile: "Sources/Vorssaint/App/AppDelegate.swift",
+                                       encoding: .utf8)) ?? ""
+        expect(launchFloor.contains("AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide()"),
+               "the launch default that every uncapped read falls back to is still set")
         // The Dock preview hit test reads Accessibility on the main thread on
         // every mouse-move sample along the Dock's edge, and the process it
         // questions is the Dock — the one that stops answering (issue #971).


### PR DESCRIPTION
## Summary

`AXUIElementSetMessagingTimeout` on the system-wide element is the default for
every Accessibility question this process asks, whoever asks it — the header
says so, and it is measurable: a new element inherits whichever global was
written last. Five features wrote it. Each reads locally as that feature's own
limit, and none of them was one. A sixth file, `DockPreviewService`, set no
timeout anywhere and simply inherited whatever the others had left. After this
the global has one writer: `AppDelegate`, once at launch, which is the only one
that meant it.

What that costs the person using the Mac: when some app stops answering, how
long Vorssaint waits before giving up depended on which unrelated feature they
had used last. Hover a Dock icon after using Finder cut/paste and it waits
0.15s; hover it after clicking a green maximize button and it waits 0.35s. Same
action, 2.3× apart, for a reason nothing on screen explains.

The sharpest case is the last row: focus-follows-mouse asks Accessibility on a
background queue, so how long it waits costs the user nothing — a slow answer
just defers a focus change to the next tick. It was setting the value for three
features that stall the main thread inside an event tap, where the same wait is
a frozen cursor and a click that looks dropped.

| | before | after |
|---|---|---|
| `WindowMaximizer` | writes the global 0.35, then hit-tests | writes nothing; the hit test inherits the launch default (also 0.35), everything it reaches capped 0.35 |
| `AutoQuitService` | writes the global 0.15, then hit-tests | writes nothing; **the hit test moves 0.15 → 0.35**, everything it reaches capped 0.15 |
| `WindowLayoutService` | writes the global 0.25, then hit-tests | writes nothing; that one read inherits the launch default |
| `FocusFollowsMouseService` | writes the global 0.25 at init | writes nothing; same |
| `FinderCutPaste` | writes the global 0.15, then asks system-wide for the focus | asks Finder's element, capped 0.15 |
| `DockPreviewService` | sets nothing anywhere; inherits | caps every element it obtains, 0.35 |
| `AppDelegate` | writes the global 0.35 once at launch | unchanged — the deliberate floor |

**No hit test is narrowed here.** A hit test can carry its own cap only when it
is asked of an application element, and that form answers for the app's own
hierarchy whatever is drawn over the point — measured with two helper windows on
one rect, one at layer 0 and one floating above: the system-wide call returns the
floating window, the layer-0 owner's application element returns its own. Each of
these paths has a caller that needs the answer to be what is actually on top:
`WindowServerWindowHitTest.candidate` skips windows that are not layer 0, so on
the traffic-light paths the `pid(of: window) == candidate.pid` comparison is what
rejects a click that landed on a panel over the window; `dockOwnsPoint` skips a
window of *ours* on the point rather than rejecting it, so a pinned preview panel
over the Dock strip reaches the hover hit test and the same comparison is what
stops it opening a preview for the icon beneath. Narrowing any of them would
remove the rejection, not the hit.

So every hit test stays on the system-wide element, writes no timeout, and
inherits the launch default for that one read. Everything reached through it
carries the value its feature chose.

The Finder guard is the one exception, and it has no hit test: it asks for the
focused element, and its caller has already established that Finder is frontmost,
so the app being asked is the same app either way.

**The Dock preview is the other half of the same rule.** #938 counts it as the
one file that queries Accessibility and caps nothing, and it is the worst place
to inherit: its reads run on the main thread on every mouse-move sample along
the Dock's edge, and the process they question is the Dock, which is the one
that stops answering in #971. It now caps every element it obtains, at the two
doors an element comes through — the hit test, and the return of
`elementAttribute`, the only place a parent element is produced — so a read
added later is capped without anyone remembering to. Its hit test goes through
the Dock's application element for the same reason as the two above.

**Three reads move, and they are the ones that cannot own a value.** A hit test
can carry its own cap only if it is asked of an application element, and that
form ignores occlusion — so on these paths the choice is: own the value, keep
the occlusion check, or write the global. Two of the three, and the global is
what this change removes. So the hit test in `AutoQuitService` goes from 0.15 to
0.35, `WindowLayoutService`'s from 0.25 to 0.35, and focus-follows-mouse's from
0.25 to 0.35 on a background queue where it stalls nothing. Against a hung app
that is one read per click or press, 2.3× longer in the auto-quit tap than
before. Restoring it means restoring a global write, or dropping an occlusion
check that a click on another app's panel over a window currently relies on.

One thing this does across the whole app, not only these files: an
Accessibility read that caps nothing has always taken the process-wide default,
and that default used to be whichever of 0.35, 0.25 and 0.15 ran most recently.
It is now the launch default, always. Swept for reads that would narrow to
widen: seven places produce an element without capping it, and only
`FinderRenameService.focusedRole` sat under code stating a tighter intent — it
caps its own now. One states 0.35 already, one is capped on the next line, and
four state nothing and were always on whatever the global held.

**Every other value is unchanged.** This is about which code owns a number, not
what the number should be. Holding that takes capping every element on a path, not only
the one it starts from: a fresh element takes the process-wide default rather
than the cap on the element it was read from — with the global at 0.5 and an
application element capped at 1.2, a window read off that element gives up at
0.505s, and at 1.205s once capped itself. So the two paths that wait 0.15s cap
what they derive — the focused element the Finder guard reads a role off, and
the window, parents and close button auto-quit walks to. Those reads were
getting 0.15 from the global before; without that write they would have started
taking `AppDelegate`'s 0.35, inside the taps that a click and every Finder
keystroke wait on. Whether a Dock hover and a ⌘-drag should wait the same length
of time is #938's question and wants an answer there, not a rider here.

**The Finder guard was the one worth being careful about.** It decides whether
⌘X cuts files or edits text, and it fails toward cutting: any Accessibility
error means "not editing", so a wrong answer there cuts files while someone is
renaming one. Asking Finder's element rather than the system-wide one had to be
the same question, not merely a similar one. Measured on 26.6.2, driving Finder
through both states — file list focused, Go to Folder field focused — the two
reads return the same role each time, and the caller has already established
that Finder is frontmost, so the app whose focus is being asked about is the
same app either way. The rename field itself was not exercised; it is the same
`AXTextField` the Go to Folder field is.

With every element on these paths carrying its own value, changing what any one
feature waits is now a change to that feature alone, which is what #938's first
question has to be settled before anyone can do. It is not yet one line: the
value is written wherever the feature produces an element, and collecting it
into a constant the way `DockPreviewService` does is a separate change that
moves no value either.

**One thing dropped rather than corrected.** Four comments justified their caps
against "the 6 second default". An element with no timeout set gives up after
1.5s — measured against a bundled, signed application holding its main thread,
three runs within 10ms of each other, a 0.4s control tracking exactly. The
figure is removed rather than replaced: Apple documents no default for
`AXUIElementSetMessagingTimeout`, so any number written here is an observation
about one OS version and rots the way this one did. What those comments need is
that their cap is shorter than the default, which is what they now say.

**The guardrail** is #938's fourth question, in two rules that a spelling cannot
retire. Which files may name `AXUIElementCreateSystemWide` at all: five, each
listed with why — `AppDelegate`, which writes it, and the ones that hold it for a
hit test and must not. A file that never names it cannot write the global
whatever it calls its variables, so that list is the whole surface. And what may
be done with it there: outside `AppDelegate` it may only be bound to a name,
never passed to another function, because a helper that caps what it is given
turns one argument into a global write with no `AXUIElementSetMessagingTimeout`
on the line to find — `bounded(AXUIElementCreateSystemWide())` is that shape, and
`bounded` is what this change recommends elsewhere. The write check reads the
call's first argument rather than the text of the line, so a receiver in front of
the name does not walk past it. Two more assertions keep the list honest: every
file on it still holds the element, and `AppDelegate` still writes the floor the
uncapped hit tests fall back to, and that the call reaching it still runs at
startup — a write nobody calls is not a floor.

## Verification

MacBook (Apple silicon), macOS 26.6.2, my own `./build.sh` release build, single
display.

```sh
./build.sh                     # no warnings
./build/Vorssaint --selftest   # SELFTEST OK
./build.sh --test              # TESTS OK (8942 checks)
```

Every assertion verified in both directions, each red on its own and green once
put back:

- reverting the Dock preview change, and putting `AXUIElementCreateSystemWide`
  back into that file
- `bounded(AXUIElementCreateSystemWide())` in a file not allowed to hold the
  element, and in one that is
- a write on the held element spelled three ways: `systemElement`,
  `self.systemElement`, `Self.shared.systemElement`
- `AppDelegate`'s launch write removed, commented out rather than deleted, and
  the call that reaches it removed and commented out — a string inside a
  function nobody calls is not a floor — the assertions that keep the list honest read code, not file text
- a file allowed to hold the element commented out of holding it

Capping happens where elements are produced rather than at the call sites, in
all five files: an element read out of another one is a fresh element and takes
the process-wide default, not the cap on the one it came from. The producers
take the value from the caller with no default, so the compiler covers the call
sites — it found two in `gestureTarget` that reading the code had not.

The occlusion difference was measured rather than reasoned about: two helper
windows on one rect, one at layer 0 and one floating above it, hit-tested from a
third process. The system-wide call returns the floating window; the layer-0
owner's application element returns its own window at the same point. That is
why only the Dock preview, which settles occlusion in `dockOwnsPoint` before it
asks, hit-tests through an application element.

**What I could not test.** Any of this against a genuinely frozen app. The
timeout only has an effect when a process stops answering, which does not happen
on demand; the behaviour of the caps themselves was measured against a synthetic
Accessibility target holding its main thread, not against a real hang. Nothing
here changes a healthy path: a query that answers in 0.02 ms reaches no timeout
either way, and every hit test returns the element it did before —
checked for the equivalent substitution on the running Dock, where hit-testing
through the application element returns the system-wide call's element,
`CFEqual`, same frame, same pid. I have not exercised the traffic-light paths on
a Mac with several displays.

## Anything else

This was opened as two pull requests and folded into one: the Dock preview half
was #1110, whose review is worth reading for the arithmetic corrections it
carried. It is the same change as the rest and reviewing it apart from
them was the wrong split.

Refs #971
Refs #938










