### PR TITLE
Keep adaptive app icons stable in the switcher

### DIFF
--- a/Sources/Vorssaint/Services/Switcher/SwitcherModels.swift
+++ b/Sources/Vorssaint/Services/Switcher/SwitcherModels.swift
@@ -95,8 +95,13 @@ struct SwitcherItem: Identifiable, Equatable {
     /// redraws it, so the switcher stayed on the bundled icon (issue #801).
     var appIcon: NSImage? {
         guard let app = NSRunningApplication(processIdentifier: pid) else { return nil }
-        guard let bundlePath = app.bundleURL?.path else { return app.icon }
-        return NSWorkspace.shared.icon(forFile: bundlePath)
+        let icon = app.bundleURL.map { NSWorkspace.shared.icon(forFile: $0.path) } ?? app.icon
+        guard let icon else { return nil }
+        var pixels: CGImage?
+        NSApplication.shared.effectiveAppearance.performAsCurrentDrawingAppearance {
+            pixels = icon.cgImage(forProposedRect: nil, context: nil, hints: nil)
+        }
+        return pixels.map { NSImage(cgImage: $0, size: icon.size) } ?? icon
     }
 
     func withMinimized(_ minimized: Bool) -> SwitcherItem {


### PR DESCRIPTION
Fixes #1166.

## What was wrong

Before: apps with appearance-aware icons, including Postman and Slack, can flicker between their light and dark artwork while the switcher selection moves.

The switcher gets the current icon through NSWorkspace.icon(forFile:). That returns an appearance-aware NSImage. SwiftUI redraws the image while animating the selected tile, so the same icon can resolve another appearance during the transition.

## The change

After: adaptive icons keep the appearance Vorssaint resolved when the switcher drew them.

The existing fresh bundle lookup from #811 remains unchanged in behavior. The switcher resolves that image under the effective appearance reported by Vorssaint and wraps its CGImage pixels in a non-adaptive NSImage before SwiftUI animates it. No cache or view-specific workaround was added. One file, +7/-2.

## Verification

./build.sh completes successfully and ./build/Vorssaint --selftest prints SELFTEST OK.

A deterministic AppKit probe confirmed the failure and fix: an adaptive NSImage changed artwork between Aqua and Dark Aqua redraws, while the CGImage snapshot kept the originally resolved artwork under both appearances.