### PR TITLE
fix(permissions): let the guide card start over on a stale entry and relaunch for Screen Recording

### DIFF
--- a/Sources/Vorssaint/Core/PermissionGuideStrings.swift
+++ b/Sources/Vorssaint/Core/PermissionGuideStrings.swift
@@ -15,6 +15,12 @@ struct PermissionGuideStrings {
     let waiting: String
     let granted: String
     let closeHelp: String
+    /// Shown once the wait has gone on a while: the usual cause is an entry
+    /// left by an earlier copy of the app, which macOS shows as on but no
+    /// longer honours.
+    let staleHint: String
+    let startOver: String
+    let relaunch: String
 }
 
 extension FeatureStrings {
@@ -45,7 +51,10 @@ extension PermissionGuideStrings {
         stepReturn: "여기로 돌아오세요. 이 카드가 자동으로 확인합니다.",
         waiting: "권한을 기다리는 중…",
         granted: "권한이 허용되었습니다!",
-        closeHelp: "닫기"
+        closeHelp: "닫기",
+        staleHint: "목록에서 이미 켜져 있나요? 그 항목은 이전 앱 사본의 것입니다. 다시 시작하여 교체하세요.",
+        startOver: "다시 시작",
+        relaunch: "적용하려면 다시 실행"
     )
 }
 
@@ -57,7 +66,10 @@ extension PermissionGuideStrings {
         stepReturn: "Come back. This card notices by itself.",
         waiting: "Waiting for the permission…",
         granted: "Permission granted!",
-        closeHelp: "Close"
+        closeHelp: "Close",
+        staleHint: "Already on in that list? That entry belongs to an earlier copy of the app. Start over to replace it.",
+        startOver: "Start over",
+        relaunch: "Relaunch to apply"
     )
 
     static let ptBR = PermissionGuideStrings(
@@ -67,7 +79,10 @@ extension PermissionGuideStrings {
         stepReturn: "Volte para cá. Este cartão percebe sozinho.",
         waiting: "Esperando a permissão…",
         granted: "Permissão concedida!",
-        closeHelp: "Fechar"
+        closeHelp: "Fechar",
+        staleHint: "Já está ativado nessa lista? Essa entrada pertence a uma cópia anterior do app. Recomece para substituí-la.",
+        startOver: "Recomeçar",
+        relaunch: "Reabrir para aplicar"
     )
 
     static let tr = PermissionGuideStrings(
@@ -77,7 +92,10 @@ extension PermissionGuideStrings {
         stepReturn: "Buraya dönün. Bu kart kendiliğinden fark eder.",
         waiting: "İzin bekleniyor…",
         granted: "İzin verildi!",
-        closeHelp: "Kapat"
+        closeHelp: "Kapat",
+        staleHint: "Bu listede zaten açık mı? O kayıt uygulamanın önceki bir kopyasına ait. Değiştirmek için baştan başlayın.",
+        startOver: "Baştan başla",
+        relaunch: "Uygulamak için yeniden başlat"
     )
 
     static let ru = PermissionGuideStrings(
@@ -87,7 +105,10 @@ extension PermissionGuideStrings {
         stepReturn: "Вернитесь сюда. Карточка заметит сама.",
         waiting: "Ожидание разрешения…",
         granted: "Разрешение получено!",
-        closeHelp: "Закрыть"
+        closeHelp: "Закрыть",
+        staleHint: "Уже включено в этом списке? Эта запись относится к прежней копии приложения. Начните заново, чтобы заменить её.",
+        startOver: "Начать заново",
+        relaunch: "Перезапустить для применения"
     )
 
     static let es = PermissionGuideStrings(
@@ -97,7 +118,10 @@ extension PermissionGuideStrings {
         stepReturn: "Vuelve aquí. Esta tarjeta lo nota sola.",
         waiting: "Esperando el permiso…",
         granted: "¡Permiso concedido!",
-        closeHelp: "Cerrar"
+        closeHelp: "Cerrar",
+        staleHint: "¿Ya está activado en esa lista? Esa entrada pertenece a una copia anterior de la app. Empieza de nuevo para reemplazarla.",
+        startOver: "Empezar de nuevo",
+        relaunch: "Reabrir para aplicar"
     )
 
     static let de = PermissionGuideStrings(
@@ -107,7 +131,10 @@ extension PermissionGuideStrings {
         stepReturn: "Komm zurück. Diese Karte merkt es von selbst.",
         waiting: "Warten auf die Berechtigung…",
         granted: "Berechtigung erteilt!",
-        closeHelp: "Schließen"
+        closeHelp: "Schließen",
+        staleHint: "In der Liste schon eingeschaltet? Dieser Eintrag gehört zu einer früheren Kopie der App. Neu beginnen, um ihn zu ersetzen.",
+        startOver: "Neu beginnen",
+        relaunch: "Zum Übernehmen neu starten"
     )
 
     static let fr = PermissionGuideStrings(
@@ -117,7 +144,10 @@ extension PermissionGuideStrings {
         stepReturn: "Revenez ici. Cette carte le remarque toute seule.",
         waiting: "En attente de l'autorisation…",
         granted: "Autorisation accordée !",
-        closeHelp: "Fermer"
+        closeHelp: "Fermer",
+        staleHint: "Déjà activé dans cette liste ? Cette entrée appartient à une copie précédente de l'app. Recommencez pour la remplacer.",
+        startOver: "Recommencer",
+        relaunch: "Relancer pour appliquer"
     )
 
     static let it = PermissionGuideStrings(
@@ -127,7 +157,10 @@ extension PermissionGuideStrings {
         stepReturn: "Torna qui. Questa scheda se ne accorge da sola.",
         waiting: "In attesa del permesso…",
         granted: "Permesso concesso!",
-        closeHelp: "Chiudi"
+        closeHelp: "Chiudi",
+        staleHint: "Già attivo in quell'elenco? Quella voce appartiene a una copia precedente dell'app. Ricomincia per sostituirla.",
+        startOver: "Ricomincia",
+        relaunch: "Riavvia per applicare"
     )
 
     static let ja = PermissionGuideStrings(
@@ -137,7 +170,10 @@ extension PermissionGuideStrings {
         stepReturn: "ここに戻ってください。このカードが自動で気づきます。",
         waiting: "許可を待っています…",
         granted: "許可されました！",
-        closeHelp: "閉じる"
+        closeHelp: "閉じる",
+        staleHint: "リストではすでにオンになっていますか？その項目は以前のコピーのものです。やり直して置き換えてください。",
+        startOver: "やり直す",
+        relaunch: "再起動して適用"
     )
 
     static let zhHans = PermissionGuideStrings(
@@ -147,7 +183,10 @@ extension PermissionGuideStrings {
         stepReturn: "回到这里，本卡片会自动察觉。",
         waiting: "正在等待权限…",
         granted: "权限已授予！",
-        closeHelp: "关闭"
+        closeHelp: "关闭",
+        staleHint: "列表里已经打开了？那条记录属于此 App 的早期副本。重新开始以替换它。",
+        startOver: "重新开始",
+        relaunch: "重新启动以生效"
     )
 
     static let zhTW = PermissionGuideStrings(
@@ -157,7 +196,10 @@ extension PermissionGuideStrings {
         stepReturn: "回到這裡，本卡片會自動察覺。",
         waiting: "正在等待權限…",
         granted: "已授予權限！",
-        closeHelp: "關閉"
+        closeHelp: "關閉",
+        staleHint: "清單裡已經開啟了？那筆項目屬於此 App 的早期副本。重新開始以取代它。",
+        startOver: "重新開始",
+        relaunch: "重新啟動以套用"
     )
 
     static let zhHK = PermissionGuideStrings(
@@ -167,6 +209,9 @@ extension PermissionGuideStrings {
         stepReturn: "回到這裡，本卡片會自動察覺。",
         waiting: "正在等待權限…",
         granted: "已授予權限！",
-        closeHelp: "關閉"
+        closeHelp: "關閉",
+        staleHint: "清單裡已經開啟了？那筆項目屬於此 App 的早期副本。重新開始以取代它。",
+        startOver: "重新開始",
+        relaunch: "重新啟動以套用"
     )
 }

--- a/Sources/Vorssaint/Core/Permissions.swift
+++ b/Sources/Vorssaint/Core/Permissions.swift
@@ -258,6 +258,28 @@ final class Permissions: ObservableObject {
         }
     }
 
+    /// Drops this app's entry from the list and asks again. The entry macOS
+    /// keeps is bound to the app's code signature, so a copy signed
+    /// differently (a local build, an update signed another way) finds the
+    /// switch on and the permission gone; nothing short of removing the entry
+    /// makes the system ask afresh. `tccutil` does that for the calling
+    /// user's own entries with no privilege, and is the command Apple
+    /// documents for the purpose.
+    func startOver(_ kind: PermissionKind) {
+        guard kind == .accessibility || kind == .screenRecording,
+              let bundleID = Bundle.main.bundleIdentifier else { return }
+        let service = kind == .accessibility ? "Accessibility" : "ScreenCapture"
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/tccutil")
+        process.arguments = ["reset", service, bundleID]
+        process.standardOutput = nil
+        process.standardError = nil
+        try? process.run()
+        process.waitUntilExit()
+        refreshActivePermissions()
+        if kind == .accessibility { requestAccessibility() } else { requestScreenRecording() }
+    }
+
     func openAccessibilitySettings() {
         open(pane: "Privacy_Accessibility")
     }

--- a/Sources/Vorssaint/Core/Permissions.swift
+++ b/Sources/Vorssaint/Core/Permissions.swift
@@ -269,15 +269,18 @@ final class Permissions: ObservableObject {
         guard kind == .accessibility || kind == .screenRecording,
               let bundleID = Bundle.main.bundleIdentifier else { return }
         let service = kind == .accessibility ? "Accessibility" : "ScreenCapture"
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/tccutil")
-        process.arguments = ["reset", service, bundleID]
-        process.standardOutput = nil
-        process.standardError = nil
-        try? process.run()
-        process.waitUntilExit()
-        refreshActivePermissions()
-        if kind == .accessibility { requestAccessibility() } else { requestScreenRecording() }
+        // Off the main thread through the bounded runner, like
+        // `SelfUninstall.resetTCC`: a stuck tccutil must not hang the UI. The
+        // hop back also lets the button's click finish before the card that
+        // holds the button is rebuilt by the new request.
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            _ = Shell.run("/usr/bin/tccutil", ["reset", service, bundleID])
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.refreshActivePermissions()
+                if kind == .accessibility { self.requestAccessibility() } else { self.requestScreenRecording() }
+            }
+        }
     }
 
     func openAccessibilitySettings() {

--- a/Sources/Vorssaint/UI/PermissionGuideOverlay.swift
+++ b/Sources/Vorssaint/UI/PermissionGuideOverlay.swift
@@ -23,7 +23,11 @@ final class PermissionGuideOverlay {
     private var panel: NSPanel?
     private var grantWatcher: AnyCancellable?
     private var dismissWork: DispatchWorkItem?
+    private var staleWork: DispatchWorkItem?
     private let pollingDemandID = UUID()
+    /// Long enough for the trip to System Settings and back; short enough
+    /// that someone staring at a switch that is already on is not left alone.
+    private static let staleAfter: TimeInterval = 12
 
     private init() {}
 
@@ -32,6 +36,8 @@ final class PermissionGuideOverlay {
         Permissions.shared.setActivePermissionSurface(pollingDemandID, visible: false)
         dismissWork?.cancel()
         dismissWork = nil
+        staleWork?.cancel()
+        staleWork = nil
         grantWatcher = nil
         panel?.orderOut(nil)
         panel = nil
@@ -43,9 +49,14 @@ final class PermissionGuideOverlay {
             : L10n.shared.s.permissionScreenRecording
         let model = PermissionGuideModel()
         let view = PermissionGuideCard(guide: guide, permissionName: permissionName,
-                                       model: model) { [weak self] in
+                                       kind: kind, model: model,
+                                       onStartOver: { Permissions.shared.startOver(kind) },
+                                       onRelaunch: { appDelegate()?.relaunchApp() }) { [weak self] in
             self?.dismiss()
         }
+        let stale = DispatchWorkItem { model.stale = true }
+        staleWork = stale
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.staleAfter, execute: stale)
 
         let host = NSHostingView(rootView: view)
         let size = host.fittingSize
@@ -82,7 +93,11 @@ final class PermissionGuideOverlay {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 model.granted = true
-                self?.scheduleDismiss()
+                model.stale = false
+                self?.staleWork?.cancel()
+                // Screen Recording applies to a fresh process only, so the
+                // card stays with a Relaunch button instead of leaving.
+                if kind == .accessibility { self?.scheduleDismiss() }
             }
     }
 
@@ -97,6 +112,8 @@ final class PermissionGuideOverlay {
     func dismiss() {
         dismissWork?.cancel()
         dismissWork = nil
+        staleWork?.cancel()
+        staleWork = nil
         grantWatcher = nil
         panel?.orderOut(nil)
         panel = nil
@@ -104,15 +121,21 @@ final class PermissionGuideOverlay {
     }
 }
 
-/// The card's only mutable state: flips once when the grant lands.
+/// The card's mutable state: `granted` flips once when the grant arrives;
+/// `stale` once the wait has gone on long enough that the usual cause is an
+/// entry left by an earlier copy of the app.
 private final class PermissionGuideModel: ObservableObject {
     @Published var granted = false
+    @Published var stale = false
 }
 
 private struct PermissionGuideCard: View {
     let guide: PermissionGuideStrings
     let permissionName: String
+    let kind: PermissionKind
     @ObservedObject var model: PermissionGuideModel
+    let onStartOver: () -> Void
+    let onRelaunch: () -> Void
     let onClose: () -> Void
 
     var body: some View {
@@ -150,6 +173,12 @@ private struct PermissionGuideCard: View {
                     Text(guide.granted)
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(.green)
+                    if kind == .screenRecording {
+                        Spacer(minLength: 8)
+                        Button(guide.relaunch, action: onRelaunch)
+                            .controlSize(.small)
+                            .buttonStyle(.borderedProminent)
+                    }
                 } else {
                     ProgressView()
                         .controlSize(.small)
@@ -159,6 +188,18 @@ private struct PermissionGuideCard: View {
                 }
             }
             .padding(.top, 2)
+
+            if model.stale, !model.granted {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(guide.staleHint)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Button(guide.startOver, action: onStartOver)
+                        .controlSize(.small)
+                }
+                .padding(.top, 2)
+            }
         }
         .padding(14)
         .frame(width: 320, alignment: .leading)
@@ -171,6 +212,7 @@ private struct PermissionGuideCard: View {
                 )
         )
         .animation(.easeOut(duration: 0.2), value: model.granted)
+        .animation(.easeOut(duration: 0.2), value: model.stale)
     }
 
     private func stepRow(_ number: Int, _ text: String) -> some View {

--- a/Sources/Vorssaint/UI/PermissionGuideOverlay.swift
+++ b/Sources/Vorssaint/UI/PermissionGuideOverlay.swift
@@ -95,6 +95,10 @@ final class PermissionGuideOverlay {
                 model.granted = true
                 model.stale = false
                 self?.staleWork?.cancel()
+                // Granted is the end of the wait either way, so the fast
+                // polling this card asked for stops here, whether the card
+                // leaves or stays.
+                if let self { Permissions.shared.setActivePermissionSurface(self.pollingDemandID, visible: false) }
                 // Screen Recording applies to a fresh process only, so the
                 // card stays with a Relaunch button instead of leaving.
                 if kind == .accessibility { self?.scheduleDismiss() }


### PR DESCRIPTION
## Summary

The permission guide card can wait forever on a switch that is already on. The entry macOS keeps for Accessibility or Screen Recording is bound to the app's code signature, so a copy signed differently (a local build, or an update signed another way) finds its switch on in System Settings and the permission gone. The card says "Turn Vorssaint on in that list", the person finds it on, and nothing happens.

Two additions to the card:

- After 12 seconds of waiting it says why that can happen and offers **Start over**, which removes this app's own entry (`tccutil reset <service> <bundle id>`, the command Apple documents for it, no privilege needed for one's own entries) and asks again, so System Settings shows a fresh row that can be turned on.
- For Screen Recording, which applies only to a fresh process, the granted state keeps the card up with a **Relaunch to apply** button (the existing `relaunchApp`) instead of fading out and leaving the feature not working.

Built on `tccutil` and the app's own permission refresh; no new dependency or permission. Strings in all thirteen languages.

What a user notices: a card that is stuck on an already-on switch explains itself and has a button that fixes it.

## Verification

MacBook Pro 14" (MacBookPro18,3, M1 Pro), macOS 15.7.7 (24G720), one display, English (US). Own build: `./build.sh --dev --install`, `./build.sh --test`. Reproduced the stuck state by rebuilding an ad-hoc-signed developer build (the switch stays on, `CGPreflightScreenCaptureAccess` stays false) and cleared it with the same `tccutil reset` the button runs. Not tested by hand yet: the button itself on screen, and a localized card. I will confirm and say so here.
