### PR TITLE
fix(screenshot): keep the capture preview from taking the keyboard

### DIFF
--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotQuickPreviewController.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotQuickPreviewController.swift
@@ -111,7 +111,6 @@ final class ScreenshotQuickPreviewController {
         self.panel = panel
         installKeyMonitor(for: panel)
         panel.orderFrontRegardless()
-        panel.makeKey()
         // A performed action turns the preview into a short confirmation; a
         // failed one keeps the full stay so the person can still act by hand.
         autoDismissDuration = runDefaultAction(defaultAction) ? 3 : 12
@@ -371,6 +370,19 @@ final class ScreenshotQuickPreviewController {
 
 private final class ScreenshotQuickPreviewPanel: NSPanel {
     override var canBecomeKey: Bool { true }
+
+    /// The preview shows up unasked for, so presenting it leaves the keyboard
+    /// where it was and a click is what hands it over. Its shortcuts read a
+    /// local monitor, and that monitor is delivered nothing until this panel is
+    /// key. The hand-off sits in `sendEvent` rather than `mouseDown` because
+    /// the hosted SwiftUI content answers a press on a button itself, and a
+    /// window's `mouseDown` never runs for the clicks a view has taken.
+    override func sendEvent(_ event: NSEvent) {
+        if event.type == .leftMouseDown, !isKeyWindow {
+            makeKey()
+        }
+        super.sendEvent(event)
+    }
 }
 
 private struct ScreenshotQuickPreviewView: View {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -14910,9 +14910,10 @@ struct MetricsTests {
         // The preview appears unasked for, so presenting it must not take the
         // keyboard away from whatever the person is typing into. Its shortcuts
         // read a local monitor, which is delivered nothing until the panel is
-        // key, so key status moves to the hover seam: presenting stays silent,
-        // and the pointer arriving is what arms the shortcuts. Comments are
-        // stripped so prose naming the API cannot answer for the code.
+        // key. Presenting stays silent and hover takes nothing either; a click
+        // hands the keyboard over in the panel's sendEvent because hosted
+        // SwiftUI content answers presses that never reach mouseDown. Comments
+        // are stripped so prose naming the API cannot answer for the code.
         let quickPreviewSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/Services/QuickTools/ScreenshotQuickPreviewController.swift",
             encoding: .utf8)) ?? ""
@@ -14926,20 +14927,17 @@ struct MetricsTests {
             .dropFirst().first?.components(separatedBy: "private func").first ?? ""
         expect(presentBody.contains("orderFrontRegardless()"),
                "the screenshot preview is presented without activating the app")
-        expect(!presentBody.contains("makeKey"),
-               "presenting the screenshot preview never takes key focus")
-        let hoverBody = quickPreviewCode.components(separatedBy: "hoverChanged:")
-            .dropFirst().first?.components(separatedBy: "})").first ?? ""
-        expect(!hoverBody.isEmpty, "the hover seam reads back for its shape check")
-        expect(!hoverBody.contains("makeKey"),
-               "merely moving the pointer over the screenshot preview never takes key focus")
         // A click is the hand-off, and it is read in sendEvent because the
         // hosted SwiftUI content answers presses that never reach mouseDown.
         let panelBody = quickPreviewCode.components(separatedBy: "class ScreenshotQuickPreviewPanel")
             .dropFirst().first?.components(separatedBy: "\n}").first ?? ""
+        let makeKeyCount = quickPreviewCode.components(separatedBy: "makeKey").count - 1
+        let panelMakeKeyCount = panelBody.components(separatedBy: "makeKey").count - 1
+        expect(makeKeyCount == panelMakeKeyCount && panelMakeKeyCount >= 1,
+               "presentation and hover never take key focus; only the panel's own click hand-off may")
         expect(panelBody.contains("sendEvent") && panelBody.contains("leftMouseDown")
-                && panelBody.contains("makeKey"),
-               "clicking the screenshot preview takes key focus, so its shortcuts still work")
+                && panelBody.contains("makeKey") && panelBody.contains("super.sendEvent"),
+               "clicking the screenshot preview takes key focus and still delivers every preview button")
 
         let cocoa = ScreenshotSupport.cocoaRect(fromWindowServer: CGRect(x: 10, y: 30, width: 200, height: 100),
                                                 mainScreenHeight: 900)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -14907,6 +14907,39 @@ struct MetricsTests {
             encoding: .utf8)) ?? ""
         expect(!captureServiceSource.contains("replaceSelection"),
                "the capture service does not cancel and recreate selection controllers when changing modes")
+        // The preview appears unasked for, so presenting it must not take the
+        // keyboard away from whatever the person is typing into. Its shortcuts
+        // read a local monitor, which is delivered nothing until the panel is
+        // key, so key status moves to the hover seam: presenting stays silent,
+        // and the pointer arriving is what arms the shortcuts. Comments are
+        // stripped so prose naming the API cannot answer for the code.
+        let quickPreviewSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/QuickTools/ScreenshotQuickPreviewController.swift",
+            encoding: .utf8)) ?? ""
+        expect(!quickPreviewSource.isEmpty, "the screenshot preview source reads back for its shape check")
+        let quickPreviewCode = quickPreviewSource.components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        // Split at the hosting controller: the hover closure is built above it,
+        // so the presentation statements are what remains.
+        let presentBody = quickPreviewCode.components(separatedBy: "let host = NSHostingController")
+            .dropFirst().first?.components(separatedBy: "private func").first ?? ""
+        expect(presentBody.contains("orderFrontRegardless()"),
+               "the screenshot preview is presented without activating the app")
+        expect(!presentBody.contains("makeKey"),
+               "presenting the screenshot preview never takes key focus")
+        let hoverBody = quickPreviewCode.components(separatedBy: "hoverChanged:")
+            .dropFirst().first?.components(separatedBy: "})").first ?? ""
+        expect(!hoverBody.isEmpty, "the hover seam reads back for its shape check")
+        expect(!hoverBody.contains("makeKey"),
+               "merely moving the pointer over the screenshot preview never takes key focus")
+        // A click is the hand-off, and it is read in sendEvent because the
+        // hosted SwiftUI content answers presses that never reach mouseDown.
+        let panelBody = quickPreviewCode.components(separatedBy: "class ScreenshotQuickPreviewPanel")
+            .dropFirst().first?.components(separatedBy: "\n}").first ?? ""
+        expect(panelBody.contains("sendEvent") && panelBody.contains("leftMouseDown")
+                && panelBody.contains("makeKey"),
+               "clicking the screenshot preview takes key focus, so its shortcuts still work")
 
         let cocoa = ScreenshotSupport.cocoaRect(fromWindowServer: CGRect(x: 10, y: 30, width: 200, height: 100),
                                                 mainScreenHeight: 900)


### PR DESCRIPTION
Refs #1089

`ScreenshotQuickPreviewController.show()` called `panel.makeKey()` right after presenting. The panel is already `.nonactivatingPanel`, so the app never came forward — but `makeKey()` still moves key status away from whatever the person is typing into, which is exactly the reported symptom: the caret leaves the browser field mid-sentence and nothing on screen explains where the keystrokes went.

Presenting now leaves the keyboard where it was, and a click is what hands it over.

**Why a click and not the presentation.** The preview's shortcuts (⌘C, ⌘S, Return, ⌫, Escape) run off `NSEvent.addLocalMonitorForEvents` guarded by `event.window === panel`, so a panel that is never key is delivered nothing and every shortcut silently dies. Simply deleting `makeKey()` would have traded a visible bug for an invisible one. Hover was the other candidate and is worse than it looks: an incidental pointer crossing would take focus, and with a configured corner placement the preview can appear under a pointer that never moved, where the hover fires on appearance and the original bug is back. A click is the first unambiguous sign the preview is the thing being used.

**Why `sendEvent` and not `mouseDown`.** The hosted SwiftUI content answers presses on its own buttons, and a window's `mouseDown` never runs for a click a view has already taken — so the hand-off would work on the panel's background and quietly not work on the buttons. `sendEvent` sees the event before view dispatch, which makes it hold for every click.

**Scope.** `makeKey()` on presentation is right for the surfaces a person summons and stays put in both: the capture history palette (reached from the command bar and the explicit history buttons in the screenshot and recorder editors) and the quick launcher, which exists to be typed into. The rule for a panel that appears unbidden is the one `ShelfTooltipPopover` already documents — order front, never take key. The preview belongs to that second group and was the only member breaking the rule.

**Behaviour change worth your call.** Pressing ⌘C the instant a capture lands, without touching the mouse, no longer reaches the preview — the keyboard now stays with the app you were working in until you click. That matches the native macOS thumbnail and is what the issue asks for, but it is a real change to a working flow, so I would rather you weighed it than found it. If you want the shortcuts armed earlier, the hover seam is the place and it is one line; I left it out on purpose.

**Verification.** macOS 26.6.2 (25G83), M5 Pro, own Developer build. `./build.sh` finishes warning-free; `./build.sh --test` passes 9093 of 9094, the exception being the pre-existing `dispatch pool starvation` check that fails on this 15-core machine and passes in CI. The source-shape test pins all three halves and was checked in both directions: green as committed, red with `makeKey()` restored to the presentation, red with the click hand-off deleted.

**Not checked.** Whether every hosted child-control click keys the panel in practice, and the interactive focus behaviour itself — both need someone clicking a real preview, which I could not do as part of this run, and the `sendEvent` placement is reasoned from AppKit's dispatch order rather than observed. Both are worth a moment when you run the branch: take a screenshot while typing into a text field (the caret should stay), then click the preview and press ⌘C and Escape (both should work).
