### PR TITLE
ci(issues): leave half-fixed reports alone, and name the reporter-check label for what it leads to

### DIFF
--- a/.github/workflows/issue-fix-status.yml
+++ b/.github/workflows/issue-fix-status.yml
@@ -13,6 +13,10 @@ name: Issue fix status
 #   two weeks of silence after that                 ->  the issue is closed,
 #   after a comment saying so and how to reopen it
 #
+# A label put on by hand joins that at the second step: the daily job asks the
+# question the release sweep would have asked, and the same two weeks run from
+# that comment. Nothing is closed on a silence nobody was asked to break.
+#
 #   a description that closes its issue with a    ->  one comment on the pull
 #   keyword, or mentions one and references none        request, before it merges
 #
@@ -421,25 +425,55 @@ jobs:
           echo "closing checks asked before $cutoff"
 
           gh issue list --state open --label "$CONFIRM_LABEL" --limit 200 \
-            --json number,labels \
+            --json number,author,labels \
             | jq -r --argjson skip "$SKIP_LABELS" \
-                '.[] | select(any(.labels[].name; IN($skip[])) | not) | .number' \
+                '.[] | select(any(.labels[].name; IN($skip[])) | not) | "\(.number) \(.author.login)"' \
             > waiting.txt
 
-          while read -r number; do
+          while read -r number login; do
             [ -n "$number" ] || continue
 
             comments=$(gh api --paginate "repos/$GH_REPO/issues/$number/comments" \
                          --jq '[.[] | {created_at, login: .user.login, body}]' | jq -s add)
 
-            # The clock starts when the reporter was asked, which is the comment,
-            # not the label -- a label notifies nobody, so an issue labelled by
-            # hand has never actually asked anyone anything. Without that comment
-            # this job leaves the issue alone forever, which is what makes it safe
-            # to point at a repository that has been labelled by hand.
+            # The clock starts when the reporter was asked, which is the comment
+            # and not the label -- a label notifies nobody, so a label applied by
+            # hand has asked no one anything yet. It gets asked here, in the same
+            # words the release sweep uses, and its two weeks start from that
+            # comment. Every issue carrying the label ends the same way, whoever
+            # put it there; the only thing the hand-applied ones lack is the
+            # question, so this writes it rather than closing on a silence the
+            # reporter was never told about.
             ask=$(jq -c '[.[] | select(.body | test("vorssaint-fix-status confirm="))] | last' <<<"$comments")
             if [ "$ask" = null ]; then
-              echo "::warning::#$number: carries $CONFIRM_LABEL with no recorded ask, left alone"
+              # Which release: the newest stable one. That is what the label
+              # claims and the only build the reporter can go and get.
+              TAG=$(gh release list --exclude-drafts --exclude-pre-releases \
+                      --limit 1 --json tagName --jq '.[0].tagName // empty')
+              if [ -z "$TAG" ]; then
+                echo "::warning::#$number: no stable release to ask about, left alone"
+                continue
+              fi
+              version=${TAG#v}
+
+              # Expanded heredoc: keep the text free of backticks and `$`.
+              cat > comment.md <<COMMENT
+          The fix for this is in **$version**.
+
+          @$login, could you update to that version and say whether it fixed things
+          on your Mac? We cannot tell from here — yours is the setup that found this.
+
+          Please say **how much of it is fixed**, not only whether it is. If part of what you
+          reported still happens, or something related turned up, say so here and the issue goes
+          back for another look — this is not a last call.
+
+          If nothing arrives in two weeks the issue will be closed as it stands, and a comment
+          reopens it at any point after that.
+
+          <!-- vorssaint-fix-status confirm=$TAG -->
+          COMMENT
+              gh issue comment "$number" --body-file comment.md
+              echo "#$number: labelled by hand, asked about $version, two weeks start now"
               continue
             fi
             asked=$(jq -r '.created_at' <<<"$ask")

--- a/.github/workflows/issue-fix-status.yml
+++ b/.github/workflows/issue-fix-status.yml
@@ -7,8 +7,8 @@ name: Issue fix status
 #   comment
 #
 #   the next stable release                         ->  every issue still
-#   carrying that label becomes `please confirm`, and its reporter is asked
-#   to check that release
+#   carrying that label becomes `please confirm close`, and its reporter is
+#   asked to check that release
 #
 #   two weeks of silence after that                 ->  the issue is closed,
 #   after a comment saying so and how to reopen it
@@ -45,10 +45,15 @@ name: Issue fix status
 # nothing either: one word from anyone stops it, and it never reads what that
 # word says.
 #
-# `please confirm` carries no version. The version lives in the comment, which
-# is the only part of this the reporter ever sees -- labels are silent, they
-# notify nobody, and a label per release would grow the repository's label list
-# without ever telling anyone anything.
+# `please confirm close` carries no version. The version lives in the comment,
+# which is the only part of this the reporter ever sees -- labels are silent,
+# they notify nobody, and a label per release would grow the repository's label
+# list without ever telling anyone anything.
+#
+# It says `close` because that is what the label is for and the only thing it
+# can lead to: an answer, or a close two weeks later. A bare `confirm` is a
+# bucket -- confirm a repro, confirm a design, confirm a duplicate -- and a
+# label that can mean three things is read as none of them.
 #
 # A `summary` issue is never touched by any of this, wherever it turns up: a
 # long-lived index has no reporter waiting on a build, and a pull request that
@@ -103,7 +108,7 @@ env:
   GH_TOKEN: ${{ github.token }}
   GH_REPO: ${{ github.repository }}
   PENDING_LABEL: fixed (pending release)
-  CONFIRM_LABEL: please confirm
+  CONFIRM_LABEL: please confirm close
   # Labels this bot keeps its hands off entirely. JSON so a name with a space
   # stays one name.
   SKIP_LABELS: '["summary","half"]'
@@ -162,7 +167,7 @@ jobs:
             gh api "repos/$GH_REPO/issues/$number/labels" -f "labels[]=$PENDING_LABEL" --silent
 
             # One fix status at a time. An issue its reporter sent back is still
-            # carrying `please confirm` from the last release, and a new fix puts
+            # carrying `please confirm close` from the last release, and a fix puts
             # it behind the next one.
             if jq -e --arg l "$CONFIRM_LABEL" 'any(.labels[]; .name == $l)' <<<"$issue" >/dev/null; then
               gh issue edit "$number" --remove-label "$CONFIRM_LABEL"
@@ -360,7 +365,7 @@ jobs:
 
           # Created once, if the repository has never had it. A release does not
           # mint a label -- the version it carries is in the comment below.
-          gh label create "$CONFIRM_LABEL" --color 7FCFCF \
+          gh label create "$CONFIRM_LABEL" --color 048c23 \
             --description "The fix is in a release; the reporter has two weeks to say whether that build fixed it" \
             || true   # already there
 

--- a/.github/workflows/issue-fix-status.yml
+++ b/.github/workflows/issue-fix-status.yml
@@ -96,8 +96,10 @@ on:
     workflows: [Release]
     types: [completed]
   schedule:
-    # Once a day is enough for a two-week clock.
-    - cron: '23 7 * * *'
+    # Once a day is enough for a two-week clock, and late is as good as
+    # on time for one: GitHub queues the top of the hour heavily and runs
+    # it when it can, which costs this job nothing.
+    - cron: '0 7 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/issue-fix-status.yml
+++ b/.github/workflows/issue-fix-status.yml
@@ -56,6 +56,15 @@ name: Issue fix status
 # the issues most often referenced, so the number that reaches these jobs most
 # is the one that must never be labelled or closed by them.
 #
+# A `half` issue is held back for the same reason at a smaller scale: two root
+# causes were reported together, one of them was fixed, and neither label above
+# is true of the other one. Labelling the whole report fixed signs for a
+# reporter who never got their half, and two weeks later this file would close
+# it on them. The label comes off when someone splits the report or lands the
+# rest; until then the fix status on it is a person's call, not this file's.
+# A closing keyword aimed at one is still shouted about, exactly as for
+# `summary` -- that is the case where GitHub, not this file, does the damage.
+#
 # Both labels and both comments are addressed to the person who filed the
 # report, and most of them are not developers. Nothing in what they read says
 # `main`, a commit, or a merge: the change is in the development build, and it
@@ -95,7 +104,9 @@ env:
   GH_REPO: ${{ github.repository }}
   PENDING_LABEL: fixed (pending release)
   CONFIRM_LABEL: please confirm
-  SKIP_LABEL: summary
+  # Labels this bot keeps its hands off entirely. JSON so a name with a space
+  # stays one name.
+  SKIP_LABELS: '["summary","half"]'
   CONFIRM_DAYS: 14
 
 jobs:
@@ -138,8 +149,10 @@ jobs:
             }
             [ "$(jq 'has("pull_request")' <<<"$issue")" = false ] || continue
             [ "$(jq -r '.state' <<<"$issue")" = open ] || continue
-            if jq -e --arg l "$SKIP_LABEL" 'any(.labels[]; .name == $l)' <<<"$issue" >/dev/null; then
-              echo "#$number: $SKIP_LABEL, left alone"
+            skip=$(jq -r --argjson skip "$SKIP_LABELS" \
+                     'first(.labels[].name | select(IN($skip[]))) // empty' <<<"$issue")
+            if [ -n "$skip" ]; then
+              echo "#$number: $skip, left alone"
               continue
             fi
             jq -e --arg l "$PENDING_LABEL" 'any(.labels[]; .name == $l)' <<<"$issue" >/dev/null && continue
@@ -248,7 +261,8 @@ jobs:
             # GitHub closes a long-lived index on merge and nothing here would
             # have said a word. The skip belongs to the `missing` form alone.
             if [ "$form" != closing ] \
-               && jq -e --arg l "$SKIP_LABEL" 'any(.labels[]; .name == $l)' <<<"$issue" >/dev/null; then
+               && jq -e --argjson skip "$SKIP_LABELS" \
+                    'any(.labels[].name; IN($skip[]))' <<<"$issue" >/dev/null; then
               continue
             fi
             printf '%s\t%s\n' "$number" "$(jq -r '.title' <<<"$issue")" >> hits.txt
@@ -353,8 +367,8 @@ jobs:
           # `gh issue list` never returns pull requests.
           gh issue list --state open --label "$PENDING_LABEL" --limit 200 \
             --json number,author,labels \
-            | jq -r --arg l "$SKIP_LABEL" \
-                '.[] | select(any(.labels[]; .name == $l) | not) | "\(.number) \(.author.login)"' \
+            | jq -r --argjson skip "$SKIP_LABELS" \
+                '.[] | select(any(.labels[].name; IN($skip[])) | not) | "\(.number) \(.author.login)"' \
             > pending.txt
 
           # Everything waiting moves, including labels applied by hand. Waiting
@@ -403,8 +417,8 @@ jobs:
 
           gh issue list --state open --label "$CONFIRM_LABEL" --limit 200 \
             --json number,labels \
-            | jq -r --arg l "$SKIP_LABEL" \
-                '.[] | select(any(.labels[]; .name == $l) | not) | .number' \
+            | jq -r --argjson skip "$SKIP_LABELS" \
+                '.[] | select(any(.labels[].name; IN($skip[])) | not) | .number' \
             > waiting.txt
 
           while read -r number; do


### PR DESCRIPTION
Four changes to `issue-fix-status.yml`, all in what the bot leaves alone and
what it calls things. No Swift, no user-facing strings.

All three labels below already exist on the repository — they were created and
renamed by hand. Nothing here mints a label; this is the workflow catching up
to them.

## The bot no longer touches a half-fixed report

One report can carry two root causes. A pull request fixes one of them, its
description references the report, and the merge job labels the whole thing
`fixed (pending release)` — which is not true of the other half. The release
sweep then asks that reporter to confirm a fix they never got, and two weeks
later the timer closes their report.

`half` is the label for that state, and this teaches the bot to leave it alone
exactly the way it already leaves `summary` alone: no status on merge, no move
at release, no close on the timer. It comes off when someone splits the report
or lands the rest, and until then the fix status on it is a person's call.

`SKIP_LABEL` becomes `SKIP_LABELS`, a JSON array so a name with a space stays
one name. The four read points are unchanged in what they decide, including
the one that still shouts about a closing keyword aimed at such an issue —
that is the case where GitHub, not this file, closes the report.

## `please confirm` becomes `please confirm close`

The label asks one question with one consequence: the reporter answers, or the
report closes two weeks later. The name now says which confirm it means. A
bare `confirm` is a bucket — confirm a repro, confirm a design, confirm a
duplicate — and a label that can mean three things is read as none of them.

Nothing is rewritten by this. The label had never been applied to anything:
`reporter-check` has not run once, so the rename lands before its first use
rather than after. `CONFIRM_LABEL` moves with it, which is the part that
matters here — leave it on the old name and the next release mints a second
label beside the renamed one.

## A label applied by hand now gets asked, instead of being skipped forever

The two-week job required its own marker comment before it would count anyone's
silence, and left every other issue carrying the label alone permanently. That
split one label in two: applied by the release sweep, it ends; applied by a
person, it never does.

The missing marker is now something the job writes rather than waits for. An
issue carrying the label with no question on it gets the question — the same
words the release sweep uses, naming the newest stable release, which is what
the label claims and the only build the reporter can go and get — and its two
weeks run from that comment.

The reason the marker was a precondition still holds and is why this is an ask
and not a close: a label notifies nobody, so nobody labelled by hand has been
asked anything, and closing on that silence would be closing on a silence they
were never told to break. Asking supplies the missing half, and after it both
paths are identical. Where there is no stable release to name, the issue is
still left alone and the run warns.

## The daily job runs at 07:00 UTC

It ran at 07:23, and the minute read as though it had been chosen for a
reason. It had not. The clock this job reads is fourteen days wide, so it does
not care when in the hour it runs, or whether it runs on time at all — which
is the one thing the top of the hour costs, since GitHub queues those heavily
and runs them late.

## Tested

YAML parses; all four `run:` blocks pass `bash -n`. The new `jq` filters were
run against live issue payloads from this repository: a `summary` issue and a
`half` issue are dropped from both list filters and both per-issue guards, and
a label whose name contains a space is not matched by either.

`close-unanswered` was run end to end against a stubbed `gh` and `date`, six
issues: labelled by hand is asked and not closed; asked twenty days ago with no
reply closes and drops the label; asked twenty days ago with any human reply is
left alone; asked three days ago waits; `summary` and `half` never reach the
loop.

What I could not test is the same thing the last change to this file could not.
`pull_request_target` reads the workflow from the base branch, so the jobs
running on this pull request are the current ones, not these. `reporter-check`
cannot run outside a `workflow_run` from Release — and it has never run at all:
the workflow's first run postdates the last stable release, so the release
sweep will execute for the first time on the next one, over the forty-two open
issues that carry `fixed (pending release)` today. That is worth a discardable
tag before a real release either way, independently of this pull request.
