### PR TITLE
fix(capture): draw what an app stacked on the window being captured

### DIFF
--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotCaptureEngine.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotCaptureEngine.swift
@@ -186,9 +186,9 @@ enum ScreenshotCaptureEngine {
     }
 
     /// Draws the clicked window together with what the app stacked on it.
-    /// ScreenCaptureKit is the only route that takes more than one window, and
-    /// the source rectangle keeps the result to the area they cover instead of
-    /// the whole display. `nil` leaves the single-window routes to answer.
+    /// ScreenCaptureKit is the only route that takes more than one window. It
+    /// captures their composited display, then crops it to the area they cover.
+    /// `nil` leaves the single-window routes to answer.
     private static func captureAttached(
         _ plan: ScreenshotCapturePolicy.AttachedCapturePlan) async -> CGImage? {
         guard let content = try? await SCShareableContent.excludingDesktopWindows(
@@ -198,23 +198,32 @@ enum ScreenshotCaptureEngine {
             content.windows.first { $0.windowID == id }
         }
         guard windows.count == plan.windowIDs.count,
-              let display = content.displays.first(where: { $0.frame.intersects(plan.bounds) })
+              let display = content.displays.first(where: { $0.frame.intersects(plan.bounds) }),
+              let screen = NSScreen.screens.first(where: { $0.displayID == display.displayID }),
+              let mainScreen = NSScreen.screens.first
         else { return nil }
         let filter = SCContentFilter(display: display, including: windows)
         let configuration = SCStreamConfiguration()
-        // The source rectangle is measured from the display's own origin.
-        configuration.sourceRect = plan.bounds.offsetBy(dx: -display.frame.origin.x,
-                                                        dy: -display.frame.origin.y)
-        // The filter knows the points-to-pixels factor of the display it ends
-        // up on, which the scale taken from the display under the pointer does
-        // not when the two have different densities.
         let pixelScale = CGFloat(filter.pointPixelScale)
-        configuration.width = max(1, Int((plan.bounds.width * pixelScale).rounded(.up)))
-        configuration.height = max(1, Int((plan.bounds.height * pixelScale).rounded(.up)))
+        configuration.width = max(1, Int((CGFloat(display.width) * pixelScale).rounded()))
+        configuration.height = max(1, Int((CGFloat(display.height) * pixelScale).rounded()))
         configuration.showsCursor = false
         configuration.colorSpaceName = CGColorSpace.sRGB
-        return try? await SCScreenshotManager.captureImage(contentFilter: filter,
-                                                           configuration: configuration)
+        guard let image = try? await SCScreenshotManager.captureImage(contentFilter: filter,
+                                                                      configuration: configuration)
+        else { return nil }
+        let cocoaBounds = ScreenshotSupport.cocoaRect(fromWindowServer: plan.bounds,
+                                                      mainScreenHeight: mainScreen.frame.height)
+        let viewBounds = ScreenshotSupport.flippedViewRect(fromCocoa: cocoaBounds,
+                                                           screenFrame: screen.frame)
+        let imageBounds = CGRect(x: 0, y: 0, width: image.width, height: image.height)
+        let pixelBounds = ScreenshotSupport.imagePixelRect(
+            fromView: viewBounds,
+            viewSize: screen.frame.size,
+            imageSize: imageBounds.size)
+        let cropBounds = ScreenshotSupport.clamp(pixelBounds, to: imageBounds)
+        guard !cropBounds.isEmpty else { return nil }
+        return image.cropping(to: cropBounds)
     }
 
     /// The window's size as the window server knows it, used to tell a whole

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotCaptureEngine.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotCaptureEngine.swift
@@ -125,6 +125,17 @@ enum ScreenshotCaptureEngine {
     /// ScreenCaptureKit when the private route is unavailable or when it
     /// returns only the visible slice of a window that runs off the screen.
     static func captureWindow(_ windowID: CGWindowID, scale: CGFloat) async -> CGImage? {
+        // A sheet or dialog the app stacked on the window is a window of its
+        // own, and neither single-window route draws it (issue #1098). The
+        // window list answers this without waiting on shareable content, so
+        // the ordinary capture keeps the faster route.
+        let onScreen = onScreenWindows()
+        if let target = onScreen.first(where: { $0.id == windowID }),
+           let plan = ScreenshotCapturePolicy.attachedCapturePlan(target: target,
+                                                                  frontToBack: onScreen),
+           let composited = await captureAttached(plan) {
+            return composited
+        }
         var clippedFallback: CGImage?
         if let image = WindowPreviewProvider.captureViaWindowServer(windowID) {
             let bounds = windowBounds(windowID)
@@ -148,6 +159,62 @@ enum ScreenshotCaptureEngine {
         let capture = try? await SCScreenshotManager.captureImage(contentFilter: filter,
                                                                   configuration: configuration)
         return capture ?? clippedFallback
+    }
+
+    /// On-screen windows front to back, as the attached-window decision needs
+    /// them. Ordinary layer-zero windows only, so a menu or the Dock cannot
+    /// read as something stacked on the clicked window.
+    private static func onScreenWindows() -> [ScreenshotCapturePolicy.CaptureWindow] {
+        guard let info = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements],
+                                                    kCGNullWindowID) as? [[String: Any]]
+        else { return [] }
+        return info.compactMap { entry in
+            guard let layer = entry[kCGWindowLayer as String] as? Int, layer == 0,
+                  let pid = entry[kCGWindowOwnerPID as String] as? pid_t,
+                  let id = (entry[kCGWindowNumber as String] as? NSNumber)?.uint32Value,
+                  let boundsDict = entry[kCGWindowBounds as String] as? [String: CGFloat]
+            else { return nil }
+            if let alpha = entry[kCGWindowAlpha as String] as? Double, alpha <= 0.01 { return nil }
+            return ScreenshotCapturePolicy.CaptureWindow(
+                id: id,
+                ownerPID: pid,
+                frame: CGRect(x: boundsDict["X"] ?? 0,
+                              y: boundsDict["Y"] ?? 0,
+                              width: boundsDict["Width"] ?? 0,
+                              height: boundsDict["Height"] ?? 0))
+        }
+    }
+
+    /// Draws the clicked window together with what the app stacked on it.
+    /// ScreenCaptureKit is the only route that takes more than one window, and
+    /// the source rectangle keeps the result to the area they cover instead of
+    /// the whole display. `nil` leaves the single-window routes to answer.
+    private static func captureAttached(
+        _ plan: ScreenshotCapturePolicy.AttachedCapturePlan) async -> CGImage? {
+        guard let content = try? await SCShareableContent.excludingDesktopWindows(
+            false, onScreenWindowsOnly: true)
+        else { return nil }
+        let windows = plan.windowIDs.compactMap { id in
+            content.windows.first { $0.windowID == id }
+        }
+        guard windows.count == plan.windowIDs.count,
+              let display = content.displays.first(where: { $0.frame.intersects(plan.bounds) })
+        else { return nil }
+        let filter = SCContentFilter(display: display, including: windows)
+        let configuration = SCStreamConfiguration()
+        // The source rectangle is measured from the display's own origin.
+        configuration.sourceRect = plan.bounds.offsetBy(dx: -display.frame.origin.x,
+                                                        dy: -display.frame.origin.y)
+        // The filter knows the points-to-pixels factor of the display it ends
+        // up on, which the scale taken from the display under the pointer does
+        // not when the two have different densities.
+        let pixelScale = CGFloat(filter.pointPixelScale)
+        configuration.width = max(1, Int((plan.bounds.width * pixelScale).rounded(.up)))
+        configuration.height = max(1, Int((plan.bounds.height * pixelScale).rounded(.up)))
+        configuration.showsCursor = false
+        configuration.colorSpaceName = CGColorSpace.sRGB
+        return try? await SCScreenshotManager.captureImage(contentFilter: filter,
+                                                           configuration: configuration)
     }
 
     /// The window's size as the window server knows it, used to tell a whole

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotCapturePolicy.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotCapturePolicy.swift
@@ -20,4 +20,58 @@ enum ScreenshotCapturePolicy {
         !isOwnWindow
             || (!hideVorssaintWindows && !protectedWindowIDs.contains(windowID))
     }
+
+    /// One on-screen window as the capture decision needs it.
+    struct CaptureWindow: Equatable {
+        let id: CGWindowID
+        let ownerPID: pid_t
+        let frame: CGRect
+    }
+
+    /// The windows a capture of one clicked window has to draw. The area is
+    /// the clicked window's own, so the shot stays the one that was asked for.
+    struct AttachedCapturePlan: Equatable {
+        /// The clicked window first, then what sits on it, back to front.
+        let windowIDs: [CGWindowID]
+        let bounds: CGRect
+    }
+
+    /// What a sheet, alert or modal dialog stacked on the clicked window adds
+    /// to its capture (issue #1098).
+    ///
+    /// macOS gives a sheet a window of its own, so asking the window server or
+    /// ScreenCaptureKit for the one window that was clicked returns it without
+    /// whatever the app put on top — the capture comes back showing a dialog
+    /// that is plainly on screen as missing. The relationship is not in the
+    /// window list, and the Accessibility API that does know it would put a
+    /// permission behind a feature that needs only Screen Recording, so the
+    /// shape it has instead: same application, in front of the window, and
+    /// lying entirely within it.
+    ///
+    /// Containment is what carries this, and it is deliberately strict.
+    /// Drawing a window the person did not choose is worse than leaving a
+    /// dialog out, because the shot then quietly holds something they never
+    /// selected, so anything that reaches past the clicked window's edge —
+    /// another document window, a compose window, an inspector — is left to
+    /// the ordinary capture. It also takes a sheet the full width of its
+    /// parent, which a rule about being smaller would have thrown away.
+    ///
+    /// `nil` when nothing is attached, which leaves the ordinary single-window
+    /// capture to answer.
+    static func attachedCapturePlan(target: CaptureWindow,
+                                    frontToBack: [CaptureWindow]) -> AttachedCapturePlan? {
+        guard target.frame.width > 0, target.frame.height > 0,
+              let position = frontToBack.firstIndex(where: { $0.id == target.id })
+        else { return nil }
+        let attached = frontToBack[..<position].filter { candidate in
+            candidate.ownerPID == target.ownerPID
+                && target.frame.contains(candidate.frame)
+        }
+        guard !attached.isEmpty else { return nil }
+        // Back to front, so the clicked window is drawn first and what the app
+        // stacked on it lands on top in the order it is shown.
+        let ordered = Array(attached.reversed())
+        return AttachedCapturePlan(windowIDs: [target.id] + ordered.map(\.id),
+                                   bounds: target.frame)
+    }
 }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -14423,6 +14423,65 @@ struct MetricsTests {
             protectedWindowIDs: protectedScreenshotWindows
         ), "screenshot cannot pick its own protected capture UI")
 
+        // A sheet or dialog the app stacked on the clicked window is a window
+        // of its own, so a single-window capture leaves it out of a shot it is
+        // plainly part of (issue #1098). Same app, in front, and lying wholly
+        // inside the clicked window is the shape that describes one; anything
+        // reaching past its edge is left alone, because drawing a window the
+        // person did not choose is worse than leaving a dialog out.
+        typealias CaptureWindow = ScreenshotCapturePolicy.CaptureWindow
+        let capturedWindow = CaptureWindow(
+            id: 1, ownerPID: 500, frame: CGRect(x: 100, y: 100, width: 800, height: 600))
+        let sheet = CaptureWindow(
+            id: 2, ownerPID: 500, frame: CGRect(x: 300, y: 100, width: 400, height: 300))
+        expect(ScreenshotCapturePolicy.attachedCapturePlan(
+            target: capturedWindow, frontToBack: [sheet, capturedWindow])
+            == ScreenshotCapturePolicy.AttachedCapturePlan(
+                windowIDs: [1, 2], bounds: capturedWindow.frame),
+               "a sheet on the clicked window joins its capture, the window drawn first")
+        expect(ScreenshotCapturePolicy.attachedCapturePlan(
+            target: capturedWindow, frontToBack: [capturedWindow, sheet]) == nil,
+               "a window behind the clicked one is not stacked on it")
+        let windowOfAnotherApp = CaptureWindow(
+            id: 3, ownerPID: 900, frame: CGRect(x: 300, y: 100, width: 400, height: 300))
+        expect(ScreenshotCapturePolicy.attachedCapturePlan(
+            target: capturedWindow, frontToBack: [windowOfAnotherApp, capturedWindow]) == nil,
+               "another application's window over the clicked one stays out of the shot")
+        // The case that decides the rule: a compose or second document window
+        // of the same app, in front and overlapping, but reaching past the
+        // edge. It is not what was asked for, so the ordinary capture answers.
+        let composeWindow = CaptureWindow(
+            id: 4, ownerPID: 500, frame: CGRect(x: 700, y: 300, width: 500, height: 400))
+        expect(ScreenshotCapturePolicy.attachedCapturePlan(
+            target: capturedWindow, frontToBack: [composeWindow, capturedWindow]) == nil,
+               "a same-app window reaching past the clicked window is not drawn into its shot")
+        let detachedWindow = CaptureWindow(
+            id: 5, ownerPID: 500, frame: CGRect(x: 2_000, y: 100, width: 200, height: 200))
+        expect(ScreenshotCapturePolicy.attachedCapturePlan(
+            target: capturedWindow, frontToBack: [detachedWindow, capturedWindow]) == nil,
+               "a window of the same app that does not touch the clicked one is not attached")
+        expect(ScreenshotCapturePolicy.attachedCapturePlan(
+            target: capturedWindow, frontToBack: [capturedWindow]) == nil,
+               "a window with nothing stacked on it keeps the ordinary single-window capture")
+        // A sheet is often exactly as wide as the window it drops out of, so
+        // the rule has to take one that matches an edge rather than shrink from
+        // it.
+        let fullWidthSheet = CaptureWindow(
+            id: 6, ownerPID: 500, frame: CGRect(x: 100, y: 100, width: 800, height: 200))
+        expect(ScreenshotCapturePolicy.attachedCapturePlan(
+            target: capturedWindow, frontToBack: [fullWidthSheet, capturedWindow])?.windowIDs
+            == [1, 6],
+               "a sheet the full width of its window still joins the capture")
+        // Two stacked windows are drawn in the order they are shown.
+        expect(ScreenshotCapturePolicy.attachedCapturePlan(
+            target: capturedWindow,
+            frontToBack: [sheet, fullWidthSheet, capturedWindow])?.windowIDs == [1, 6, 2],
+               "what is stacked on the window is drawn back to front")
+        // A target the list does not hold cannot have anything in front of it.
+        expect(ScreenshotCapturePolicy.attachedCapturePlan(
+            target: capturedWindow, frontToBack: [sheet]) == nil,
+               "a window missing from the list does not treat everything as stacked on it")
+
         expect(ScreenshotSupport.sanitizedDelay(5) == 5
                 && ScreenshotSupport.sanitizedDelay(7) == 0
                 && ScreenshotSupport.sanitizedDelay(-3) == 0,


### PR DESCRIPTION
Refs #1098

Draft on purpose: the reasoning and the tests are here, the hardware run is not. I have no second display and have not put the reporter's Mail dialog in front of this build, and the last section says exactly what that leaves open.

A capture of a clicked window now draws what the app has stacked on it.

macOS gives a sheet a window of its own, so both single-window routes — `WindowPreviewProvider.captureViaWindowServer` and the `SCContentFilter(desktopIndependentWindow:)` fallback — return the window without it, which is why the dialog that is plainly on screen is missing from the file. `ScreenshotCapturePolicy.attachedCapturePlan(target:frontToBack:)` decides what belongs in the shot, and `SCContentFilter(display:including:)` draws them together. Nothing attached means `nil`, and the existing fast path answers exactly as before.

**The rule, and why it is this strict.** Same application, in front of the clicked window, and lying entirely within it. The relationship is not in the window list, and the Accessibility API that does know it would put a second permission behind a feature that needs only Screen Recording, so the shape a sheet always has stands in for it.

Containment is doing the work, and the case that set it is a Mail compose window over the message viewer: same app, in front, overlapping, smaller. An earlier version of this took anything smaller in both directions and would have drawn it into the shot. Putting a window in the picture that the person did not choose is worse than leaving a dialog out of it — the file then quietly holds something they never selected, which is a privacy question rather than a fidelity one — so anything reaching past the edge is left to the ordinary capture. Containment also takes a sheet exactly as wide as its parent, which the "smaller" rule would have thrown away, and it keeps the captured area the clicked window's own frame, so the preview placement and the stored capture metadata still describe the same rectangle.

**What this gives up.** A dialog hanging over its parent's edge is not contained, so it is left out and that capture behaves as it does today. It degrades to the current behaviour rather than risking the wrong picture.

**Scope.** The screenshot path only. The recorder reaches the same defect through `RecorderCaptureEngine.filter(for:in:excluding:)`, and it is filed separately (#1147) because a live stream has to keep answering the question as sheets come and go, which a filter fixed at start time cannot — likely a different mechanism, and not something to bolt onto this. The switcher's thumbnail route is left alone, as you said.

**Tests.** Nine behaviour cases on the pure decision: a sheet joins with the window drawn first; a full-width sheet joins; two stacked windows are ordered back to front; a window behind is not attached; another app's window is not; a same-app window reaching past the edge is not; a non-touching window is not; nothing attached returns `nil`; and a target missing from the list does not treat everything as being in front of it.

**Verification.** macOS 26.6.2 (25G83), M5 Pro, single 1× display, own Developer build. `./build.sh` finishes warning-free and `./build.sh --test` passes 9096 of 9097, the exception being the pre-existing `dispatch pool starvation` check that fails on this 15-core machine and passes in CI.

**Measured, on 26.6.2.** A harness put an `NSAlert` sheet and an app-modal dialog over a window of known frame and read the window list back. Both come back as their own window, same pid, **layer 0**, ordered **in front** of their parent, and **entirely inside** it with zero overhang on every edge:

```
COMPARE role=SHEET     samePID=true layer=0 contained=true inFront=true
        child={x=626,y=438,w=260,h=138} parent={x=356,y=207,w=800,h=601}
        overhang={left=0,right=0,top=0,bottom=0}
COMPARE role=APP_MODAL samePID=true layer=0 contained=true inFront=true
        child={x=526,y=377,w=460,h=261} parent={x=356,y=207,w=800,h=601}
        overhang={left=0,right=0,top=0,bottom=0}
```

Those were the two ways this could have been a no-op: the window list is filtered to layer zero, and the rule wants strict containment. Both hold for the two kinds of window the issue is about.

**Still not verified.** The reporter's own Mail dialog, since a system-provided dialog is not guaranteed to behave like an `NSAlert`; and whether `SCContentFilter(display:including:)` draws the second window as expected, which needs Screen Recording granted to something I can watch. Multi-display is no longer on this list — the source rectangle that depended on how a display origin is read is gone, and the shot is cropped with the helpers the region capture already uses.
