### PR TITLE
perf(switcher): skip the user-facing check for windows already collected

### DIFF
--- a/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowEnumerator.swift
@@ -631,6 +631,12 @@ enum WindowEnumerator {
             guard !isCancelled() else { return nil }
             if let window = accessibilityWindowAttribute(app, attribute as String) {
                 guard !isCancelled() else { return nil }
+                // The main and focused window are almost always ones the
+                // window list already described, and usually the same window
+                // as each other. CFEqual answers that locally, while
+                // isUserFacingWindow spends several Accessibility round trips
+                // in the other process to reach a window we would then drop.
+                guard !contains(window, in: axWindows) else { continue }
                 AXUIElementSetMessagingTimeout(window, 0.35)
                 if isUserFacingWindow(window,
                                       bundleIdentifier: bundleIdentifier,
@@ -638,7 +644,7 @@ enum WindowEnumerator {
                                       normalLevelWindowIDs: normalLevelWindowIDs,
                                       screenFrames: screenFrames,
                                       isCancelled: isCancelled) {
-                    appendUnique(window, to: &axWindows)
+                    axWindows.append(window)
                 }
             }
         }
@@ -838,8 +844,12 @@ enum WindowEnumerator {
     }
 
     private static func appendUnique(_ window: AXUIElement, to windows: inout [AXUIElement]) {
-        guard !windows.contains(where: { CFEqual($0, window) }) else { return }
+        guard !contains(window, in: windows) else { return }
         windows.append(window)
+    }
+
+    private static func contains(_ window: AXUIElement, in windows: [AXUIElement]) -> Bool {
+        windows.contains { CFEqual($0, window) }
     }
 
     private static func accessibilityWindowAttribute(_ app: AXUIElement, _ attribute: String) -> AXUIElement? {


### PR DESCRIPTION
## Summary

`WindowEnumerator.accessibilityWindows(for:)` collects an app's windows from
`kAXWindows`, then adds whatever `kAXMainWindow` and `kAXFocusedWindow` point
at. Both of those lookups ran `isUserFacingWindow` first and only then asked
`appendUnique` whether the window had already been collected. The main and
focused window are almost always already in the window list, and usually the
same window as each other, so both lookups paid the full predicate to produce
a window that was then discarded.

The dedup test now runs first. It is `CFEqual` over a handful of
`AXUIElement`s, entirely in-process; the predicate is not.

Arithmetic, per app, per enumeration. `isUserFacingWindow` costs 4
Accessibility round trips for an ordinary standard window (`AXFullScreen`,
`AXSubrole`, `AXMinimized`, `AXSubrole` again), 1 for a full-screen one, and 8
on the undescribed-subrole path, which adds `AXRole`, then `AXPosition` and
`AXSize` — `accessibilityFrame(for:)` reads the position and the size
separately, which an earlier version of this description counted as one — and
finally `_AXUIElementGetWindow` for the window id.

8 is the ceiling on that path rather than 9. The minimized branch reads
`AXRole` a second time, but the two reads cannot both be spent on a window
that also reaches the id: a window answering `AXWindow` there returns early,
and a window answering anything else fails the `role == kAXWindowRole` test
that gates `AXWindowResolver.windowID(for:)`. So the two worst paths are
`AXFullScreen`, `AXSubrole`, `AXMinimized`, `AXSubrole`, `AXRole`,
`AXPosition`, `AXSize`, window id for a window that is not minimized, and the
same eight with the minimized `AXRole` read in place of the id for one that
is. Reaching nine would need the two `AXRole` reads to disagree within a
single call.

With both lookups landing on already-collected windows — the common case —
that is 8 round trips saved per app, 4 per lookup for the ordinary standard
window they normally land on. Nothing is saved when an app reports a main or
focused window genuinely absent from its window list; there the predicate runs
exactly as before, behind one extra `CFEqual` scan.

The size of this is modest. On the batched switcher path the per-app queries
already run 24-wide, so the wall-clock gain there is small. It matters more on
`listWindows(for:)`, which Dock Preview and the window preview call
synchronously on the main thread for a single app, where the whole saving
comes off that call directly.

This is a pure reordering. For a window already collected, the old code
evaluated the predicate and then dropped the window; the new code drops it
without evaluating. Every other window takes an identical path, so the
resulting array and its order are unchanged.

Deliberately not changed: the `kAXWindows` loop above keeps its original order,
since an app repeating a window inside its own window array does not happen and
reordering there would buy nothing.

`AutoQuitService.standardWindows(of:)` has the same predicate-then-dedup order
with the same two lookups, and it is not fixed here because #1214 fixes it
there. That PR turns its `appendUnique` into `appendIfStandard`, which runs the
`CFEqual` match before `isStandardWindow`, in both its window loop and its
main/focused loop — the same change as this one, in the file that owns it. It
is open on that file right now, so making the edit here as well would only put
two branches in conflict over one fix. If #1214 is dropped, that call site
still needs this treatment.

## Verification

This revision changes the description only. No code has changed since the
review above, and the commit is the one that was reviewed; nothing was rebuilt
for it. The correction to the round-trip ceiling was traced through
`isUserFacingWindow`, `isFullscreenWindow`, `accessibilityFrame(for:)` and
`AXWindowResolver.windowID(for:)` by reading them, and the claim about #1214
comes from reading its diff.

The build and test results below are from the original submission.

Mac17,3 (Apple M5), macOS 26.6.2 build 25G83, single display, local release
build signed with the self-signed `Vorssaint Utils Signing` identity.

```sh
./build.sh                 # no errors, no warnings; build/Vorssaint produced (41.5 MB)
./build/Vorssaint --selftest   # SELFTEST OK
./build.sh --test          # 2 of 9399 assertions failed
```

Both test failures are pre-existing and unrelated: `nil layout falls back to
ANSI semicolon` and `App Switcher icon-row hints describe default app and
window shortcuts`. They read the live keyboard layout, and this machine's
active input source is `com.apple.keylayout.PinyinKeyboard`, whose semicolon
key is a full-width `；`. The same two fail on a clean checkout of `main` here,
with the same 2-of-9399 count.

`WindowEnumerator.swift` is not in the `build.sh --test` compile list and the
code is `AXUIElement`-bound, so there is no unit test to add for it.

**What I could not test:** codesigning does not complete on this machine —
`./build.sh` ends with `errSecInternalComponent` on the fan-control helper, so
no `.app` bundle is produced and **the app was never launched**. The switcher,
Dock Preview and window preview were not exercised against this build. The
argument above comes from reading the code, not from a measurement.

## Anything else

No open issue reports this, so there is no `Refs` line. #938 covers
Accessibility messaging timeout ownership and is adjacent — the skipped path
no longer calls `AXUIElementSetMessagingTimeout` on a window it is about to
drop — but that is a different defect and this change neither moves the 0.35 s
value nor changes who owns it.

#1214 is the sibling fix in `AutoQuitService`. The two are independent: they
touch different files and neither depends on the other landing.
