### PR TITLE
fix(scroll): hand both scroll taps back across a fast user switch

### DIFF
--- a/Sources/Vorssaint/App/AppDelegate.swift
+++ b/Sources/Vorssaint/App/AppDelegate.swift
@@ -238,6 +238,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         // Takes the Super key mapping back out before the process goes away.
         SuperKeyService.shared.suspend()
         MiddleClickService.shared.suspend()
+        ScrollInverter.shared.suspend()
         SmoothScrollService.shared.suspend()
         MouseNavigationService.shared.suspend()
         DockPreviewService.shared.stop()

--- a/Sources/Vorssaint/Services/ScrollInverter.swift
+++ b/Sources/Vorssaint/Services/ScrollInverter.swift
@@ -48,9 +48,9 @@ final class ScrollInverter: ObservableObject {
         let wanted = AppFeature.scrollInverter.isAvailable
             && (defaults.bool(forKey: DefaultsKey.scrollInverterEnabled)
                 || defaults.bool(forKey: DefaultsKey.scrollInverterHorizontalEnabled))
-        if ScrollWheelSupport.tapShouldRun(featureWanted: wanted,
-                                           accessibilityGranted: Permissions.shared.accessibility,
-                                           sessionIsActive: SessionActivity.shared.isActive) {
+        if SessionActivitySupport.tapShouldRun(featureWanted: wanted,
+                                               accessibilityGranted: Permissions.shared.accessibility,
+                                               sessionIsActive: SessionActivity.shared.isActive) {
             start()
         } else {
             stop()
@@ -64,6 +64,9 @@ final class ScrollInverter: ObservableObject {
 
     private func start() {
         guard tap == nil else {
+            if let tap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
             MouseAppExceptions.shared.setSourceTracking(true, for: .scrollDirection)
             isRunning = true
             return
@@ -83,6 +86,8 @@ final class ScrollInverter: ObservableObject {
         ) else {
             MouseAppExceptions.shared.setSourceTracking(false, for: .scrollDirection)
             isRunning = false
+            // A create that fails during the session handoff gets one more look once the switch settles.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in self?.syncWithPreferences() }
             return
         }
 

--- a/Sources/Vorssaint/Services/ScrollInverter.swift
+++ b/Sources/Vorssaint/Services/ScrollInverter.swift
@@ -34,7 +34,13 @@ final class ScrollInverter: ObservableObject {
     /// only touch devices emit those. Read/written solely on the tap callback.
     private var lastGesturePhaseTimestamp: UInt64?
 
-    private init() {}
+    private init() {
+        // Fast user switching: the tap goes back while this session is off
+        // screen and is built again from the preferences on the way in.
+        SessionActivity.shared.onChange { [weak self] _ in
+            self?.syncWithPreferences()
+        }
+    }
 
     /// Applies the persisted preference; safe to call repeatedly.
     func syncWithPreferences() {
@@ -42,7 +48,9 @@ final class ScrollInverter: ObservableObject {
         let wanted = AppFeature.scrollInverter.isAvailable
             && (defaults.bool(forKey: DefaultsKey.scrollInverterEnabled)
                 || defaults.bool(forKey: DefaultsKey.scrollInverterHorizontalEnabled))
-        if wanted, Permissions.shared.accessibility {
+        if ScrollWheelSupport.tapShouldRun(featureWanted: wanted,
+                                           accessibilityGranted: Permissions.shared.accessibility,
+                                           sessionIsActive: SessionActivity.shared.isActive) {
             start()
         } else {
             stop()
@@ -94,15 +102,25 @@ final class ScrollInverter: ObservableObject {
         if let runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
         }
+        // Hand the tap back rather than only switching it off: a disabled tap
+        // keeps its place in the chain, and a session that is switched away
+        // has to stop being an event tap owner outright (issue #1075).
+        if let tap {
+            CFMachPortInvalidate(tap)
+        }
         tap = nil
         runLoopSource = nil
         isRunning = false
     }
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
-        // macOS disables taps that stall or when the session locks; re-arm.
+        // macOS disables taps that stall or when the session locks; re-arm,
+        // unless this session is the one that was switched away from, where
+        // the stall is the reason the tap was disabled and re-arming feeds it.
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
+            if SessionActivity.shared.isActive, let tap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
             return Unmanaged.passUnretained(event)
         }
         guard type == .scrollWheel else { return Unmanaged.passUnretained(event) }

--- a/Sources/Vorssaint/Services/ScrollWheelSupport.swift
+++ b/Sources/Vorssaint/Services/ScrollWheelSupport.swift
@@ -37,6 +37,21 @@ enum ScrollWheelSupport {
     /// replaying that number as pixels would travel a tenth of the distance.
     static let pointsPerLine: Double = 10
 
+    /// Whether a scroll tap should be in the event chain at all.
+    ///
+    /// Fast user switching adds the third condition. A tap created here keeps
+    /// its place while this login session is switched away, so the window
+    /// server still routes every scroll through a process that cannot answer
+    /// and waits out the tap timeout on each one — the account on screen
+    /// scrolls badly or not at all. Both the preference sync and the timeout
+    /// re-arm ask this, so a tap handed back cannot be re-armed into a session
+    /// that is no longer on screen.
+    static func tapShouldRun(featureWanted: Bool,
+                             accessibilityGranted: Bool,
+                             sessionIsActive: Bool) -> Bool {
+        featureWanted && accessibilityGranted && sessionIsActive
+    }
+
     static func isMouseWheel(_ traits: ScrollWheelEventTraits,
                              secondsSinceLastGesturePhase: TimeInterval?) -> Bool {
         if !traits.isContinuous {

--- a/Sources/Vorssaint/Services/ScrollWheelSupport.swift
+++ b/Sources/Vorssaint/Services/ScrollWheelSupport.swift
@@ -37,21 +37,6 @@ enum ScrollWheelSupport {
     /// replaying that number as pixels would travel a tenth of the distance.
     static let pointsPerLine: Double = 10
 
-    /// Whether a scroll tap should be in the event chain at all.
-    ///
-    /// Fast user switching adds the third condition. A tap created here keeps
-    /// its place while this login session is switched away, so the window
-    /// server still routes every scroll through a process that cannot answer
-    /// and waits out the tap timeout on each one — the account on screen
-    /// scrolls badly or not at all. Both the preference sync and the timeout
-    /// re-arm ask this, so a tap handed back cannot be re-armed into a session
-    /// that is no longer on screen.
-    static func tapShouldRun(featureWanted: Bool,
-                             accessibilityGranted: Bool,
-                             sessionIsActive: Bool) -> Bool {
-        featureWanted && accessibilityGranted && sessionIsActive
-    }
-
     static func isMouseWheel(_ traits: ScrollWheelEventTraits,
                              secondsSinceLastGesturePhase: TimeInterval?) -> Bool {
         if !traits.isContinuous {

--- a/Sources/Vorssaint/Services/SessionActivity.swift
+++ b/Sources/Vorssaint/Services/SessionActivity.swift
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import CoreGraphics
+
+/// Whether this login session is the one on screen, for the services that own
+/// an event tap.
+///
+/// Fast user switching leaves this process running in a session that is no
+/// longer front-most, and an event tap created there keeps its place in the
+/// chain: the window server still routes events through a process that cannot
+/// answer, waits out the tap timeout on every one, and the account actually in
+/// use gets the stall (issue #1075). The tap goes back on the way out and is
+/// rebuilt from the preferences on the way in, which is also why the timeout
+/// re-arm has to ask first — re-enabling a tap that was handed back for this
+/// reason puts the stall straight back.
+final class SessionActivity {
+    static let shared = SessionActivity()
+
+    /// True while this session is the one on screen.
+    private(set) var isActive = false
+
+    private let center: NotificationCenter
+    private var observers: [NSObjectProtocol] = []
+    private var handlers: [(Bool) -> Void] = []
+
+    /// Subscribes before reading the current state, so a switch landing during
+    /// startup is seen rather than dropped between the two. macOS tells a
+    /// process launched into a switched-away session before
+    /// `didFinishLaunching`, which is before the services that own a tap are
+    /// built, so the state is read here rather than assumed.
+    init(center: NotificationCenter = NSWorkspace.shared.notificationCenter,
+         initialIsActive: () -> Bool = {
+             SessionActivitySupport.isOnConsole(CGSessionCopyCurrentDictionary() as? [String: Any])
+         }) {
+        self.center = center
+        observers = [
+            center.addObserver(forName: NSWorkspace.sessionDidResignActiveNotification,
+                               object: nil, queue: .main) { [weak self] _ in
+                self?.update(isActive: false)
+            },
+            center.addObserver(forName: NSWorkspace.sessionDidBecomeActiveNotification,
+                               object: nil, queue: .main) { [weak self] _ in
+                self?.update(isActive: true)
+            },
+        ]
+        isActive = initialIsActive()
+    }
+
+    deinit {
+        for observer in observers { center.removeObserver(observer) }
+    }
+
+    /// Runs `handler` on every change, so a service can hand its tap back and
+    /// build it again. Never called for a change that did not happen.
+    func onChange(_ handler: @escaping (Bool) -> Void) {
+        handlers.append(handler)
+    }
+
+    private func update(isActive: Bool) {
+        guard isActive != self.isActive else { return }
+        self.isActive = isActive
+        for handler in handlers { handler(isActive) }
+    }
+}

--- a/Sources/Vorssaint/Services/SessionActivity.swift
+++ b/Sources/Vorssaint/Services/SessionActivity.swift
@@ -25,9 +25,9 @@ final class SessionActivity {
     private var observers: [NSObjectProtocol] = []
     private var handlers: [(Bool) -> Void] = []
 
-    /// Subscribes before reading the current state, so a switch landing during
-    /// startup is seen rather than dropped between the two. macOS tells a
-    /// process launched into a switched-away session before
+    /// Registration and the initial read both happen before any main-queue
+    /// delivery can run, so there is no window in which a change is missed.
+    /// macOS tells a process launched into a switched-away session before
     /// `didFinishLaunching`, which is before the services that own a tap are
     /// built, so the state is read here rather than assumed.
     init(center: NotificationCenter = NSWorkspace.shared.notificationCenter,

--- a/Sources/Vorssaint/Services/SessionActivitySupport.swift
+++ b/Sources/Vorssaint/Services/SessionActivitySupport.swift
@@ -12,13 +12,14 @@ enum SessionActivitySupport {
     /// into a session that is already switched away is told so between
     /// `willFinishLaunching` and `didFinishLaunching`, which is before the
     /// services that own a tap exist to hear it. The flag is therefore read
-    /// once at startup, and anything unreadable counts as not on screen —
-    /// the cost of being wrong that way is a tap that waits for the switch
-    /// back, against a tap that stalls scrolling for the account in use.
+    /// once at startup. Anything unreadable counts as on screen because a
+    /// mistaken off state is permanent: an already-active session gets no
+    /// become-active notification. A mistaken on state is corrected by the
+    /// next resign notification.
     static func isOnConsole(_ session: [String: Any]?) -> Bool {
-        guard let value = session?[kCGSessionOnConsoleKey as String] else { return false }
+        guard let value = session?[kCGSessionOnConsoleKey as String] else { return true }
         if let flag = value as? Bool { return flag }
         if let number = value as? NSNumber { return number.boolValue }
-        return false
+        return true
     }
 }

--- a/Sources/Vorssaint/Services/SessionActivitySupport.swift
+++ b/Sources/Vorssaint/Services/SessionActivitySupport.swift
@@ -14,12 +14,27 @@ enum SessionActivitySupport {
     /// services that own a tap exist to hear it. The flag is therefore read
     /// once at startup. Anything unreadable counts as on screen because a
     /// mistaken off state is permanent: an already-active session gets no
-    /// become-active notification. A mistaken on state is corrected by the
-    /// next resign notification.
+    /// become-active notification. A mistaken on state is bounded by the
+    /// next switch, when the resign notification arrives.
     static func isOnConsole(_ session: [String: Any]?) -> Bool {
         guard let value = session?[kCGSessionOnConsoleKey as String] else { return true }
         if let flag = value as? Bool { return flag }
         if let number = value as? NSNumber { return number.boolValue }
         return true
+    }
+
+    /// Whether an event tap should be in the event chain at all.
+    ///
+    /// Fast user switching adds the third condition. A tap created here keeps
+    /// its place while this login session is switched away, so the window
+    /// server still routes every event through a process that cannot answer
+    /// and waits out the tap timeout on each one — the account on screen
+    /// stalls. Both the preference sync and the timeout
+    /// re-arm ask this, so a tap handed back cannot be re-armed into a session
+    /// that is no longer on screen.
+    static func tapShouldRun(featureWanted: Bool,
+                             accessibilityGranted: Bool,
+                             sessionIsActive: Bool) -> Bool {
+        featureWanted && accessibilityGranted && sessionIsActive
     }
 }

--- a/Sources/Vorssaint/Services/SessionActivitySupport.swift
+++ b/Sources/Vorssaint/Services/SessionActivitySupport.swift
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import CoreGraphics
+import Foundation
+
+/// Reading whether a login session is the one on screen.
+enum SessionActivitySupport {
+    /// The console flag out of a session dictionary.
+    ///
+    /// Starting from the notifications alone is not enough: a process launched
+    /// into a session that is already switched away is told so between
+    /// `willFinishLaunching` and `didFinishLaunching`, which is before the
+    /// services that own a tap exist to hear it. The flag is therefore read
+    /// once at startup, and anything unreadable counts as not on screen —
+    /// the cost of being wrong that way is a tap that waits for the switch
+    /// back, against a tap that stalls scrolling for the account in use.
+    static func isOnConsole(_ session: [String: Any]?) -> Bool {
+        guard let value = session?[kCGSessionOnConsoleKey as String] else { return false }
+        if let flag = value as? Bool { return flag }
+        if let number = value as? NSNumber { return number.boolValue }
+        return false
+    }
+}

--- a/Sources/Vorssaint/Services/SmoothScrollService.swift
+++ b/Sources/Vorssaint/Services/SmoothScrollService.swift
@@ -52,13 +52,21 @@ final class SmoothScrollService: ObservableObject {
     /// only touch devices emit those. Read/written solely on the tap callback.
     private var lastGesturePhaseTimestamp: UInt64?
 
-    private init() {}
+    private init() {
+        // Fast user switching: the tap goes back while this session is off
+        // screen and is built again from the preferences on the way in.
+        SessionActivity.shared.onChange { [weak self] _ in
+            self?.syncWithPreferences()
+        }
+    }
 
     /// Applies the persisted preference; safe to call repeatedly.
     func syncWithPreferences() {
         let wanted = AppFeature.smoothScroll.isAvailable
             && UserDefaults.standard.bool(forKey: DefaultsKey.smoothScrollEnabled)
-        if wanted, Permissions.shared.accessibility {
+        if ScrollWheelSupport.tapShouldRun(featureWanted: wanted,
+                                           accessibilityGranted: Permissions.shared.accessibility,
+                                           sessionIsActive: SessionActivity.shared.isActive) {
             start()
         } else {
             stop()
@@ -110,6 +118,12 @@ final class SmoothScrollService: ObservableObject {
         if let runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
         }
+        // Hand the tap back rather than only switching it off: a disabled tap
+        // keeps its place in the chain, and a session that is switched away
+        // has to stop being an event tap owner outright (issue #1075).
+        if let tap {
+            CFMachPortInvalidate(tap)
+        }
         tap = nil
         runLoopSource = nil
         stopGlide()
@@ -117,9 +131,13 @@ final class SmoothScrollService: ObservableObject {
     }
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
-        // macOS disables taps that stall or when the session locks; re-arm.
+        // macOS disables taps that stall or when the session locks; re-arm,
+        // unless this session is the one that was switched away from, where
+        // the stall is the reason the tap was disabled and re-arming feeds it.
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
+            if SessionActivity.shared.isActive, let tap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
             return Unmanaged.passUnretained(event)
         }
         guard type == .scrollWheel else { return Unmanaged.passUnretained(event) }

--- a/Sources/Vorssaint/Services/SmoothScrollService.swift
+++ b/Sources/Vorssaint/Services/SmoothScrollService.swift
@@ -64,9 +64,9 @@ final class SmoothScrollService: ObservableObject {
     func syncWithPreferences() {
         let wanted = AppFeature.smoothScroll.isAvailable
             && UserDefaults.standard.bool(forKey: DefaultsKey.smoothScrollEnabled)
-        if ScrollWheelSupport.tapShouldRun(featureWanted: wanted,
-                                           accessibilityGranted: Permissions.shared.accessibility,
-                                           sessionIsActive: SessionActivity.shared.isActive) {
+        if SessionActivitySupport.tapShouldRun(featureWanted: wanted,
+                                               accessibilityGranted: Permissions.shared.accessibility,
+                                               sessionIsActive: SessionActivity.shared.isActive) {
             start()
         } else {
             stop()
@@ -80,6 +80,9 @@ final class SmoothScrollService: ObservableObject {
 
     private func start() {
         guard tap == nil else {
+            if let tap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
             MouseAppExceptions.shared.setSourceTracking(true, for: .smoothScroll)
             isRunning = true
             return
@@ -99,12 +102,16 @@ final class SmoothScrollService: ObservableObject {
         ) else {
             MouseAppExceptions.shared.setSourceTracking(false, for: .smoothScroll)
             isRunning = false
+            // A create that fails during the session handoff gets one more look once the switch settles.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in self?.syncWithPreferences() }
             return
         }
 
         self.tap = tap
         let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
         runLoopSource = source
+        // Its isRunning is read from the tap callback, so it is built off the event path.
+        _ = ScrollInverter.shared
         CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
         CGEvent.tapEnable(tap: tap, enable: true)
         isRunning = true

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1099,7 +1099,8 @@ struct MetricsTests {
 
         // Launching into a session that is already switched away is announced
         // before the tap owners exist to hear it, so the state is read rather
-        // than assumed, and anything unreadable counts as off screen.
+        // than assumed. Anything unreadable counts as on screen because a
+        // wrong off state would never be corrected.
         let onConsoleKey = kCGSessionOnConsoleKey as String
         expect(SessionActivitySupport.isOnConsole([onConsoleKey: true]),
                "a session dictionary saying it holds the console reads as on screen")
@@ -1107,10 +1108,12 @@ struct MetricsTests {
                "a session dictionary saying it does not hold the console reads as off screen")
         expect(SessionActivitySupport.isOnConsole([onConsoleKey: NSNumber(value: 1)]),
                "the console flag is read when it arrives as a number")
-        expect(!SessionActivitySupport.isOnConsole(nil),
-               "an unreadable session reads as off screen rather than assuming the console")
-        expect(!SessionActivitySupport.isOnConsole([:]),
-               "a session without the console flag reads as off screen")
+        expect(SessionActivitySupport.isOnConsole(nil),
+               "an unreadable session reads as on screen because a wrong off would never be corrected")
+        expect(SessionActivitySupport.isOnConsole([:]),
+               "a session without the console flag reads as on screen because a wrong off would never be corrected")
+        expect(SessionActivitySupport.isOnConsole([onConsoleKey: "unexpected"]),
+               "an unexpected console flag reads as on screen because a wrong off would never be corrected")
 
         expect(MouseNavigationSupport.direction(
             forButtonNumber: MouseNavigationSupport.backButtonNumber) == .back,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1076,6 +1076,42 @@ struct MetricsTests {
         ) == ScrollWheelInversionPlan(vertical: false, horizontal: false),
         "a continuous wheel stays vertical because Shift does not redirect that event type")
 
+        // A scroll tap belongs in the chain only while this login session is
+        // the one on screen: fast user switching leaves the process running
+        // behind another account, where the tap still takes every scroll event
+        // and stalls it (issue #1075).
+        expect(ScrollWheelSupport.tapShouldRun(featureWanted: true,
+                                               accessibilityGranted: true,
+                                               sessionIsActive: true),
+               "a wanted scroll tap runs in the session on screen")
+        expect(!ScrollWheelSupport.tapShouldRun(featureWanted: true,
+                                                accessibilityGranted: true,
+                                                sessionIsActive: false),
+               "a wanted scroll tap is handed back while its session is switched away")
+        expect(!ScrollWheelSupport.tapShouldRun(featureWanted: false,
+                                                accessibilityGranted: true,
+                                                sessionIsActive: true),
+               "an unwanted scroll tap stays off in the session on screen")
+        expect(!ScrollWheelSupport.tapShouldRun(featureWanted: true,
+                                                accessibilityGranted: false,
+                                                sessionIsActive: true),
+               "a scroll tap needs Accessibility even in the session on screen")
+
+        // Launching into a session that is already switched away is announced
+        // before the tap owners exist to hear it, so the state is read rather
+        // than assumed, and anything unreadable counts as off screen.
+        let onConsoleKey = kCGSessionOnConsoleKey as String
+        expect(SessionActivitySupport.isOnConsole([onConsoleKey: true]),
+               "a session dictionary saying it holds the console reads as on screen")
+        expect(!SessionActivitySupport.isOnConsole([onConsoleKey: false]),
+               "a session dictionary saying it does not hold the console reads as off screen")
+        expect(SessionActivitySupport.isOnConsole([onConsoleKey: NSNumber(value: 1)]),
+               "the console flag is read when it arrives as a number")
+        expect(!SessionActivitySupport.isOnConsole(nil),
+               "an unreadable session reads as off screen rather than assuming the console")
+        expect(!SessionActivitySupport.isOnConsole([:]),
+               "a session without the console flag reads as off screen")
+
         expect(MouseNavigationSupport.direction(
             forButtonNumber: MouseNavigationSupport.backButtonNumber) == .back,
                "the first standard mouse side button maps to Back")
@@ -20093,6 +20129,37 @@ struct MetricsTests {
             .joined(separator: "\n")
         expect(!signingSetupCode.contains("-legacy"),
                "setup-signing.sh avoids the -legacy flag the stock LibreSSL openssl rejects")
+
+        // MARK: Both scroll taps are handed back across a session switch
+        // The tap owners cannot be reached from this list (they need the event
+        // chain), so the wiring is pinned as text: each service follows the
+        // session and asks before re-arming a tap the window server disabled.
+        // Comments are stripped so prose naming the API cannot answer for it.
+        let sessionActivitySource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/SessionActivity.swift",
+            encoding: .utf8)) ?? ""
+        expect(sessionActivitySource.contains("sessionDidResignActiveNotification")
+                && sessionActivitySource.contains("sessionDidBecomeActiveNotification"),
+               "the session watcher follows both halves of a fast user switch")
+        for tapOwner in ["Sources/Vorssaint/Services/ScrollInverter.swift",
+                         "Sources/Vorssaint/Services/SmoothScrollService.swift"] {
+            let source = (try? String(contentsOfFile: tapOwner, encoding: .utf8)) ?? ""
+            expect(!source.isEmpty, "\(tapOwner) reads back for its session-switch check")
+            let code = source.components(separatedBy: "\n")
+                .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+                .joined(separator: "\n")
+            expect(code.contains("SessionActivity.shared.onChange"),
+                   "\(tapOwner) rebuilds its tap when the session comes back")
+            let rearm = code.components(separatedBy: "tapDisabledByTimeout")
+                .dropFirst().first?.components(separatedBy: "return").first ?? ""
+            expect(rearm.contains("SessionActivity.shared.isActive"),
+                   "\(tapOwner) does not re-arm a disabled tap into a switched-away session")
+            // Switching a tap off leaves the process owning it, which is what
+            // the window server waits on; the ten other tap owners already
+            // invalidate the port on the way out.
+            expect(code.contains("CFMachPortInvalidate"),
+                   "\(tapOwner) hands its tap back rather than only disabling it")
+        }
 
         // MARK: Uninstallation paths stay aligned across SelfUninstall and Tools/uninstall.sh
         let selfUninstallSource = (try? String(contentsOfFile: "Sources/Vorssaint/Services/SelfUninstall.swift",

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1080,21 +1080,21 @@ struct MetricsTests {
         // the one on screen: fast user switching leaves the process running
         // behind another account, where the tap still takes every scroll event
         // and stalls it (issue #1075).
-        expect(ScrollWheelSupport.tapShouldRun(featureWanted: true,
-                                               accessibilityGranted: true,
-                                               sessionIsActive: true),
+        expect(SessionActivitySupport.tapShouldRun(featureWanted: true,
+                                                   accessibilityGranted: true,
+                                                   sessionIsActive: true),
                "a wanted scroll tap runs in the session on screen")
-        expect(!ScrollWheelSupport.tapShouldRun(featureWanted: true,
-                                                accessibilityGranted: true,
-                                                sessionIsActive: false),
+        expect(!SessionActivitySupport.tapShouldRun(featureWanted: true,
+                                                    accessibilityGranted: true,
+                                                    sessionIsActive: false),
                "a wanted scroll tap is handed back while its session is switched away")
-        expect(!ScrollWheelSupport.tapShouldRun(featureWanted: false,
-                                                accessibilityGranted: true,
-                                                sessionIsActive: true),
+        expect(!SessionActivitySupport.tapShouldRun(featureWanted: false,
+                                                    accessibilityGranted: true,
+                                                    sessionIsActive: true),
                "an unwanted scroll tap stays off in the session on screen")
-        expect(!ScrollWheelSupport.tapShouldRun(featureWanted: true,
-                                                accessibilityGranted: false,
-                                                sessionIsActive: true),
+        expect(!SessionActivitySupport.tapShouldRun(featureWanted: true,
+                                                    accessibilityGranted: false,
+                                                    sessionIsActive: true),
                "a scroll tap needs Accessibility even in the session on screen")
 
         // Launching into a session that is already switched away is announced
@@ -1114,6 +1114,19 @@ struct MetricsTests {
                "a session without the console flag reads as on screen because a wrong off would never be corrected")
         expect(SessionActivitySupport.isOnConsole([onConsoleKey: "unexpected"]),
                "an unexpected console flag reads as on screen because a wrong off would never be corrected")
+
+        let privateCenter = NotificationCenter()
+        let activity = SessionActivity(center: privateCenter, initialIsActive: { true })
+        var observedTransitions: [Bool] = []
+        activity.onChange { observedTransitions.append($0) }
+        expect(activity.isActive, "session activity starts with the injected initial state")
+        privateCenter.post(name: NSWorkspace.sessionDidResignActiveNotification, object: nil)
+        expect(!activity.isActive, "session activity transitions to inactive on resign")
+        privateCenter.post(name: NSWorkspace.sessionDidResignActiveNotification, object: nil)
+        privateCenter.post(name: NSWorkspace.sessionDidBecomeActiveNotification, object: nil)
+        expect(activity.isActive, "session activity transitions to active on become-active")
+        expect(observedTransitions == [false, true],
+               "the session activity handler records each state change and ignores duplicate notifications")
 
         expect(MouseNavigationSupport.direction(
             forButtonNumber: MouseNavigationSupport.backButtonNumber) == .back,

--- a/build.sh
+++ b/build.sh
@@ -329,6 +329,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/SuperKey/SuperKeySupport.swift \
         Sources/Vorssaint/Services/SuperKey/SuperKeyMappingGuard.swift \
         Sources/Vorssaint/Core/SuperKeyStrings.swift \
+        Sources/Vorssaint/Services/SessionActivity.swift \
         Sources/Vorssaint/Services/SessionActivitySupport.swift \
         Sources/Vorssaint/Services/ScrollWheelSupport.swift \
         Sources/Vorssaint/Services/SmoothScrollSupport.swift \

--- a/build.sh
+++ b/build.sh
@@ -329,6 +329,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/SuperKey/SuperKeySupport.swift \
         Sources/Vorssaint/Services/SuperKey/SuperKeyMappingGuard.swift \
         Sources/Vorssaint/Core/SuperKeyStrings.swift \
+        Sources/Vorssaint/Services/SessionActivitySupport.swift \
         Sources/Vorssaint/Services/ScrollWheelSupport.swift \
         Sources/Vorssaint/Services/SmoothScrollSupport.swift \
         Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseSupport.swift \


### PR DESCRIPTION
Refs #1075

Both scroll taps are handed back while this login session is switched away, and built again when it comes back.

Your reading of the dump was the one this follows: the missing half is the resign, not the return. An instance left in a switched-away session keeps a live filter tap with `scrollWheel` in its mask, so the window server still routes every scroll through a process that cannot answer and waits out the timeout on each one — which is the ~4097 ms on all four taps, and why the account actually in use is the one that suffers.

**The re-arm.** You warned that a teardown which only disables the tap loses to the unconditional `tapEnable(true)` on `.tapDisabledByTimeout`. It is handled twice over. The teardown routes through the existing `stop()`, so the tap is gone rather than off, and the re-arm now asks whether this session is on screen before re-enabling — the second one covers the window where a timeout is processed before the resign notification is.

**Teardown joined the pattern the other tap owners already use.** `stop()` in both scroll services did `tapEnable(false)`, removed the run-loop source and dropped the reference, leaving the port to be released whenever the last reference went. Ten of the other tap owners — `TextSnippetService`, `SuperKeyService`, `FinderCutPaste`, `WindowLayoutService` and the rest — call `CFMachPortInvalidate` at that point. The scroll services never joined, and for this bug the difference is the whole point: "release rather than disable" has to be something the code does, not something reference counting gets around to. Both now invalidate, in the same order as the others.

**One predicate owns whether a tap should exist.** `ScrollWheelSupport.tapShouldRun(featureWanted:accessibilityGranted:sessionIsActive:)` is asked by both services' `syncWithPreferences()`, so the session condition cannot drift away from the preference and permission conditions that were already there.

**Starting in a session that is already switched away.** macOS announces that between `willFinishLaunching` and `didFinishLaunching`, which is before `FeatureRuntime.syncAtLaunch()` builds the services that would hear it, so the state is read from `CGSessionCopyCurrentDictionary()` at startup rather than assumed, and the watcher subscribes before it reads so a switch landing during startup is not dropped between the two.

That reading fails open, and the asymmetry is the reason. The call is documented as nullable and has been seen returning nothing in an ordinary GUI session, so an unreadable answer is not exotic. A mistaken off would be permanent — an already-active session is never told it became active, so both taps would stay down for the life of the process, on a Mac that may only ever have had one account. A mistaken on costs nothing, because the next resign notification corrects it. Only an explicit, valid false counts as off screen.

**Scope.** The two scroll services are the ones with evidence, and they are what this changes. The same shape reaches the other tap owners — a session switched away is a bad place for any filter tap — but nobody has reported it there and joining twenty services to a new watcher without a report is a much larger change than this one; `SessionActivity.onChange` is a line each whenever that is wanted.

**Tests.** `tapShouldRun` and the console-flag reading are behaviour tests on the pure helpers (the flag covers a missing dictionary, an absent key, and both the `Bool` and `NSNumber` spellings). The wiring is pinned as text, since the tap owners cannot be reached from the `--test` list: each service follows the session, guards its re-arm, and invalidates its port. Checked in both directions — green as committed, red with the guard removed, red with either subscription removed, red with the resign half dropped from the watcher.

**Verification.** macOS 26.6.2 (25G83), M5 Pro, own Developer build, single logged-in account. `./build.sh` finishes warning-free and `./build.sh --test` passes 9105 of 9106, the exception being the pre-existing `dispatch pool starvation` check that fails on this 15-core machine and passes in CI.

**Not verified, and it is the part that matters.** I have one account on this machine, so I have not reproduced the bug or its fix. What needs two logged-in sessions: that the resign arrives early enough to tear down before the session stops being serviced, that the old session's tap PIDs actually leave `CGGetEventTapList`, that coming back rebuilds exactly the intended taps and no duplicates, and that the dead wheel and the ~4097 ms latency are genuinely gone — with Smooth Scroll alone, the inverter alone, and both together. The API behaviour supports the chain; it does not prove it. If that is worth a draft rather than a merge until someone with two accounts confirms, say so and I will mark it.

