### PR TITLE
fix(window-layout): stop treating spanning displays as system tiling

### DIFF
--- a/Sources/Vorssaint/Services/WindowLayout/WindowGestureSupport.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowGestureSupport.swift
@@ -368,17 +368,45 @@ enum WindowEdgeSnapSupport {
     static var isSystemTilingEnabled: Bool {
         guard #available(macOS 15.0, *),
               let defaults = UserDefaults(suiteName: "com.apple.WindowManager") else { return false }
-        return systemTilingEnabled { key in
-            guard defaults.object(forKey: key) != nil else { return nil }
-            return defaults.bool(forKey: key)
-        }
+        return systemTilingEnabled(
+            valueFor: { key in
+                guard defaults.object(forKey: key) != nil else { return nil }
+                return defaults.bool(forKey: key)
+            },
+            displaysSpan: displaysSpan(spacesPreference("spans-displays"))
+        )
     }
 
     /// The system's edge tiling choices arrive enabled when their preference
     /// has never been written. Keeping this pure makes the conflict gate
     /// testable without changing somebody's desktop settings.
-    static func systemTilingEnabled(valueFor: (String) -> Bool?) -> Bool {
-        systemTilingKeys.contains { valueFor($0) ?? true }
+    ///
+    /// When displays span (Separate Spaces off) those switches are greyed
+    /// out and the system's own tiling is inert, so a missing key must not
+    /// pin the gate on — the warning's own instruction is unreachable then
+    /// (issue #1079).
+    static func systemTilingEnabled(valueFor: (String) -> Bool?,
+                                    displaysSpan: Bool = false) -> Bool {
+        if displaysSpan { return false }
+        return systemTilingKeys.contains { valueFor($0) ?? true }
+    }
+
+    /// Separate Spaces off is the only configuration where displays span.
+    /// An absent preference is Apple's default: one Space per display.
+    static func displaysSpan(_ value: Bool?) -> Bool {
+        value ?? false
+    }
+
+    private static func spacesPreference(_ key: String) -> Bool? {
+        if let defaults = UserDefaults(suiteName: "com.apple.spaces"),
+           defaults.object(forKey: key) != nil {
+            return defaults.bool(forKey: key)
+        }
+        guard let domain = UserDefaults.standard.persistentDomain(forName: "com.apple.spaces"),
+              let raw = domain[key] else { return nil }
+        if let bool = raw as? Bool { return bool }
+        if let number = raw as? NSNumber { return number.boolValue }
+        return nil
     }
 
     static var isSystemTopWindowOverviewDragEnabled: Bool {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -4574,6 +4574,15 @@ struct MetricsTests {
                    $0 == "EnableTilingByEdgeDrag" ? true : false
                },
                "one enabled system edge gesture is enough to prevent competing previews")
+        expect(!WindowEdgeSnapSupport.systemTilingEnabled(valueFor: { _ in nil }, displaysSpan: true)
+                && !WindowEdgeSnapSupport.systemTilingEnabled(valueFor: { _ in true }, displaysSpan: true),
+               "spanning displays make system tiling inert, even when its keys are missing or on")
+        expect(WindowEdgeSnapSupport.systemTilingEnabled(valueFor: { _ in true }, displaysSpan: false),
+               "separate Spaces still honour a written system tiling switch")
+        expect(!WindowEdgeSnapSupport.displaysSpan(nil)
+                && !WindowEdgeSnapSupport.displaysSpan(false)
+                && WindowEdgeSnapSupport.displaysSpan(true),
+               "an unwritten spans-displays preference is separate Spaces, Apple's default")
 
         let dragFrame = CGRect(x: 100, y: 100, width: 800, height: 500)
         expect(WindowEdgeSnapSupport.classify(


### PR DESCRIPTION
## Summary

Edge snap stays off, and Settings keeps the orange "macOS is using the same edges" warning, when Displays have separate spaces is off and the three `com.apple.WindowManager` tiling keys have never been written.

That combination is a trap: macOS greys the four Desktop & Dock switches out, so the warning tells you to change something you cannot reach. PathGao already narrowed it on #1079 — `?? true` is Apple's default when Separate Spaces is on, and the gate should not hard-suppress in the configuration where those switches are inert.

The gate now asks `com.apple.spaces` `spans-displays` as well. When displays span, system tiling is treated as off even if the WindowManager keys are missing or still `1`. Separate Spaces on is unchanged: an unwritten key still counts as enabled.

## Verification

MacBook Pro 14, M1 Pro, macOS 26.6.1 (25G76), one display, Separate Spaces on. Local debug build of this branch.

```
./build.sh --test
```

TESTS OK (8821 checks). The new ones cover spanning-displays overriding missing and enabled keys, and the default for an unwritten `spans-displays`.

On this Mac `defaults read com.apple.WindowManager` has none of `EnableTilingByEdgeDrag`, `EnableTilingOptionAccelerator`, `EnableTopTilingByEdgeDrag`, and `spans-displays` is `0`. That matches cause A on the issue (keys absent on Tahoe) for the default Separate Spaces layout.

I did not turn Separate Spaces off. That needs a logout here, and I did not want to bounce the session just to watch the orange text go away. So the live `spacesPreference` read is the part I have not seen with my own eyes.

Refs #1079

Made with [Cursor](https://cursor.com)