### PR TITLE
fix(clipboard): keep the pointer out of arrow-key selection and stop the list bouncing

### DIFF
--- a/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
+++ b/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
@@ -446,7 +446,15 @@ final class ClipboardHistoryService: ObservableObject {
         quickSelectionIndex = clampedQuickSelectionIndex(for: filteredQuickEntries.count)
     }
 
+    /// Where the pointer sat when the keyboard last moved the selection. Rows
+    /// scrolling under a still pointer report hover, and hover would otherwise
+    /// take the preview back from the row the arrow keys chose.
+    private(set) var keyboardSelectionPointer: NSPoint?
+
     func moveQuickSelection(_ delta: Int) {
+        // Out of the way while the keys drive, back at the first real move.
+        NSCursor.setHiddenUntilMouseMoves(true)
+        keyboardSelectionPointer = NSEvent.mouseLocation
         let count = filteredQuickEntries.count
         guard count > 0 else {
             quickSelectionIndex = 0

--- a/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
+++ b/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
@@ -1374,6 +1374,17 @@ enum ClipboardImageStore {
         return image
     }
 
+    /// The Finder icon for a path, cached: the workspace lookup is a round
+    /// trip, and a list row asks for it every time it is drawn.
+    static func fileIcon(atPath path: String) -> NSImage {
+        if let cached = fileIcons.object(forKey: path as NSString) { return cached }
+        let icon = NSWorkspace.shared.icon(forFile: path)
+        fileIcons.setObject(icon, forKey: path as NSString)
+        return icon
+    }
+
+    private static let fileIcons = NSCache<NSString, NSImage>()
+
     static func isImageFile(atPath path: String) -> Bool {
         ClipboardHistoryImageSupport.isImageFilePath(path)
     }

--- a/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
+++ b/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
@@ -1141,8 +1141,11 @@ final class ClipboardHistoryService: ObservableObject {
             guard let self, let panel, event.window === panel else { return event }
             // A multiline editor owns its normal editing keys. The search box
             // uses a field editor, so its existing list shortcuts stay intact.
+            // The read-only preview is a text view too, but the list keeps
+            // the keys over it: only ⌘C and ⌘A, which the list declines below
+            // when nothing is batch-selected, reach it.
             if let textView = panel.firstResponder as? NSTextView,
-               !textView.isFieldEditor {
+               !textView.isFieldEditor, textView.isEditable {
                 return event
             }
             let modifiers = event.modifierFlags.intersection([.command, .option, .shift, .control])

--- a/Sources/Vorssaint/UI/MenuPanel/ClipboardEntryPreviewSidebar.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/ClipboardEntryPreviewSidebar.swift
@@ -23,6 +23,8 @@ struct ClipboardEntryPreviewSidebar: View {
             if let entry {
                 if editingEntryID == entry.id {
                     textEditor(entry)
+                } else if entry.kind == .text {
+                    ClipboardTextPreview(text: entry.text)
                 } else {
                     contentScrollView(entry)
                 }

--- a/Sources/Vorssaint/UI/MenuPanel/ClipboardQuickPanelView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/ClipboardQuickPanelView.swift
@@ -281,6 +281,12 @@ private struct QuickEntryRow: View, Equatable {
     let language: AppLanguage
     @Binding var hoveredEntryID: UUID?
     @Binding var previewEntryID: UUID?
+    /// The pane follows a row only once the pointer has rested on it: while
+    /// rows stream under a still pointer during a scroll, every one of them
+    /// would otherwise redraw the pane, and a long entry costs a frame or two
+    /// each time.
+    @State private var previewFollowTask: Task<Void, Never>?
+    private static let previewFollowDelay: Duration = .milliseconds(120)
 
     private var history: ClipboardHistoryService { .shared }
     private var l10n: L10n { .shared }
@@ -339,8 +345,13 @@ private struct QuickEntryRow: View, Equatable {
             withAnimation(.easeOut(duration: 0.1)) {
                 hoveredEntryID = hovering ? entry.id : (hoveredEntryID == entry.id ? nil : hoveredEntryID)
             }
-            if hovering, !previewIsEditing {
-                previewEntryID = entry.id
+            previewFollowTask?.cancel()
+            guard hovering, !previewIsEditing else { return }
+            let id = entry.id
+            previewFollowTask = Task { @MainActor in
+                try? await Task.sleep(for: Self.previewFollowDelay)
+                guard !Task.isCancelled else { return }
+                previewEntryID = id
             }
         }
         .onTapGesture { activate(entry) }

--- a/Sources/Vorssaint/UI/MenuPanel/ClipboardQuickPanelView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/ClipboardQuickPanelView.swift
@@ -169,12 +169,18 @@ struct ClipboardQuickPanelView: View {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 6)
             ForEach(Array(entries.enumerated()), id: \.element.id) { index, entry in
-                entryRow(entry,
-                         shortcutIndex: shortcutIndex(for: entry),
-                         isSelected: history.quickSelectionIsVisible
-                            && history.selectedQuickEntryID == entry.id,
-                         isBatchSelected: history.isQuickBatchSelected(entry),
-                         isHovered: hoveredEntryID == entry.id)
+                QuickEntryRow(entry: entry,
+                              shortcutIndex: shortcutIndex(for: entry),
+                              isSelected: history.quickSelectionIsVisible
+                                 && history.selectedQuickEntryID == entry.id,
+                              isBatchSelected: history.isQuickBatchSelected(entry),
+                              isHovered: hoveredEntryID == entry.id,
+                              canReorderEntries: canReorderEntries,
+                              previewIsEditing: previewIsEditing,
+                              language: l10n.language,
+                              hoveredEntryID: $hoveredEntryID,
+                              previewEntryID: $previewEntryID)
+                    .equatable()
                     .id(entry.id)
                 if index < entries.count - 1 {
                     Divider()
@@ -197,11 +203,89 @@ struct ClipboardQuickPanelView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private func entryRow(_ entry: ClipboardHistoryEntry,
-                          shortcutIndex: Int?,
-                          isSelected: Bool,
-                          isBatchSelected: Bool,
-                          isHovered: Bool) -> some View {
+
+    private var footer: some View {
+        HStack(spacing: 8) {
+            if history.quickBatchCount > 0 {
+                Button(String(format: text.pasteSelectedFormat, history.quickBatchCount)) {
+                    history.copySelectedQuickEntry()
+                }
+                .buttonStyle(.borderedProminent)
+                Button(String(format: text.copySelectedFormat, history.quickBatchCount)) {
+                    history.copySelectedQuickEntryOnly()
+                }
+                Button(text.clearSelection) {
+                    history.clearQuickBatchSelection()
+                }
+            } else {
+                Button {
+                    history.clearRecent()
+                } label: {
+                    Label(text.clearRecent, systemImage: "trash")
+                }
+                .disabled(history.recentEntries.isEmpty)
+            }
+            Spacer()
+            HStack(spacing: 5) {
+                Image(systemName: "doc.on.clipboard")
+                Text("\(history.entries.count)")
+            }
+            .font(.system(size: 10.5, weight: .medium))
+            .foregroundStyle(.secondary)
+        }
+        .controlSize(.small)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    private func shortcutIndex(for entry: ClipboardHistoryEntry) -> Int? {
+        guard let index = filtered.firstIndex(where: { $0.id == entry.id }), index < 9 else { return nil }
+        return index
+    }
+
+    private func scrollSelectedEntry(with proxy: ScrollViewProxy) {
+        guard history.quickSelectionIsVisible, let id = history.selectedQuickEntryID else { return }
+        // No anchor and no animation: the list moves only when the selected
+        // row is off screen, and then straight to it, so every arrow press
+        // costs the same and the rows never redraw mid-slide.
+        proxy.scrollTo(id)
+    }
+}
+
+/// One row of the list, a view of its own with value inputs so SwiftUI can
+/// skip the rows a change did not touch. Before this every hover, and every
+/// row passing under a still pointer during a scroll, rebuilt the whole list,
+/// which is what made a flick stall for a quarter second at a time.
+private struct QuickEntryRow: View, Equatable {
+    let entry: ClipboardHistoryEntry
+    let shortcutIndex: Int?
+    let isSelected: Bool
+    let isBatchSelected: Bool
+    let isHovered: Bool
+    let canReorderEntries: Bool
+    let previewIsEditing: Bool
+    let language: AppLanguage
+    @Binding var hoveredEntryID: UUID?
+    @Binding var previewEntryID: UUID?
+
+    private var history: ClipboardHistoryService { .shared }
+    private var l10n: L10n { .shared }
+    private var text: ClipboardFeatureStrings { FeatureStrings.clipboard(language) }
+
+    // The bindings are channels back to the list, not part of what the row
+    // looks like, so they stay out of the comparison.
+    static func == (lhs: QuickEntryRow, rhs: QuickEntryRow) -> Bool {
+        lhs.entry == rhs.entry
+            && lhs.shortcutIndex == rhs.shortcutIndex
+            && lhs.isSelected == rhs.isSelected
+            && lhs.isBatchSelected == rhs.isBatchSelected
+            && lhs.isHovered == rhs.isHovered
+            && lhs.canReorderEntries == rhs.canReorderEntries
+            && lhs.previewIsEditing == rhs.previewIsEditing
+            && lhs.language == rhs.language
+    }
+
+    var body: some View {
         HStack(alignment: .center, spacing: 9) {
             Button {
                 history.toggleQuickBatchSelection(entry)
@@ -445,7 +529,7 @@ struct ClipboardQuickPanelView: View {
         guard entry.kind == .files,
               let path = entry.filePaths.first(where: { FileManager.default.fileExists(atPath: $0) })
         else { return nil }
-        return NSWorkspace.shared.icon(forFile: path)
+        return ClipboardImageStore.fileIcon(atPath: path)
     }
 
     private func kindSymbol(_ kind: ClipboardHistoryEntryKind) -> String {
@@ -463,53 +547,6 @@ struct ClipboardQuickPanelView: View {
         if isSelected { return Color.accentColor.opacity(isHovered ? 0.13 : 0.09) }
         if isHovered { return Color.primary.opacity(0.055) }
         return .clear
-    }
-
-    private var footer: some View {
-        HStack(spacing: 8) {
-            if history.quickBatchCount > 0 {
-                Button(String(format: text.pasteSelectedFormat, history.quickBatchCount)) {
-                    history.copySelectedQuickEntry()
-                }
-                .buttonStyle(.borderedProminent)
-                Button(String(format: text.copySelectedFormat, history.quickBatchCount)) {
-                    history.copySelectedQuickEntryOnly()
-                }
-                Button(text.clearSelection) {
-                    history.clearQuickBatchSelection()
-                }
-            } else {
-                Button {
-                    history.clearRecent()
-                } label: {
-                    Label(text.clearRecent, systemImage: "trash")
-                }
-                .disabled(history.recentEntries.isEmpty)
-            }
-            Spacer()
-            HStack(spacing: 5) {
-                Image(systemName: "doc.on.clipboard")
-                Text("\(history.entries.count)")
-            }
-            .font(.system(size: 10.5, weight: .medium))
-            .foregroundStyle(.secondary)
-        }
-        .controlSize(.small)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-    }
-
-    private func shortcutIndex(for entry: ClipboardHistoryEntry) -> Int? {
-        guard let index = filtered.firstIndex(where: { $0.id == entry.id }), index < 9 else { return nil }
-        return index
-    }
-
-    private func scrollSelectedEntry(with proxy: ScrollViewProxy) {
-        guard history.quickSelectionIsVisible, let id = history.selectedQuickEntryID else { return }
-        // No anchor and no animation: the list moves only when the selected
-        // row is off screen, and then straight to it, so every arrow press
-        // costs the same and the rows never redraw mid-slide.
-        proxy.scrollTo(id)
     }
 }
 

--- a/Sources/Vorssaint/UI/MenuPanel/ClipboardQuickPanelView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/ClipboardQuickPanelView.swift
@@ -121,16 +121,17 @@ struct ClipboardQuickPanelView: View {
         } else {
             ScrollViewReader { proxy in
                 ScrollView {
-                    // Lazy: a large history would otherwise build every row,
-                    // and decode every image thumbnail, each time the panel
-                    // opens.
-                    LazyVStack(alignment: .leading, spacing: 0) {
-                        if history.quickQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                            section(title: text.pinned, entries: history.pinnedEntries)
-                            section(title: text.recent, entries: history.recentEntries,
-                                    followsSection: !history.pinnedEntries.isEmpty)
+                    // A plain stack for an ordinary history: with every row
+                    // already laid out, scrolling is the clip view moving and
+                    // nothing else, which is what makes it smooth. Only a
+                    // very large history goes lazy, where building every row
+                    // (and decoding every thumbnail) on open would cost more
+                    // than the placement work a lazy stack does per tick.
+                    Group {
+                        if filtered.count <= Self.eagerRowLimit {
+                            VStack(alignment: .leading, spacing: 0) { sections }
                         } else {
-                            section(title: text.newestFirst, entries: filtered)
+                            LazyVStack(alignment: .leading, spacing: 0) { sections }
                         }
                     }
                     .padding(.horizontal, 10)
@@ -153,6 +154,19 @@ struct ClipboardQuickPanelView: View {
 
     /// Emits the header and rows straight into the enclosing lazy stack. If
     /// wrapped, the whole section becomes one lazy unit and builds every row.
+    private static let eagerRowLimit = 300
+
+    @ViewBuilder
+    private var sections: some View {
+        if history.quickQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            section(title: text.pinned, entries: history.pinnedEntries)
+            section(title: text.recent, entries: history.recentEntries,
+                    followsSection: !history.pinnedEntries.isEmpty)
+        } else {
+            section(title: text.newestFirst, entries: filtered)
+        }
+    }
+
     @ViewBuilder
     private func section(title: String, entries: [ClipboardHistoryEntry],
                          followsSection: Bool = false) -> some View {

--- a/Sources/Vorssaint/UI/MenuPanel/ClipboardQuickPanelView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/ClipboardQuickPanelView.swift
@@ -137,6 +137,7 @@ struct ClipboardQuickPanelView: View {
                     .padding(.vertical, 6)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
+                .background(ScrollBounceDisabler())
                 .onChange(of: history.quickSelectionIndex) { _, _ in
                     scrollSelectedEntry(with: proxy)
                 }
@@ -234,6 +235,9 @@ struct ClipboardQuickPanelView: View {
         .contentShape(Rectangle())
         .contextMenu { entryActions(entry) }
         .onHover { hovering in
+            // A row arriving under a pointer that has not moved since the
+            // arrow keys took over is not a hover.
+            if hovering, NSEvent.mouseLocation == history.keyboardSelectionPointer { return }
             withAnimation(.easeOut(duration: 0.1)) {
                 hoveredEntryID = hovering ? entry.id : (hoveredEntryID == entry.id ? nil : hoveredEntryID)
             }
@@ -502,8 +506,32 @@ struct ClipboardQuickPanelView: View {
 
     private func scrollSelectedEntry(with proxy: ScrollViewProxy) {
         guard history.quickSelectionIsVisible, let id = history.selectedQuickEntryID else { return }
-        withAnimation(.easeOut(duration: 0.12)) {
-            proxy.scrollTo(id, anchor: .center)
+        // No anchor and no animation: the list moves only when the selected
+        // row is off screen, and then straight to it, so every arrow press
+        // costs the same and the rows never redraw mid-slide.
+        proxy.scrollTo(id)
+    }
+}
+
+/// Turns off the rubber-band bounce of the enclosing scroll view. SwiftUI's
+/// `scrollBounceBehavior` still bounces once the content is taller than the
+/// view, and a list of rows has nothing to show past its ends.
+private struct ScrollBounceDisabler: NSViewRepresentable {
+    func makeNSView(context: Context) -> BounceDisablingView { BounceDisablingView() }
+    func updateNSView(_ view: BounceDisablingView, context: Context) { view.apply() }
+
+    final class BounceDisablingView: NSView {
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            apply()
+        }
+
+        func apply() {
+            // The scroll view is an ancestor only once SwiftUI has placed
+            // this view, which is after the current layout pass.
+            DispatchQueue.main.async { [weak self] in
+                self?.enclosingScrollView?.verticalScrollElasticity = .none
+            }
         }
     }
 }

--- a/Sources/Vorssaint/UI/MenuPanel/ClipboardTextPreview.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/ClipboardTextPreview.swift
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import SwiftUI
+
+/// The preview pane's text, as an AppKit text view. SwiftUI's selectable
+/// `Text` lays the whole string out before it can draw, and a 20 KB entry
+/// costs a visible pause every time the selection lands on it; TextKit lays
+/// out what is on screen and the rest as it scrolls. Read only, selectable,
+/// so ⌘C on a fragment keeps working.
+struct ClipboardTextPreview: NSViewRepresentable {
+    let text: String
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scroll = NSTextView.scrollableTextView()
+        scroll.drawsBackground = false
+        scroll.hasVerticalScroller = true
+        scroll.autohidesScrollers = true
+        scroll.borderType = .noBorder
+        guard let textView = scroll.documentView as? NSTextView else { return scroll }
+        textView.drawsBackground = false
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isRichText = false
+        textView.font = .systemFont(ofSize: 12)
+        textView.textContainerInset = NSSize(width: 8, height: 12)
+        textView.textContainer?.lineFragmentPadding = 4
+        textView.textContainer?.widthTracksTextView = true
+        textView.string = text
+        return scroll
+    }
+
+    func updateNSView(_ scroll: NSScrollView, context: Context) {
+        guard let textView = scroll.documentView as? NSTextView, textView.string != text else { return }
+        textView.string = text
+        textView.scroll(.zero)
+    }
+}


### PR DESCRIPTION
## Summary

Stepping through the clipboard window with ↑/↓ had three things working against it.

- The pointer stayed where it was, and rows scrolling under it reported hover, which moved the preview back to whatever sat under the pointer. Now the pointer is hidden until it moves (`NSCursor.setHiddenUntilMouseMoves`), and a hover from a pointer that has not moved since the last arrow press is ignored.
- Every arrow press animated the list to centre the selected row, so a press near the middle cost nothing and one near an edge cost a slide, with rows redrawing mid-slide. The list now scrolls only when the selected row is off screen, and then straight to it, so every press costs the same.
- The list rubber-banded past its ends. `scrollBounceBehavior` still bounces once the content is taller than the view, so an `NSViewRepresentable` in the list's background sets the enclosing scroll view's vertical elasticity to none.

Two more, found by measuring a wheel flick (30 ticks of 12 px over 480 ms) with a probe that captures the window every frame and reads the scroll delta by lining consecutive frames up:

- Each row is now a view of its own (`QuickEntryRow`, `Equatable` on its value inputs), so a hover redraws one row rather than the whole list, and file icons are cached instead of asked of the workspace on every draw.
- The preview pane follows a hovered row only once the pointer has rested on it for 120 ms. During a scroll, rows stream under a still pointer and each one redrew the pane; with a long entry among them that was a stall of 200 ms or more per pass.
- The list is a plain `VStack` up to 300 entries and lazy past that: with the rows laid out once, a scroll is the clip view moving and nothing else.
- The preview pane shows text through an AppKit text view (`ClipboardTextPreview`, read only, selectable) instead of a selectable SwiftUI `Text`. `Text` lays the whole string out before drawing, so an arrow press that lands on a 20 KB entry paused for ~130 ms and the next press's scroll arrived merged with it; TextKit lays out what is on screen. The window's key monitor treats a read-only text view like the rest of the pane, so ↑/↓ stay with the list and ⌘C still copies a selected fragment.

Measured on this Mac (M1 Pro, 15.7.7), same history with two ~20 KB entries mid-list, release optimisation in both builds: 3.3.2 delivers 348 of 360 px in steady 12 px steps with a longest stall of 57–63 ms; this branch delivers 344 px in 12 px steps with a longest stall of 56 ms. Before these changes the same flick delivered 190–235 px with stalls of 245–267 ms. Arrow keys, pressed every 150 ms through a list with a 21 KB entry at row 11: before, press 11 stalled ~130 ms and press 12 scrolled two rows at once; after, every press that has to scroll does so within 28–64 ms, one row each. Note that a `--dev` build (`-Onone`) stalls far more than a release build on the same code; the comparison above is `-O` against `-O`.

What a user notices: arrow keys move the selection one row per press at a steady pace, the pointer does not fight them, the list stops at its first and last row, and a flick scrolls evenly.

## Verification

MacBook Pro 14" (MacBookPro18,3, M1 Pro), macOS 15.7.7 (24G720), one built-in Retina display, one Space, English (US). Own build: `./build.sh --dev --install`, `./build.sh --test` passes (8937 checks). Scrolling was measured as above rather than judged by eye. Not yet checked by hand: the arrow-key feel and the hover fight (reported from use of the developer build), and a trackpad's momentum scroll against the disabled elasticity. I will confirm on screen and say so here.
