### PR TITLE
fix(switcher): list windows from apps that draw their own chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Vorssaint expands screen text recognition, clipboard, Super key, Dock Preview, A
 - Cleaner leftover scans now cover more preference panes and plugin folders while refusing nested app data, version folders, links and other ambiguous paths.
 
 ### Fixed
+- App Switcher now lists windows from apps that draw their own title bar or use borderless windows. Thanks to @PathGao.
 - Switching capture modes in the screen capture chooser now transitions smoothly without flickering or restarting the overlay session.
 - Clicking long text previews in the menu panel's clipboard section now keeps the preview confined to its row instead of overflowing across neighboring items. Thanks to @andreisuslov.
 - Navigating clipboard history with arrow keys now prevents hovering pointers from fighting keyboard selection, keeps the list responsive during scrolling and renders large text previews without layout pauses. Thanks to @andreisuslov.

--- a/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
+++ b/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
@@ -515,17 +515,32 @@ enum SwitcherSupport {
             || lower.hasPrefix("com.adobe.characteranimator")
     }
 
-    /// Some full-screen playback surfaces keep a nonstandard Accessibility
-    /// subrole. A screen-sized AX window is still a real switch target, while
-    /// smaller utility surfaces remain filtered. Compatibility-hosted windows
-    /// retain their existing role-based exception at every size.
+    /// Whether a window whose Accessibility subrole is not a standard one is
+    /// still a switch target.
+    ///
+    /// `AXUnknown` is the absence of a description, not a description of a
+    /// utility surface: apps that draw their own title bar ship borderless
+    /// windows, and macOS reports those as an undescribed `AXWindow`. The
+    /// window server tells those apart from overlays for us — an ordinary
+    /// window sits at the normal window level, while a HUD or panel floats
+    /// above it — so a normal-level undescribed window is a real window
+    /// whoever shipped it (issues #215, #512). Compatibility-hosted windows
+    /// keep their own exception for the surfaces that resolve to no window
+    /// server id at all (issue #274), and a screen-sized surface stays
+    /// switchable so full-screen playback on another desktop is not lost.
+    ///
+    /// Every subrole the app did describe is left alone: a dialog, a sheet or
+    /// a floating panel is filtered as before unless it fills the screen.
     static func isSwitchableNonstandardWindow(role: String?,
                                               subrole: String?,
                                               fillsScreen: Bool,
+                                              hasNormalWindowLevel: Bool,
                                               acceptsUndescribedSubroles: Bool) -> Bool {
         guard role == "AXWindow" else { return false }
-        if acceptsUndescribedSubroles && subrole == "AXUnknown" { return true }
-        return fillsScreen && (subrole == "AXUnknown" || subrole == "AXFloatingWindow")
+        if subrole == "AXUnknown" {
+            return hasNormalWindowLevel || acceptsUndescribedSubroles || fillsScreen
+        }
+        return fillsScreen && subrole == "AXFloatingWindow"
     }
 
     /// Finds the regular app that contains an accessory helper bundle.

--- a/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
@@ -118,6 +118,14 @@ enum WindowEnumerator {
         // after that. Mapping those pids to a regular app used to admit their
         // leftover surfaces as switchable windows, which is how an app's
         // preview outlived its quit (issue #807).
+        // The window server's own layering: an ordinary window sits at level 0
+        // while HUDs, panels and overlays float above. It is the signal that
+        // keeps undescribed overlays out of the switcher once undescribed
+        // windows count as switch targets.
+        let normalLevelWindowIDs = Set(raw.compactMap { info -> CGWindowID? in
+            guard (info[kCGWindowLayer as String] as? NSNumber)?.intValue == 0 else { return nil }
+            return (info[kCGWindowNumber as String] as? NSNumber)?.uint32Value
+        })
         let runningApps = NSWorkspace.shared.runningApplications.filter { !$0.isTerminated }
         let hiddenAppPIDs = Set(runningApps.lazy
             .filter { $0.isHidden }
@@ -175,7 +183,8 @@ enum WindowEnumerator {
             filterPID: filterPID)
         let accessibilityWindows = accessibilityWindows(for: accessibilityPids,
                                                         bundleIdentifiers: bundleIdentifiers,
-                                                        undescribedSubrolePids: compatibilityLayerPids)
+                                                        undescribedSubrolePids: compatibilityLayerPids,
+                                                        normalLevelWindowIDs: normalLevelWindowIDs)
 
         var seen = Set<CGWindowID>()
         var windows: [SwitcherItem] = []
@@ -449,7 +458,8 @@ enum WindowEnumerator {
 
     private static func accessibilityWindows(for pids: Set<pid_t>,
                                              bundleIdentifiers: [pid_t: String] = [:],
-                                             undescribedSubrolePids: Set<pid_t> = []) -> [pid_t: AccessibilityWindowSnapshotList] {
+                                             undescribedSubrolePids: Set<pid_t> = [],
+                                             normalLevelWindowIDs: Set<CGWindowID>) -> [pid_t: AccessibilityWindowSnapshotList] {
         guard Permissions.shared.accessibility else { return [:] }
 
         let orderedPIDs = pids.sorted()
@@ -471,6 +481,7 @@ enum WindowEnumerator {
                     for: pid,
                     bundleIdentifier: bundleIdentifiers[pid],
                     acceptsUndescribedSubroles: undescribedSubrolePids.contains(pid),
+                    normalLevelWindowIDs: normalLevelWindowIDs,
                     screenFrames: screenFrames
                 )
                 resultLock.lock()
@@ -497,6 +508,7 @@ enum WindowEnumerator {
     private static func accessibilityWindows(for pid: pid_t,
                                              bundleIdentifier: String? = nil,
                                              acceptsUndescribedSubroles: Bool = false,
+                                             normalLevelWindowIDs: Set<CGWindowID>,
                                              screenFrames: [CGRect]) -> AccessibilityWindowSnapshotList? {
         let app = AXUIElementCreateApplication(pid)
         // This runs on the main thread (tap callback and activation warm-ups):
@@ -515,6 +527,7 @@ enum WindowEnumerator {
                 if isUserFacingWindow(window,
                                       bundleIdentifier: bundleIdentifier,
                                       acceptsUndescribedSubroles: acceptsUndescribedSubroles,
+                                      normalLevelWindowIDs: normalLevelWindowIDs,
                                       screenFrames: screenFrames) {
                     appendUnique(window, to: &axWindows)
                 }
@@ -526,6 +539,7 @@ enum WindowEnumerator {
                 if isUserFacingWindow(window,
                                       bundleIdentifier: bundleIdentifier,
                                       acceptsUndescribedSubroles: acceptsUndescribedSubroles,
+                                      normalLevelWindowIDs: normalLevelWindowIDs,
                                       screenFrames: screenFrames) {
                     appendUnique(window, to: &axWindows)
                 }
@@ -667,6 +681,7 @@ enum WindowEnumerator {
     private static func isUserFacingWindow(_ window: AXUIElement,
                                            bundleIdentifier: String? = nil,
                                            acceptsUndescribedSubroles: Bool = false,
+                                           normalLevelWindowIDs: Set<CGWindowID>,
                                            screenFrames: [CGRect]) -> Bool {
         if isFullscreenWindow(window) { return true }
         if boolAttribute(window, kAXMinimizedAttribute as String),
@@ -681,15 +696,20 @@ enum WindowEnumerator {
             let canBePlaybackSurface = subrole == "AXUnknown" || subrole == "AXFloatingWindow"
             let fillsScreen = canBePlaybackSurface
                 && frameLooksFullscreen(accessibilityFrame(for: window), screenFrames: screenFrames)
-            // Compatibility-layer processes draw their own window chrome on
-            // borderless surfaces, which Accessibility reports as AXUnknown;
-            // for them the window role is the real signal.
-            // Other apps can expose full-screen playback the same way. The
-            // screen-sized frame keeps ordinary utility windows filtered.
+            // Apps that draw their own window chrome — game clients, DAWs,
+            // compatibility layers — ship borderless windows, which
+            // Accessibility reports as an undescribed AXWindow. Only the
+            // window server can say whether such a surface is one of those
+            // real windows or an overlay floating above them.
+            let hasNormalWindowLevel = subrole == "AXUnknown"
+                && role == (kAXWindowRole as String)
+                && (AXWindowResolver.windowID(for: window)
+                    .map(normalLevelWindowIDs.contains) ?? false)
             return SwitcherSupport.isSwitchableNonstandardWindow(
                 role: role,
                 subrole: subrole,
                 fillsScreen: fillsScreen,
+                hasNormalWindowLevel: hasNormalWindowLevel,
                 acceptsUndescribedSubroles: acceptsUndescribedSubroles)
         }
         return stringAttribute(window, kAXRoleAttribute as String) == "AXWindow"

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -2284,38 +2284,58 @@ struct MetricsTests {
             role: "AXWindow",
             subrole: "AXUnknown",
             fillsScreen: true,
+            hasNormalWindowLevel: false,
             acceptsUndescribedSubroles: false),
                "App Switcher accepts a screen-sized window with a nonstandard subrole")
         expect(SwitcherSupport.isSwitchableNonstandardWindow(
             role: "AXWindow",
             subrole: "AXFloatingWindow",
             fillsScreen: true,
+            hasNormalWindowLevel: false,
             acceptsUndescribedSubroles: false),
                "App Switcher accepts a screen-sized floating playback surface")
         expect(!SwitcherSupport.isSwitchableNonstandardWindow(
             role: "AXWindow",
             subrole: "AXUnknown",
             fillsScreen: false,
+            hasNormalWindowLevel: false,
             acceptsUndescribedSubroles: false),
                "App Switcher filters a smaller window with a nonstandard subrole")
         expect(!SwitcherSupport.isSwitchableNonstandardWindow(
             role: "AXGroup",
             subrole: "AXUnknown",
             fillsScreen: true,
+            hasNormalWindowLevel: false,
             acceptsUndescribedSubroles: false),
                "App Switcher requires a real window role for a full-screen surface")
         expect(!SwitcherSupport.isSwitchableNonstandardWindow(
             role: "AXWindow",
             subrole: "AXDialog",
             fillsScreen: true,
+            hasNormalWindowLevel: false,
             acceptsUndescribedSubroles: false),
                "App Switcher does not turn a screen-sized dialog into a playback window")
         expect(SwitcherSupport.isSwitchableNonstandardWindow(
             role: "AXWindow",
             subrole: "AXUnknown",
             fillsScreen: false,
+            hasNormalWindowLevel: false,
             acceptsUndescribedSubroles: true),
                "App Switcher preserves hosted windows with custom chrome")
+        expect(SwitcherSupport.isSwitchableNonstandardWindow(
+            role: "AXWindow",
+            subrole: "AXUnknown",
+            fillsScreen: false,
+            hasNormalWindowLevel: true,
+            acceptsUndescribedSubroles: false),
+               "App Switcher accepts an ordinary window from an app that describes none")
+        expect(!SwitcherSupport.isSwitchableNonstandardWindow(
+            role: "AXWindow",
+            subrole: "AXFloatingWindow",
+            fillsScreen: false,
+            hasNormalWindowLevel: true,
+            acceptsUndescribedSubroles: false),
+               "App Switcher keeps a described floating panel filtered at the normal window level")
         expect(SwitcherSupport.sessionSourceItem(frontmostPID: nil,
                                                  focusedWindowID: nil,
                                                  items: [embeddedWindow]) == nil,


### PR DESCRIPTION
## Summary

Apps that draw their own title bar never appear in the App Switcher at all.

macOS gives a borderless window the `AXUnknown` subrole. The switcher read
that as "utility surface" and accepted it only when it filled a screen or the
process was a compatibility layer (`isSwitchableNonstandardWindow`). For an
app whose windows are all borderless, nothing passed the filter, and the
Accessibility cross-check that removes stale surfaces then vetoed every window
server surface the app owned — so the app disappeared from Cmd-Tab entirely
rather than losing one window. That veto has behaved this way since at least
v3.1.12, which is why the report predates the ghost-window fix in #826.

`AXUnknown` is the absence of a description, not a description of a utility
surface, so no bundle identifier can decide this correctly. The window server
already separates the two: an ordinary window sits at the normal window level
and a HUD, palette or overlay floats above it. An undescribed `AXWindow` at
the normal level is now a switch target whichever app shipped it. Subroles the
app did describe are untouched — a dialog, sheet or floating panel is filtered
exactly as before unless it fills the screen.

Measured on the shapes an AppKit app can produce (role, subrole, window
server layer):

| window | subrole | layer | before | after |
| --- | --- | --- | --- | --- |
| `.borderless` | `AXUnknown` | 0 | filtered | switchable |
| `.borderless` at `.floating` level | `AXUnknown` | 3 | filtered | filtered |
| `.borderless, .resizable` | `AXDialog` | 0 | filtered | filtered |
| `.titled` | `AXStandardWindow` | 0 | switchable | switchable |

Alternatives considered:

- **Add the bundle identifiers to `isSupportedMediaFloatingWindow`.** That
  list is the same defect handled per app; it has already been extended once
  and would need a line for every game client, DAW and custom-chrome app that
  ever gets reported.
- **Drop the screen-size requirement for every nonstandard subrole.** Panels
  and dialogs would become switcher entries; the measurements above show the
  window level draws the line where the subrole cannot.
- **Stop the veto instead — treat any window the app still lists as proof its
  surface is real.** This fixes the disappearance without deciding what is a
  switch target, but it puts every dialog and panel surface back into the
  list, which is a wider behaviour change than the report asks for.

The `AXUnknown` half of the media-app allowlist is now redundant for anything
at the normal window level, and the compatibility-layer exception only still
matters for surfaces that resolve to no window server id. Both are left in
place: removing them needs a check on Adobe and Crossover hardware, which I do
not have.

## Verification

Mac17,3 (Apple M5), macOS 26.6.2 build 25G83, two displays, one Space, my own
`./build.sh` release build.

```
./build.sh                  # no warnings
./build/Vorssaint --selftest  # SELFTEST OK
./build.sh --test           # TESTS OK (8974 checks)
```

Since I have neither FL Studio nor Steam, I verified the filter against live
Accessibility data instead: a probe built the same window shapes as the table
above, then ran both the old and the new rule over every window of every
regular app running on this Mac. One verdict changed — the normal-level
borderless window flipped from filtered to switchable. Eleven other live
windows kept their verdict and nothing became newly filtered.

**Not tested:** FL Studio and Steam themselves, so I cannot confirm they use
this window shape rather than another nonstandard one; other Spaces and
full-screen Spaces; Adobe and Crossover apps, whose existing exceptions this
change leaves in place but no longer needs at the normal window level.

## Anything else

#512 carries two reports and this covers only the second one, FL Studio never
appearing; the closed-window half was fixed by #826.

Refs #512
Refs #215
