### PR TITLE
feat(widgets): add a desktop performance widget

### DIFF
--- a/Resources/VorssaintWidgets-Info.plist
+++ b/Resources/VorssaintWidgets-Info.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>VorssaintWidgets</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.vorssaint.utils.widgets</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Vorssaint</string>
+	<key>CFBundleDisplayName</key>
+	<string>Vorssaint</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<!-- Xcode stamps this on every extension it builds, and the widget host
+	     uses it to decide the bundle is loadable on this platform. Building
+	     with swiftc directly means writing it by hand. -->
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>DTPlatformName</key>
+	<string>macosx</string>
+	<key>DTSDKName</key>
+	<string>macosx14.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>14.0</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/Resources/VorssaintWidgets.entitlements
+++ b/Resources/VorssaintWidgets.entitlements
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Widget extensions must be sandboxed; that is what makes the snapshot
+	     file necessary in the first place, since this process can read neither
+	     the SMC nor any volume. The two exceptions below are its only contact
+	     with the rest of the machine: reading the metrics Vorssaint sampled
+	     and wrote out. Read-only — the extension has nothing to say back.
+	     A sandbox exception cannot express "~", so the path is the fixed,
+	     absolute shared directory. Nothing private travels through it. -->
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.temporary-exception.files.absolute-path.read-only</key>
+	<array>
+		<string>/Users/Shared/Vorssaint/</string>
+	</array>
+</dict>
+</plist>

--- a/Sources/Vorssaint/App/AppDelegate.swift
+++ b/Sources/Vorssaint/App/AppDelegate.swift
@@ -80,6 +80,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         installMainMenu()
         PanelLayout.resetCollapsedSectionsOnce(for: "2.15.1")
 
+        // Placing or removing a desktop widget is what starts and stops the
+        // sampling that feeds it, and the system posts no notification for it.
+        // Re-asked here and whenever the menu panel opens, which is the moment
+        // an accessory app reliably gets.
+        WidgetSnapshotPublisher.shared.startObservingWidgetPresence()
+        WidgetSnapshotPublisher.shared.refreshInstalledWidgets()
+
         statusController = StatusItemController()
         statusController.onLeftClick = { [weak self] in
             self?.captureStatusClick()

--- a/Sources/Vorssaint/Services/SelfUninstall.swift
+++ b/Sources/Vorssaint/Services/SelfUninstall.swift
@@ -138,6 +138,16 @@ enum SelfUninstall {
         try? FileManager.default.removeItem(atPath: "\(home)/Library/HTTPStorages/\(id)")
         try? FileManager.default.removeItem(
             atPath: "\(home)/Library/HTTPStorages/\(id).binarycookies")
+        // The desktop widgets read their metrics from here; it lives outside
+        // the home directory because a sandboxed extension cannot be granted a
+        // path containing "~". Taken from the store rather than rebuilt, so a
+        // change to the layout cannot leave this behind pointing at the old one.
+        try? FileManager.default.removeItem(at: WidgetSnapshotStore.directory)
+        // Take the parent too, but only once it is empty: another install, or
+        // another account, keeps its own directory in there and removeItem
+        // would take that with it. rmdir refuses a non-empty directory, which
+        // is exactly the guard needed here.
+        _ = rmdir(WidgetSnapshotStore.directory.deletingLastPathComponent().path)
     }
 
     /// Moves the app's own bundle to the Trash after it quits, then quits. The

--- a/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
@@ -118,6 +118,7 @@ final class SystemMonitor: ObservableObject {
     private var panelClients = 0
     private var menuPanelNeeds: SystemMonitorPanelNeeds = .none
     private var menuBarActive = false
+    private var widgetsActive = false
     private var alertsActive = false
     private var refreshInFlight = false
     private var pendingRefresh = false
@@ -236,6 +237,9 @@ final class SystemMonitor: ObservableObject {
         runOnMain { [weak self] in
             guard let self else { return }
             panelClients += 1
+            // Cheap moment to notice a widget the user placed or removed while
+            // the app was idle; the system announces neither.
+            WidgetSnapshotPublisher.shared.refreshInstalledWidgets()
             ensureTimer()
             refresh(suppressImmediateGPU: true)
             scheduleDeferredGPURefreshIfNeeded()
@@ -350,6 +354,26 @@ final class SystemMonitor: ObservableObject {
         refresh()
     }
 
+    /// Keeps the light samplers alive while a desktop widget is placed. Widgets
+    /// are off screen, so they are their own activation flag: with none placed
+    /// this stays false and the monitor idles exactly as it does today.
+    func setWidgetsActive(_ active: Bool) {
+        runOnMain { [weak self] in
+            guard let self else { return }
+            guard active != widgetsActive else {
+                if active { resyncIfPlanChanged() }
+                return
+            }
+            widgetsActive = active
+            if active {
+                ensureTimer()
+                refresh()
+            } else {
+                stopTimerIfIdle()
+            }
+        }
+    }
+
     /// The hub switching a metric on or off changes the plan without touching
     /// any activation flag; resample right away like any settings change.
     func planDidChange() {
@@ -392,7 +416,9 @@ final class SystemMonitor: ObservableObject {
     /// independent surfaces cannot desync.
     private var fullMonitorVisible: Bool { panelClients > 0 }
 
-    private var shouldRun: Bool { fullMonitorVisible || menuPanelNeeds.any || menuBarActive || alertsActive }
+    private var shouldRun: Bool {
+        fullMonitorVisible || menuPanelNeeds.any || menuBarActive || alertsActive || widgetsActive
+    }
 
     private func shouldSample(defaults: UserDefaults = .standard) -> Bool {
         shouldRun && currentPlan(defaults: defaults).any
@@ -482,6 +508,15 @@ final class SystemMonitor: ObservableObject {
            Self.fanTelemetryAvailable {
             plan.needFanSpeed = fullMonitorVisible || menuPanelNeeds.fanSpeed
                 || defaults.bool(forKey: DefaultsKey.menuBarFanSpeed)
+        }
+
+        // A placed desktop widget asks only for what it draws, so a widget on
+        // the desktop never wakes the SMC: no temperatures, no fan telemetry.
+        if widgetsActive {
+            plan.needCPU = true
+            plan.needMemory = true
+            plan.needDisk = true
+            plan.needGPUUsage = true
         }
 
         // The hub gates whole metric families: an unavailable metric never
@@ -816,6 +851,7 @@ final class SystemMonitor: ObservableObject {
                     self.snapshot = next
                     self.lastPublishedPlan = plan
                     self.lastPublishedForeground = foregroundSampling
+                    WidgetSnapshotPublisher.shared.publish(next)
                 }
                 self.refreshInFlight = false
                 let shouldRunPendingRefresh = self.pendingRefresh

--- a/Sources/Vorssaint/Services/Widgets/WidgetSnapshotPublisher.swift
+++ b/Sources/Vorssaint/Services/Widgets/WidgetSnapshotPublisher.swift
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+import WidgetKit
+
+/// Feeds the desktop widgets, and only while they exist.
+///
+/// The monitor's whole design is that nothing samples unless something on
+/// screen needs it. Widgets are off screen, so the trigger is whether the user
+/// has actually placed one: `WidgetCenter` reports the installed
+/// configurations, and until one shows up this publisher keeps the monitor
+/// exactly as idle as it is today. No setting to find, nothing to switch on —
+/// dropping a widget on the desktop is the switch.
+/// Main-thread only, like the monitor that drives it.
+final class WidgetSnapshotPublisher {
+    static let shared = WidgetSnapshotPublisher()
+
+    /// True while at least one Vorssaint widget is placed. Read by the monitor
+    /// when it builds its sampling plan.
+    private(set) var widgetsInstalled = false
+
+    /// Widget timelines are budgeted by the system; reloading faster than this
+    /// spends that budget without ever reaching the screen.
+    private static let minimumPublishInterval: TimeInterval = 30
+
+    private var lastPublishedAt: Date?
+    private var lastPublished: WidgetSnapshot?
+
+    private init() {}
+
+    /// Starts listening for a widget announcing itself. A widget that is placed
+    /// while the app is already running would otherwise sit on "open Vorssaint"
+    /// until the next time the app happened to ask.
+    func startObservingWidgetPresence() {
+        DistributedNotificationCenter.default().addObserver(
+            forName: WidgetPresenceSignal.name,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self, !self.widgetsInstalled else { return }
+            self.refreshInstalledWidgets()
+        }
+    }
+
+    /// Re-checks whether any widget is placed. Cheap, but not free: call it on
+    /// app launch and when the app comes back to the foreground, not per tick.
+    func refreshInstalledWidgets(completion: (() -> Void)? = nil) {
+        WidgetCenter.shared.getCurrentConfigurations { [weak self] result in
+            let installed: Bool
+            switch result {
+            case .success(let configurations): installed = !configurations.isEmpty
+            // The extension may be missing entirely (a build without it, or a
+            // damaged bundle). Treating that as "no widgets" keeps the monitor
+            // idle rather than sampling for a consumer that cannot exist.
+            case .failure: installed = false
+            }
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.widgetsInstalled = installed
+                SystemMonitor.shared.setWidgetsActive(installed)
+                completion?()
+            }
+        }
+    }
+
+    /// Called from the monitor's publish step. Drops the sampled values into
+    /// the shared file and nudges WidgetKit, throttled and change-gated.
+    func publish(_ snapshot: SystemSnapshot) {
+        guard widgetsInstalled else { return }
+        let now = Date()
+        if let last = lastPublishedAt, now.timeIntervalSince(last) < Self.minimumPublishInterval {
+            return
+        }
+
+        let bootVolume = snapshot.disk?.devices.first { $0.mountPath == "/" }
+        var next = WidgetSnapshot(capturedAt: now)
+        next.cpuUsage = snapshot.cpuUsage
+        next.gpuUsage = snapshot.gpuUsage
+        next.memoryUsed = snapshot.memoryUsed
+        next.memoryTotal = snapshot.memoryTotal
+        next.memoryPressure = Self.pressureName(snapshot.memoryPressure)
+        next.diskUsed = bootVolume?.usedBytes
+        next.diskTotal = bootVolume?.totalBytes
+
+        // `capturedAt` always differs, so compare the values that get drawn:
+        // an unchanged reading must not spend a timeline reload.
+        if var previous = lastPublished {
+            previous.capturedAt = now
+            if previous == next { return }
+        }
+
+        guard WidgetSnapshotStore.write(next) else { return }
+        lastPublished = next
+        lastPublishedAt = now
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    private static func pressureName(_ pressure: MemoryPressure) -> String? {
+        switch pressure {
+        case .normal: return "normal"
+        case .warning: return "warning"
+        case .critical: return "critical"
+        case .unknown: return nil
+        }
+    }
+}

--- a/Sources/Vorssaint/Services/Widgets/WidgetSnapshotStore.swift
+++ b/Sources/Vorssaint/Services/Widgets/WidgetSnapshotStore.swift
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+/// The metrics the desktop widgets draw, and the file they travel through.
+///
+/// Widget extensions are sandboxed and run in their own process, so they can
+/// read neither the SMC nor the volumes Vorssaint samples. The app does the
+/// sampling and drops a snapshot here; the extension only renders it.
+///
+/// The path is fixed and absolute on purpose: a sandbox temporary exception
+/// cannot express `~`, so a directory under the home folder is unreachable
+/// from the extension's entitlement. It is still per account, and private to
+/// it (0700), so living outside `$HOME` costs no privacy.
+struct WidgetSnapshot: Codable, Equatable {
+    var capturedAt: Date
+
+    var cpuUsage: Double?          // 0...1
+    var gpuUsage: Double?          // 0...1
+    var memoryUsed: UInt64?
+    var memoryTotal: UInt64?
+    var memoryPressure: String?    // MemoryPressure.rawValue-ish, already localized upstream
+    var diskUsed: UInt64?
+    var diskTotal: UInt64?
+
+}
+
+enum WidgetSnapshotStore {
+    /// Identifies which install this file belongs to. The official app and the
+    /// local Developer build run side by side on the same Mac and share
+    /// `/Users/Shared`, so one directory for both would have them overwriting
+    /// each other's snapshot and — worse — consuming each other's commands,
+    /// since consuming one deletes it.
+    ///
+    /// The extension derives its container's id by dropping its own `.widgets`
+    /// suffix, which is how both ends land on the same directory without the
+    /// app having to tell it.
+    static let containerIdentifier: String = {
+        guard let identifier = Bundle.main.bundleIdentifier else {
+            // No bundle: the test harness, or the bare binary being probed.
+            // Deliberately not the release id — that is a live install's
+            // directory, and a test run must never write into, or clean up
+            // after, the app someone is actually using.
+            return "com.vorssaint.utils.no-bundle"
+        }
+        if identifier.hasSuffix(".widgets") {
+            return String(identifier.dropLast(".widgets".count))
+        }
+        return identifier
+    }()
+
+    /// Per install *and* per account. `/Users/Shared` is one directory for the
+    /// whole Mac, so a single path per install would be created by whichever
+    /// user logged in first and left every other account unable to write to
+    /// it — their widget would sit empty forever. The uid in the path gives
+    /// each account its own, and lets it be private (0700) rather than
+    /// world-readable, since nobody else has any reason to read it.
+    ///
+    /// The sandbox exception covers the parent, so the extra level needs no
+    /// entitlement change; the extension runs as the user whose widget it is,
+    /// and so resolves the same path the app wrote.
+    static let directory = URL(fileURLWithPath: "/Users/Shared/Vorssaint", isDirectory: true)
+        .appendingPathComponent("\(containerIdentifier)-\(getuid())", isDirectory: true)
+    static let snapshotURL = directory.appendingPathComponent("widget-snapshot.json")
+
+    /// A snapshot older than this is stale: Vorssaint is not running, or its
+    /// monitor stopped. The widget says so instead of showing frozen numbers.
+    static let staleAfter: TimeInterval = 10 * 60
+
+    static func read() -> WidgetSnapshot? {
+        guard let data = try? Data(contentsOf: snapshotURL) else { return nil }
+        return try? JSONDecoder().decode(WidgetSnapshot.self, from: data)
+    }
+
+    /// Writes atomically so a widget reading mid-write never sees half a file.
+    @discardableResult
+    static func write(_ snapshot: WidgetSnapshot) -> Bool {
+        guard let data = try? JSONEncoder().encode(snapshot) else { return false }
+        do {
+            try FileManager.default.createDirectory(at: directory,
+                                                    withIntermediateDirectories: true,
+                                                    attributes: [.posixPermissions: 0o700])
+            try data.write(to: snapshotURL, options: .atomic)
+            // .atomic replaces the file, so the mode has to be reapplied.
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600],
+                                                   ofItemAtPath: snapshotURL.path)
+            return true
+        } catch {
+            return false
+        }
+    }
+}
+
+/// How a widget says "I exist" across the sandbox.
+///
+/// The app cannot be notified by the system when a widget is placed, and a
+/// widget cannot reach the app except through the shared directory it may not
+/// yet have a reason to watch. A distributed notification crosses the sandbox
+/// in one hop and costs nothing when no widget is around to send it.
+///
+/// It only ever turns sampling *on*. Turning it off stays with
+/// `WidgetCenter.getCurrentConfigurations`, which is the authoritative answer:
+/// a removed widget sends nothing, and silence is not proof on its own.
+enum WidgetPresenceSignal {
+    /// Namespaced per install, so the Developer build's widgets do not wake the
+    /// official app into sampling for widgets that are not its own.
+    static let name = Notification.Name(
+        "\(WidgetSnapshotStore.containerIdentifier).widget-present")
+
+    static func post() {
+        DistributedNotificationCenter.default().postNotificationName(name,
+                                                                     object: nil,
+                                                                     userInfo: nil,
+                                                                     deliverImmediately: true)
+    }
+}

--- a/Sources/VorssaintWidgets/VorssaintWidgets.swift
+++ b/Sources/VorssaintWidgets/VorssaintWidgets.swift
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import SwiftUI
+import WidgetKit
+
+/// The desktop widgets.
+///
+/// This process is sandboxed and cannot read a single sensor, so it does no
+/// sampling of its own: every value comes from the snapshot Vorssaint writes
+/// (`WidgetSnapshotStore`). When the app is not running the file goes stale and
+/// the widgets say so rather than presenting frozen numbers as current.
+
+struct MetricsEntry: TimelineEntry {
+    let date: Date
+    let snapshot: WidgetSnapshot?
+
+    /// Vorssaint has not written in a while: it is closed, or its monitor
+    /// stopped. Either way the numbers on screen are history.
+    var isStale: Bool {
+        guard let snapshot else { return true }
+        return Date().timeIntervalSince(snapshot.capturedAt) > WidgetSnapshotStore.staleAfter
+    }
+}
+
+struct MetricsProvider: TimelineProvider {
+    func placeholder(in context: Context) -> MetricsEntry {
+        MetricsEntry(date: Date(), snapshot: Self.sample)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (MetricsEntry) -> Void) {
+        // The widget gallery preview runs before the user has ever placed one,
+        // so there may be no file yet; show plausible values rather than dashes.
+        let snapshot = context.isPreview ? Self.sample : (WidgetSnapshotStore.read() ?? Self.sample)
+        completion(MetricsEntry(date: Date(), snapshot: snapshot))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<MetricsEntry>) -> Void) {
+        // Vorssaint samples only while a widget is placed, and the system tells
+        // it nothing when one appears. Announcing every timeline request is how
+        // a freshly dropped widget gets data without waiting for the app to
+        // next ask: it starts the sampling that fills the very file being read.
+        WidgetPresenceSignal.post()
+        let now = Date()
+        let snapshot = WidgetSnapshotStore.read()
+        // Two entries, one reload. The second is timed to the moment the
+        // current reading goes stale, so a widget left behind by a closed app
+        // starts saying so on time instead of showing old numbers as current
+        // until the next refresh comes round.
+        var entries = [MetricsEntry(date: now, snapshot: snapshot)]
+        if let capturedAt = snapshot?.capturedAt {
+            let goesStaleAt = capturedAt.addingTimeInterval(WidgetSnapshotStore.staleAfter)
+            // Only if it is still ahead of us: an entry dated in the past is
+            // not a second entry, it is an out-of-order timeline.
+            if goesStaleAt > now {
+                entries.append(MetricsEntry(date: goesStaleAt, snapshot: snapshot))
+            }
+        }
+        // The app pushes reloads as it samples; this is only the fallback for
+        // when it is not running, and asking faster just burns the system's
+        // refresh budget without producing fresher data.
+        let next = now.addingTimeInterval(15 * 60)
+        completion(Timeline(entries: entries, policy: .after(next)))
+    }
+
+    private static var sample: WidgetSnapshot {
+        var snapshot = WidgetSnapshot(capturedAt: Date())
+        snapshot.cpuUsage = 0.23
+        snapshot.gpuUsage = 0.11
+        snapshot.memoryUsed = 11_500_000_000
+        snapshot.memoryTotal = 16_000_000_000
+        snapshot.memoryPressure = "normal"
+        snapshot.diskUsed = 340_000_000_000
+        snapshot.diskTotal = 500_000_000_000
+        return snapshot
+    }
+}
+
+// MARK: - Shared pieces
+
+enum WidgetFormat {
+    static func percent(_ value: Double?) -> String {
+        guard let value else { return "—" }
+        return "\(Int((value * 100).rounded()))%"
+    }
+
+    static func celsius(_ value: Double?) -> String {
+        guard let value else { return "—" }
+        return "\(Int(value.rounded()))°"
+    }
+
+    /// Decimal units, matching how macOS reports storage.
+    static func bytes(_ value: UInt64?) -> String {
+        guard let value else { return "—" }
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        formatter.allowedUnits = [.useGB, .useTB]
+        return formatter.string(fromByteCount: Int64(value))
+    }
+
+    static func fraction(_ used: UInt64?, _ total: UInt64?) -> Double? {
+        guard let used, let total, total > 0 else { return nil }
+        return min(1, Double(used) / Double(total))
+    }
+}
+
+/// One labelled bar. The bar is the reason to glance at a widget at all, so it
+/// stays legible at small sizes: value on the right, no decorations.
+struct MetricRow: View {
+    let label: String
+    let value: String
+    let fraction: Double?
+    var tint: Color = .accentColor
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 4) {
+                Text(label)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 4)
+                Text(value)
+                    .font(.caption.weight(.medium))
+                    .monospacedDigit()
+            }
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(.quaternary)
+                    Capsule()
+                        .fill(tint)
+                        .frame(width: max(2, geometry.size.width * (fraction ?? 0)))
+                }
+            }
+            .frame(height: 4)
+            .opacity(fraction == nil ? 0.35 : 1)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(value)")
+    }
+}
+
+/// Shown instead of numbers when the snapshot is missing or stale.
+struct StaleOverlay: View {
+    var body: some View {
+        Text("Abre Vorssaint")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+    }
+}
+
+// MARK: - System metrics
+
+struct MetricsWidgetView: View {
+    var entry: MetricsEntry
+
+    var body: some View {
+        let snapshot = entry.snapshot
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label("Sistema", systemImage: "gauge.with.dots.needle.33percent")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if entry.isStale { StaleOverlay() }
+            }
+            MetricRow(label: "CPU",
+                      value: WidgetFormat.percent(snapshot?.cpuUsage),
+                      fraction: snapshot?.cpuUsage,
+                      tint: .blue)
+            MetricRow(label: "GPU",
+                      value: WidgetFormat.percent(snapshot?.gpuUsage),
+                      fraction: snapshot?.gpuUsage,
+                      tint: .purple)
+            MetricRow(label: "RAM",
+                      value: WidgetFormat.bytes(snapshot?.memoryUsed),
+                      fraction: WidgetFormat.fraction(snapshot?.memoryUsed, snapshot?.memoryTotal),
+                      tint: memoryTint)
+            MetricRow(label: "SSD",
+                      value: WidgetFormat.bytes(snapshot?.diskUsed),
+                      fraction: WidgetFormat.fraction(snapshot?.diskUsed, snapshot?.diskTotal),
+                      tint: .teal)
+        }
+        .opacity(entry.isStale ? 0.5 : 1)
+    }
+
+    /// Memory pressure is the one reading where the colour carries information
+    /// the bar cannot: a nearly full bar under normal pressure is fine.
+    private var memoryTint: Color {
+        switch entry.snapshot?.memoryPressure {
+        case "critical": return .red
+        case "warning": return .orange
+        default: return .green
+        }
+    }
+}
+
+struct VorssaintMetricsWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "VorssaintMetrics", provider: MetricsProvider()) { entry in
+            MetricsWidgetView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+                .padding(2)
+        }
+        .configurationDisplayName("Rendimiento")
+        .description("CPU, GPU, memoria y disco de tu Mac.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+@main
+struct VorssaintWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        VorssaintMetricsWidget()
+    }
+}

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -19650,6 +19650,39 @@ struct MetricsTests {
                + "(ran \(detachedRuns) time(s))")
         try? FileManager.default.removeItem(at: detachRoot)
 
+        // MARK: Widget snapshot
+        // The two ends are separate processes that never share memory, so the
+        // file is the whole contract between them.
+        let widgetDirectory = WidgetSnapshotStore.directory
+        let hadWidgetDirectory = FileManager.default.fileExists(atPath: widgetDirectory.path)
+        // A test run must not touch a live install's channel: no bundle means a
+        // suffixed identifier, so this is the harness's own directory.
+        expect(widgetDirectory.path.contains("no-bundle"),
+               "the tests write to their own directory, never a real install's")
+
+        // The snapshot has to survive the trip through the file: the two ends
+        // are separate processes that never share memory.
+        var widgetSample = WidgetSnapshot(capturedAt: Date())
+        widgetSample.cpuUsage = 0.42
+        widgetSample.memoryUsed = 11_500_000_000
+        widgetSample.memoryPressure = "warning"
+        expect(WidgetSnapshotStore.write(widgetSample), "a snapshot is written")
+        let readBack = WidgetSnapshotStore.read()
+        expect(readBack?.cpuUsage == 0.42, "usage survives the round trip")
+        expect(readBack?.memoryUsed == 11_500_000_000, "byte counts survive the round trip")
+        expect(readBack?.memoryPressure == "warning", "pressure survives the round trip")
+        // The reader must not mistake a half-written or foreign file for data.
+        try? "not json".write(to: WidgetSnapshotStore.snapshotURL, atomically: true, encoding: .utf8)
+        expect(WidgetSnapshotStore.read() == nil, "unreadable content is no snapshot at all")
+
+        try? FileManager.default.removeItem(at: WidgetSnapshotStore.snapshotURL)
+        if !hadWidgetDirectory {
+            try? FileManager.default.removeItem(at: widgetDirectory)
+            // Leave nothing behind on the machine running the tests; rmdir
+            // spares the parent if a real install is using it.
+            _ = rmdir(widgetDirectory.deletingLastPathComponent().path)
+        }
+
         if failures.isEmpty {
             print("TESTS OK (\(checks) checks)")
             exit(0)

--- a/Tools/uninstall.sh
+++ b/Tools/uninstall.sh
@@ -59,6 +59,14 @@ rm -rf "$HOME/Library/Caches/$BUNDLE"
 # Written by URLSession on the app's behalf, so they exist without the app ever
 # naming the path; `defaults delete` does not reach them either.
 rm -rf "$HOME/Library/HTTPStorages/$BUNDLE" "$HOME/Library/HTTPStorages/$BUNDLE.binarycookies"
+
+# Metrics the desktop widgets read. It sits outside $HOME because a sandboxed
+# widget extension cannot be granted a path containing "~", and carries the uid
+# because /Users/Shared is one directory for every account on the Mac. rmdir,
+# not rm -rf, on the parent: another install or another account keeps its own
+# directory in there and must survive this one being removed.
+rm -rf "/Users/Shared/Vorssaint/$BUNDLE-$(id -u)"
+rmdir "/Users/Shared/Vorssaint" 2>/dev/null || true
 # `defaults delete` does not reach ByHost. The (N) qualifier is load-bearing:
 # without it zsh aborts the command on an unmatched pattern, which is the
 # ordinary case, and prints an error over a successful uninstall.

--- a/build.sh
+++ b/build.sh
@@ -39,6 +39,7 @@ else
     BUILD_CONFIGURATION="release"
 fi
 FAN_HELPER_ID="$APP_BUNDLE_ID.fan-control"
+WIDGET_EXT_ID="$APP_BUNDLE_ID.widgets"
 TARGET="arm64-apple-macosx14.0"
 ENTITLEMENTS="Resources/Vorssaint.entitlements"
 LEGACY_IDENTITY="Vorssaint Utils Signing"
@@ -347,6 +348,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/Cleaner/CleanerSchedule.swift \
         Sources/Vorssaint/Services/Uninstall/UninstallerSupport.swift \
         Sources/Vorssaint/Services/ManagedDownloads/WhatsAppDownloadSupport.swift \
+        Sources/Vorssaint/Services/Widgets/WidgetSnapshotStore.swift \
         Tests/MetricsTests.swift \
         -o build/metrics-tests
     # `set -e` would end the script on a failing run before the sweep below.
@@ -386,6 +388,14 @@ swiftc -O -target "$TARGET" -sdk "$SDK" "${SDK_COMPAT_FLAGS[@]}" "${BUILD_VARIAN
     Sources/FanControlHelper/main.swift \
     -o "build/$FAN_HELPER_ID"
 "build/$FAN_HELPER_ID" --selftest
+
+echo "▸ Compiling widget extension…"
+swiftc "${APP_OPTIMIZATION_FLAGS[@]}" -target "$TARGET" -sdk "$SDK" "${SDK_COMPAT_FLAGS[@]}" \
+    "${BUILD_VARIANT_FLAGS[@]}" -parse-as-library -application-extension \
+    -Xlinker -e -Xlinker _NSExtensionMain \
+    Sources/Vorssaint/Services/Widgets/WidgetSnapshotStore.swift \
+    Sources/VorssaintWidgets/*.swift \
+    -o "build/VorssaintWidgets"
 
 echo "▸ Generating app icon…"
 swift Tools/MakeIcon.swift build/AppIcon.iconset
@@ -464,6 +474,19 @@ FAN_HELPER_VERSION="$(
 )"
 /usr/libexec/PlistBuddy -c "Add :VorssaintFanControlHelperVersion string '$FAN_HELPER_VERSION'" \
     "$STAGE/Contents/Info.plist"
+WIDGET_APPEX="$STAGE/Contents/PlugIns/VorssaintWidgets.appex"
+mkdir -p "$WIDGET_APPEX/Contents/MacOS"
+cp build/VorssaintWidgets "$WIDGET_APPEX/Contents/MacOS/VorssaintWidgets"
+cp Resources/VorssaintWidgets-Info.plist "$WIDGET_APPEX/Contents/Info.plist"
+if (( DEV )); then
+    # Its own identifier, so the Developer build's widgets appear next to the
+    # official app's in the gallery instead of replacing them.
+    /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $WIDGET_EXT_ID" \
+        "$WIDGET_APPEX/Contents/Info.plist"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName Vorssaint (Developer)" \
+        "$WIDGET_APPEX/Contents/Info.plist"
+fi
+
 printf 'APPL????' > "$STAGE/Contents/PkgInfo"
 cp build/AppIcon.icns "$STAGE/Contents/Resources/AppIcon.icns"
 cp build/MenuBarIcon.png build/MenuBarIcon@2x.png build/BrandMark.png "$STAGE/Contents/Resources/"
@@ -516,10 +539,28 @@ codesign_fan_helper() {
     fi
 }
 
+# The extension is the only sandboxed code in the bundle, so it is signed with
+# its own entitlements rather than the app's.
+codesign_widget_extension() {
+    local target="$1"
+    local entitlements="Resources/VorssaintWidgets.entitlements"
+    if [[ -n "$DEVID" ]]; then
+        codesign_with_timestamp_retry --force --strip-disallowed-xattrs --options runtime --timestamp \
+            --entitlements "$entitlements" --identifier "$WIDGET_EXT_ID" --sign "$DEVID" "$target"
+    elif security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"; then
+        codesign --force --strip-disallowed-xattrs --entitlements "$entitlements" \
+            --identifier "$WIDGET_EXT_ID" --sign "$LEGACY_IDENTITY" "$target"
+    else
+        codesign --force --strip-disallowed-xattrs --entitlements "$entitlements" \
+            --identifier "$WIDGET_EXT_ID" --sign - "$target"
+    fi
+}
+
 sign_bundle() {
     local bundle="$1"
     local executable="$bundle/Contents/MacOS/$EXECUTABLE"
     local helper="$bundle/Contents/Library/LaunchServices/$FAN_HELPER_ID"
+    local appex="$bundle/Contents/PlugIns/VorssaintWidgets.appex"
 
     if [[ -n "$DEVID" ]]; then
         echo "  signing with Developer ID (hardened runtime): $DEVID"
@@ -529,6 +570,7 @@ sign_bundle() {
         echo "  signing ad-hoc (no identity installed — run Tools/setup-signing.sh)"
     fi
     [[ -f "$helper" ]] && codesign_fan_helper "$helper"
+    [[ -d "$appex" ]] && codesign_widget_extension "$appex"
     codesign_app "$bundle"
 
     # If local filesystem metadata invalidates the first signature, sign once
@@ -537,6 +579,7 @@ sign_bundle() {
         echo "  re-signing after filesystem metadata settled"
         xattr -c -r "$bundle" 2>/dev/null || true
         [[ -f "$helper" ]] && codesign_fan_helper "$helper"
+        [[ -d "$appex" ]] && codesign_widget_extension "$appex"
         codesign_app "$bundle"
     fi
     [[ -f "$executable" ]] && codesign --verify --strict "$executable"


### PR DESCRIPTION
Refs #1138

**Scope cut down after review.** This was three widgets; it is now one. Temperature and Quick actions are kept on a branch and will follow separately, once the direction here is settled. 1360 lines became 624, and with the buttons went the App Intents, the metadata build step, the command channel and the write access.

Still a draft while Q1 and Q2 in the issue are open — whether this belongs here at all, and whether the shared directory is acceptable.

## What a user sees

One widget to drop on the desktop: **CPU, GPU, memory** (tinted by pressure) **and the boot volume**, small or medium.

With no widget placed nothing changes: the monitor stays exactly as idle as it is today. Placing one is the switch, removing the last one turns it back off — no setting, no hub entry.

## How it works, and why

A widget extension is sandboxed in its own process and can read neither the SMC nor any volume, so the app samples and writes a snapshot and the extension only renders it — **read-only, with nothing to say back**. The path is absolute and outside `$HOME` because a sandbox temporary exception cannot express `~`, and it is namespaced per bundle id so an official install and a local Developer build do not overwrite each other's data. Only usage percentages and free space travel through it, and a stale snapshot is shown as stale instead of as current numbers.

The widget asks only for what it draws, so a widget on the desktop never wakes the SMC.

`build.sh` compiles and signs the extension next to the fan helper, with its own entitlements and before the app.

## On the three points raised in review

**Uninstall — already covered, please re-check.** Both paths carry it in this branch: `SelfUninstall.removePreferences()` removes `/Users/Shared/Vorssaint/<bundle id>` and then `rmdir`s the parent, which refuses a non-empty directory so a second install's data survives; `Tools/uninstall.sh` does the same. Worth naming a third route that neither of us mentioned: `--uninstall` on the binary (`Uninstaller.runAndExit`) only detaches the daemon and login item and deletes no files — the script does that part. What I have verified is that the code is on both paths, not that either runs clean end to end: when I removed my own Developer build I deleted the directory by hand.

**Q3 — taking the suggestion, and it is better than what I had.** Putting already-localized labels in the snapshot removes the problem instead of solving it: no second catalog, and a language change lands on the next sample. It applies to the Quick actions widget, so it will land with that one. This PR needs none of it — the widget has no user-facing text beyond its gallery entry.

**Q4 — done, Performance only.** As you say, that makes it cheap: no intents, so no localization work at all.

## Callers checked

- `SystemMonitor.currentPlan` / `shouldRun` — the new activation flag follows the shape of `menuBarActive` and `alertsActive` rather than adding a path of its own, and the existing `available(_:)` gates still veto every metric.
- `SelfUninstall.removePreferences` and `Tools/uninstall.sh` — both updated, so neither uninstall route leaves the directory behind.

## Verified on

MacBook Pro (Apple Silicon), macOS 26.6 build 25.5.0, Spanish, own Developer build signed with the local identity. `./build.sh` finishes without warnings, `--selftest` passes, and the unit tests pass except for the pre-existing dispatch pool starvation check, which fails the same way on a clean `main`.

Checked by hand: the widget appears in the gallery and renders live values; the extension loads from a locally signed, Team-ID-less bundle; a stale snapshot is presented as stale.

**Not verified:** a second Mac, an Intel Mac, a Developer ID signature, multiple displays or Spaces.

## Note

The extension leaves a sandbox container at `~/Library/Containers/<bundle id>.widgets` — new here, since the app itself is not sandboxed. It holds no user data and `containermanagerd` owns it, so no uninstall route can remove it without Full Disk Access; macOS reclaims it. Flagged rather than papered over with a removal that would silently fail.
