### PR TITLE
feat: add JavaScript Custom Actions

### DIFF
--- a/Sources/Vorssaint/App/FeatureRuntime.swift
+++ b/Sources/Vorssaint/App/FeatureRuntime.swift
@@ -233,6 +233,13 @@ final class FeatureRuntime: ObservableObject {
         .radialMenu: { RadialMenuService.shared.syncWithPreferences() },
         .scratchpad: { ScratchpadService.shared.syncWithPreferences() },
         .commandBar: { CommandBarService.shared.syncWithPreferences() },
+        .customActions: {
+            if AppFeature.customActions.isAvailable {
+                CustomActionService.shared.syncWithPreferences()
+            } else {
+                CustomActionService.shared.suspend()
+            }
+        },
         .cleaner: {
             CleanerScheduler.shared.syncWithPreferences()
             WhatsAppDownloadScheduler.shared.syncWithPreferences()

--- a/Sources/Vorssaint/App/FeatureRuntime.swift
+++ b/Sources/Vorssaint/App/FeatureRuntime.swift
@@ -129,6 +129,7 @@ final class FeatureRuntime: ObservableObject {
     /// Launch path: replaces the old unconditional sync block. Only available
     /// features get their binding run, so nothing else even instantiates.
     func syncAtLaunch() {
+        CustomActionService.shared.syncWithPreferences()
         for feature in AppFeature.allCases where feature.isAvailable {
             Self.bindings[feature]?()
         }

--- a/Sources/Vorssaint/Core/CustomActionsStrings.swift
+++ b/Sources/Vorssaint/Core/CustomActionsStrings.swift
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+/// Localized chrome for the Custom Actions editor. The action name, description
+/// and script remain user-authored data and are intentionally not translated.
+struct CustomActionsFeatureStrings {
+    let pageTitle: String
+    let actionSection: String
+    let name: String
+    let description: String
+    let enabled: String
+    let javascriptSection: String
+    let availableVariables: String
+    let inputOutputSection: String
+    let input: String
+    let selectedText: String
+    let clipboardText: String
+    let automatic: String
+    let output: String
+    let replaceSelection: String
+    let insertAtCursor: String
+    let copyToClipboard: String
+    let preview: String
+    let showCommandBar: String
+    let showRadialMenu: String
+    let testInputSection: String
+    let testInputPlaceholder: String
+    let testInputHint: String
+    let testButton: String
+    let saveButton: String
+    let newButton: String
+    let duplicateButton: String
+    let deleteButton: String
+    let testOnlyHint: String
+}
+
+extension FeatureStrings {
+    static func customActions(_ language: AppLanguage) -> CustomActionsFeatureStrings {
+        switch language {
+        case .ptBR: return .ptBR
+        default: return .enUS
+        }
+    }
+}
+
+extension CustomActionsFeatureStrings {
+    static let enUS = CustomActionsFeatureStrings(
+        pageTitle: "Custom Actions",
+        actionSection: "Custom Action",
+        name: "Name",
+        description: "Description",
+        enabled: "Enabled",
+        javascriptSection: "JavaScript",
+        availableVariables: "Available: selectedText, clipboardText, input",
+        inputOutputSection: "Input and Output",
+        input: "Input",
+        selectedText: "Selected text",
+        clipboardText: "Clipboard",
+        automatic: "Automatic",
+        output: "Output",
+        replaceSelection: "Replace selection",
+        insertAtCursor: "Insert at cursor",
+        copyToClipboard: "Copy to clipboard",
+        preview: "Preview",
+        showCommandBar: "Show in Command Bar",
+        showRadialMenu: "Show in Radial Menu",
+        testInputSection: "Test input",
+        testInputPlaceholder: "Type or paste text to test this action",
+        testInputHint: "Testing uses this text only. It does not change the selected text or clipboard.",
+        testButton: "Test",
+        saveButton: "Save",
+        newButton: "New",
+        duplicateButton: "Duplicate",
+        deleteButton: "Delete",
+        testOnlyHint: "Preview only — use Command Bar, shortcut or Radial Menu to apply"
+    )
+
+    static let ptBR = CustomActionsFeatureStrings(
+        pageTitle: "Ações personalizadas",
+        actionSection: "Ação personalizada",
+        name: "Nome",
+        description: "Descrição",
+        enabled: "Ativada",
+        javascriptSection: "JavaScript",
+        availableVariables: "Disponíveis: selectedText, clipboardText, input",
+        inputOutputSection: "Entrada e saída",
+        input: "Entrada",
+        selectedText: "Texto selecionado",
+        clipboardText: "Clipboard",
+        automatic: "Automático",
+        output: "Saída",
+        replaceSelection: "Substituir seleção",
+        insertAtCursor: "Inserir no cursor",
+        copyToClipboard: "Copiar para o clipboard",
+        preview: "Pré-visualização",
+        showCommandBar: "Mostrar na Barra de comandos",
+        showRadialMenu: "Mostrar no Menu radial",
+        testInputSection: "Texto para testar",
+        testInputPlaceholder: "Digite ou cole um texto para testar esta ação",
+        testInputHint: "O teste usa somente este texto. Ele não altera o texto selecionado nem o clipboard.",
+        testButton: "Testar",
+        saveButton: "Salvar",
+        newButton: "Novo",
+        duplicateButton: "Duplicar",
+        deleteButton: "Excluir",
+        testOnlyHint: "Somente prévia — use a Barra de comandos, o atalho ou o Menu radial para aplicar"
+    )
+}

--- a/Sources/Vorssaint/Core/CustomActionsStrings.swift
+++ b/Sources/Vorssaint/Core/CustomActionsStrings.swift
@@ -8,6 +8,10 @@ import Foundation
 struct CustomActionsFeatureStrings {
     let pageTitle: String
     let actionSection: String
+    let nameColumn: String
+    let statusColumn: String
+    let activeStatus: String
+    let inactiveStatus: String
     let name: String
     let description: String
     let enabled: String
@@ -49,6 +53,10 @@ extension CustomActionsFeatureStrings {
     static let enUS = CustomActionsFeatureStrings(
         pageTitle: "Custom Actions",
         actionSection: "Custom Action",
+        nameColumn: "Name",
+        statusColumn: "Status",
+        activeStatus: "Enabled",
+        inactiveStatus: "Disabled",
         name: "Name",
         description: "Description",
         enabled: "Enabled",
@@ -80,6 +88,10 @@ extension CustomActionsFeatureStrings {
     static let ptBR = CustomActionsFeatureStrings(
         pageTitle: "Ações personalizadas",
         actionSection: "Ação personalizada",
+        nameColumn: "Nome",
+        statusColumn: "Estado",
+        activeStatus: "Ativada",
+        inactiveStatus: "Desativada",
         name: "Nome",
         description: "Descrição",
         enabled: "Ativada",

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -461,6 +461,7 @@ enum DefaultsKey {
     static let commandBarPins = "commandBarPins"             // row keys kept at the top, in order
     static let commandBarHidden = "commandBarHidden"         // row keys the person never wants offered
     static let commandBarLinks = "commandBarLinks"           // Data: [CommandBarLink] JSON
+    static let customActions = "customActions"               // Data: [CustomAction] JSON
     static let commandBarRowShortcuts = "commandBarRowShortcuts" // {row key: shortcut}
     static let commandBarPositionOffset = "commandBarPositionOffset" // "dx,dy" from the default spot
     // The folders a file search looks in, one per line, written with a tilde

--- a/Sources/Vorssaint/Core/FeatureCatalog.swift
+++ b/Sources/Vorssaint/Core/FeatureCatalog.swift
@@ -28,7 +28,7 @@ enum AppFeature: String, CaseIterable {
     // Tools
     case quickLauncher, quickToggles, colorPicker, screenOCR, cleaningMode, mediaTools,
          cleaner, uninstaller, homebrew, appUpdates, screenshot, cameraPreview, radialMenu, scratchpad,
-         commandBar, screenRecorder, killProcess
+         commandBar, customActions, screenRecorder, killProcess
     // System monitor, one entry per metric family (temperatures live with
     // their parent metric: CPU temp with CPU, battery temp with power).
     case monitorCPU, monitorGPU, monitorMemory, monitorNetwork, monitorDisk, monitorPower, fanControl
@@ -100,7 +100,7 @@ extension AppFeature {
             return .energyDisplay
         case .quickLauncher, .quickToggles, .colorPicker, .screenOCR, .cleaningMode, .mediaTools,
              .cleaner, .uninstaller, .homebrew, .appUpdates, .screenshot, .cameraPreview, .radialMenu,
-             .scratchpad, .commandBar, .screenRecorder, .killProcess:
+             .scratchpad, .commandBar, .customActions, .screenRecorder, .killProcess:
             return .tools
         case .monitorCPU, .monitorGPU, .monitorMemory, .monitorNetwork, .monitorDisk, .monitorPower,
              .fanControl:
@@ -161,6 +161,7 @@ extension AppFeature {
         case .radialMenu: return "circle.grid.cross"
         case .scratchpad: return "note.text"
         case .commandBar: return "command"
+        case .customActions: return "wand.and.stars"
         case .killProcess: return "xmark.octagon"
         case .monitorCPU: return "cpu"
         case .monitorGPU: return "rectangle.connected.to.line.below"
@@ -224,7 +225,7 @@ extension AppFeature {
         case .windowLayout, .diskImageInstaller, .mixer, .micMute, .keepAwake,
              .quickLauncher, .quickToggles, .colorPicker, .screenOCR, .cleaningMode, .mediaTools,
              .cleaner, .uninstaller, .homebrew, .appUpdates, .screenshot, .cameraPreview, .scratchpad,
-             .commandBar, .screenRecorder, .killProcess,
+             .commandBar, .customActions, .screenRecorder, .killProcess,
              .monitorCPU, .monitorGPU, .monitorMemory, .monitorNetwork, .monitorDisk, .monitorPower,
              .fanControl:
             return []
@@ -242,7 +243,7 @@ extension AppFeature {
         case .scrollInverter, .focusFollowsMouse, .smoothScroll, .mouseNavigation, .mouseButtonShortcuts, .middleClick,
              .keyboardDebounce, .textSnippets, .superKey, .mouseClickDebounce,
              .dockClick, .windowMaximizer, .windowLayout,
-             .autoQuit, .cleaningMode, .pastePlain, .radialMenu,
+             .autoQuit, .cleaningMode, .pastePlain, .radialMenu, .customActions,
              // The bar reads other apps' menus and windows and types at the
              // caret, all of it through Accessibility.
              .commandBar:
@@ -301,7 +302,7 @@ extension AppFeature {
         Dictionary(uniqueKeysWithValues: allCases.map {
             ($0.availabilityKey,
              $0 != .focusFollowsMouse && $0 != .fanControl && $0 != .diskImageInstaller
-                && $0 != .killProcess)
+                && $0 != .killProcess && $0 != .customActions)
         })
     }
 
@@ -325,6 +326,11 @@ extension AppFeature {
                     RadialMenuSupport.decode(dataFor(DefaultsKey.radialMenuItems)))
                     || RadialMenuMouseTrigger.sanitized(
                         stringFor(DefaultsKey.radialMenuMouseButton)) != .off
+            case (.customActions, .accessibility):
+                return CustomActionSupport.decode(dataFor(DefaultsKey.customActions)).contains {
+                    $0.enabled && ($0.input == .selectedText || $0.input == .automatic
+                                   || $0.output == .replaceSelection || $0.output == .insertAtCursor)
+                }
             case (.keepAwake, .accessibility):
                 return boolFor(DefaultsKey.keepAwakeMouseJiggleEnabled)
             case (.mixer, .accessibility):

--- a/Sources/Vorssaint/Core/FeaturePresets.swift
+++ b/Sources/Vorssaint/Core/FeaturePresets.swift
@@ -117,7 +117,7 @@ extension AppFeature {
         case .mouseAcceleration, .pastePlain, .soundOutputSwitcher, .micMute,
              .musicBlock, .bluetoothSleep, .keepAwake, .brightness, .quickLauncher, .quickToggles, .colorPicker,
              .screenOCR, .cleaningMode, .mediaTools, .cleaner, .uninstaller, .homebrew, .screenshot,
-             .cameraPreview, .scratchpad, .commandBar, .screenRecorder, .fanControl,
+             .cameraPreview, .scratchpad, .commandBar, .customActions, .screenRecorder, .fanControl,
              .diskImageInstaller, .killProcess:
             return .idle
         case .appUpdates:

--- a/Sources/Vorssaint/Core/SettingsBackupSupport.swift
+++ b/Sources/Vorssaint/Core/SettingsBackupSupport.swift
@@ -34,6 +34,7 @@ enum SettingsBackupSupport {
         DefaultsKey.radialMenuItems,
         DefaultsKey.radialMenuProfiles,
         DefaultsKey.commandBarLinks,
+        DefaultsKey.customActions,
         DefaultsKey.commandBarRowShortcuts,
         DefaultsKey.language,
         DefaultsKey.appVolumes,

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarCatalog.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarCatalog.swift
@@ -179,6 +179,7 @@ enum CommandBarCatalog {
         entries.append(contentsOf: linkEntries(
             CommandBarLinks.decode(UserDefaults.standard.data(forKey: DefaultsKey.commandBarLinks)),
             bar: bar))
+        entries.append(contentsOf: CustomActionService.shared.commandBarEntries())
         return entries
     }
 

--- a/Sources/Vorssaint/Services/CustomActions/CustomActionService.swift
+++ b/Sources/Vorssaint/Services/CustomActions/CustomActionService.swift
@@ -97,7 +97,8 @@ final class CustomActionService: ObservableObject {
     }
 
     func commandBarEntries() -> [CommandBarEntry] {
-        actions.filter { $0.enabled && $0.showInCommandBar }.map { action in
+        guard AppFeature.customActions.isAvailable else { return [] }
+        return actions.filter { $0.enabled && $0.showInCommandBar }.map { action in
             CommandBarEntry(id: "custom-action.\(action.id.uuidString)",
                             stableKey: "custom-action.\(action.id.uuidString)",
                             title: action.name,

--- a/Sources/Vorssaint/Services/CustomActions/CustomActionService.swift
+++ b/Sources/Vorssaint/Services/CustomActions/CustomActionService.swift
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import Carbon.HIToolbox
+import Combine
+import CoreGraphics
+
+/// Coordinates user-defined text transformations. The JavaScript runtime is
+/// deliberately kept behind this service: scripts receive a snapshot of
+/// strings, while AppKit, pasteboard and Accessibility remain native-only.
+final class CustomActionService: ObservableObject {
+    static let shared = CustomActionService()
+
+    @Published private(set) var actions: [CustomAction] = []
+    @Published private(set) var lastError: String?
+    @Published private(set) var lastPreview: String?
+
+    private var generation = 0
+    private var hotkeys: [QuickToolHotkey] = []
+    private init() {}
+
+    func syncWithPreferences() {
+        actions = CustomActionSupport.decode(UserDefaults.standard.data(forKey: DefaultsKey.customActions))
+        syncHotkeys()
+    }
+
+    func suspend() {
+        generation &+= 1
+        for hotkey in hotkeys { hotkey.unregister() }
+        hotkeys = []
+        lastPreview = nil
+        lastError = nil
+    }
+
+    func save(_ action: CustomAction) -> Bool {
+        guard let action = CustomActionSupport.sanitized(action) else { return false }
+        var next = actions
+        if let index = next.firstIndex(where: { $0.id == action.id }) {
+            next[index] = action
+        } else {
+            next.append(action)
+        }
+        guard let data = CustomActionSupport.encode(next) else { return false }
+        UserDefaults.standard.set(data, forKey: DefaultsKey.customActions)
+        actions = CustomActionSupport.decode(data)
+        syncHotkeys()
+        return true
+    }
+
+    func remove(_ action: CustomAction) {
+        let next = actions.filter { $0.id != action.id }
+        UserDefaults.standard.set(CustomActionSupport.encode(next), forKey: DefaultsKey.customActions)
+        actions = next
+        syncHotkeys()
+    }
+
+    func duplicate(_ action: CustomAction) -> CustomAction? {
+        var copy = action
+        copy = CustomAction(id: UUID(), name: action.name + " Copy",
+                            description: action.description, script: action.script,
+                            input: action.input, output: action.output,
+                            shortcut: "", showInRadialMenu: action.showInRadialMenu,
+                            showInCommandBar: action.showInCommandBar, enabled: action.enabled)
+        return save(copy) ? copy : nil
+    }
+
+    /// Runs an action using the context that existed at invocation time.
+    /// Reading selection and pasteboard is off the main thread because either
+    /// service can block behind another application.
+    func execute(_ action: CustomAction, context: CustomActionContext? = nil,
+                 applyOutput: Bool = true) {
+        guard action.enabled else { return }
+        generation &+= 1
+        let runGeneration = generation
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let snapshot = context ?? CustomActionContext(
+                selectedText: CommandBarSelectionReader.readSelectedText(),
+                clipboardText: NSPasteboard.general.string(forType: .string) ?? "")
+            let result = CustomActionSupport.execute(script: action.script,
+                                                      context: snapshot,
+                                                      input: action.input)
+            DispatchQueue.main.async {
+                guard let self, self.generation == runGeneration else { return }
+                switch result {
+                case .failure(let error):
+                    self.lastError = error.localizedDescription
+                    self.lastPreview = nil
+                case .success(let text):
+                    self.lastError = nil
+                    self.lastPreview = text
+                    guard applyOutput else { return }
+                    self.apply(text, output: action.output, context: snapshot)
+                }
+            }
+        }
+    }
+
+    func commandBarEntries() -> [CommandBarEntry] {
+        actions.filter { $0.enabled && $0.showInCommandBar }.map { action in
+            CommandBarEntry(id: "custom-action.\(action.id.uuidString)",
+                            stableKey: "custom-action.\(action.id.uuidString)",
+                            title: action.name,
+                            subtitle: action.description.isEmpty ? "Custom Action" : action.description,
+                            keywords: "custom action javascript \(action.name)",
+                            icon: .symbol("wand.and.stars"),
+                            countsUsage: false) { [weak self] _ in
+                self?.execute(action)
+            }
+        }
+    }
+
+    private func apply(_ text: String, output: CustomActionOutput, context: CustomActionContext) {
+        switch output {
+        case .preview:
+            lastPreview = text
+        case .copyToClipboard:
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(text, forType: .string)
+        case .insertAtCursor:
+            writeAndPaste(text, replacingSelection: false)
+        case .replaceSelection:
+            guard !context.selectedText.isEmpty else {
+                lastError = "Não existe texto selecionado para substituir."
+                return
+            }
+            writeAndPaste(text, replacingSelection: true)
+        }
+    }
+
+    private func syncHotkeys() {
+        for hotkey in hotkeys { hotkey.unregister() }
+        hotkeys = []
+        var id: UInt32 = 500
+        for action in actions where action.enabled && !action.shortcut.isEmpty {
+            guard let shortcut = GlobalShortcut(storageValue: action.shortcut) else { continue }
+            let hotkey = QuickToolHotkey(id: id)
+            hotkey.onPress = { [weak self] in self?.execute(action) }
+            _ = hotkey.sync(enabled: true, shortcut: shortcut)
+            hotkeys.append(hotkey)
+            id += 1
+        }
+    }
+
+    private func writeAndPaste(_ text: String, replacingSelection _: Bool) {
+        NSPasteboard.general.clearContents()
+        guard NSPasteboard.general.setString(text, forType: .string) else {
+            lastError = "Não foi possível escrever o resultado no clipboard."
+            return
+        }
+        postPasteWhenModifiersAreReleased(attempt: 0)
+    }
+
+    private func postPasteWhenModifiersAreReleased(attempt: Int) {
+        guard attempt < 100 else {
+            lastError = "Não foi possível entregar o resultado ao campo atual."
+            return
+        }
+        let held = CGEventSource.flagsState(.combinedSessionState)
+            .intersection([.maskCommand, .maskAlternate, .maskShift, .maskControl])
+        guard held.isEmpty else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.015) { [weak self] in
+                self?.postPasteWhenModifiersAreReleased(attempt: attempt + 1)
+            }
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) {
+            guard let source = CGEventSource(stateID: .hidSystemState),
+                  let down = CGEvent(keyboardEventSource: source,
+                                     virtualKey: CGKeyCode(kVK_ANSI_V), keyDown: true),
+                  let up = CGEvent(keyboardEventSource: source,
+                                   virtualKey: CGKeyCode(kVK_ANSI_V), keyDown: false)
+            else { return }
+            down.flags = .maskCommand
+            up.flags = .maskCommand
+            down.post(tap: .cghidEventTap)
+            up.post(tap: .cghidEventTap)
+        }
+    }
+}

--- a/Sources/Vorssaint/Services/CustomActions/CustomActionService.swift
+++ b/Sources/Vorssaint/Services/CustomActions/CustomActionService.swift
@@ -48,6 +48,12 @@ final class CustomActionService: ObservableObject {
         return true
     }
 
+    func setEnabled(_ action: CustomAction, enabled: Bool) {
+        var updated = action
+        updated.enabled = enabled
+        _ = save(updated)
+    }
+
     func remove(_ action: CustomAction) {
         let next = actions.filter { $0.id != action.id }
         UserDefaults.standard.set(CustomActionSupport.encode(next), forKey: DefaultsKey.customActions)

--- a/Sources/Vorssaint/Services/CustomActions/CustomActionSupport.swift
+++ b/Sources/Vorssaint/Services/CustomActions/CustomActionSupport.swift
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+import JavaScriptCore
+
+enum CustomActionInput: String, Codable, CaseIterable, Identifiable {
+    case selectedText
+    case clipboardText
+    case automatic
+
+    var id: String { rawValue }
+}
+
+enum CustomActionOutput: String, Codable, CaseIterable, Identifiable {
+    case replaceSelection
+    case insertAtCursor
+    case copyToClipboard
+    case preview
+
+    var id: String { rawValue }
+}
+
+struct CustomAction: Codable, Identifiable, Equatable {
+    let id: UUID
+    var name: String
+    var description: String
+    var script: String
+    var input: CustomActionInput
+    var output: CustomActionOutput
+    var shortcut: String
+    var showInRadialMenu: Bool
+    var showInCommandBar: Bool
+    var enabled: Bool
+
+    init(id: UUID = UUID(), name: String = "", description: String = "",
+         script: String = "", input: CustomActionInput = .automatic,
+         output: CustomActionOutput = .preview, shortcut: String = "",
+         showInRadialMenu: Bool = false, showInCommandBar: Bool = true,
+         enabled: Bool = true) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.script = script
+        self.input = input
+        self.output = output
+        self.shortcut = shortcut
+        self.showInRadialMenu = showInRadialMenu
+        self.showInCommandBar = showInCommandBar
+        self.enabled = enabled
+    }
+}
+
+struct CustomActionContext: Equatable {
+    let selectedText: String
+    let clipboardText: String
+
+    func input(for source: CustomActionInput) -> String {
+        switch source {
+        case .selectedText: return selectedText
+        case .clipboardText: return clipboardText
+        case .automatic: return selectedText.isEmpty ? clipboardText : selectedText
+        }
+    }
+}
+
+enum CustomActionRuntimeError: LocalizedError, Equatable {
+    case emptyScript
+    case scriptTooLarge
+    case forbiddenAPI(String)
+    case javascript(String)
+    case nonTextResult
+    case resultTooLarge
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyScript: return "O script JavaScript está vazio."
+        case .scriptTooLarge: return "O script excede o limite permitido."
+        case .forbiddenAPI(let name): return "A API '\(name)' não está disponível em Custom Actions."
+        case .javascript(let message): return message
+        case .nonTextResult: return "O script precisa retornar um texto."
+        case .resultTooLarge: return "O resultado excede o limite permitido."
+        }
+    }
+}
+
+enum CustomActionSupport {
+    static let maxScriptLength = 64 * 1024
+    static let maxResultLength = 1_000_000
+    static let maxStoredActions = 100
+
+    static func sanitized(_ action: CustomAction) -> CustomAction? {
+        let name = String(action.name.trimmingCharacters(in: .whitespacesAndNewlines).prefix(80))
+        let description = String(action.description.trimmingCharacters(in: .whitespacesAndNewlines).prefix(240))
+        guard !name.isEmpty, !action.script.isEmpty, action.script.utf8.count <= maxScriptLength else { return nil }
+        guard GlobalShortcut(storageValue: action.shortcut) != nil || action.shortcut.isEmpty else { return nil }
+        var copy = action
+        copy.name = name
+        copy.description = description
+        return copy
+    }
+
+    static func decode(_ data: Data?) -> [CustomAction] {
+        guard let data, let actions = try? JSONDecoder().decode([CustomAction].self, from: data) else { return [] }
+        var ids = Set<UUID>()
+        return actions.compactMap { action in
+            guard ids.insert(action.id).inserted else { return nil }
+            return sanitized(action)
+        }.prefix(maxStoredActions).map { $0 }
+    }
+
+    static func encode(_ actions: [CustomAction]) -> Data? {
+        try? JSONEncoder().encode(Array(actions.compactMap(sanitized).prefix(maxStoredActions)))
+    }
+
+    static func validate(script: String) -> CustomActionRuntimeError? {
+        guard !script.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return .emptyScript }
+        guard script.utf8.count <= maxScriptLength else { return .scriptTooLarge }
+        let forbidden = ["FileManager", "NSProcessInfo", "NSURLSession", "XMLHttpRequest", "process", "require", "importScripts", "eval", "Function"]
+        if let token = forbidden.first(where: { script.contains($0) }) { return .forbiddenAPI(token) }
+        return nil
+    }
+
+    static func resolveInput(context: CustomActionContext, source: CustomActionInput) -> String {
+        context.input(for: source)
+    }
+
+    static func execute(script: String, context: CustomActionContext, input: CustomActionInput) -> Result<String, CustomActionRuntimeError> {
+        if let error = validate(script: script) { return .failure(error) }
+        let selected = JSContext()!
+        var exception: String?
+        selected.exceptionHandler = { _, value in exception = value?.toString() }
+        selected.setObject(context.selectedText, forKeyedSubscript: "selectedText" as NSString)
+        selected.setObject(context.clipboardText, forKeyedSubscript: "clipboardText" as NSString)
+        selected.setObject(resolveInput(context: context, source: input), forKeyedSubscript: "input" as NSString)
+        let value = selected.evaluateScript("(function() {\n\(script)\n})()")
+        if let exception { return .failure(.javascript(exception)) }
+        guard let value, !value.isNull, !value.isUndefined, let output = value.toString() else {
+            return .failure(.nonTextResult)
+        }
+        guard output.utf8.count <= maxResultLength else { return .failure(.resultTooLarge) }
+        return .success(output)
+    }
+}

--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
@@ -364,6 +364,10 @@ final class RadialMenuService: ObservableObject {
         items.compactMap { item in
             var item = item
             if let tool = item.tool, !tool.isRunnable() { return nil }
+            if item.kind == .customAction,
+               !CustomActionService.shared.actions.contains(where: {
+                   $0.id.uuidString == item.payload && $0.enabled && $0.showInRadialMenu
+               }) { return nil }
             if item.kind == .quickToggle, !AppFeature.quickToggles.isAvailable { return nil }
             if item.kind == .windowLayout, !AppFeature.windowLayout.isAvailable { return nil }
             if item.kind == .submenu {
@@ -638,6 +642,11 @@ final class RadialMenuService: ObservableObject {
             }
         case .tool:
             if let tool = item.tool { run(tool) }
+        case .customAction:
+            if let id = UUID(uuidString: item.payload),
+               let action = CustomActionService.shared.actions.first(where: { $0.id == id }) {
+                CustomActionService.shared.execute(action)
+            }
         case .quickToggle:
             if let action = item.quickToggle { run(action) }
         case .windowLayout:

--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuSupport.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuSupport.swift
@@ -192,7 +192,7 @@ enum RadialMenuProfilePreset: String, CaseIterable, Identifiable {
 /// value. Submenus keep their actions in `children`.
 struct RadialMenuItem: Codable, Identifiable, Equatable {
     enum Kind: String, Codable, CaseIterable {
-        case app, file, url, shortcut, tool, quickToggle, windowLayout, media, submenu
+        case app, file, url, shortcut, tool, customAction, quickToggle, windowLayout, media, submenu
     }
 
     var id = UUID()
@@ -228,6 +228,7 @@ struct RadialMenuItem: Codable, Identifiable, Equatable {
         case .url: return "link"
         case .shortcut: return "command"
         case .tool: return tool?.symbolName ?? "wrench.and.screwdriver"
+        case .customAction: return "wand.and.stars"
         case .quickToggle: return quickToggle?.symbolName ?? "togglepower"
         case .windowLayout: return windowLayoutAction?.symbolName ?? AppFeature.windowLayout.symbolName
         case .media:
@@ -580,6 +581,8 @@ enum RadialMenuSupport {
         case .url: return normalizedURL(item.payload) != nil
         case .shortcut: return GlobalShortcut(storageValue: item.payload) != nil
         case .tool: return item.tool != nil
+        case .customAction:
+            return UUID(uuidString: item.payload) != nil
         case .quickToggle: return item.quickToggle != nil
         case .windowLayout: return item.windowLayoutAction != nil
         case .media: return item.mediaKey != nil

--- a/Sources/Vorssaint/UI/RadialMenu/RadialMenuView.swift
+++ b/Sources/Vorssaint/UI/RadialMenu/RadialMenuView.swift
@@ -262,6 +262,8 @@ extension RadialMenuItem {
         case .tool:
             guard let tool else { return text.kindTool }
             return tool.feature.hubTitle(L10n.shared.s, hub: FeatureStrings.hub(L10n.shared.language))
+        case .customAction:
+            return CustomActionService.shared.actions.first { $0.id.uuidString == payload }?.name ?? "Custom Action"
         case .quickToggle:
             return quickToggle?.radialTitle ?? FeatureStrings.quickToggles(L10n.shared.language).pageTitle
         case .windowLayout:

--- a/Sources/Vorssaint/UI/Settings/CustomActionsSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/CustomActionsSettings.swift
@@ -4,29 +4,82 @@
 import SwiftUI
 
 struct CustomActionsSettings: View {
+    private enum SortKey: Equatable {
+        case name
+        case status
+    }
+
     @ObservedObject private var service = CustomActionService.shared
     @ObservedObject private var l10n = L10n.shared
     @State private var selectedID: CustomAction.ID?
     @State private var draft = CustomAction()
     @State private var testInput = ""
+    @State private var sortKey = SortKey.name
+    @State private var sortAscending = true
 
     private var strings: CustomActionsFeatureStrings {
         FeatureStrings.customActions(l10n.language)
     }
 
+    private var sortedActions: [CustomAction] {
+        service.actions.sorted { left, right in
+            switch sortKey {
+            case .name:
+                return sortAscending
+                    ? left.name.localizedStandardCompare(right.name) == .orderedAscending
+                    : left.name.localizedStandardCompare(right.name) == .orderedDescending
+            case .status:
+                if left.enabled != right.enabled {
+                    return sortAscending ? left.enabled : !left.enabled
+                }
+                let comparison = left.name.localizedStandardCompare(right.name)
+                return sortAscending
+                    ? comparison == .orderedAscending
+                    : comparison == .orderedDescending
+            }
+        }
+    }
+
     var body: some View {
         HStack(spacing: 0) {
-            List(selection: $selectedID) {
-                ForEach(service.actions) { action in
-                    VStack(alignment: .leading, spacing: 3) {
-                        Text(action.name).font(.headline)
-                        Text(action.description.isEmpty ? action.input.rawValue : action.description)
-                            .font(.caption).foregroundStyle(.secondary).lineLimit(1)
-                    }
-                    .tag(action.id)
-                    .contextMenu {
-                        Button(strings.duplicateButton) { select(service.duplicate(action)) }
-                        Button(strings.deleteButton, role: .destructive) { service.remove(action) }
+            VStack(spacing: 0) {
+                HStack(spacing: 10) {
+                    sortButton(strings.nameColumn, key: .name)
+                    Spacer()
+                    sortButton(strings.statusColumn, key: .status)
+                        .frame(width: 92, alignment: .leading)
+                }
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                Divider()
+
+                List(selection: $selectedID) {
+                    ForEach(sortedActions) { action in
+                        HStack(spacing: 10) {
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(action.name).font(.headline)
+                                Text(action.description.isEmpty ? inputName(action.input) : action.description)
+                                    .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                            }
+                            Spacer(minLength: 8)
+                            Toggle("", isOn: Binding(
+                                get: { action.enabled },
+                                set: { service.setEnabled(action, enabled: $0) }
+                            ))
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                            .help(action.enabled ? strings.activeStatus : strings.inactiveStatus)
+                        }
+                        .contentShape(Rectangle())
+                        .tag(action.id)
+                        .contextMenu {
+                            Button(strings.duplicateButton) { select(service.duplicate(action)) }
+                            Button(strings.deleteButton, role: .destructive) { service.remove(action) }
+                        }
+                        .accessibilityElement(children: .contain)
+                        .accessibilityLabel("(action.name), (action.enabled ? strings.activeStatus : strings.inactiveStatus)")
                     }
                 }
             }
@@ -91,7 +144,15 @@ struct CustomActionsSettings: View {
                             guard service.save(draft) else { return }
                             selectedID = draft.id
                         }
-                        Button(strings.newButton) { draft = CustomAction(); selectedID = nil; testInput = "" }
+                        if let selectedID,
+                           let selected = service.actions.first(where: { $0.id == selectedID }) {
+                            Button(strings.duplicateButton) { select(service.duplicate(selected)) }
+                        }
+                        Button(strings.newButton) {
+                            draft = CustomAction()
+                            selectedID = nil
+                            testInput = ""
+                        }
                     }
                     if let error = service.lastError {
                         Label(error, systemImage: "exclamationmark.triangle")
@@ -122,5 +183,33 @@ struct CustomActionsSettings: View {
         guard let action else { return }
         draft = action
         selectedID = action.id
+    }
+
+    private func sortButton(_ title: String, key: SortKey) -> some View {
+        Button {
+            if sortKey == key {
+                sortAscending.toggle()
+            } else {
+                sortKey = key
+                sortAscending = true
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(title)
+                if sortKey == key {
+                    Image(systemName: sortAscending ? "chevron.up" : "chevron.down")
+                        .font(.caption2.weight(.bold))
+                }
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func inputName(_ input: CustomActionInput) -> String {
+        switch input {
+        case .selectedText: return strings.selectedText
+        case .clipboardText: return strings.clipboardText
+        case .automatic: return strings.automatic
+        }
     }
 }

--- a/Sources/Vorssaint/UI/Settings/CustomActionsSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/CustomActionsSettings.swift
@@ -49,7 +49,7 @@ struct CustomActionsSettings: View {
                     sortButton(strings.nameColumn, key: .name)
                     Spacer()
                     sortButton(strings.statusColumn, key: .status)
-                        .frame(width: statusColumnWidth, alignment: .leading)
+                        .frame(width: statusColumnWidth, alignment: .center)
                 }
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
@@ -74,8 +74,7 @@ struct CustomActionsSettings: View {
                             .toggleStyle(.switch)
                             .controlSize(.small)
                             .help(action.enabled ? strings.activeStatus : strings.inactiveStatus)
-                            .frame(width: 38, alignment: .trailing)
-                            .frame(width: statusColumnWidth, alignment: .trailing)
+                            .frame(width: statusColumnWidth, alignment: .center)
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .contentShape(Rectangle())

--- a/Sources/Vorssaint/UI/Settings/CustomActionsSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/CustomActionsSettings.swift
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import SwiftUI
+
+struct CustomActionsSettings: View {
+    @ObservedObject private var service = CustomActionService.shared
+    @State private var selectedID: CustomAction.ID?
+    @State private var draft = CustomAction()
+
+    var body: some View {
+        HStack(spacing: 0) {
+            List(selection: $selectedID) {
+                ForEach(service.actions) { action in
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(action.name).font(.headline)
+                        Text(action.description.isEmpty ? action.input.rawValue : action.description)
+                            .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                    }
+                    .tag(action.id)
+                    .contextMenu {
+                        Button("Duplicate") { select(service.duplicate(action)) }
+                        Button("Delete", role: .destructive) { service.remove(action) }
+                    }
+                }
+            }
+            .frame(minWidth: 220, idealWidth: 240)
+
+            Divider()
+
+            Form {
+                Section("Custom Action") {
+                    TextField("Name", text: $draft.name)
+                    TextField("Description", text: $draft.description)
+                    Toggle("Enabled", isOn: $draft.enabled)
+                }
+
+                Section("JavaScript") {
+                    TextEditor(text: $draft.script)
+                        .font(.system(.body, design: .monospaced))
+                        .frame(minHeight: 180)
+                        .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
+                    Text("Available: selectedText, clipboardText, input")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+
+                Section("Input and Output") {
+                    Picker("Input", selection: $draft.input) {
+                        Text("Selected text").tag(CustomActionInput.selectedText)
+                        Text("Clipboard").tag(CustomActionInput.clipboardText)
+                        Text("Automatic").tag(CustomActionInput.automatic)
+                    }
+                    Picker("Output", selection: $draft.output) {
+                        Text("Replace selection").tag(CustomActionOutput.replaceSelection)
+                        Text("Insert at cursor").tag(CustomActionOutput.insertAtCursor)
+                        Text("Copy to clipboard").tag(CustomActionOutput.copyToClipboard)
+                        Text("Preview").tag(CustomActionOutput.preview)
+                    }
+                    Toggle("Show in Command Bar", isOn: $draft.showInCommandBar)
+                    Toggle("Show in Radial Menu", isOn: $draft.showInRadialMenu)
+                }
+
+                Section {
+                    HStack {
+                        Button("Test") {
+                            service.execute(draft, context: CustomActionContext(
+                                selectedText: "Selected sample",
+                                clipboardText: "Clipboard sample"), applyOutput: false)
+                        }
+                        Button("Save") {
+                            guard service.save(draft) else { return }
+                            selectedID = draft.id
+                        }
+                        Button("New") { draft = CustomAction(); selectedID = nil }
+                    }
+                    if let error = service.lastError {
+                        Label(error, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                    }
+                    if let preview = service.lastPreview {
+                        Text(preview).textSelection(.enabled)
+                            .font(.system(.body, design: .monospaced))
+                            .padding(8)
+                            .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
+                    }
+                }
+            }
+            .formStyle(.grouped)
+            .padding()
+        }
+        .navigationTitle("Custom Actions")
+        .onAppear { service.syncWithPreferences(); select(service.actions.first) }
+        .onChange(of: selectedID) { _, id in
+            guard let id, let action = service.actions.first(where: { $0.id == id }) else { return }
+            draft = action
+        }
+    }
+
+    private func select(_ action: CustomAction?) {
+        guard let action else { return }
+        draft = action
+        selectedID = action.id
+    }
+}

--- a/Sources/Vorssaint/UI/Settings/CustomActionsSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/CustomActionsSettings.swift
@@ -75,8 +75,9 @@ struct CustomActionsSettings: View {
                             .controlSize(.small)
                             .help(action.enabled ? strings.activeStatus : strings.inactiveStatus)
                             .frame(width: 38, alignment: .trailing)
+                            .frame(width: statusColumnWidth, alignment: .trailing)
                         }
-                        .frame(width: statusColumnWidth, alignment: .trailing)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                         .contentShape(Rectangle())
                         .tag(action.id)
                         .contextMenu {

--- a/Sources/Vorssaint/UI/Settings/CustomActionsSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/CustomActionsSettings.swift
@@ -21,6 +21,8 @@ struct CustomActionsSettings: View {
         FeatureStrings.customActions(l10n.language)
     }
 
+    private let statusColumnWidth: CGFloat = 92
+
     private var sortedActions: [CustomAction] {
         service.actions.sorted { left, right in
             switch sortKey {
@@ -47,7 +49,7 @@ struct CustomActionsSettings: View {
                     sortButton(strings.nameColumn, key: .name)
                     Spacer()
                     sortButton(strings.statusColumn, key: .status)
-                        .frame(width: 92, alignment: .leading)
+                        .frame(width: statusColumnWidth, alignment: .leading)
                 }
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
@@ -70,8 +72,11 @@ struct CustomActionsSettings: View {
                             ))
                             .labelsHidden()
                             .toggleStyle(.switch)
+                            .controlSize(.small)
                             .help(action.enabled ? strings.activeStatus : strings.inactiveStatus)
+                            .frame(width: 38, alignment: .trailing)
                         }
+                        .frame(width: statusColumnWidth, alignment: .trailing)
                         .contentShape(Rectangle())
                         .tag(action.id)
                         .contextMenu {
@@ -92,6 +97,7 @@ struct CustomActionsSettings: View {
                     TextField(strings.name, text: $draft.name)
                     TextField(strings.description, text: $draft.description)
                     Toggle(strings.enabled, isOn: $draft.enabled)
+                        .controlSize(.small)
                 }
 
                 Section(strings.javascriptSection) {
@@ -116,7 +122,9 @@ struct CustomActionsSettings: View {
                         Text(strings.preview).tag(CustomActionOutput.preview)
                     }
                     Toggle(strings.showCommandBar, isOn: $draft.showInCommandBar)
+                        .controlSize(.small)
                     Toggle(strings.showRadialMenu, isOn: $draft.showInRadialMenu)
+                        .controlSize(.small)
                 }
 
                 Section(strings.testInputSection) {

--- a/Sources/Vorssaint/UI/Settings/CustomActionsSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/CustomActionsSettings.swift
@@ -5,8 +5,14 @@ import SwiftUI
 
 struct CustomActionsSettings: View {
     @ObservedObject private var service = CustomActionService.shared
+    @ObservedObject private var l10n = L10n.shared
     @State private var selectedID: CustomAction.ID?
     @State private var draft = CustomAction()
+    @State private var testInput = ""
+
+    private var strings: CustomActionsFeatureStrings {
+        FeatureStrings.customActions(l10n.language)
+    }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -19,8 +25,8 @@ struct CustomActionsSettings: View {
                     }
                     .tag(action.id)
                     .contextMenu {
-                        Button("Duplicate") { select(service.duplicate(action)) }
-                        Button("Delete", role: .destructive) { service.remove(action) }
+                        Button(strings.duplicateButton) { select(service.duplicate(action)) }
+                        Button(strings.deleteButton, role: .destructive) { service.remove(action) }
                     }
                 }
             }
@@ -29,49 +35,63 @@ struct CustomActionsSettings: View {
             Divider()
 
             Form {
-                Section("Custom Action") {
-                    TextField("Name", text: $draft.name)
-                    TextField("Description", text: $draft.description)
-                    Toggle("Enabled", isOn: $draft.enabled)
+                Section(strings.actionSection) {
+                    TextField(strings.name, text: $draft.name)
+                    TextField(strings.description, text: $draft.description)
+                    Toggle(strings.enabled, isOn: $draft.enabled)
                 }
 
-                Section("JavaScript") {
+                Section(strings.javascriptSection) {
                     TextEditor(text: $draft.script)
                         .font(.system(.body, design: .monospaced))
                         .frame(minHeight: 180)
                         .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
-                    Text("Available: selectedText, clipboardText, input")
+                    Text(strings.availableVariables)
                         .font(.caption).foregroundStyle(.secondary)
                 }
 
-                Section("Input and Output") {
-                    Picker("Input", selection: $draft.input) {
-                        Text("Selected text").tag(CustomActionInput.selectedText)
-                        Text("Clipboard").tag(CustomActionInput.clipboardText)
-                        Text("Automatic").tag(CustomActionInput.automatic)
+                Section(strings.inputOutputSection) {
+                    Picker(strings.input, selection: $draft.input) {
+                        Text(strings.selectedText).tag(CustomActionInput.selectedText)
+                        Text(strings.clipboardText).tag(CustomActionInput.clipboardText)
+                        Text(strings.automatic).tag(CustomActionInput.automatic)
                     }
-                    Picker("Output", selection: $draft.output) {
-                        Text("Replace selection").tag(CustomActionOutput.replaceSelection)
-                        Text("Insert at cursor").tag(CustomActionOutput.insertAtCursor)
-                        Text("Copy to clipboard").tag(CustomActionOutput.copyToClipboard)
-                        Text("Preview").tag(CustomActionOutput.preview)
+                    Picker(strings.output, selection: $draft.output) {
+                        Text(strings.replaceSelection).tag(CustomActionOutput.replaceSelection)
+                        Text(strings.insertAtCursor).tag(CustomActionOutput.insertAtCursor)
+                        Text(strings.copyToClipboard).tag(CustomActionOutput.copyToClipboard)
+                        Text(strings.preview).tag(CustomActionOutput.preview)
                     }
-                    Toggle("Show in Command Bar", isOn: $draft.showInCommandBar)
-                    Toggle("Show in Radial Menu", isOn: $draft.showInRadialMenu)
+                    Toggle(strings.showCommandBar, isOn: $draft.showInCommandBar)
+                    Toggle(strings.showRadialMenu, isOn: $draft.showInRadialMenu)
                 }
 
-                Section {
-                    HStack {
-                        Button("Test") {
-                            service.execute(draft, context: CustomActionContext(
-                                selectedText: "Selected sample",
-                                clipboardText: "Clipboard sample"), applyOutput: false)
+                Section(strings.testInputSection) {
+                    ZStack(alignment: .topLeading) {
+                        TextEditor(text: $testInput)
+                            .frame(minHeight: 76, maxHeight: 130)
+                            .overlay(RoundedRectangle(cornerRadius: 6).stroke(.quaternary))
+                        if testInput.isEmpty {
+                            Text(strings.testInputPlaceholder)
+                                .foregroundStyle(.tertiary)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 8)
+                                .allowsHitTesting(false)
                         }
-                        Button("Save") {
+                    }
+                    Text(strings.testInputHint)
+                        .font(.caption).foregroundStyle(.secondary)
+                    HStack {
+                        Button(strings.testButton) {
+                            service.execute(draft, context: CustomActionContext(
+                                selectedText: testInput,
+                                clipboardText: testInput), applyOutput: false)
+                        }
+                        Button(strings.saveButton) {
                             guard service.save(draft) else { return }
                             selectedID = draft.id
                         }
-                        Button("New") { draft = CustomAction(); selectedID = nil }
+                        Button(strings.newButton) { draft = CustomAction(); selectedID = nil; testInput = "" }
                     }
                     if let error = service.lastError {
                         Label(error, systemImage: "exclamationmark.triangle")
@@ -83,12 +103,14 @@ struct CustomActionsSettings: View {
                             .padding(8)
                             .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
                     }
+                    Text(strings.testOnlyHint)
+                        .font(.caption2).foregroundStyle(.secondary)
                 }
             }
             .formStyle(.grouped)
             .padding()
         }
-        .navigationTitle("Custom Actions")
+        .navigationTitle(strings.pageTitle)
         .onAppear { service.syncWithPreferences(); select(service.actions.first) }
         .onChange(of: selectedID) { _, id in
             guard let id, let action = service.actions.first(where: { $0.id == id }) else { return }

--- a/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
@@ -741,6 +741,7 @@ extension AppFeature {
         case .radialMenu: return FeatureStrings.radialMenu(L10n.shared.language).pageTitle
         case .scratchpad: return FeatureStrings.scratchpad(L10n.shared.language).pageTitle
         case .commandBar: return FeatureStrings.commandBar(L10n.shared.language).pageTitle
+        case .customActions: return "Custom Actions"
         case .cleaningMode: return s.cleaningMenuItem
         case .mediaTools: return s.mediaName
         case .cleaner: return s.cleanerName
@@ -804,6 +805,7 @@ extension AppFeature {
         case .radialMenu: return FeatureStrings.radialMenu(L10n.shared.language).hubDescription
         case .scratchpad: return FeatureStrings.scratchpad(L10n.shared.language).hubDescription
         case .commandBar: return FeatureStrings.commandBar(L10n.shared.language).hubDescription
+        case .customActions: return "Transforme texto com scripts JavaScript locais"
         case .cleaningMode: return hub.descCleaningMode
         case .mediaTools: return hub.descMediaTools
         case .cleaner:

--- a/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
@@ -241,6 +241,7 @@ extension AppFeature {
         case .scratchpad:
             return FeatureSettingsDestination(.quickTools, sectionAnchor: .scratchpad)
         case .commandBar: return FeatureSettingsDestination(.commandBar)
+        case .customActions: return FeatureSettingsDestination(.customActions)
         case .screenRecorder:
             return FeatureSettingsDestination(.screenshot, sectionAnchor: .screenRecorder)
 

--- a/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
@@ -8,7 +8,7 @@ import Foundation
 /// below and the unit tests can reason about pages without pulling UI in.
 enum SettingsPage: Hashable {
     case general, features, energy, monitor
-    case mouse, switcher, keyDebounce, superKey, cutPaste, autoQuit, cleaner, uninstaller, urlCleaner, homebrew, appUpdates, media, clipboard, windowLayout, shelf, quickTools, textSnippets, screenshot, radialMenu, commandBar, killProcess
+    case mouse, switcher, keyDebounce, superKey, cutPaste, autoQuit, cleaner, uninstaller, urlCleaner, homebrew, appUpdates, media, clipboard, windowLayout, shelf, quickTools, textSnippets, screenshot, radialMenu, commandBar, customActions, killProcess
     case shortcuts, advanced, about, releaseNotes, support
 }
 
@@ -289,6 +289,7 @@ enum FeatureVisibilitySupport {
         case .screenshot: return [.screenshot, .screenRecorder, .screenOCR, .colorPicker]
         case .radialMenu: return [.radialMenu]
         case .commandBar: return [.commandBar]
+        case .customActions: return [.customActions]
         case .general, .features, .shortcuts, .advanced, .about, .releaseNotes, .support:
             return []
         }

--- a/Sources/Vorssaint/UI/Settings/RadialMenuSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/RadialMenuSettings.swift
@@ -543,6 +543,7 @@ private struct RadialItemRow: View {
         case .url: return text.kindURL
         case .shortcut: return text.kindShortcut
         case .tool: return text.kindTool
+        case .customAction: return "Custom Action"
         case .quickToggle: return FeatureStrings.quickToggles(L10n.shared.language).pageTitle
         case .windowLayout: return FeatureStrings.windowLayout(L10n.shared.language).title
         case .media: return text.kindMedia
@@ -723,6 +724,9 @@ private struct RadialItemEditor: View {
                     if !availableTools.isEmpty {
                         Text(text.kindTool).tag(RadialMenuItem.Kind.tool)
                     }
+                    if !CustomActionService.shared.actions.filter({ $0.enabled && $0.showInRadialMenu }).isEmpty {
+                        Text("Custom Action").tag(RadialMenuItem.Kind.customAction)
+                    }
                     if !availableQuickToggles.isEmpty {
                         Text(FeatureStrings.quickToggles(l10n.language).pageTitle)
                             .tag(RadialMenuItem.Kind.quickToggle)
@@ -799,6 +803,7 @@ private struct RadialItemEditor: View {
             if kind != .url { item.customIconData = nil }
             switch kind {
             case .tool: item.payload = availableTools.first?.rawValue ?? ""
+            case .customAction: item.payload = CustomActionService.shared.actions.first(where: { $0.enabled && $0.showInRadialMenu })?.id.uuidString ?? ""
             case .quickToggle: item.payload = availableQuickToggles.first?.rawValue ?? ""
             case .windowLayout: item.payload = WindowLayoutAction.leftHalf.rawValue
             case .media: item.payload = RadialMenuMediaKey.playPause.rawValue
@@ -900,6 +905,12 @@ private struct RadialItemEditor: View {
                 ForEach(availableTools) { tool in
                     Text(tool.feature.hubTitle(l10n.s, hub: FeatureStrings.hub(l10n.language)))
                         .tag(tool.rawValue)
+                }
+            }
+        case .customAction:
+            Picker("Custom Action", selection: $item.payload) {
+                ForEach(CustomActionService.shared.actions.filter { $0.enabled && $0.showInRadialMenu }) { action in
+                    Text(action.name).tag(action.id.uuidString)
                 }
             }
         case .quickToggle:

--- a/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
@@ -207,6 +207,10 @@ enum SettingsDirectory {
                                       icon: "command",
                                       keywords: [FeatureStrings.commandBar(language).openButton,
                                                  FeatureStrings.commandBar(language).searchPlaceholder]),
+                SettingsDirectoryItem(page: .customActions,
+                                      title: "Custom Actions",
+                                      icon: "wand.and.stars",
+                                      keywords: ["JavaScript", "selectedText", "clipboardText", "transform"]),
                 SettingsDirectoryItem(page: .quickTools, title: s.quickToolsTab, icon: "wand.and.rays",
                                        featureKeywords: [
                                         (.quickLauncher, [s.launcherName]),

--- a/Sources/Vorssaint/UI/Settings/SettingsView.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsView.swift
@@ -350,6 +350,7 @@ struct SettingsView: View {
         case .textSnippets: TextSnippetsSettings()
         case .radialMenu: RadialMenuSettings()
         case .commandBar: CommandBarSettings()
+        case .customActions: CustomActionsSettings()
         case .energy: EnergySettings()
         case .monitor: MonitorSettings()
         case .mouse: MouseSettings()

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21319,6 +21319,33 @@ struct MetricsTests {
                + "(ran \(detachedRuns) time(s))")
         try? FileManager.default.removeItem(at: detachRoot)
 
+        // MARK: Custom Actions
+        let customContext = CustomActionContext(selectedText: "Hello  123", clipboardText: "Copied text")
+        let upper = CustomActionSupport.execute(script: "return input.toUpperCase()",
+                                                 context: customContext, input: .selectedText)
+        expect(upper == .success("HELLO  123"),
+               "custom action executes JavaScript against selectedText/input")
+        let automatic = CustomActionSupport.execute(script: "return input.replace(/\\s+/g, ' ').trim()",
+                                                     context: customContext, input: .automatic)
+        expect(automatic == .success("Hello 123"),
+               "custom action automatic input prefers selected text")
+        let clipboard = CustomActionSupport.execute(script: "return input.toUpperCase()",
+                                                     context: CustomActionContext(selectedText: "", clipboardText: "clip"),
+                                                     input: .automatic)
+        expect(clipboard == .success("CLIP"),
+               "custom action automatic input falls back to clipboard")
+        expect(CustomActionSupport.execute(script: "return process.version",
+                                            context: customContext, input: .selectedText)
+                   == .failure(.forbiddenAPI("process")),
+               "custom action rejects process access")
+        expect(CustomActionSupport.execute(script: "throw new Error('bad')",
+                                            context: customContext, input: .selectedText)
+                   == .failure(.javascript("Error: bad")),
+               "custom action reports JavaScript exceptions")
+        let customRadial = RadialMenuItem(kind: .customAction, payload: UUID().uuidString)
+        expect(RadialMenuSupport.isValidPayload(customRadial),
+               "radial custom action payload validates as a UUID")
+
         if failures.isEmpty {
             print("TESTS OK (\(checks) checks)")
             exit(0)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -12346,7 +12346,7 @@ struct MetricsTests {
 
         // MARK: Features hub catalog
 
-        expect(AppFeature.allCases.count == 56, "feature catalog has 56 features")
+        expect(AppFeature.allCases.count == 57, "feature catalog has 57 features")
         expect(Set(AppFeature.allCases.map(\.rawValue)).count == AppFeature.allCases.count,
                "feature ids are unique")
         expect(AppFeature.allCases.map(\.rawValue) == [
@@ -12359,7 +12359,7 @@ struct MetricsTests {
             "keepAwake", "brightness", "extraBrightness", "bluetoothSleep",
             "quickLauncher", "quickToggles", "colorPicker", "screenOCR", "cleaningMode", "mediaTools",
             "cleaner", "uninstaller", "homebrew", "appUpdates", "screenshot", "cameraPreview",
-            "radialMenu", "scratchpad", "commandBar", "screenRecorder", "killProcess",
+            "radialMenu", "scratchpad", "commandBar", "customActions", "screenRecorder", "killProcess",
             "monitorCPU", "monitorGPU", "monitorMemory", "monitorNetwork", "monitorDisk", "monitorPower",
             "fanControl",
         ], "feature ids are stable (they persist inside availability keys)")
@@ -12427,9 +12427,10 @@ struct MetricsTests {
                 && (AppFeature.availabilityDefaults[AppFeature.diskImageInstaller.availabilityKey] as? Bool) == false
                 && (AppFeature.availabilityDefaults[AppFeature.focusFollowsMouse.availabilityKey] as? Bool) == false
                 && (AppFeature.availabilityDefaults[AppFeature.killProcess.availabilityKey] as? Bool) == false
+                && (AppFeature.availabilityDefaults[AppFeature.customActions.availabilityKey] as? Bool) == false
                 && AppFeature.allCases.filter {
                     $0 != .focusFollowsMouse && $0 != .fanControl && $0 != .diskImageInstaller
-                        && $0 != .killProcess
+                        && $0 != .killProcess && $0 != .customActions
                 }.allSatisfy {
                     (AppFeature.availabilityDefaults[$0.availabilityKey] as? Bool) == true
                 },

--- a/build.sh
+++ b/build.sh
@@ -259,6 +259,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/Recorder/RecorderEditDocument.swift \
         Sources/Vorssaint/Core/AppInfo.swift \
         Sources/Vorssaint/Core/GlobalShortcut.swift \
+        Sources/Vorssaint/Services/CustomActions/CustomActionSupport.swift \
         Sources/Vorssaint/Core/Localization.swift \
         Sources/Vorssaint/Core/Localizations/Strings+*.swift \
         Sources/Vorssaint/Core/FeatureStrings.swift \

--- a/build.sh
+++ b/build.sh
@@ -217,6 +217,7 @@ if (( TEST )); then
         Sources/Vorssaint/Core/FeatureCatalog.swift \
         Sources/Vorssaint/Core/FeaturePresets.swift \
         Sources/Vorssaint/Core/FeatureHubStrings.swift \
+        Sources/Vorssaint/Core/CustomActionsStrings.swift \
         Sources/Vorssaint/Core/ShortcutSettingsStrings.swift \
         Sources/Vorssaint/Core/SettingsBackupSupport.swift \
         Sources/Vorssaint/Core/BackupStrings.swift \


### PR DESCRIPTION
## Summary

Adds Custom Actions, a local JavaScript text-transformation feature for selected text and clipboard content. Users can create actions, test them with a preview, and run them from the Command Bar, Radial Menu, or an individual shortcut.

## Included

- `selectedText`, `clipboardText`, and automatic `input` variables
- restricted JavaScript data-transform runtime with size and API guards
- Replace Selection, Insert at Cursor, Copy to Clipboard, and Preview outputs
- installable Custom Actions feature module with lifecycle gating
- Command Bar, Radial Menu, and dynamic shortcut integration
- editor with editable test input, preview/error feedback, duplication, deletion, enable/disable toggles, and sortable Name/Status list
- local persistence and settings backup coverage
- Portuguese UI strings with English fallback for other locales

## Safety and privacy

Scripts receive strings only and do not receive filesystem, shell, network, process, AppKit, or direct clipboard APIs. Execution errors validate before output and preserve the original selection/clipboard. Accessibility is requested only for flows that need selection or insertion.

## Verification

- `swift build`
- `./build.sh --test` — 9,347 checks
- `./build.sh --dev`
- `./build.sh`
- `./build/Vorssaint --selftest` — SELFTEST OK
- Developer bundle manually installed and validated at `/Applications/Vorssaint (Developer).app`

## Review notes

The PR is based on `upstream/main` and contains only the Custom Actions resource. The local Ditado integration remains on the personal integration branch and is not included here. Global Accessibility/TCC behavior still needs maintainer-side manual review on a clean Developer bundle.