### PR TITLE
ci(issues): put half-fixed reports back on the release track

### DIFF
--- a/.github/workflows/issue-fix-status.yml
+++ b/.github/workflows/issue-fix-status.yml
@@ -116,8 +116,13 @@ env:
   PENDING_LABEL: fixed (pending release)
   CONFIRM_LABEL: please confirm close
   # Labels this bot keeps its hands off entirely. JSON so a name with a space
-  # stays one name.
-  SKIP_LABELS: '["summary","half"]'
+  # stays one name. `half` is deliberately not one of them: a report whose
+  # landed part reaches a release is asked and timed like any other, because
+  # that part may be the one the reporter wanted, and silence leaves nothing to
+  # act on -- a remainder that still bites someone comes back as its own report.
+  # It only changes what the release comment says, below.
+  SKIP_LABELS: '["summary"]'
+  HALF_LABEL: half
   CONFIRM_DAYS: 14
 
 jobs:
@@ -378,22 +383,42 @@ jobs:
           # `gh issue list` never returns pull requests.
           gh issue list --state open --label "$PENDING_LABEL" --limit 200 \
             --json number,author,labels \
-            | jq -r --argjson skip "$SKIP_LABELS" \
-                '.[] | select(any(.labels[].name; IN($skip[])) | not) | "\(.number) \(.author.login)"' \
+            | jq -r --argjson skip "$SKIP_LABELS" --arg half "$HALF_LABEL" \
+                '.[] | select(any(.labels[].name; IN($skip[])) | not)
+                     | "\(.number) \(.author.login) \(any(.labels[].name; . == $half))"' \
             > pending.txt
 
           # Everything waiting moves, including labels applied by hand. Waiting
           # means the fix is on main and no stable release had gone out since;
           # this is that release. Nothing here reads a commit, so an issue whose
           # label arrived without one is no longer stuck waiting forever.
-          while read -r number login; do
+          while read -r number login half; do
             [ -n "$number" ] || continue
 
             gh api "repos/$GH_REPO/issues/$number/labels" -f "labels[]=$CONFIRM_LABEL" --silent
             gh issue edit "$number" --remove-label "$PENDING_LABEL" || true
 
             # Expanded heredoc: keep the text free of backticks and `$`.
-            cat > comment.md <<COMMENT
+            if [ "$half" = true ]; then
+              # Asked about the half that landed, not about a fix it never got.
+              # Same timer as everything else.
+              cat > comment.md <<COMMENT
+          Part of what you reported is fixed, and that part is out now, in **$version**.
+
+          @$login, the rest of this issue is not fixed. The comment above names which part
+          that is, and it still stands after this release.
+
+          Could you update and say where that leaves you? The half that landed may be the
+          half you needed. If it is not, say what still happens on your Mac and the issue
+          goes back for another look.
+
+          If nothing arrives in two weeks the issue will be closed as it stands, including
+          the part that is still open. A comment reopens it at any point after that.
+
+          <!-- vorssaint-fix-status confirm=$TAG half=true -->
+          COMMENT
+            else
+              cat > comment.md <<COMMENT
           The fix for this is out now, in **$version**.
 
           @$login, could you update to that version and say whether it fixed things
@@ -408,6 +433,7 @@ jobs:
 
           <!-- vorssaint-fix-status confirm=$TAG -->
           COMMENT
+            fi
             gh issue comment "$number" --body-file comment.md
             echo "#$number: moved to $CONFIRM_LABEL on $TAG"
           done < pending.txt

--- a/.github/workflows/issue-fix-status.yml
+++ b/.github/workflows/issue-fix-status.yml
@@ -65,14 +65,12 @@ name: Issue fix status
 # the issues most often referenced, so the number that reaches these jobs most
 # is the one that must never be labelled or closed by them.
 #
-# A `half` issue is held back for the same reason at a smaller scale: two root
-# causes were reported together, one of them was fixed, and neither label above
-# is true of the other one. Labelling the whole report fixed signs for a
-# reporter who never got their half, and two weeks later this file would close
-# it on them. The label comes off when someone splits the report or lands the
-# rest; until then the fix status on it is a person's call, not this file's.
-# A closing keyword aimed at one is still shouted about, exactly as for
-# `summary` -- that is the case where GitHub, not this file, does the damage.
+# A `half` issue is tracked on the same release timeline, but with tailored
+# wording: two root causes were reported together, one of them was fixed, and
+# the release sweep tells the reporter which part landed and that the rest
+# remains open. The same two-week silence timer applies, closing the issue if
+# the landed part was all that was needed, while any reply reopens it for
+# further work.
 #
 # Both labels and both comments are addressed to the person who filed the
 # report, and most of them are not developers. Nothing in what they read says


### PR DESCRIPTION
## Summary

`half` stops being a label the fix-status bot avoids, and becomes a label that changes what it says.

#1135 taught this bot to leave `half` alone the way it leaves `summary` alone: no fix status on merge, no move at release, no close on the timer. That was one reading of a two-cause report — do not call it fixed when one cause lands. This is the other reading: the half that landed may be the half the reporter wanted, and if nobody answers there is nothing further to act on. A remainder that still bites someone comes back as its own report.

So `SKIP_LABELS` keeps only `summary`, and the four jobs treat a half-fixed report like any other: labelled on merge, hinted about in `reference-hint`, asked when a release carries it, closed after the same two weeks of silence.

What `half` still does is pick the release comment. A reporter whose issue is half fixed is told which half landed, that the rest is not fixed and the comment naming it still stands, and that the close covers the open part too — instead of being asked to confirm a fix they never got, which is the case #1135 was written against.

The label description loses its now-false second half; it reads `Only part of this is done. The rest is named in a comment.`

## Verification

No Swift source is touched, so `./build.sh`, `--selftest` and `./build.sh --test` prove nothing about this change and were not run for it. CI runs them on this PR anyway.

What was run, on macOS 26.6 with `jq 1.7`:

- YAML parses, all four jobs intact, `RELEASE_SKIP_LABELS` (an earlier draft of this) absent
- `bash -n` on each of the four jobs' `run` blocks
- every `jq` selector dry-run against the repository's real data — the 45 open issues currently carrying `fixed (pending release)` — plus three synthetic rows for the label combinations that do not exist yet:

| job | half | summary | summary + half |
|---|---|---|---|
| `fixed-on-main` | labelled | left alone | left alone |
| `reporter-check` | selected, half wording | skipped | skipped |
| `close-unanswered` | closed | skipped | skipped |

`while read -r number login half` splits the three fields correctly; the seven issues currently carrying both `fixed (pending release)` and `half` (#341, #768, #828, #888, #938, #956, #1061) all resolve to the half wording.

**What I could not test:** `reporter-check` only fires on a stable tag whose release is published, so the `gh issue edit` / `gh issue comment` calls in the new branch have not executed. What is verified is which issues each job selects and which wording each one takes, not the mutations themselves. The first stable release after this merges is where that shows.

## Anything else

Refs #1135
