### PR TITLE
fix(shortcuts): resolve shortcut key labels against the active keyboard layout

### DIFF
--- a/Sources/Vorssaint/Core/GlobalShortcut.swift
+++ b/Sources/Vorssaint/Core/GlobalShortcut.swift
@@ -389,6 +389,75 @@ struct GlobalShortcut: Equatable, Hashable {
 
     private var keyLabel: String? {
         switch Int(keyCode) {
+        case kVK_Tab: return "Tab"
+        case kVK_Space: return "Space"
+        case kVK_Return: return "Return"
+        case kVK_Escape: return "Esc"
+        case kVK_LeftArrow: return "←"
+        case kVK_RightArrow: return "→"
+        case kVK_UpArrow: return "↑"
+        case kVK_DownArrow: return "↓"
+        // Editing and navigation keys. They print as the caps the keyboard
+        // itself carries, the same way the arrows above do: spelling them out
+        // ("Page Down") would overflow the shortcut field on a full keyboard
+        // combination, and these caps are what every menu on this system shows.
+        case kVK_Delete: return "⌫"
+        case kVK_ForwardDelete: return "⌦"
+        case kVK_Home: return "↖"
+        case kVK_End: return "↘"
+        case kVK_PageUp: return "⇞"
+        case kVK_PageDown: return "⇟"
+        case kVK_ANSI_KeypadEnter: return "⌤"
+        case kVK_F1: return "F1"
+        case kVK_F2: return "F2"
+        case kVK_F3: return "F3"
+        case kVK_F4: return "F4"
+        case kVK_F5: return "F5"
+        case kVK_F6: return "F6"
+        case kVK_F7: return "F7"
+        case kVK_F8: return "F8"
+        case kVK_F9: return "F9"
+        case kVK_F10: return "F10"
+        case kVK_F11: return "F11"
+        case kVK_F12: return "F12"
+        // The upper function keys exist on full and external keyboards and are
+        // rarely claimed by anything else, which makes them good shortcuts.
+        case kVK_F13: return "F13"
+        case kVK_F14: return "F14"
+        case kVK_F15: return "F15"
+        case kVK_F16: return "F16"
+        case kVK_F17: return "F17"
+        case kVK_F18: return "F18"
+        case kVK_F19: return "F19"
+        case kVK_F20: return "F20"
+        default:
+            if let layout = Self.layoutKeyLabel(for: keyCode) {
+                return layout
+            }
+            return Self.fallbackKeyLabel(for: keyCode)
+        }
+    }
+
+    /// The character the current keyboard layout prints for a key, uppercased,
+    /// so keys the static table does not know (ISO and JIS extras) as well as
+    /// layout-dependent letter and symbol keys (QWERTZ, AZERTY, Dvorak, etc.)
+    /// get a real cap. Returns nil for anything unprintable.
+    ///
+    /// Answered from the cache: deriving a label asks Text Input Services,
+    /// which traps the process off the main thread, and the Switcher's tap
+    /// asks for one on every key from its own (issue #578).
+    private static func layoutKeyLabel(for keyCode: Int64) -> String? {
+        if Thread.isMainThread {
+            startObservingLayoutChangesIfNeeded()
+            let label = derivedLayoutKeyLabel(for: keyCode)
+            layoutLabelLock.withLock { layoutLabels[keyCode] = label }
+            return label
+        }
+        return layoutLabelLock.withLock { layoutLabels[keyCode] }
+    }
+
+    private static func fallbackKeyLabel(for keyCode: Int64) -> String? {
+        switch Int(keyCode) {
         case kVK_ANSI_A: return "A"
         case kVK_ANSI_B: return "B"
         case kVK_ANSI_C: return "C"
@@ -425,25 +494,6 @@ struct GlobalShortcut: Equatable, Hashable {
         case kVK_ANSI_7: return "7"
         case kVK_ANSI_8: return "8"
         case kVK_ANSI_9: return "9"
-        case kVK_Tab: return "Tab"
-        case kVK_Space: return "Space"
-        case kVK_Return: return "Return"
-        case kVK_Escape: return "Esc"
-        case kVK_LeftArrow: return "←"
-        case kVK_RightArrow: return "→"
-        case kVK_UpArrow: return "↑"
-        case kVK_DownArrow: return "↓"
-        // Editing and navigation keys. They print as the caps the keyboard
-        // itself carries, the same way the arrows above do: spelling them out
-        // ("Page Down") would overflow the shortcut field on a full keyboard
-        // combination, and these caps are what every menu on this system shows.
-        case kVK_Delete: return "⌫"
-        case kVK_ForwardDelete: return "⌦"
-        case kVK_Home: return "↖"
-        case kVK_End: return "↘"
-        case kVK_PageUp: return "⇞"
-        case kVK_PageDown: return "⇟"
-        case kVK_ANSI_KeypadEnter: return "⌤"
         case kVK_ANSI_Minus: return "-"
         case kVK_ANSI_Equal: return "="
         case kVK_ANSI_LeftBracket: return "["
@@ -455,58 +505,28 @@ struct GlobalShortcut: Equatable, Hashable {
         case kVK_ANSI_Period: return "."
         case kVK_ANSI_Slash: return "/"
         case kVK_ANSI_Grave: return "`"
-        case kVK_F1: return "F1"
-        case kVK_F2: return "F2"
-        case kVK_F3: return "F3"
-        case kVK_F4: return "F4"
-        case kVK_F5: return "F5"
-        case kVK_F6: return "F6"
-        case kVK_F7: return "F7"
-        case kVK_F8: return "F8"
-        case kVK_F9: return "F9"
-        case kVK_F10: return "F10"
-        case kVK_F11: return "F11"
-        case kVK_F12: return "F12"
-        // The upper function keys exist on full and external keyboards and are
-        // rarely claimed by anything else, which makes them good shortcuts.
-        case kVK_F13: return "F13"
-        case kVK_F14: return "F14"
-        case kVK_F15: return "F15"
-        case kVK_F16: return "F16"
-        case kVK_F17: return "F17"
-        case kVK_F18: return "F18"
-        case kVK_F19: return "F19"
-        case kVK_F20: return "F20"
-        // The extra ISO key beside/above Tab (§ on British, ^ on German
-        // keyboards) has no ANSI constant; without a label it could not be
-        // recorded as a shortcut at all on ISO keyboards (issue #187).
-        case kVK_ISO_Section: return Self.layoutKeyLabel(for: keyCode) ?? "§"
-        default: return Self.layoutKeyLabel(for: keyCode)
+        case kVK_ISO_Section: return "§"
+        default: return nil
         }
-    }
-
-    /// The character the current keyboard layout prints for a key, uppercased,
-    /// so keys the static table does not know (ISO and JIS extras) still get a
-    /// real cap. Returns nil for anything unprintable, keeping those invalid.
-    ///
-    /// Answered from the cache: deriving a label asks Text Input Services,
-    /// which traps the process off the main thread, and the Switcher's tap
-    /// asks for one on every key from its own (issue #578).
-    private static func layoutKeyLabel(for keyCode: Int64) -> String? {
-        if Thread.isMainThread {
-            let label = derivedLayoutKeyLabel(for: keyCode)
-            layoutLabelLock.withLock { layoutLabels[keyCode] = label }
-            return label
-        }
-        return layoutLabelLock.withLock { layoutLabels[keyCode] }
     }
 
     private static let layoutLabelLock = NSLock()
     private static var layoutLabels: [Int64: String] = [:]
+    private static var layoutObserver: NSObjectProtocol?
+
+    private static func startObservingLayoutChangesIfNeeded() {
+        guard Thread.isMainThread, layoutObserver == nil else { return }
+        layoutObserver = DistributedNotificationCenter.default().addObserver(
+            forName: NSNotification.Name(kTISNotifySelectedKeyboardInputSourceChanged as String),
+            object: nil,
+            queue: .main
+        ) { _ in refreshLayoutLabels() }
+    }
 
     /// Fills the cache before the Switcher's tap starts or after the layout
-    /// changes. The service owns the observer so it exists only with the tap.
+    /// changes.
     static func refreshLayoutLabels() {
+        startObservingLayoutChangesIfNeeded()
         guard let layoutData = currentLayoutData() else {
             layoutLabelLock.withLock { layoutLabels.removeAll() }
             return
@@ -535,8 +555,8 @@ struct GlobalShortcut: Equatable, Hashable {
         return Unmanaged<CFData>.fromOpaque(layoutData).takeUnretainedValue() as Data
     }
 
-    private static func derivedLayoutKeyLabel(for code: UInt16,
-                                              layoutData: Data) -> String? {
+    static func derivedLayoutKeyLabel(for code: UInt16,
+                                      layoutData: Data) -> String? {
         var deadKeyState: UInt32 = 0
         var chars = [UniChar](repeating: 0, count: 4)
         var length = 0

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -3432,6 +3432,45 @@ struct MetricsTests {
         expect(backgroundISOKeyIsValid,
                "layout-dependent shortcut labels are safe to read off the main thread")
 
+        let testAlphanumericKeys: [Int] = [
+            kVK_ANSI_A, kVK_ANSI_B, kVK_ANSI_C, kVK_ANSI_D, kVK_ANSI_E, kVK_ANSI_F,
+            kVK_ANSI_G, kVK_ANSI_H, kVK_ANSI_I, kVK_ANSI_J, kVK_ANSI_K, kVK_ANSI_L,
+            kVK_ANSI_M, kVK_ANSI_N, kVK_ANSI_O, kVK_ANSI_P, kVK_ANSI_Q, kVK_ANSI_R,
+            kVK_ANSI_S, kVK_ANSI_T, kVK_ANSI_U, kVK_ANSI_V, kVK_ANSI_W, kVK_ANSI_X,
+            kVK_ANSI_Y, kVK_ANSI_Z,
+            kVK_ANSI_0, kVK_ANSI_1, kVK_ANSI_2, kVK_ANSI_3, kVK_ANSI_4,
+            kVK_ANSI_5, kVK_ANSI_6, kVK_ANSI_7, kVK_ANSI_8, kVK_ANSI_9,
+        ]
+        for keyCode in testAlphanumericKeys {
+            let shortcut = GlobalShortcut(keyCode: Int64(keyCode), modifiers: [.command])
+            expect(shortcut.isValid, "alphanumeric key \(keyCode) is a valid shortcut")
+            expect(!shortcut.displayString.isEmpty && !shortcut.displayString.contains("Key "),
+                   "alphanumeric key \(keyCode) produces a real cap in displayString")
+        }
+
+        let structuralKeys: [(Int, String)] = [
+            (kVK_Tab, "Tab"), (kVK_Space, "Space"), (kVK_Return, "Return"),
+            (kVK_Escape, "Esc"), (kVK_LeftArrow, "←"), (kVK_RightArrow, "→"),
+            (kVK_UpArrow, "↑"), (kVK_DownArrow, "↓"),
+        ]
+        for (keyCode, expectedCap) in structuralKeys {
+            let shortcut = GlobalShortcut(keyCode: Int64(keyCode), modifiers: [.control, .option])
+            expect(shortcut.displayString.hasSuffix(expectedCap),
+                   "special key \(keyCode) prints \(expectedCap)")
+        }
+
+        let layoutDependentKeys: [Int] = [
+            kVK_ANSI_LeftBracket, kVK_ANSI_RightBracket, kVK_ANSI_Semicolon,
+            kVK_ANSI_Quote, kVK_ANSI_Comma, kVK_ANSI_Period, kVK_ANSI_Slash,
+            kVK_ANSI_Grave, kVK_ANSI_Minus, kVK_ANSI_Equal, kVK_ANSI_Backslash,
+        ]
+        for keyCode in layoutDependentKeys {
+            let shortcut = GlobalShortcut(keyCode: Int64(keyCode), modifiers: [.command])
+            expect(shortcut.isValid, "layout-dependent key \(keyCode) is a valid shortcut")
+            expect(!shortcut.displayString.isEmpty && !shortcut.displayString.contains("Key "),
+                   "layout-dependent key \(keyCode) produces a real cap in displayString")
+        }
+
         // The native full screen action, wired like the sixths: real strings,
         // a stable id, and no system-wide key claimed until someone asks.
         expect(WindowLayoutAction.allCases.contains(.fullScreen)
@@ -8864,7 +8903,8 @@ struct MetricsTests {
         }
         let defaultSwitcherHints = SwitcherSupport.shortcutHints(for: .switcherDefault,
                                                                  windowShortcut: .switcherWindowDefault)
-        expect(defaultSwitcherHints.apps == "⌘Tab" && defaultSwitcherHints.windows == "⌘ `",
+        expect(defaultSwitcherHints.apps == GlobalShortcut.switcherDefault.displayString
+                && defaultSwitcherHints.windows == GlobalShortcut.switcherWindowDefault.displayString,
                "App Switcher icon-row hints describe default app and window shortcuts")
         let customSwitcherHints = SwitcherSupport.shortcutHints(
             for: GlobalShortcut(keyCode: Int64(kVK_Tab), modifiers: [.option]),


### PR DESCRIPTION
## Summary

Shortcut key labels (in Settings, the Menu Panel, Quick Launcher, App Switcher hints, and the Shortcut Recorder) were statically mapped from ANSI key codes (`kVK_ANSI_A`...`kVK_ANSI_Z`, numbers, symbols) directly to US QWERTY characters.

On non-US layouts (such as Turkish Q / German QWERTZ, French AZERTY, Dvorak, Colemak, or custom layouts created via Ukelele):
- On Turkish Q: pressing the physical Turkish keys `Ğ`, `Ü`, `Ş`, `İ`, `Ö`, `Ç`, `<` recorded their keycodes but displayed US punctuation `[`, `]`, `;`, `'`, `,`, `.`, ` ` ` instead.
- On German QWERTZ: pressing physical **Z** (key code 16, `kVK_ANSI_Y`) recorded key code 16 but displayed `⌘Y` instead of `⌘Z`.
- On French AZERTY: pressing **A** (key code 12, `kVK_ANSI_Q`) displayed `⌘Q` instead of `⌘A`.
- `matchesByCharacter` failed because it compared the typed character against the hardcoded ANSI label rather than the active layout character.

### Changes:
- Routed alphanumeric and symbol keys through `layoutKeyLabel(for:)` which derives the character using `UCKeyTranslate` on the active keyboard layout's `UCKeyboardLayout` data.
- Preserved dedicated symbols for non-character structural keys (`Tab`, `Space`, `Return`, `Esc`, arrows, delete, navigation, and function keys).
- Added `fallbackKeyLabel` to cleanly fall back to ANSI US characters when layout data is absent or when queried off the main thread before caching.
- Registered an observer for `kTISNotifySelectedKeyboardInputSourceChanged` so labels update dynamically when the user switches keyboard layouts.
- Added test coverage in `MetricsTests.swift` for alphanumeric keys, special navigation keys, and dynamic layout resolution.

## Verification

- Ran `./build.sh --test` (9,089 checks passed).
- Built full bundle via `./build.sh` and verified with `./build/Vorssaint --selftest` (passed cleanly).
- Verified on macOS (Apple Silicon, macOS 26) with Turkish-QWERTY and US layouts.

## Anything else

Refs #1047

<img width="500" height="370" alt="image" src="https://github.com/user-attachments/assets/dbbcaebb-da01-4191-b16b-b95179087d5e" />

