### PR TITLE
fix(uninstall): restore sleep instead of assuming it was restored

### DIFF
--- a/Sources/Vorssaint/Services/SelfUninstall.swift
+++ b/Sources/Vorssaint/Services/SelfUninstall.swift
@@ -101,15 +101,38 @@ enum SelfUninstall {
 
     private static func detachFromSystem() {
         FanControlService.restoreAndUnregisterForRemoval()
-        // Restore normal sleep if a closed-lid session left it disabled.
         if UserDefaults.standard.bool(forKey: DefaultsKey.sleepDisabledFlag) {
-            _ = Sudoers.pmsetDisableSleep(false)
+            restoreSleepBeforeRemoval()
         }
         // Unregister the login item (scoped to our bundle id). The stored
         // intent goes with it, or the startup repair would quietly register
         // the item again after the user asked for a clean detach.
         UserDefaults.standard.set(false, forKey: DefaultsKey.launchAtLoginWanted)
         try? SMAppService.mainApp.unregister()
+    }
+
+    /// Puts normal sleep back before the app goes.
+    ///
+    /// `KeepAwakeManager` is allowed to give up on a failed revert when the app
+    /// is merely quitting, because "the next start repairs a revert that was
+    /// missed". Removal is the one exit with no next start, and the flag that
+    /// would trigger that repair is deleted with the rest of the preferences a
+    /// moment later — so a reinstall does not fix it either, since recovery
+    /// reads the flag before it reads the setting. This is the last chance
+    /// anything has, which is why it may ask for the password the launch-time
+    /// recovery would have asked for.
+    private static func restoreSleepBeforeRemoval() {
+        // The flag can outlive the setting, so a stale one must not put a
+        // password dialog in front of someone uninstalling. Only a reading that
+        // answered, and answered "off", is allowed to skip the rest: a probe
+        // that failed says nothing. Going on then costs a no-op call, and a
+        // dialog only if that call fails too — the case where sleep really may
+        // still be off with nothing else left to put it back.
+        let probe = Shell.run("/usr/bin/pmset", ["-g"])
+        if probe.status == 0, !SudoersSupport.sleepDisabled(inPmsetOutput: probe.output) { return }
+        if Sudoers.pmsetDisableSleep(false) { return }
+        _ = AdminShell.runSync("pmset disablesleep 0",
+                               prompt: L10n.shared.s.adminPromptRecover)
     }
 
     private static func removeSudoersRuleIfPresent(then: @escaping () -> Void) {

--- a/Sources/Vorssaint/Support/Uninstaller.swift
+++ b/Sources/Vorssaint/Support/Uninstaller.swift
@@ -20,8 +20,21 @@ enum Uninstaller {
         print(detached
               ? "UNINSTALL: fan helper daemon unregistered"
               : "UNINSTALL: fan helper daemon still registered")
+        // This runs before `NSApplication.shared` exists, so the password
+        // dialog the in-app uninstall falls back to is not available here: it
+        // brings the app forward through `NSApp`, which is still nil. Reporting
+        // is all this path can do, and `Tools/uninstall.sh` reads the setting
+        // back itself rather than trusting the line below.
         if UserDefaults.standard.bool(forKey: DefaultsKey.sleepDisabledFlag) {
-            _ = Sudoers.pmsetDisableSleep(false)
+            // A probe that did not answer proves nothing. Only a reading
+            // that came back, and came back off, clears the restore.
+            let probe = Shell.run("/usr/bin/pmset", ["-g"])
+            let restored = Sudoers.pmsetDisableSleep(false)
+                || (probe.status == 0
+                    && !SudoersSupport.sleepDisabled(inPmsetOutput: probe.output))
+            print(restored
+                  ? "UNINSTALL: normal sleep restored"
+                  : "UNINSTALL: sleep is still disabled")
         }
         do {
             try SMAppService.mainApp.unregister()
@@ -30,8 +43,9 @@ enum Uninstaller {
             print("UNINSTALL: login item was not registered")
         }
         // Only the daemon decides the status. A login item that was never
-        // registered is not a failure; a daemon left behind is the one thing
-        // the caller cannot see for itself.
+        // registered is not a failure, and sleep is a setting the caller can
+        // read back for itself; a daemon left behind is the one thing it
+        // cannot.
         exit(detached ? EXIT_SUCCESS : EXIT_FAILURE)
     }
 }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -20586,6 +20586,22 @@ struct MetricsTests {
         }
         expect(uninstallScriptSource.contains("Library/Preferences/ByHost"),
                "script uninstall sweeps ByHost preferences")
+        // Restoring sleep used to be fired and forgotten at both exits. A
+        // failure there leaves `pmset disablesleep 1` set system-wide, and
+        // removal deletes the flag that launch-time recovery reads before it
+        // reads the setting, so nothing repairs it afterwards — a reinstall
+        // included.
+        let uninstallerSource = (try? String(contentsOfFile: "Sources/Vorssaint/Support/Uninstaller.swift",
+                                             encoding: .utf8)) ?? ""
+        expect(!uninstallerSource.isEmpty,
+               "uninstaller entry point reads back for the sleep restore check")
+        expect(!selfUninstallSource.contains("_ = Sudoers.pmsetDisableSleep")
+                && !uninstallerSource.contains("_ = Sudoers.pmsetDisableSleep"),
+               "neither uninstall path discards the result of restoring sleep")
+        expect(selfUninstallSource.contains("adminPromptRecover"),
+               "in-app uninstall escalates a failed sleep restore to the password prompt")
+        expect(uninstallScriptSource.contains("SleepDisabled"),
+               "script uninstall reads the sleep setting back for itself")
 
         // MARK: Detached command reruns (counted last, so a late rerun still fails)
         // The `||` form reran the whole installer — as root — on every non-zero

--- a/Tools/uninstall.sh
+++ b/Tools/uninstall.sh
@@ -44,6 +44,13 @@ if (( detached )); then
     (( $? == 113 )) && detached=0
 fi
 
+# Whether the closed-lid feature is the reason sleep is off. Read here because
+# the preferences that hold it are deleted a few lines below, and without it a
+# check on the setting alone would blame Vorssaint for a `pmset disablesleep 1`
+# that somebody else, or the user, had set.
+sleep_was_ours=0
+[[ "$(defaults read "$BUNDLE" vorssDisabledSleep 2>/dev/null)" == "1" ]] && sleep_was_ours=1
+
 echo "▸ Resetting permissions (Accessibility, Screen Recording)…"
 tccutil reset All "$BUNDLE" >/dev/null 2>&1 || true
 
@@ -70,10 +77,42 @@ if ls $RULES >/dev/null 2>&1; then
     osascript -e "do shell script \"rm -f $RULES\" with administrator privileges with prompt \"Vorssaint uninstaller\"" || true
 fi
 
-if (( detached == 0 )); then
+# `--uninstall` restores sleep, but it runs before the app has an
+# NSApplication and so cannot raise the password dialog the in-app uninstall
+# falls back to. A restore that needed one therefore reaches here as a setting
+# still switched on. `pmset -g` reads it without sudo, and this is the only
+# warning anyone will get: the app that knew the setting was its doing has
+# just been removed.
+sleep_stuck=0
+sleep_unknown=0
+if (( sleep_was_ours )); then
+    sleep_state="$(pmset -g 2>/dev/null | awk '/SleepDisabled/ { print $2 }')"
+    # "0" is the only answer that proves sleep came back, and "1" the only one
+    # that proves it did not. Anything else is pmset not answering: it must not
+    # pass as success, and it must not be reported as a failed restore either.
+    if [[ "$sleep_state" == "1" ]]; then
+        sleep_stuck=1
+    elif [[ "$sleep_state" != "0" ]]; then
+        sleep_unknown=1
+    fi
+fi
+
+if (( detached == 0 && sleep_stuck == 0 && sleep_unknown == 0 )); then
     echo "✓ Vorssaint fully removed."
-else
+    exit 0
+fi
+if (( detached )); then
     echo "⚠ Vorssaint removed, but its fan helper is still registered with the system." >&2
     echo "  Reinstall Vorssaint, then use Settings › Advanced to uninstall from inside the app." >&2
-    exit 1
 fi
+if (( sleep_stuck )); then
+    echo "⚠ Vorssaint removed, but this Mac still has sleep switched off." >&2
+    echo "  Closed-lid mode disabled it, and restoring it needed a password this script could not ask for." >&2
+    echo "  Put it back with: sudo pmset disablesleep 0" >&2
+fi
+if (( sleep_unknown )); then
+    echo "⚠ Vorssaint removed, but whether sleep came back could not be read." >&2
+    echo "  Closed-lid mode had switched it off. Check with: pmset -g | grep SleepDisabled" >&2
+    echo "  If that reads 1, put it back with: sudo pmset disablesleep 0" >&2
+fi
+exit 1


### PR DESCRIPTION
Refs #1173

Both uninstall paths discarded the result of restoring sleep, so a failure left
`pmset disablesleep 1` set system-wide with nothing able to repair it — the
launch-time recovery reads `sleepDisabledFlag`, and removal deletes it.

**In-app** (`SelfUninstall`) now does what `KeepAwakeManager.recoverIfNeeded`
does when it finds the same thing: reads the setting, tries the password-free
path, and falls back to the password prompt.

**`--uninstall`** cannot do that. It runs before `NSApplication.shared` exists,
and the prompt brings the app forward through `NSApp`, which is still nil there
— so it reports instead of asking.

**`Tools/uninstall.sh`** reads the setting back itself rather than trusting that
line, the same way it already confirms the daemon with `launchctl` rather than
trusting an exit code.

## Three answers, not two

Every new check here separates "proved fine" from "proved broken" from "could
not tell", because collapsing the third into either of the others is how the
original bug read as success:

- The script treats `0` as the only proof sleep came back and `1` as the only
  proof it did not. Anything else is `pmset` not answering, and gets its own
  warning that does not claim a cause it has not established.
- `Uninstaller` clears the restore only on a probe that actually returned.
- `SelfUninstall` skips the rest only on a probe that returned *and* said off.
  A probe that failed carries on: a no-op call at worst, and a dialog only if
  that call fails too, which is the case where sleep really may still be off.

It also reads Vorssaint's own flag *before* deleting the preferences that hold
it, so a warning fires only when closed-lid mode is actually the reason. A
`pmset disablesleep 1` the user or another app set is not Vorssaint's to claim.
When something does fire, the script no longer says "fully removed" and names
the command that puts it back.

Four assertions added to the existing uninstall-alignment block, including a
guard that neither path goes back to discarding the result.

## Checked

- `./build.sh --test` — 9157 assertions, one failure, the dispatch pool
  starvation precondition from #1172. It fails the same way on clean `main` on
  this Mac and is unrelated to this change.
- The failing call, end to end, with the sudoers rule backed up, removed and
  restored around it: `pmsetDisableSleep(false)` returns false (exit 1) while
  `SleepDisabled` stays 1. `Sudoers.pmsetDisableSleep(false)` is exactly that
  shell call and its exit status.
- Every branch of the new script logic against real values: the flag as written
  by Swift (`defaults read` gives `1`), and the `pmset -g` reading at `0`, at
  `1`, and unreadable.
- `zsh -n Tools/uninstall.sh`.

## Not checked, and worth saying

I did not run a real uninstall on my own installation, so the new code has not
been observed inside a live removal — only the call it turns on, and the script
logic in isolation. Same gap I flagged in #991.

Three things I decided rather than discovered, all easy to reverse:

- The in-app fallback reuses `adminPromptRecover` ("Vorssaint quit while the
  Mac's sleep was disabled…") rather than adding a string in 13 languages. The
  meaning fits; the word "quit" is not exactly what is happening. Happy to add
  a dedicated string if you would rather have one.
- If the password-free path is broken *and* rule files are still present, the
  in-app uninstall can now show two password dialogs: one to restore sleep, one
  to remove the rule. They cannot be merged, because the rule-removal prompt is
  skipped exactly when the rule is missing, which is the usual reason the first
  one was needed.
- If someone dismisses that dialog, the in-app path carries on and removes the
  app with sleep still off, and has no window left to say so. The script path
  warns; this one cannot. Worth a second opinion.

The exit status of `--uninstall` still depends only on the daemon. Sleep is
something the caller can read back for itself, so it did not need to change.
