### PR TITLE
fix(recorder): keep a clicked window's sheets and dialogs in the recording

### DIFF
--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotSelectionController.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotSelectionController.swift
@@ -346,8 +346,7 @@ final class ScreenshotSelectionController {
     /// anchored to it. The point rectangle is derived from the SNAPPED pixels,
     /// so what gets recorded and what the person was shown never disagree.
     private func region(fromView viewRect: CGRect,
-                        on panel: ScreenshotOverlayPanel,
-                        windowID: CGWindowID?) -> RecorderSupport.Region {
+                        on panel: ScreenshotOverlayPanel) -> RecorderSupport.Region {
         let displayPixels = CGRect(origin: .zero, size: panel.pixelSize)
         let raw = ScreenshotSupport.imagePixelRect(fromView: viewRect,
                                                    viewSize: panel.screenFrame.size,
@@ -360,7 +359,6 @@ final class ScreenshotSelectionController {
                                  height: snapped.height / scale)
         return RecorderSupport.Region(
             displayID: panel.displayID,
-            windowID: windowID,
             pixelRect: snapped,
             anchorRect: ScreenshotSupport.cocoaRect(fromFlippedView: snappedView,
                                                     screenFrame: panel.screenFrame),
@@ -373,11 +371,11 @@ final class ScreenshotSelectionController {
         markCapturePending()
         Self.lastRegion = (panel.displayID, viewRect)
         if activeMode == .geometry {
-            finish(.region(region(fromView: viewRect, on: panel, windowID: nil)))
+            finish(.region(region(fromView: viewRect, on: panel)))
             return
         }
         if scrollingCaptureEnabled {
-            finish(.scrollingRegion(region(fromView: viewRect, on: panel, windowID: nil)))
+            finish(.scrollingRegion(region(fromView: viewRect, on: panel)))
             return
         }
         let pixelRect = ScreenshotSupport.imagePixelRect(
@@ -411,11 +409,11 @@ final class ScreenshotSelectionController {
         guard activeMode != .color else { return }
         markCapturePending()
         if activeMode == .geometry {
-            finish(.region(region(fromView: frame, on: panel, windowID: windowID)))
+            finish(.region(region(fromView: frame, on: panel)))
             return
         }
         if scrollingCaptureEnabled {
-            finish(.scrollingRegion(region(fromView: frame, on: panel, windowID: windowID)))
+            finish(.scrollingRegion(region(fromView: frame, on: panel)))
             return
         }
         Task { @MainActor [weak self] in
@@ -440,7 +438,7 @@ final class ScreenshotSelectionController {
         markCapturePending()
         if activeMode == .geometry {
             let whole = CGRect(origin: .zero, size: panel.screenFrame.size)
-            finish(.region(region(fromView: whole, on: panel, windowID: nil)))
+            finish(.region(region(fromView: whole, on: panel)))
             return
         }
         if let frozen = panel.frozenImage {

--- a/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
@@ -217,17 +217,12 @@ final class RecorderCaptureEngine: NSObject {
                                   mode: mode)
         case .displayRegion:
             guard let display else { return nil }
+            // The fixed display rectangle records the current Space, so a Space
+            // switch records what replaces the window there, matching the
+            // fixed-rectangle contract assumed by the pointer track.
             let excluded = Set(windowNumbers.map { CGWindowID($0) })
             let ownPID = NSRunningApplication.current.processIdentifier
             let ownWindows = content.windows.filter { $0.owningApplication?.processID == ownPID }
-            if window != nil {
-                let protectedWindows = ownWindows.filter { excluded.contains($0.windowID) }
-                return PreparedFilter(
-                    content: SCContentFilter(display: display,
-                                             excludingWindows: protectedWindows),
-                    mode: mode)
-            }
-
             guard let ownApplication = content.applications.first(where: { $0.processID == ownPID })
                     ?? ownWindows.compactMap(\.owningApplication).first else { return nil }
             let exceptedIDs = RecorderSupport.exceptedOwnWindowIDs(

--- a/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
@@ -82,11 +82,11 @@ final class RecorderCaptureEngine: NSObject {
         // Keep the call and optional binding as separate type-checking targets.
         // Older Swift compilers otherwise crash in their constraint walker when
         // this expression sits inside the larger async start routine.
-        let preparedFilter: PreparedFilter? = Self.filter(
+        let preparedFilter: SCContentFilter? = Self.filter(
             for: region,
             in: content,
             excluding: excludedWindowNumbers)
-        guard let preparedFilter else { return .noContent }
+        guard let filter = preparedFilter else { return .noContent }
 
         let configuration = SCStreamConfiguration()
         configuration.width = Int(region.pixelRect.width)
@@ -95,9 +95,9 @@ final class RecorderCaptureEngine: NSObject {
                                                     timescale: CMTimeScale(frameRate))
         configuration.pixelFormat = kCVPixelFormatType_32BGRA
         configuration.colorSpaceName = CGColorSpace.sRGB
-        // The straddling-window fallback keeps the output dimensions chosen
-        // when recording starts as that window's buffer changes size.
-        configuration.scalesToFit = preparedFilter.mode == .independentWindow
+        // The recorded rectangle is fixed and the source rect matches the
+        // output size, so there is nothing to scale into the frame.
+        configuration.scalesToFit = false
         configuration.preservesAspectRatio = true
         configuration.captureResolution = .best
         // The pointer is drawn by us afterwards, from the track the sampler
@@ -109,9 +109,7 @@ final class RecorderCaptureEngine: NSObject {
         // they would be baked into the frame the background is drawn behind.
         configuration.ignoreShadowsDisplay = true
         configuration.ignoreShadowsSingleWindow = true
-        if preparedFilter.mode == .displayRegion {
-            configuration.sourceRect = Self.sourceRect(for: region)
-        }
+        configuration.sourceRect = Self.sourceRect(for: region)
         if capturesSystemAudio {
             configuration.capturesAudio = true
             configuration.sampleRate = 48_000
@@ -120,9 +118,7 @@ final class RecorderCaptureEngine: NSObject {
             configuration.excludesCurrentProcessAudio = true
         }
 
-        let stream = SCStream(filter: preparedFilter.content,
-                              configuration: configuration,
-                              delegate: self)
+        let stream = SCStream(filter: filter, configuration: configuration, delegate: self)
         do {
             try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: queue)
             if capturesSystemAudio {
@@ -193,53 +189,28 @@ final class RecorderCaptureEngine: NSObject {
 
     // MARK: - Filter
 
-    private struct PreparedFilter {
-        let content: SCContentFilter
-        let mode: RecorderSupport.CaptureFilterMode
-    }
-
     private static func filter(for region: RecorderSupport.Region,
                                in content: SCShareableContent,
-                               excluding windowNumbers: [Int]) -> PreparedFilter? {
-        let window = region.windowID.flatMap { windowID in
-            content.windows.first(where: { $0.windowID == windowID })
-        }
-        let display = content.displays.first(where: { $0.displayID == region.displayID })
-        // The mode is judged in Cocoa space at both call sites, so the guide and the filter cannot disagree about which mode applies.
-        let mode = RecorderSupport.captureFilterMode(
-            clickedWindowID: region.windowID,
-            selectionFrame: region.anchorRect,
-            displayFrame: NSScreen.screens.first { $0.displayID == region.displayID }?.frame)
-
-        switch mode {
-        case .independentWindow:
-            guard let window else {
-                // A window gone by the time the stream starts records its display, as main did.
-                fallthrough
-            }
-            return PreparedFilter(content: SCContentFilter(desktopIndependentWindow: window),
-                                  mode: mode)
-        case .displayRegion:
-            guard let display else { return nil }
-            // The fixed display rectangle records the current Space, so a Space
-            // switch records what replaces the window there, matching the
-            // fixed-rectangle contract assumed by the pointer track.
-            let excluded = Set(windowNumbers.map { CGWindowID($0) })
-            let ownPID = NSRunningApplication.current.processIdentifier
-            let ownWindows = content.windows.filter { $0.owningApplication?.processID == ownPID }
-            guard let ownApplication = content.applications.first(where: { $0.processID == ownPID })
-                    ?? ownWindows.compactMap(\.owningApplication).first else { return nil }
-            let exceptedIDs = RecorderSupport.exceptedOwnWindowIDs(
-                ownWindowIDs: Set(ownWindows.map(\.windowID)),
-                protectedWindowIDs: excluded
-            )
-            let ordinaryWindows = ownWindows.filter { exceptedIDs.contains($0.windowID) }
-            return PreparedFilter(
-                content: SCContentFilter(display: display,
-                                         excludingApplications: [ownApplication],
-                                         exceptingWindows: ordinaryWindows),
-                mode: .displayRegion)
-        }
+                               excluding windowNumbers: [Int]) -> SCContentFilter? {
+        guard let display = content.displays.first(where: { $0.displayID == region.displayID })
+        else { return nil }
+        // Every recording is a fixed rectangle of its display, so what the app
+        // stacks inside it is captured without anything to track. The rectangle
+        // records the current Space, so a Space switch records what replaces
+        // the window there.
+        let excluded = Set(windowNumbers.map { CGWindowID($0) })
+        let ownPID = NSRunningApplication.current.processIdentifier
+        let ownWindows = content.windows.filter { $0.owningApplication?.processID == ownPID }
+        guard let ownApplication = content.applications.first(where: { $0.processID == ownPID })
+                ?? ownWindows.compactMap(\.owningApplication).first else { return nil }
+        let exceptedIDs = RecorderSupport.exceptedOwnWindowIDs(
+            ownWindowIDs: Set(ownWindows.map(\.windowID)),
+            protectedWindowIDs: excluded
+        )
+        let ordinaryWindows = ownWindows.filter { exceptedIDs.contains($0.windowID) }
+        return SCContentFilter(display: display,
+                               excludingApplications: [ownApplication],
+                               exceptingWindows: ordinaryWindows)
     }
 
     /// The recorded area inside the display, in points with a top-left origin,

--- a/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
@@ -207,7 +207,7 @@ final class RecorderCaptureEngine: NSObject {
         let display = content.displays.first(where: { $0.displayID == region.displayID })
         let mode = RecorderSupport.captureFilterMode(
             clickedWindowID: region.windowID,
-            windowFrame: window?.frame,
+            selectionFrame: region.anchorRect,
             displayFrame: display?.frame)
 
         switch mode {

--- a/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
@@ -205,14 +205,18 @@ final class RecorderCaptureEngine: NSObject {
             content.windows.first(where: { $0.windowID == windowID })
         }
         let display = content.displays.first(where: { $0.displayID == region.displayID })
+        // The mode is judged in Cocoa space at both call sites, so the guide and the filter cannot disagree about which mode applies.
         let mode = RecorderSupport.captureFilterMode(
             clickedWindowID: region.windowID,
             selectionFrame: region.anchorRect,
-            displayFrame: display?.frame)
+            displayFrame: NSScreen.screens.first { $0.displayID == region.displayID }?.frame)
 
         switch mode {
         case .independentWindow:
-            guard let window else { return nil }
+            guard let window else {
+                // A window gone by the time the stream starts records its display, as main did.
+                fallthrough
+            }
             return PreparedFilter(content: SCContentFilter(desktopIndependentWindow: window),
                                   mode: mode)
         case .displayRegion:
@@ -234,7 +238,7 @@ final class RecorderCaptureEngine: NSObject {
                 content: SCContentFilter(display: display,
                                          excludingApplications: [ownApplication],
                                          exceptingWindows: ordinaryWindows),
-                mode: mode)
+                mode: .displayRegion)
         }
     }
 

--- a/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
@@ -82,11 +82,11 @@ final class RecorderCaptureEngine: NSObject {
         // Keep the call and optional binding as separate type-checking targets.
         // Older Swift compilers otherwise crash in their constraint walker when
         // this expression sits inside the larger async start routine.
-        let preparedFilter: SCContentFilter? = Self.filter(
+        let preparedFilter: PreparedFilter? = Self.filter(
             for: region,
             in: content,
             excluding: excludedWindowNumbers)
-        guard let filter = preparedFilter else { return .noContent }
+        guard let preparedFilter else { return .noContent }
 
         let configuration = SCStreamConfiguration()
         configuration.width = Int(region.pixelRect.width)
@@ -95,10 +95,9 @@ final class RecorderCaptureEngine: NSObject {
                                                     timescale: CMTimeScale(frameRate))
         configuration.pixelFormat = kCVPixelFormatType_32BGRA
         configuration.colorSpaceName = CGColorSpace.sRGB
-        // An independent window keeps the output dimensions chosen when the
-        // recording starts. Scaling it into that output makes later window
-        // resizes follow the recording instead of leaving an empty frame.
-        configuration.scalesToFit = region.windowID != nil
+        // The straddling-window fallback keeps the output dimensions chosen
+        // when recording starts as that window's buffer changes size.
+        configuration.scalesToFit = preparedFilter.mode == .independentWindow
         configuration.preservesAspectRatio = true
         configuration.captureResolution = .best
         // The pointer is drawn by us afterwards, from the track the sampler
@@ -110,7 +109,7 @@ final class RecorderCaptureEngine: NSObject {
         // they would be baked into the frame the background is drawn behind.
         configuration.ignoreShadowsDisplay = true
         configuration.ignoreShadowsSingleWindow = true
-        if region.windowID == nil {
+        if preparedFilter.mode == .displayRegion {
             configuration.sourceRect = Self.sourceRect(for: region)
         }
         if capturesSystemAudio {
@@ -121,7 +120,9 @@ final class RecorderCaptureEngine: NSObject {
             configuration.excludesCurrentProcessAudio = true
         }
 
-        let stream = SCStream(filter: filter, configuration: configuration, delegate: self)
+        let stream = SCStream(filter: preparedFilter.content,
+                              configuration: configuration,
+                              delegate: self)
         do {
             try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: queue)
             if capturesSystemAudio {
@@ -192,28 +193,54 @@ final class RecorderCaptureEngine: NSObject {
 
     // MARK: - Filter
 
+    private struct PreparedFilter {
+        let content: SCContentFilter
+        let mode: RecorderSupport.CaptureFilterMode
+    }
+
     private static func filter(for region: RecorderSupport.Region,
                                in content: SCShareableContent,
-                               excluding windowNumbers: [Int]) -> SCContentFilter? {
-        if let windowID = region.windowID,
-           let window = content.windows.first(where: { $0.windowID == windowID }) {
-            return SCContentFilter(desktopIndependentWindow: window)
+                               excluding windowNumbers: [Int]) -> PreparedFilter? {
+        let window = region.windowID.flatMap { windowID in
+            content.windows.first(where: { $0.windowID == windowID })
         }
-        guard let display = content.displays.first(where: { $0.displayID == region.displayID })
-        else { return nil }
-        let excluded = Set(windowNumbers.map { CGWindowID($0) })
-        let ownPID = NSRunningApplication.current.processIdentifier
-        let ownWindows = content.windows.filter { $0.owningApplication?.processID == ownPID }
-        guard let ownApplication = content.applications.first(where: { $0.processID == ownPID })
-                ?? ownWindows.compactMap(\.owningApplication).first else { return nil }
-        let exceptedIDs = RecorderSupport.exceptedOwnWindowIDs(
-            ownWindowIDs: Set(ownWindows.map(\.windowID)),
-            protectedWindowIDs: excluded
-        )
-        let ordinaryWindows = ownWindows.filter { exceptedIDs.contains($0.windowID) }
-        return SCContentFilter(display: display,
-                               excludingApplications: [ownApplication],
-                               exceptingWindows: ordinaryWindows)
+        let display = content.displays.first(where: { $0.displayID == region.displayID })
+        let mode = RecorderSupport.captureFilterMode(
+            clickedWindowID: region.windowID,
+            windowFrame: window?.frame,
+            displayFrame: display?.frame)
+
+        switch mode {
+        case .independentWindow:
+            guard let window else { return nil }
+            return PreparedFilter(content: SCContentFilter(desktopIndependentWindow: window),
+                                  mode: mode)
+        case .displayRegion:
+            guard let display else { return nil }
+            let excluded = Set(windowNumbers.map { CGWindowID($0) })
+            let ownPID = NSRunningApplication.current.processIdentifier
+            let ownWindows = content.windows.filter { $0.owningApplication?.processID == ownPID }
+            if window != nil {
+                let protectedWindows = ownWindows.filter { excluded.contains($0.windowID) }
+                return PreparedFilter(
+                    content: SCContentFilter(display: display,
+                                             excludingWindows: protectedWindows),
+                    mode: mode)
+            }
+
+            guard let ownApplication = content.applications.first(where: { $0.processID == ownPID })
+                    ?? ownWindows.compactMap(\.owningApplication).first else { return nil }
+            let exceptedIDs = RecorderSupport.exceptedOwnWindowIDs(
+                ownWindowIDs: Set(ownWindows.map(\.windowID)),
+                protectedWindowIDs: excluded
+            )
+            let ordinaryWindows = ownWindows.filter { exceptedIDs.contains($0.windowID) }
+            return PreparedFilter(
+                content: SCContentFilter(display: display,
+                                         excludingApplications: [ownApplication],
+                                         exceptingWindows: ordinaryWindows),
+                mode: mode)
+        }
     }
 
     /// The recorded area inside the display, in points with a top-left origin,

--- a/Sources/Vorssaint/Services/Recorder/RecorderIndicator.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderIndicator.swift
@@ -37,7 +37,7 @@ final class RecorderIndicator {
     /// Keeps the chosen area visible without trapping clicks. The panel is
     /// app-owned capture chrome, so the recorder leaves it out of the video.
     func showRegionGuide(for region: RecorderSupport.Region) {
-        guard regionGuide == nil, region.windowID == nil,
+        guard regionGuide == nil,
               let screen = NSScreen.screens.first(where: { $0.displayID == region.displayID })
         else { return }
 

--- a/Sources/Vorssaint/Services/Recorder/RecorderSupport.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderSupport.swift
@@ -230,13 +230,28 @@ enum RecorderSupport {
         ownWindowIDs.subtracting(protectedWindowIDs)
     }
 
+    enum CaptureFilterMode: Equatable {
+        case displayRegion
+        case independentWindow
+    }
+
+    static func captureFilterMode(clickedWindowID: CGWindowID?,
+                                  windowFrame: CGRect?,
+                                  displayFrame: CGRect?) -> CaptureFilterMode {
+        guard clickedWindowID != nil, let windowFrame else { return .displayRegion }
+        guard windowFrame.width > 0, windowFrame.height > 0,
+              let displayFrame, displayFrame.contains(windowFrame)
+        else { return .independentWindow }
+        return .displayRegion
+    }
+
     /// The area a recording covers, resolved once when the person confirms it
     /// and never recomputed: a window that moves keeps recording the region it
     /// was picked in, which is what the pointer track and the zoom assume.
     struct Region: Equatable {
         let displayID: CGDirectDisplayID
-        /// Set only when a window was clicked, so the stream can follow that
-        /// window's own buffer instead of a slice of the display.
+        /// Set only when a window was clicked, so its display bounds can be
+        /// recorded unless the window crosses a display edge.
         let windowID: CGWindowID?
         /// Top-left origin, in the display's pixels, already even on both axes.
         let pixelRect: CGRect

--- a/Sources/Vorssaint/Services/Recorder/RecorderSupport.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderSupport.swift
@@ -236,11 +236,11 @@ enum RecorderSupport {
     }
 
     static func captureFilterMode(clickedWindowID: CGWindowID?,
-                                  windowFrame: CGRect?,
+                                  selectionFrame: CGRect?,
                                   displayFrame: CGRect?) -> CaptureFilterMode {
-        guard clickedWindowID != nil, let windowFrame else { return .displayRegion }
-        guard windowFrame.width > 0, windowFrame.height > 0,
-              let displayFrame, displayFrame.contains(windowFrame)
+        guard clickedWindowID != nil, let selectionFrame else { return .displayRegion }
+        guard selectionFrame.width > 0, selectionFrame.height > 0,
+              let displayFrame, displayFrame.contains(selectionFrame)
         else { return .independentWindow }
         return .displayRegion
     }

--- a/Sources/Vorssaint/Services/Recorder/RecorderSupport.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderSupport.swift
@@ -230,29 +230,15 @@ enum RecorderSupport {
         ownWindowIDs.subtracting(protectedWindowIDs)
     }
 
-    enum CaptureFilterMode: Equatable {
-        case displayRegion
-        case independentWindow
-    }
-
-    static func captureFilterMode(clickedWindowID: CGWindowID?,
-                                  selectionFrame: CGRect?,
-                                  displayFrame: CGRect?) -> CaptureFilterMode {
-        guard clickedWindowID != nil, let selectionFrame else { return .displayRegion }
-        guard selectionFrame.width > 0, selectionFrame.height > 0,
-              let displayFrame, displayFrame.contains(selectionFrame)
-        else { return .independentWindow }
-        return .displayRegion
-    }
-
     /// The area a recording covers, resolved once when the person confirms it
     /// and never recomputed: a window that moves keeps recording the region it
     /// was picked in, which is what the pointer track and the zoom assume.
+    ///
+    /// A clicked window becomes the rectangle it occupied on the display it was
+    /// picked from. The selection is already clipped to that display, so a
+    /// window spanning two displays records the part on the selected one.
     struct Region: Equatable {
         let displayID: CGDirectDisplayID
-        /// Set only when a window was clicked, so its display bounds can be
-        /// recorded unless the window crosses a display edge.
-        let windowID: CGWindowID?
         /// Top-left origin, in the display's pixels, already even on both axes.
         let pixelRect: CGRect
         /// The same area in Cocoa global points, for anchoring panels to it.

--- a/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
+++ b/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
@@ -305,13 +305,7 @@ final class ScreenRecorderService: ObservableObject {
         let indicator = RecorderIndicator(
             onPause: { [weak self] in self?.togglePause() },
             onStop: { [weak self] in self?.stop() })
-        let filterMode = RecorderSupport.captureFilterMode(
-            clickedWindowID: region.windowID,
-            selectionFrame: region.anchorRect,
-            displayFrame: NSScreen.screens.first { $0.displayID == region.displayID }?.frame)
-        if filterMode == .displayRegion {
-            indicator.showRegionGuide(for: region)
-        }
+        indicator.showRegionGuide(for: region)
         self.indicator = indicator
         pendingStartGeneration &+= 1
         let generation = pendingStartGeneration

--- a/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
+++ b/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
@@ -305,7 +305,14 @@ final class ScreenRecorderService: ObservableObject {
         let indicator = RecorderIndicator(
             onPause: { [weak self] in self?.togglePause() },
             onStop: { [weak self] in self?.stop() })
-        indicator.showRegionGuide(for: region)
+        let screen = NSScreen.screens.first { $0.displayID == region.displayID }
+        let filterMode = RecorderSupport.captureFilterMode(
+            clickedWindowID: region.windowID,
+            selectionFrame: region.anchorRect,
+            displayFrame: screen?.frame)
+        if filterMode == .displayRegion {
+            indicator.showRegionGuide(for: region)
+        }
         self.indicator = indicator
         pendingStartGeneration &+= 1
         let generation = pendingStartGeneration

--- a/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
+++ b/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
@@ -305,11 +305,10 @@ final class ScreenRecorderService: ObservableObject {
         let indicator = RecorderIndicator(
             onPause: { [weak self] in self?.togglePause() },
             onStop: { [weak self] in self?.stop() })
-        let screen = NSScreen.screens.first { $0.displayID == region.displayID }
         let filterMode = RecorderSupport.captureFilterMode(
             clickedWindowID: region.windowID,
             selectionFrame: region.anchorRect,
-            displayFrame: screen?.frame)
+            displayFrame: NSScreen.screens.first { $0.displayID == region.displayID }?.frame)
         if filterMode == .displayRegion {
             indicator.showRegionGuide(for: region)
         }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -19036,27 +19036,27 @@ struct MetricsTests {
         let containedRecorderWindow = CGRect(x: 120, y: 80, width: 800, height: 600)
         expect(RecorderSupport.captureFilterMode(
             clickedWindowID: nil,
-            windowFrame: nil,
+            selectionFrame: nil,
             displayFrame: recorderDisplayFrame) == .displayRegion,
                "a drawn recording region keeps the ordinary display filter")
         expect(RecorderSupport.captureFilterMode(
             clickedWindowID: 7,
-            windowFrame: containedRecorderWindow,
+            selectionFrame: containedRecorderWindow,
             displayFrame: recorderDisplayFrame) == .displayRegion,
                "a clicked window inside one display records its bounds from that display")
         expect(RecorderSupport.captureFilterMode(
             clickedWindowID: 7,
-            windowFrame: CGRect(x: 1_200, y: 80, width: 800, height: 600),
+            selectionFrame: CGRect(x: 1_200, y: 80, width: 800, height: 600),
             displayFrame: recorderDisplayFrame) == .independentWindow,
                "a clicked window crossing a display edge keeps independent-window capture")
         expect(RecorderSupport.captureFilterMode(
             clickedWindowID: 7,
-            windowFrame: containedRecorderWindow,
+            selectionFrame: containedRecorderWindow,
             displayFrame: nil) == .independentWindow,
                "a clicked window without its selected display keeps independent-window capture")
         expect(RecorderSupport.captureFilterMode(
             clickedWindowID: 7,
-            windowFrame: nil,
+            selectionFrame: nil,
             displayFrame: recorderDisplayFrame) == .displayRegion,
                "an unresolved clicked window preserves the existing display fallback")
 
@@ -19087,12 +19087,34 @@ struct MetricsTests {
                 && !displayFilterBranch.contains("desktopIndependentWindow:")
                 && !displayFilterBranch.contains("excludingWindows:"),
                "the bounded mode uses application exclusion, never a fixed window list")
+        expect(recorderCaptureCode.contains("selectionFrame: region.anchorRect")
+                && !recorderCaptureCode.contains("selectionFrame: window?.frame"),
+               "capture mode uses the selection-time rectangle, never a moved window frame")
         expect(recorderCaptureCode.contains(
             "configuration.scalesToFit = preparedFilter.mode == .independentWindow")
                 && recorderCaptureCode.contains("if preparedFilter.mode == .displayRegion {")
                 && recorderCaptureCode.contains(
                     "configuration.sourceRect = Self.sourceRect(for: region)"),
                "the two filter modes configure independent scaling or fixed display bounds")
+
+        let recorderServiceSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift",
+            encoding: .utf8)) ?? ""
+        expect(!recorderServiceSource.isEmpty,
+               "the recorder service reads back for its region-guide wiring check")
+        let recorderServiceCode = recorderServiceSource.components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        let recorderRecordMethod = recorderServiceCode.components(separatedBy: "func record(")
+            .dropFirst().first?.components(separatedBy: "private func prepareCountdown").first ?? ""
+        expect(recorderRecordMethod.contains("let filterMode = RecorderSupport.captureFilterMode(")
+                && recorderRecordMethod.contains("selectionFrame: region.anchorRect")
+                && recorderRecordMethod.contains("displayFrame: screen?.frame")
+                && recorderRecordMethod.contains("if filterMode == .displayRegion {\n            indicator.showRegionGuide(for: region)\n        }")
+                && recorderRecordMethod.components(
+                    separatedBy: "indicator.showRegionGuide(for: region)").count == 2
+                && !recorderRecordMethod.contains("if filterMode == .independentWindow {\n            indicator.showRegionGuide"),
+               "the region guide follows bounded mode and stays absent for the independent fallback")
 
         expect(RecordingShareDuration.allCases.map(\.rawValue) == [3_600, 21_600],
                "recording links allow only one or six hours")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -19079,14 +19079,18 @@ struct MetricsTests {
         let displayFilterBranch = recorderFilterSwitch
             .components(separatedBy: "case .displayRegion:").dropFirst().first ?? ""
         expect(independentFilterBranch.contains("SCContentFilter(desktopIndependentWindow: window)")
+                && independentFilterBranch.contains("guard let window else {")
+                && independentFilterBranch.contains("fallthrough")
+                && !independentFilterBranch.contains("return nil")
                 && !independentFilterBranch.contains("excludingApplications:")
                 && !independentFilterBranch.contains("excludingWindows:"),
-               "the independent mode uses only the straddling-window filter")
+               "the independent mode keeps a found straddling window independent and sends a missing one to display capture")
         expect(displayFilterBranch.contains("excludingApplications: [ownApplication]")
                 && displayFilterBranch.contains("exceptingWindows: ordinaryWindows")
                 && !displayFilterBranch.contains("desktopIndependentWindow:")
-                && !displayFilterBranch.contains("excludingWindows:"),
-               "the bounded mode uses application exclusion, never a fixed window list")
+                && !displayFilterBranch.contains("excludingWindows:")
+                && displayFilterBranch.contains("mode: .displayRegion"),
+               "the bounded mode and missing-window fallback use the display filter with display-region configuration")
         expect(recorderCaptureCode.contains("selectionFrame: region.anchorRect")
                 && !recorderCaptureCode.contains("selectionFrame: window?.frame"),
                "capture mode uses the selection-time rectangle, never a moved window frame")
@@ -19107,9 +19111,20 @@ struct MetricsTests {
             .joined(separator: "\n")
         let recorderRecordMethod = recorderServiceCode.components(separatedBy: "func record(")
             .dropFirst().first?.components(separatedBy: "private func prepareCountdown").first ?? ""
+        let recorderCaptureModeCall = recorderCaptureCode.components(
+            separatedBy: "let mode = RecorderSupport.captureFilterMode(")
+            .dropFirst().first?.components(separatedBy: ")\n\n        switch mode").first ?? ""
+        let recorderServiceModeCall = recorderRecordMethod.components(
+            separatedBy: "let filterMode = RecorderSupport.captureFilterMode(")
+            .dropFirst().first?.components(separatedBy: ")\n        if filterMode").first ?? ""
+        expect(recorderCaptureModeCall.contains("NSScreen.screens")
+                && recorderServiceModeCall.contains("NSScreen.screens")
+                && !recorderCaptureModeCall.contains("display?.frame")
+                && !recorderServiceModeCall.contains("display?.frame"),
+               "both capture-mode callers derive their display frame from NSScreen, never a ScreenCaptureKit display frame")
         expect(recorderRecordMethod.contains("let filterMode = RecorderSupport.captureFilterMode(")
                 && recorderRecordMethod.contains("selectionFrame: region.anchorRect")
-                && recorderRecordMethod.contains("displayFrame: screen?.frame")
+                && recorderRecordMethod.contains("displayFrame: NSScreen.screens.first { $0.displayID == region.displayID }?.frame")
                 && recorderRecordMethod.contains("if filterMode == .displayRegion {\n            indicator.showRegionGuide(for: region)\n        }")
                 && recorderRecordMethod.components(
                     separatedBy: "indicator.showRegionGuide(for: region)").count == 2

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -19032,6 +19032,65 @@ struct MetricsTests {
             ownWindowIDs: [1, 2, 3], protectedWindowIDs: [2, 4]) == [1, 3],
                "recording keeps existing ordinary app windows but never its protected chrome")
 
+        let recorderDisplayFrame = CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        let containedRecorderWindow = CGRect(x: 120, y: 80, width: 800, height: 600)
+        expect(RecorderSupport.captureFilterMode(
+            clickedWindowID: nil,
+            windowFrame: nil,
+            displayFrame: recorderDisplayFrame) == .displayRegion,
+               "a drawn recording region keeps the ordinary display filter")
+        expect(RecorderSupport.captureFilterMode(
+            clickedWindowID: 7,
+            windowFrame: containedRecorderWindow,
+            displayFrame: recorderDisplayFrame) == .displayRegion,
+               "a clicked window inside one display records its bounds from that display")
+        expect(RecorderSupport.captureFilterMode(
+            clickedWindowID: 7,
+            windowFrame: CGRect(x: 1_200, y: 80, width: 800, height: 600),
+            displayFrame: recorderDisplayFrame) == .independentWindow,
+               "a clicked window crossing a display edge keeps independent-window capture")
+        expect(RecorderSupport.captureFilterMode(
+            clickedWindowID: 7,
+            windowFrame: containedRecorderWindow,
+            displayFrame: nil) == .independentWindow,
+               "a clicked window without its selected display keeps independent-window capture")
+        expect(RecorderSupport.captureFilterMode(
+            clickedWindowID: 7,
+            windowFrame: nil,
+            displayFrame: recorderDisplayFrame) == .displayRegion,
+               "an unresolved clicked window preserves the existing display fallback")
+
+        // ScreenCaptureKit wiring cannot run in this helper binary. Comments
+        // are stripped, and each mode is checked for its own initializer and
+        // against the other one, so either direction drifting fails the test.
+        let recorderCaptureSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift",
+            encoding: .utf8)) ?? ""
+        expect(!recorderCaptureSource.isEmpty,
+               "the recorder capture engine reads back for its filter wiring check")
+        let recorderCaptureCode = recorderCaptureSource.components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        let recorderFilterSwitch = recorderCaptureCode.components(separatedBy: "switch mode {")
+            .dropFirst().first?.components(separatedBy: "private static func sourceRect").first ?? ""
+        let independentFilterBranch = recorderFilterSwitch
+            .components(separatedBy: "case .independentWindow:").dropFirst().first?
+            .components(separatedBy: "case .displayRegion:").first ?? ""
+        let displayFilterBranch = recorderFilterSwitch
+            .components(separatedBy: "case .displayRegion:").dropFirst().first ?? ""
+        expect(independentFilterBranch.contains("SCContentFilter(desktopIndependentWindow: window)")
+                && !independentFilterBranch.contains("excludingWindows:"),
+               "the independent mode uses only the straddling-window filter")
+        expect(displayFilterBranch.contains("excludingWindows: protectedWindows")
+                && !displayFilterBranch.contains("desktopIndependentWindow:"),
+               "the contained-window mode uses only the bounds-limited display filter")
+        expect(recorderCaptureCode.contains(
+            "configuration.scalesToFit = preparedFilter.mode == .independentWindow")
+                && recorderCaptureCode.contains("if preparedFilter.mode == .displayRegion {")
+                && recorderCaptureCode.contains(
+                    "configuration.sourceRect = Self.sourceRect(for: region)"),
+               "the two filter modes configure independent scaling or fixed display bounds")
+
         expect(RecordingShareDuration.allCases.map(\.rawValue) == [3_600, 21_600],
                "recording links allow only one or six hours")
         let recordingShareEndpoint = RecordingSharingSupport.endpoint(

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -19032,37 +19032,24 @@ struct MetricsTests {
             ownWindowIDs: [1, 2, 3], protectedWindowIDs: [2, 4]) == [1, 3],
                "recording keeps existing ordinary app windows but never its protected chrome")
 
-        let recorderDisplayFrame = CGRect(x: 0, y: 0, width: 1_440, height: 900)
-        let containedRecorderWindow = CGRect(x: 120, y: 80, width: 800, height: 600)
-        expect(RecorderSupport.captureFilterMode(
-            clickedWindowID: nil,
-            selectionFrame: nil,
-            displayFrame: recorderDisplayFrame) == .displayRegion,
-               "a drawn recording region keeps the ordinary display filter")
-        expect(RecorderSupport.captureFilterMode(
-            clickedWindowID: 7,
-            selectionFrame: containedRecorderWindow,
-            displayFrame: recorderDisplayFrame) == .displayRegion,
-               "a clicked window inside one display records its bounds from that display")
-        expect(RecorderSupport.captureFilterMode(
-            clickedWindowID: 7,
-            selectionFrame: CGRect(x: 1_200, y: 80, width: 800, height: 600),
-            displayFrame: recorderDisplayFrame) == .independentWindow,
-               "a clicked window crossing a display edge keeps independent-window capture")
-        expect(RecorderSupport.captureFilterMode(
-            clickedWindowID: 7,
-            selectionFrame: containedRecorderWindow,
-            displayFrame: nil) == .independentWindow,
-               "a clicked window without its selected display keeps independent-window capture")
-        expect(RecorderSupport.captureFilterMode(
-            clickedWindowID: 7,
-            selectionFrame: nil,
-            displayFrame: recorderDisplayFrame) == .displayRegion,
-               "an unresolved clicked window preserves the existing display fallback")
+        // A clicked window is clipped to the display it was picked from before
+        // it ever becomes a Region, which is why recording needs no straddling
+        // fallback: there is no rectangle that escapes its display.
+        let recorderDisplayPixels = CGRect(x: 0, y: 0, width: 1_440, height: 900)
+        let straddlingWindow = CGRect(x: 1_200, y: 80, width: 800, height: 600)
+        let clippedWindow = RecorderSupport.snappedPixelRect(straddlingWindow,
+                                                             in: recorderDisplayPixels)
+        expect(recorderDisplayPixels.contains(clippedWindow)
+                && clippedWindow.width > 0 && clippedWindow.height > 0,
+               "a clicked window crossing a display edge records the part on the selected display")
+        let containedWindow = CGRect(x: 120, y: 80, width: 800, height: 600)
+        expect(RecorderSupport.snappedPixelRect(containedWindow, in: recorderDisplayPixels)
+                == containedWindow,
+               "a clicked window inside one display keeps the rectangle it was picked with")
 
-        // ScreenCaptureKit wiring cannot run in this helper binary. Comments
-        // are stripped, and each mode is checked for its own initializer and
-        // against the other one, so either direction drifting fails the test.
+        // ScreenCaptureKit wiring cannot run in this helper binary, so the
+        // single filter construction is checked by shape. Comments are stripped
+        // so a mention in prose cannot satisfy a check.
         let recorderCaptureSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift",
             encoding: .utf8)) ?? ""
@@ -19071,35 +19058,18 @@ struct MetricsTests {
         let recorderCaptureCode = recorderCaptureSource.components(separatedBy: "\n")
             .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
             .joined(separator: "\n")
-        let recorderFilterSwitch = recorderCaptureCode.components(separatedBy: "switch mode {")
-            .dropFirst().first?.components(separatedBy: "private static func sourceRect").first ?? ""
-        let independentFilterBranch = recorderFilterSwitch
-            .components(separatedBy: "case .independentWindow:").dropFirst().first?
-            .components(separatedBy: "case .displayRegion:").first ?? ""
-        let displayFilterBranch = recorderFilterSwitch
-            .components(separatedBy: "case .displayRegion:").dropFirst().first ?? ""
-        expect(independentFilterBranch.contains("SCContentFilter(desktopIndependentWindow: window)")
-                && independentFilterBranch.contains("guard let window else {")
-                && independentFilterBranch.contains("fallthrough")
-                && !independentFilterBranch.contains("return nil")
-                && !independentFilterBranch.contains("excludingApplications:")
-                && !independentFilterBranch.contains("excludingWindows:"),
-               "the independent mode keeps a found straddling window independent and sends a missing one to display capture")
-        expect(displayFilterBranch.contains("excludingApplications: [ownApplication]")
-                && displayFilterBranch.contains("exceptingWindows: ordinaryWindows")
-                && !displayFilterBranch.contains("desktopIndependentWindow:")
-                && !displayFilterBranch.contains("excludingWindows:")
-                && displayFilterBranch.contains("mode: .displayRegion"),
-               "the bounded mode and missing-window fallback use the display filter with display-region configuration")
-        expect(recorderCaptureCode.contains("selectionFrame: region.anchorRect")
-                && !recorderCaptureCode.contains("selectionFrame: window?.frame"),
-               "capture mode uses the selection-time rectangle, never a moved window frame")
-        expect(recorderCaptureCode.contains(
-            "configuration.scalesToFit = preparedFilter.mode == .independentWindow")
-                && recorderCaptureCode.contains("if preparedFilter.mode == .displayRegion {")
-                && recorderCaptureCode.contains(
-                    "configuration.sourceRect = Self.sourceRect(for: region)"),
-               "the two filter modes configure independent scaling or fixed display bounds")
+        expect(recorderCaptureCode.contains("excludingApplications: [ownApplication]")
+                && recorderCaptureCode.contains("exceptingWindows: ordinaryWindows")
+                && !recorderCaptureCode.contains("desktopIndependentWindow")
+                && !recorderCaptureCode.contains("excludingWindows:"),
+               "recording builds one display filter that excludes the app with its ordinary windows")
+        expect(recorderCaptureCode.contains("configuration.sourceRect = Self.sourceRect(for: region)")
+                && !recorderCaptureCode.contains("if preparedFilter.mode")
+                && recorderCaptureCode.contains("configuration.scalesToFit = false"),
+               "every recording fixes its source rectangle and scales nothing into the frame")
+        expect(!recorderCaptureCode.contains("captureFilterMode")
+                && !recorderCaptureCode.contains("region.windowID"),
+               "the capture engine no longer resolves a filter mode or a clicked window")
 
         let recorderServiceSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift",
@@ -19111,25 +19081,17 @@ struct MetricsTests {
             .joined(separator: "\n")
         let recorderRecordMethod = recorderServiceCode.components(separatedBy: "func record(")
             .dropFirst().first?.components(separatedBy: "private func prepareCountdown").first ?? ""
-        let recorderCaptureModeCall = recorderCaptureCode.components(
-            separatedBy: "let mode = RecorderSupport.captureFilterMode(")
-            .dropFirst().first?.components(separatedBy: ")\n\n        switch mode").first ?? ""
-        let recorderServiceModeCall = recorderRecordMethod.components(
-            separatedBy: "let filterMode = RecorderSupport.captureFilterMode(")
-            .dropFirst().first?.components(separatedBy: ")\n        if filterMode").first ?? ""
-        expect(recorderCaptureModeCall.contains("NSScreen.screens")
-                && recorderServiceModeCall.contains("NSScreen.screens")
-                && !recorderCaptureModeCall.contains("display?.frame")
-                && !recorderServiceModeCall.contains("display?.frame"),
-               "both capture-mode callers derive their display frame from NSScreen, never a ScreenCaptureKit display frame")
-        expect(recorderRecordMethod.contains("let filterMode = RecorderSupport.captureFilterMode(")
-                && recorderRecordMethod.contains("selectionFrame: region.anchorRect")
-                && recorderRecordMethod.contains("displayFrame: NSScreen.screens.first { $0.displayID == region.displayID }?.frame")
-                && recorderRecordMethod.contains("if filterMode == .displayRegion {\n            indicator.showRegionGuide(for: region)\n        }")
+        expect(recorderRecordMethod.contains("indicator.showRegionGuide(for: region)")
                 && recorderRecordMethod.components(
                     separatedBy: "indicator.showRegionGuide(for: region)").count == 2
-                && !recorderRecordMethod.contains("if filterMode == .independentWindow {\n            indicator.showRegionGuide"),
-               "the region guide follows bounded mode and stays absent for the independent fallback")
+                && !recorderRecordMethod.contains("captureFilterMode"),
+               "every recording shows the boundary of the rectangle it records")
+
+        let recorderSupportSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Recorder/RecorderSupport.swift",
+            encoding: .utf8)) ?? ""
+        expect(!recorderSupportSource.isEmpty && !recorderSupportSource.contains("CaptureFilterMode"),
+               "no capture filter mode survives for a straddling case the selection cannot produce")
 
         expect(RecordingShareDuration.allCases.map(\.rawValue) == [3_600, 21_600],
                "recording links allow only one or six hours")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -19079,11 +19079,14 @@ struct MetricsTests {
         let displayFilterBranch = recorderFilterSwitch
             .components(separatedBy: "case .displayRegion:").dropFirst().first ?? ""
         expect(independentFilterBranch.contains("SCContentFilter(desktopIndependentWindow: window)")
+                && !independentFilterBranch.contains("excludingApplications:")
                 && !independentFilterBranch.contains("excludingWindows:"),
                "the independent mode uses only the straddling-window filter")
-        expect(displayFilterBranch.contains("excludingWindows: protectedWindows")
-                && !displayFilterBranch.contains("desktopIndependentWindow:"),
-               "the contained-window mode uses only the bounds-limited display filter")
+        expect(displayFilterBranch.contains("excludingApplications: [ownApplication]")
+                && displayFilterBranch.contains("exceptingWindows: ordinaryWindows")
+                && !displayFilterBranch.contains("desktopIndependentWindow:")
+                && !displayFilterBranch.contains("excludingWindows:"),
+               "the bounded mode uses application exclusion, never a fixed window list")
         expect(recorderCaptureCode.contains(
             "configuration.scalesToFit = preparedFilter.mode == .independentWindow")
                 && recorderCaptureCode.contains("if preparedFilter.mode == .displayRegion {")


### PR DESCRIPTION
Refs #1147

A recording started by clicking a window was scoped to that one CGWindowID, so a sheet or dialog the app stacked on it mid-recording was never in the video — same root as #1098, but a live stream cannot resolve children once at start and be done.

This takes the bounds-limited display capture you leaned toward: when a clicked window's recording begins, the filter is the display excluding Vorssaint's own capture UI, with the stream's source rectangle fixed to the window's frame. Whatever the app stacks inside that rectangle is in the video by construction, with nothing to track while sheets come and go. Every recording builds that one filter — there is no second path left.

Deliberate behavior changes, stated plainly — four, after review: the recorded rectangle stays fixed if the window is moved mid-recording (which the pointer track and zoom already assume, so the old following filter was the thing out of step); another window dragged over the rectangle is visible in the recording (it is what the screen showed); the rectangle records the current Space, so switching Spaces mid-recording records what replaces the window there, where the old filter followed the window across; and a window spanning two displays records the part on the display it was picked from, where main scaled the whole window into those dimensions.

That fourth one is what dropping the straddle fallback costs, and the selection path had already made the choice: `anchorRect` comes from `snappedPixelRect(raw, in: displayPixels)`, which intersects with the display and clamps to its edges, so no `Region` escapes the display it was picked from and the fallback's predicate could not be false. `pixelRect` has been that clipped rectangle all along, and the pointer track, the zoom and the dimensions badge all read it, so the on-display slice is the reading consistent with everything downstream.

The truth table went with the function it tested. In its place the invariant that makes the fallback unnecessary is tested where it lives — `snappedPixelRect` clipping a straddling rect to its display, and leaving a contained one alone — with shape checks that no filter mode, clicked window or scaling survives in the engine, and that every recording shows its boundary guide.

Verification: `./build.sh` warning-free; `./build.sh --test` passes with only the known starvation failure. Needs live recording hardware: sheets appearing/disappearing mid-recording landing in the file, the fixed-rectangle behavior when the window moves, exclusion of the recording indicator, and mixed-DPI dimensions. No second display here, so the straddle geometry is read off the selection path rather than run.
