### PR TITLE
chore: ignore local agent and secret files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,24 @@ AGENTS.md
 CLAUDE.md
 E2E/
 
+# Local AI agent and planning workspaces
+.agents/
+.claude/
+.serena/
+_bmad/
+_bmad-output/
+
+# Local environment and secret files
+.env
+.env.*
+!.env.example
+!.env.sample
+*.secret
+*.secrets
+secrets/
+credentials.json
+service-account*.json
+
 # macOS noise
 .DS_Store
 


### PR DESCRIPTION
## Summary

Ignore local AI-agent and planning workspaces so contributor-specific BMAD, Claude, Serena, and agent files cannot be added accidentally. Also ignore common local environment, credential, service-account, and secret-file names while keeping `.env.example` and `.env.sample` available as safe templates.

## Verification

Ran on Apple Silicon macOS with an ad-hoc release build:

```sh
./build.sh
./build/Vorssaint --selftest
./build.sh --test
gitleaks git . --redact --no-banner
gitleaks dir . --redact --no-banner
```

Results: `SELFTEST OK`, `TESTS OK (9130 checks)`, and no leaks found across 769 commits or the current working tree.

No runtime behavior changed.