### PR TITLE
fix: give the Accessibility messaging timeout one writer

### DIFF
--- a/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
+++ b/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
@@ -172,7 +172,7 @@ final class AutoQuitService: ObservableObject {
 
         let appElement = AXUIElementCreateApplication(pid)
         // A launching app that is busy (say, blocked on a Keychain prompt)
-        // would hold every synchronous AX call below for the 6 second default
+        // would hold every synchronous AX call below for the default
         // timeout apiece, freezing the main thread and every event tap with
         // it: typing dies system wide (issue #189). Give up fast and retry
         // with growing spacing until the app services its run loop again.
@@ -335,7 +335,7 @@ final class AutoQuitService: ObservableObject {
 
         let appElement = AXUIElementCreateApplication(pid)
         // Bounded AX: an unresponsive app must not hold the main thread
-        // (and with it every event tap) for the 6 second default timeout.
+        // (and with it every event tap) for the default timeout.
         AXUIElementSetMessagingTimeout(appElement, 0.35)
         let hasMinimizedWindow = hasKnownMinimizedWindow(pid: pid, appElement: appElement)
         let hasVisibleWindow = hasUserFacingWindow(pid: pid, appElement: appElement)
@@ -784,11 +784,8 @@ final class AutoQuitService: ObservableObject {
 
     private func elementAt(point: CGPoint) -> AXUIElement? {
         let system = AXUIElementCreateSystemWide()
-        // This runs while a click is being handled, and the app being asked is
-        // the one that was just told to close, which is exactly when an app
-        // stops answering. A short limit here means a slow answer is dropped
-        // rather than holding this app, and every tap it runs, still.
-        AXUIElementSetMessagingTimeout(system, 0.15)
+        // No cap here: on the system-wide element a timeout is the default for
+        // every question this process asks, whoever asks it (#938).
         var element: AXUIElement?
         guard AXUIElementCopyElementAtPosition(system, Float(point.x), Float(point.y), &element) == .success
         else { return nil }

--- a/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
@@ -427,11 +427,8 @@ final class FinderCutPaste: ObservableObject {
     /// paste shortcuts must be left to the system (e.g. renaming a file).
     private func isEditingText() -> Bool {
         let system = AXUIElementCreateSystemWide()
-        // The whole session's typing waits for this tap to answer, and this
-        // question goes to whichever app is in front. A file browser reading a
-        // share that went away is exactly the app that stops answering, so the
-        // wait is kept short enough not to be felt.
-        AXUIElementSetMessagingTimeout(system, 0.15)
+        // No cap here: on the system-wide element a timeout is the default for
+        // every question this process asks, whoever asks it (#938).
         var focused: CFTypeRef?
         guard AXUIElementCopyAttributeValue(system, "AXFocusedUIElement" as CFString, &focused) == .success,
               let focused,

--- a/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
+++ b/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
@@ -8,11 +8,9 @@ import CoreGraphics
 final class FocusFollowsMouseService {
     static let shared = FocusFollowsMouseService()
 
-    private let systemElement: AXUIElement = {
-        let element = AXUIElementCreateSystemWide()
-        AXUIElementSetMessagingTimeout(element, 0.25)
-        return element
-    }()
+    /// No cap on this one: on the system-wide element a timeout is the default
+    /// for every question this process asks, whoever asks it (#938).
+    private let systemElement = AXUIElementCreateSystemWide()
     private let queryQueue = DispatchQueue(label: "com.vorssaint.focus-follows-mouse")
     private var timer: Timer?
     private var mouseMonitor: Any?

--- a/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
@@ -602,7 +602,7 @@ enum WindowEnumerator {
         guard !isCancelled() else { return nil }
         let app = AXUIElementCreateApplication(pid)
         // An app that is not servicing its run loop would hold every AX call
-        // for the 6 second default timeout. The Switcher's serial session queue
+        // for the default timeout. The Switcher's serial session queue
         // must stay available for later shortcuts. The six synchronous
         // listWindows(for:) Dock and preview callers run on main, where a long
         // wait also stalls the event taps (issue #189).

--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
@@ -294,7 +294,7 @@ final class WindowLayoutService: ObservableObject {
             else { continue }
             let axApp = AXUIElementCreateApplication(pid)
             // Bounded AX: a hung app in the MRU list must not stall the main
-            // thread (and every event tap) for the 6 second default timeout.
+            // thread (and every event tap) for the default timeout.
             AXUIElementSetMessagingTimeout(axApp, 0.35)
             for attribute in [kAXFocusedWindowAttribute, kAXMainWindowAttribute] {
                 if let window = windowAttribute(axApp, attribute as String),
@@ -1716,7 +1716,8 @@ final class WindowLayoutService: ObservableObject {
     private func gestureTarget(at point: CGPoint,
                                requiresResize: Bool) -> WindowGestureTarget? {
         let system = AXUIElementCreateSystemWide()
-        AXUIElementSetMessagingTimeout(system, 0.25)
+        // No cap here: on the system-wide element a timeout is the default for
+        // every question this process asks, whoever asks it (#938).
         var rawElement: AXUIElement?
         guard AXUIElementCopyElementAtPosition(system, Float(point.x), Float(point.y), &rawElement) == .success,
               let element = rawElement

--- a/Sources/Vorssaint/Services/WindowMaximizer.swift
+++ b/Sources/Vorssaint/Services/WindowMaximizer.swift
@@ -239,10 +239,8 @@ final class WindowMaximizer: ObservableObject {
 
     private func elementAt(point: CGPoint) -> AXUIElement? {
         let system = AXUIElementCreateSystemWide()
-        // Bounded AX inside the mouse tap: a hung app under the cursor must
-        // not stall the main thread (and with it every event tap) for the
-        // 6 second default timeout.
-        AXUIElementSetMessagingTimeout(system, 0.35)
+        // No cap here: on the system-wide element a timeout is the default for
+        // every question this process asks, whoever asks it (#938).
         var element: AXUIElement?
         guard AXUIElementCopyElementAtPosition(system, Float(point.x), Float(point.y), &element) == .success,
               let element


### PR DESCRIPTION
## Summary

`AXUIElementSetMessagingTimeout` on the system-wide element sets the default for
every Accessibility question this process asks, whoever asks it — the header says
so, and it is measurable: a fresh element takes whichever global was written
last, and a value written on a specific element survives a later write to the
global.

Six places wrote it. `AppDelegate` means it: once at launch, documented as the
floor for the paths that cap nothing of their own. The other five each read
locally as that feature's own limit, and none of them was one.

| | wrote | trigger |
|---|---|---|
| `AutoQuitService` | 0.15 | clicking a window's close button |
| `FinderCutPaste` | 0.15 | ⌘X/⌘C/⌘V in Finder |
| `WindowLayoutService` | 0.25 | a modifier-drag on a window |
| `FocusFollowsMouseService` | 0.25 | enabling the feature |
| `WindowMaximizer` | 0.35 | clicking a green button |

Last writer wins, so how long Vorssaint waited on a frozen app depended on which
unrelated feature you had used most recently. Hover a Dock icon after using
Finder cut/paste and it waited 0.15s; after clicking a green maximize button,
0.35s. Same action, 2.3× apart, for a reason nothing on screen explains.

Those five stop writing it, and the reads they make wait the launch default —
which is what an uncapped read was always meant to get. The ~30 timeouts written
on specific application and window elements are untouched: those are genuinely
local, and each feature keeps its values.

**What this costs.** Against an app that has stopped answering, the reads on
those five paths wait 0.35s where they used to wait 0.15s or 0.25s — a few
hundred milliseconds per click or keystroke, and only when something is already
wrong. Two of the deleted lines carried reasoning worth keeping even though the
line is gone: auto-quit asks the app it has just told to close, which is exactly
the app that stops answering; the Finder guard runs on a tap the whole session's
typing waits behind. If either deserves to wait less than the floor, the way to
give it that is a timeout on the elements it holds, which is #938's second
question and not this change.

**Also, a figure four comments cite for the unset default.** Measured on 26.6.2
against a bundled, signed application holding its main thread: an element with no
timeout set gives up at 1.5s — three runs within 10ms of each other, with a 0.4s
control tracking exactly. Not the 6s those comments claim. Removed rather than
corrected, since Apple documents no default and any figure written here rots the
way this one did.

## Verification

MacBook (Apple silicon), macOS 26.6.2, my own `./build.sh` release build, single
display.

```sh
./build.sh                     # no warnings
./build/Vorssaint --selftest   # SELFTEST OK
./build.sh --test              # TESTS OK (9076 checks)
```

No test is added: the change is the absence of five calls, and the assertion that
would pin it — no file but `AppDelegate` may write the process-wide default — is
#938's fourth question, which wants an answer before a rule enforces one.

**What I could not test.** Any of this against a genuinely frozen app. The
timeout has an effect only when a process stops answering, which does not happen
on demand; the behaviour of the global was measured against a synthetic
Accessibility target holding its main thread. Nothing changes on a healthy path:
a query that answers in 0.02s reaches no timeout either way.

## Anything else

Refs #938
