### PR TITLE
perf(fan-control): let the one-second timer coalesce with other wakes

### DIFF
--- a/Sources/Vorssaint/Services/FanControl/FanControlService.swift
+++ b/Sources/Vorssaint/Services/FanControl/FanControlService.swift
@@ -546,6 +546,11 @@ final class FanControlService: ObservableObject {
                 self.refresh()
             }
         }
+        // The helper drops cooling once a heartbeat is `heartbeatLimit` seconds
+        // old, so a second's cadence has six to spare; matching the leeway the
+        // helper's own watchdog already takes lets these wakes coalesce with
+        // everything else on the run loop instead of standing alone.
+        timer?.tolerance = 0.1
     }
 
     private func stopIdleWorkIfPossible() {


### PR DESCRIPTION
## Summary

`FanControlService`'s one-second timer was the only repeating timer in the app without a `tolerance`, so its wake could never coalesce with any other work already scheduled on the run loop. Every other repeating timer here sets one — 21 of 22 before this change.

It now sets `0.1`, which is the same leeway the fan helper's own watchdog already takes on its own one-second timer (`timer.schedule(deadline: .now() + 1, repeating: 1, leeway: .milliseconds(100))`). The number is copied from there rather than picked: the helper restores cooling once a heartbeat is `FanControlSupport.heartbeatLimit` (7 seconds) old, so a one-second cadence has six seconds of headroom and a tenth of a second cannot put the heartbeat at risk.

**This is a small change and worth saying so plainly.** The timer only runs while the fan panel is visible, a cooling job is active, or a recovery is pending — `startTimerIfNeeded` guards on exactly those and `stopIdleWorkIfPossible` tears it down otherwise. So it never fires in an idle app, and this changes nothing about background energy use. What it fixes is one timer that stood alone during the window when it does run, in a codebase that otherwise sets tolerance consistently.

### Deliberately not changed

The cadence, the guards, and the heartbeat and refresh logic inside the closure are untouched. `FanControlSupport.heartbeatLimit` is unchanged.

## Verification

Mac17,3 (Apple M5), macOS 26.6.2 build 25G83, single display, release build via `./build.sh` with no flags, arm64.

```
./build.sh                    # compiled with no warnings; build/Vorssaint produced, 41.5 MB arm64
./build/Vorssaint --selftest  # SELFTEST OK
./build.sh --test             # unchanged against this branch's base
```

**What I could not test: the app was never launched, and the fan panel was never opened.** `./build.sh` cannot finish codesigning in the environment I built in, so no `.app` bundle exists to run. Nothing exercised the timer.

A reviewer with fan control hardware should confirm that a cooling job still holds — the heartbeat keeps flowing and cooling is not dropped for a lost heartbeat — and that the panel's readings still refresh at the same rate while it is open.

Two assertions in the suite fail on this machine, `nil layout falls back to ANSI semicolon` and `App Switcher icon-row hints describe default app and window shortcuts`. Both are pre-existing and unrelated: they read the live keyboard layout, and this machine's active input source is `com.apple.keylayout.PinyinKeyboard`, whose semicolon key is a full-width `；`. They reproduce identically on unmodified `main`.

## Anything else

No open issue reports this, so there is no `Refs` line.

One of four independent performance fixes from the same review, each in a different service file.
