### PR TITLE
fix(signing): give Developer builds the stable identity they were promised

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,20 +25,27 @@ SwiftPM aware editors can index the code.
 Hitting a build or permission snag while developing? See the
 [troubleshooting guide](docs/TROUBLESHOOTING.md).
 
-### Stable signing (optional)
+### Stable signing
 
-By default `build.sh` signs ad hoc, and that code hash changes on every build,
-so macOS asks again for Accessibility and Screen Recording after each rebuild.
-Run this once
+By default `build.sh` signs ad hoc, and that code hash changes on every build.
+macOS ties Accessibility and Screen Recording grants to the hash, so each
+rebuild silently orphans them: System Settings keeps showing the app as
+granted, the app is no longer trusted, and no new prompt appears. Developer
+builds (`--dev`) therefore create a free, self signed identity called
+`Vorssaint Utils Signing` in a dedicated keychain automatically when no
+identity is installed. For plain local builds, run the same setup once
+yourself:
 
 ```sh
 ./Tools/setup-signing.sh
 ```
 
-to create a free, self signed identity called `Vorssaint Utils Signing` in a
-dedicated keychain. `build.sh` then signs local builds with it and gives them a
+Either way `build.sh` then signs local builds with it and gives them a
 constant designated requirement, so granted permissions stick across rebuilds.
-It is a local convenience only and never shows up outside the keychain.
+If a permission was granted to an earlier ad-hoc build, clear the stale grant
+once (`tccutil reset Accessibility com.vorssaint.utils.dev`) and grant it
+again. The identity is a local convenience only and never shows up outside
+the keychain.
 
 Official releases work differently. CI signs the app and DMG with an Apple
 **Developer ID**, using credentials isolated in the protected `release-signing`

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -19519,6 +19519,33 @@ struct MetricsTests {
                    "defaults suite \(argument) is named inside a namespace build.sh sweeps")
         }
 
+        // MARK: An identity-less Developer build creates its stable signing identity
+        // An ad-hoc signature changes hash on every build, so macOS orphans
+        // Accessibility and Screen Recording grants on each rebuild while
+        // System Settings keeps showing them as granted. build.sh therefore
+        // routes identity-less --dev builds through Tools/setup-signing.sh
+        // before signing. The needle is the invocation at the start of a
+        // command line: the ad-hoc fallback's advice string also names the
+        // script, and must not satisfy this check.
+        let runsSigningSetup = buildScript.components(separatedBy: "\n").contains {
+            $0.range(of: #"^\s*(if\s+!?\s*)?\./Tools/setup-signing\.sh"#,
+                     options: .regularExpression) != nil
+        }
+        expect(runsSigningSetup,
+               "an identity-less Developer build invokes Tools/setup-signing.sh itself")
+        // The setup script must run against the stock /usr/bin/openssl, which
+        // is LibreSSL: it rejects OpenSSL 3's -legacy flag outright, and the
+        // script once died on exactly that with its stderr discarded. The
+        // portable spelling names the PBE algorithms instead of the flag.
+        let signingSetup = (try? String(contentsOfFile: "Tools/setup-signing.sh",
+                                        encoding: .utf8)) ?? ""
+        expect(!signingSetup.isEmpty, "the signing setup script reads back for its shape check")
+        let signingSetupCode = signingSetup.components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#") }
+            .joined(separator: "\n")
+        expect(!signingSetupCode.contains("-legacy"),
+               "setup-signing.sh avoids the -legacy flag the stock LibreSSL openssl rejects")
+
         // MARK: Uninstallation paths stay aligned across SelfUninstall and Tools/uninstall.sh
         let selfUninstallSource = (try? String(contentsOfFile: "Sources/Vorssaint/Services/SelfUninstall.swift",
                                               encoding: .utf8)) ?? ""

--- a/Tools/setup-signing.sh
+++ b/Tools/setup-signing.sh
@@ -38,8 +38,16 @@ openssl req -x509 -newkey rsa:2048 -keyout "$WORK/key.pem" -out "$WORK/cert.pem"
     -addext "keyUsage=critical,digitalSignature" \
     -addext "extendedKeyUsage=critical,codeSigning" \
     -addext "basicConstraints=critical,CA:false" 2>/dev/null
-openssl pkcs12 -export -legacy -inkey "$WORK/key.pem" -in "$WORK/cert.pem" \
-    -out "$WORK/id.p12" -passout pass:"$KCPASS" -name "$IDENTITY" 2>/dev/null
+# The PBE and MAC algorithms are named explicitly: the stock /usr/bin/openssl
+# is LibreSSL, which rejects OpenSSL 3's -legacy flag, while OpenSSL 3's
+# defaults (AES-256, PBKDF2) are newer than what security(1) imports reliably.
+# These three are accepted by both and produce the same portable file.
+openssl pkcs12 -export -inkey "$WORK/key.pem" -in "$WORK/cert.pem" \
+    -out "$WORK/id.p12" -passout pass:"$KCPASS" -name "$IDENTITY" \
+    -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1 || {
+    echo "✗ openssl pkcs12 could not export the identity." >&2
+    exit 1
+}
 
 security delete-keychain "$KC" 2>/dev/null || true
 security create-keychain -p "$KCPASS" "$KC"
@@ -50,4 +58,11 @@ security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KCPASS" 
 EXISTING=$(security list-keychains -d user | sed 's/"//g' | xargs)
 security list-keychains -d user -s "$KC" ${=EXISTING}
 
+# Import succeeding is not evidence codesign can see it: read it back the same
+# way build.sh looks it up, so a broken search list fails here and not as a
+# silent ad-hoc fallback three builds later.
+security find-identity -p codesigning 2>/dev/null | grep -q "$IDENTITY" || {
+    echo "✗ Identity imported but codesign cannot find it; keychain search list may be off." >&2
+    exit 1
+}
 echo "✓ Created signing identity '$IDENTITY'. Future ./build.sh runs use it automatically."

--- a/build.sh
+++ b/build.sh
@@ -50,6 +50,24 @@ developer_id_identity() {
         | sed -E 's/.*"(.*)".*/\1/' || true
 }
 
+# The Developer build exists for iterative local work, where an ad-hoc
+# signature is a trap: macOS ties Accessibility and Screen Recording grants to
+# the exact binary hash, so every rebuild orphans them while System Settings
+# keeps showing them as granted, and no new prompt ever appears. When no
+# identity is installed, create the stable local one up front instead of
+# falling through to ad-hoc — setup-signing.sh is free, offline and idempotent.
+if (( DEV )) && [[ -z "$(developer_id_identity)" ]] \
+    && ! security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"; then
+    echo "▸ No signing identity installed; creating the stable local one…"
+    if ! ./Tools/setup-signing.sh; then
+        echo "  ⚠ Tools/setup-signing.sh failed; signing ad-hoc instead." >&2
+        echo "    Accessibility and Screen Recording grants will not survive rebuilds:" >&2
+        echo "    System Settings will show them as granted while the app is not trusted." >&2
+        echo "    After fixing the identity, clear the stale grant once with:" >&2
+        echo "      tccutil reset Accessibility $APP_BUNDLE_ID" >&2
+    fi
+fi
+
 codesign_with_timestamp_retry() {
     local attempt
     for attempt in 1 2 3; do

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -59,6 +59,11 @@ To wipe Vorssaint's granted permissions and let macOS ask again from scratch, pi
   tccutil reset ScreenCapture com.vorssaint.utils
   ```
 
+  A self-built Developer variant has its own grants under
+  `com.vorssaint.utils.dev`. Resetting is the way out when System Settings
+  shows the permission as granted but the app disagrees — that happens when a
+  grant was given to an earlier ad-hoc build whose signature no longer matches.
+
 ## Clean uninstall
 
 The bundled script takes out everything Vorssaint added, the app itself, its preferences and saved state, the login item, its privacy grants, and the optional closed lid `sudoers` rule.


### PR DESCRIPTION
Refs #1123

A Developer build's Accessibility grant dies on every rebuild while System Settings keeps showing it as granted, because the stable-signing setup the docs point at has never worked on a stock Mac: `Tools/setup-signing.sh` calls `openssl pkcs12 -export -legacy`, `-legacy` is an OpenSSL 3 flag the stock LibreSSL rejects, and the script's `2>/dev/null` turns that into a silent exit 1. `build.sh` then falls through to ad-hoc, whose designated requirement is the binary's own cdhash — a different app to tccd after every rebuild, with no new prompt because the stale TCC row still exists.

Four small pieces, all on that one chain:

- **`Tools/setup-signing.sh`** exports the p12 with explicitly named PBE/MAC algorithms (`-keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1`), which LibreSSL and OpenSSL 3 both accept and turn into the same portable file, instead of the `-legacy` flag only OpenSSL 3 knows. It now fails loudly, and finally reads the identity back the same way `build.sh` looks it up — import succeeding is not evidence codesign can see it.
- **`build.sh`** runs `Tools/setup-signing.sh` itself when a `--dev` build finds no identity (the script is free, offline and idempotent; CI never passes `--dev`, so CI is untouched). If setup still fails, the ad-hoc fallback now says what will break and how to recover, instead of one quiet mid-build line.
- **`CONTRIBUTING.md`** claimed ad-hoc rebuilds mean "macOS asks again" — it does not ask again, which is the whole trap; AI-CONTRIBUTIONS.md already described the real behaviour ("the grants lapse without a word"). The two now agree, and the stale-grant recovery (`tccutil reset Accessibility com.vorssaint.utils.dev`) is written down. `TROUBLESHOOTING.md` names the Developer variant's own bundle id in the reset section.
- **Two source-shape tests** go red if either half regresses: one pins the `./Tools/setup-signing.sh` invocation at the start of a command line in `build.sh` (the ad-hoc fallback's advice string also names the script and must not satisfy it), the other pins the absence of `-legacy` in the setup script's code lines. Both checked in both directions: green on this branch, red with the respective file reverted.

Verified on macOS 26.6.2 (25G83), M5 Pro, Command Line Tools only, no Homebrew OpenSSL, no Developer ID identity: from that clean state, `./build.sh --dev --install` creates the identity, signs with it, and the installed bundle's designated requirement becomes `identifier "com.vorssaint.utils.dev" and certificate root = H"…"` — stable across a second rebuild. After a one-time `tccutil reset` of the orphaned grant, Accessibility sticks across rebuilds. `./build.sh --test` passes.

The pkcs12 spelling was exercised under both generations: LibreSSL 3.3.6 (`/usr/bin/openssl`) and Homebrew OpenSSL 3.6.3 each export with those flags, and LibreSSL reads the OpenSSL 3 output back (`pbeWithSHA1And3-KeyTripleDES-CBC`, MAC verified). Not checked: a machine where a Developer ID or the legacy identity already exists takes the pre-existing branches, which are untouched here but were not re-run.
