### PR TITLE
test(fan-control): lock in the multi-sensor curve point fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Vorssaint expands screen text recognition, clipboard, Super key, Dock Preview, A
 - Settings backups now keep machine-local program paths out of exported files and preserve local exceptions across a restore. Thanks to @iltonandrew.
 - Uninstalling a feature now removes it from Command Bar pins in Settings.
 - Pressing Escape in the clipboard history quick panel now clears batch selection or closes the panel directly instead of closing the preview pane first. Thanks to @naveenkrdy.
-- Adding points to a custom fan curve now updates and saves the curve instead of discarding the new point.
+- Adding points to a custom fan curve now preserves every sensor and saves the point without crashing. Thanks to @azusatea122602.
 - The battery icon in the menu bar now preserves its rectangular aspect ratio when split into its own item instead of rendering as a square. Thanks to @Yahddyyp.
 - Cleaning Mode now uses a forgiving 6-second press window for the Escape unlock gesture and resets the count when modifier keys are pressed while wiping. Thanks to @iltonandrew.
 - Dock previews now move to the vacated screen edge when an auto-hiding Dock slides away instead of floating detached. Thanks to @iltonandrew.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ Vorssaint expands screen text recognition, clipboard, Super key, Dock Preview, A
 - Settings backups now keep machine-local program paths out of exported files and preserve local exceptions across a restore. Thanks to @iltonandrew.
 - Uninstalling a feature now removes it from Command Bar pins in Settings.
 - Pressing Escape in the clipboard history quick panel now clears batch selection or closes the panel directly instead of closing the preview pane first. Thanks to @naveenkrdy.
-- Adding points to a custom fan curve now preserves every sensor and saves the point without crashing. Thanks to @azusatea122602.
+- Adding points to a custom fan curve now preserves every sensor and saves the point without crashing.
 - The battery icon in the menu bar now preserves its rectangular aspect ratio when split into its own item instead of rendering as a square. Thanks to @Yahddyyp.
 - Cleaning Mode now uses a forgiving 6-second press window for the Escape unlock gesture and resets the count when modifier keys are pressed while wiping. Thanks to @iltonandrew.
 - Dock previews now move to the vacated screen edge when an auto-hiding Dock slides away instead of floating detached. Thanks to @iltonandrew.

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -12139,6 +12139,20 @@ struct MetricsTests {
                 && FanControlPolicy.nextCurvePoint(for: iterativePoints) == nil
                 && FanControlPolicy.addingCurvePoint(to: iterativePoints) == nil,
                "adding fan curve points fills up to the maximum point limit with strictly valid curves")
+        let secondCurve = FanControlCurve(sensor: .averageCPU,
+                                          points: defaultCurve.points)
+        var updatedCurves = [defaultCurve, secondCurve]
+        if let secondPoints = FanControlPolicy.addingCurvePoint(to: updatedCurves[1].points) {
+            updatedCurves[1].points = secondPoints
+        }
+        let storedUpdatedCurves = FanControlConfiguration.decodeCurves(
+            FanControlConfiguration.encodeCurves(updatedCurves) ?? ""
+        )
+        expect(updatedCurves.count == 2
+                && updatedCurves.first == defaultCurve
+                && updatedCurves[1].points == addedPoints
+                && storedUpdatedCurves == updatedCurves,
+               "adding a point to the second fan curve preserves every valid stored curve")
         let m3FanTemperatures = FanControlPolicy.aggregatedTemperatures(
             cpuReadings: [("Te05", 44), ("Tf4E", 53), ("Tf4F", 76)],
             gpuReadings: [48],


### PR DESCRIPTION
## Summary

- cover the exact second-sensor Add point sequence reported in #1119
- verify both curves and the new point survive the same encoding and validation round trip used by persisted settings
- credit the reporter in the Unreleased note

## Root cause

v3.3.3-beta.3 persisted an appended point before sorting it. The storage binding immediately rejected that temporary ordering, fell back from two curves to one, and the following mutation indexed the missing second curve. Commit 69bceb87 landed after beta.3 and already changed main to calculate, sort, and validate the points before one write. This PR deliberately avoids duplicating that runtime fix and adds lasting coverage for the reported sequence.

## Validation

- ./build.sh --test: TESTS OK (9089 checks)
- ./build.sh --dev --install
- built and installed Developer selftests: SELFTEST OK
- installed Developer bundle passed strict code-signature verification
- focused SwiftUI Binding probe reproduced the beta path as SIGTRAP and current main as one valid write preserving both curves

Refs #1119