### PR TITLE
fix(quit-protection): follow the keyboard layout and bound the confirmation swallow

### DIFF
--- a/Sources/Vorssaint/Core/GlobalShortcut.swift
+++ b/Sources/Vorssaint/Core/GlobalShortcut.swift
@@ -525,13 +525,33 @@ struct GlobalShortcut: Equatable, Hashable {
         return nil
     }
 
+    /// The same question the keycaps ask, backwards: a caller that knows the
+    /// character a shortcut is named for (Command-Q) needs the key the system
+    /// will resolve it to, which moves with the layout. `usesCommand` picks the
+    /// same table the caps read, so Command-Q answers 12 on Russian and Greek,
+    /// 7 on Dvorak, and 12 again on DVORAK-QWERTYCMD.
+    ///
+    /// Answered from the cache alone, so an event tap can ask on every key from
+    /// its own thread. nil until a layout has been read, which leaves the caller
+    /// on whatever it did without one.
+    static func layoutKeyCode(for character: String, usesCommand: Bool) -> Int64? {
+        let key = LayoutKeyCodeKey(label: character.uppercased(), usesCommand: usesCommand)
+        return layoutLabelLock.withLock { layoutKeyCodes[key] }
+    }
+
     private struct LayoutLabelKey: Hashable {
         let keyCode: Int64
         let usesCommand: Bool
     }
 
+    private struct LayoutKeyCodeKey: Hashable {
+        let label: String
+        let usesCommand: Bool
+    }
+
     private static let layoutLabelLock = NSLock()
     private static var layoutLabels: [LayoutLabelKey: String] = [:]
+    private static var layoutKeyCodes: [LayoutKeyCodeKey: Int64] = [:]
     private static var keyboardLayoutObserver: AnyObject?
 
     /// Starts observing system keyboard layout changes so the keycap cache stays
@@ -550,10 +570,14 @@ struct GlobalShortcut: Equatable, Hashable {
     /// or when simulating a specific keyboard layout in tests.
     static func refreshLayoutLabels(layoutData: Data? = currentLayoutData()) {
         guard let layoutData else {
-            layoutLabelLock.withLock { layoutLabels.removeAll() }
+            layoutLabelLock.withLock {
+                layoutLabels.removeAll()
+                layoutKeyCodes.removeAll()
+            }
             return
         }
         var labels: [LayoutLabelKey: String] = [:]
+        var keyCodes: [LayoutKeyCodeKey: Int64] = [:]
         for keyCode in UInt16(0)...127 {
             for usesCommand in [false, true] {
                 if let label = derivedLayoutKeyLabel(for: keyCode,
@@ -561,10 +585,20 @@ struct GlobalShortcut: Equatable, Hashable {
                                                      usesCommand: usesCommand) {
                     labels[LayoutLabelKey(keyCode: Int64(keyCode),
                                           usesCommand: usesCommand)] = label
+                    // Ascending, so a character two keys can type answers with
+                    // the first of them rather than with whichever the
+                    // dictionary happens to hand back.
+                    let keyCodeKey = LayoutKeyCodeKey(label: label, usesCommand: usesCommand)
+                    if keyCodes[keyCodeKey] == nil {
+                        keyCodes[keyCodeKey] = Int64(keyCode)
+                    }
                 }
             }
         }
-        layoutLabelLock.withLock { layoutLabels = labels }
+        layoutLabelLock.withLock {
+            layoutLabels = labels
+            layoutKeyCodes = keyCodes
+        }
     }
 
     private static func derivedLayoutKeyLabel(for keyCode: Int64,

--- a/Sources/Vorssaint/Core/QuitProtectionSupport.swift
+++ b/Sources/Vorssaint/Core/QuitProtectionSupport.swift
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Vorssaint
 
-import Carbon.HIToolbox
 import Foundation
 
 enum QuitProtectionShortcut: String, CaseIterable, Identifiable {
@@ -10,6 +9,11 @@ enum QuitProtectionShortcut: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
     var character: String { self == .quit ? "q" : "w" }
+    /// Which key the active layout answers this shortcut on with Command held,
+    /// read from the keycap cache that already holds the layout's Command
+    /// table. nil while no layout has been read, which leaves matching on the
+    /// character.
+    var commandKeyCode: Int64? { GlobalShortcut.layoutKeyCode(for: character, usesCommand: true) }
     /// The US position, used only while no keyboard layout can be read.
     var fallbackKeyCode: Int64 { self == .quit ? 12 : 13 }
     var symbol: String { self == .quit ? "⌘Q" : "⌘W" }
@@ -193,90 +197,5 @@ enum QuitProtectionSupport {
     static func scopeFor(_ rawValue: String?) -> QuitProtectionScope {
         guard let rawValue, let value = QuitProtectionScope(rawValue: rawValue) else { return .all }
         return value
-    }
-}
-
-/// Which physical key the system will read as Command-Q and Command-W.
-///
-/// Keyboard layouts carry their own Command table, and every non-Latin layout
-/// points it back at the Latin letters: Russian types "й" on the Q key but
-/// still quits there, and "Dvorak - QWERTY ⌘" moves Q back under the QWERTY
-/// position exactly while Command is held. Asking the layout the same question
-/// the system asks is what keeps protection on the key that actually quits.
-enum QuitProtectionKeyLayout {
-    private static let lock = NSLock()
-    private static var keyCodes: [QuitProtectionShortcut: Int64] = [:]
-    private static var layoutObserver: AnyObject?
-
-    /// nil while no layout has answered, which leaves matching on the character.
-    static func commandKeyCode(for shortcut: QuitProtectionShortcut) -> Int64? {
-        lock.withLock { keyCodes[shortcut] }
-    }
-
-    /// Called when the tap starts. Switching layout moves both shortcuts without
-    /// producing an event of ours, so the resolution has to follow it.
-    /// Safe to call more than once.
-    static func startObserving() {
-        refresh()
-        guard layoutObserver == nil else { return }
-        layoutObserver = DistributedNotificationCenter.default().addObserver(
-            forName: NSNotification.Name(kTISNotifySelectedKeyboardInputSourceChanged as String),
-            object: nil,
-            queue: .main
-        ) { _ in refresh() }
-    }
-
-    /// Takes a layout directly as well, so tests can resolve against a specific
-    /// keyboard layout instead of the one the machine happens to be running.
-    static func refresh(layoutData: Data? = commandLayoutData()) {
-        let resolved = layoutData.map { keyCodes(in: $0) } ?? [:]
-        lock.withLock { keyCodes = resolved }
-    }
-
-    static func keyCodes(in layoutData: Data) -> [QuitProtectionShortcut: Int64] {
-        var resolved: [QuitProtectionShortcut: Int64] = [:]
-        for code in UInt16(0)...127 {
-            guard let character = commandCharacter(for: code, layoutData: layoutData),
-                  let shortcut = QuitProtectionShortcut.allCases
-                      .first(where: { $0.character == character }),
-                  resolved[shortcut] == nil
-            else { continue }
-            resolved[shortcut] = Int64(code)
-            if resolved.count == QuitProtectionShortcut.allCases.count { break }
-        }
-        return resolved
-    }
-
-    /// An input method (Pinyin, Korean) carries no layout of its own; Command
-    /// shortcuts fall back to the ASCII-capable layout there, and so do we.
-    private static func commandLayoutData() -> Data? {
-        guard Thread.isMainThread else { return nil }
-        return unicodeLayoutData(TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue())
-            ?? unicodeLayoutData(
-                TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?.takeRetainedValue()
-            )
-    }
-
-    private static func unicodeLayoutData(_ source: TISInputSource?) -> Data? {
-        guard let source,
-              let layoutData = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData)
-        else { return nil }
-        return Unmanaged<CFData>.fromOpaque(layoutData).takeUnretainedValue() as Data
-    }
-
-    private static func commandCharacter(for code: UInt16, layoutData: Data) -> String? {
-        var deadKeyState: UInt32 = 0
-        var chars = [UniChar](repeating: 0, count: 4)
-        var length = 0
-        let status = layoutData.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) -> OSStatus in
-            guard let layout = bytes.bindMemory(to: UCKeyboardLayout.self).baseAddress
-            else { return OSStatus(paramErr) }
-            return UCKeyTranslate(layout, code, UInt16(kUCKeyActionDown),
-                                  UInt32((cmdKey >> 8) & 0xFF),
-                                  UInt32(LMGetKbdType()), OptionBits(kUCKeyTranslateNoDeadKeysBit),
-                                  &deadKeyState, chars.count, &length, &chars)
-        }
-        guard status == noErr, length == 1 else { return nil }
-        return String(utf16CodeUnits: chars, count: length).lowercased()
     }
 }

--- a/Sources/Vorssaint/Core/QuitProtectionSupport.swift
+++ b/Sources/Vorssaint/Core/QuitProtectionSupport.swift
@@ -153,6 +153,18 @@ enum QuitProtectionSupport {
         return keyCode == shortcut.fallbackKeyCode
     }
 
+    /// A held Command-Q must not repeat into the protected app: each repeat
+    /// would restart a hold or count as the second of a double press. Nothing
+    /// past that point acts without Command, so the drop asks for it. Matching
+    /// resolves the shortcut from the layout's Command table, which answers for
+    /// the bare key too — the Q and W keys on a Latin layout, the keys that type
+    /// "й" and "ц" on Russian, ";" and "ς" on Greek — and dropping their
+    /// autorepeat unconditionally left holding those keys with protection on
+    /// producing one character and no repeat.
+    static func dropsAutorepeat(isRepeat: Bool, command: Bool) -> Bool {
+        isRepeat && command
+    }
+
     /// The post-confirmation swallow holds until the keys that confirmed the
     /// shortcut come back up. A key up can be lost — the tap is re-enabled
     /// after being disabled on timeout, a tap ahead of ours takes the event,

--- a/Sources/Vorssaint/Core/QuitProtectionSupport.swift
+++ b/Sources/Vorssaint/Core/QuitProtectionSupport.swift
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Vorssaint
 
+import Carbon.HIToolbox
 import Foundation
 
 enum QuitProtectionShortcut: String, CaseIterable, Identifiable {
@@ -9,7 +10,7 @@ enum QuitProtectionShortcut: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
     var character: String { self == .quit ? "q" : "w" }
-    /// Positional fallback only. Matching uses the layout-resolved character first.
+    /// The US position, used only while no keyboard layout can be read.
     var fallbackKeyCode: Int64 { self == .quit ? 12 : 13 }
     var symbol: String { self == .quit ? "⌘Q" : "⌘W" }
 }
@@ -98,17 +99,22 @@ enum QuitProtectionSupport {
     /// user cannot bypass protection by pressing plain Command-Q/Command-W.
     static func isBaseShortcut(keyCharacter: String?,
                                keyCode: Int64,
+                               commandKeyCode: Int64?,
                                command: Bool,
                                control: Bool,
                                option: Bool,
                                shift: Bool,
                                shortcut: QuitProtectionShortcut) -> Bool {
         guard command, !control, !option, !shift else { return false }
-        return matchesKey(keyCharacter: keyCharacter, keyCode: keyCode, shortcut: shortcut)
+        return matchesKey(keyCharacter: keyCharacter,
+                          keyCode: keyCode,
+                          commandKeyCode: commandKeyCode,
+                          shortcut: shortcut)
     }
 
     static func isExtraShortcut(keyCharacter: String?,
                                 keyCode: Int64,
+                                commandKeyCode: Int64?,
                                 command: Bool,
                                 control: Bool,
                                 option: Bool,
@@ -122,16 +128,44 @@ enum QuitProtectionSupport {
         case .option: hasExtra = option && !shift && !control
         case .control: hasExtra = control && !shift && !option
         }
-        return hasExtra && matchesKey(keyCharacter: keyCharacter, keyCode: keyCode, shortcut: shortcut)
+        return hasExtra && matchesKey(keyCharacter: keyCharacter,
+                                      keyCode: keyCode,
+                                      commandKeyCode: commandKeyCode,
+                                      shortcut: shortcut)
     }
 
+    /// `commandKeyCode` is the key the active layout types this shortcut on
+    /// with Command held, which is the same question the system asks of a menu
+    /// key equivalent. It is the identity to compare against: the character the
+    /// event carries is the one typed *without* Command, so a Cyrillic layout
+    /// reports "й" and a Greek one ";" for the very key that quits. The
+    /// character is left as the answer only while no layout can be read.
     static func matchesKey(keyCharacter: String?,
                            keyCode: Int64,
+                           commandKeyCode: Int64?,
                            shortcut: QuitProtectionShortcut) -> Bool {
+        if let commandKeyCode {
+            return keyCode == commandKeyCode
+        }
         if let keyCharacter {
             return keyCharacter.lowercased() == shortcut.character
         }
         return keyCode == shortcut.fallbackKeyCode
+    }
+
+    /// The post-confirmation swallow holds until the keys that confirmed the
+    /// shortcut come back up. A key up can be lost — the tap is re-enabled
+    /// after being disabled on timeout, a tap ahead of ours takes the event,
+    /// the session switches user — and a swallow that never ends takes
+    /// Command-Q and every key's autorepeat with it, with nothing the user can
+    /// do to recover them. It therefore also expires on its own.
+    static let swallowTimeoutMilliseconds = 2_000.0
+
+    static func swallowRemainsActive(startTimestamp: UInt64,
+                                     currentTimestamp: UInt64) -> Bool {
+        guard currentTimestamp >= startTimestamp else { return false }
+        return currentTimestamp - startTimestamp
+            <= UInt64(swallowTimeoutMilliseconds * 1_000_000)
     }
 
     static func modeFor(_ rawValue: String?) -> QuitProtectionMode {
@@ -147,5 +181,90 @@ enum QuitProtectionSupport {
     static func scopeFor(_ rawValue: String?) -> QuitProtectionScope {
         guard let rawValue, let value = QuitProtectionScope(rawValue: rawValue) else { return .all }
         return value
+    }
+}
+
+/// Which physical key the system will read as Command-Q and Command-W.
+///
+/// Keyboard layouts carry their own Command table, and every non-Latin layout
+/// points it back at the Latin letters: Russian types "й" on the Q key but
+/// still quits there, and "Dvorak - QWERTY ⌘" moves Q back under the QWERTY
+/// position exactly while Command is held. Asking the layout the same question
+/// the system asks is what keeps protection on the key that actually quits.
+enum QuitProtectionKeyLayout {
+    private static let lock = NSLock()
+    private static var keyCodes: [QuitProtectionShortcut: Int64] = [:]
+    private static var layoutObserver: AnyObject?
+
+    /// nil while no layout has answered, which leaves matching on the character.
+    static func commandKeyCode(for shortcut: QuitProtectionShortcut) -> Int64? {
+        lock.withLock { keyCodes[shortcut] }
+    }
+
+    /// Called when the tap starts. Switching layout moves both shortcuts without
+    /// producing an event of ours, so the resolution has to follow it.
+    /// Safe to call more than once.
+    static func startObserving() {
+        refresh()
+        guard layoutObserver == nil else { return }
+        layoutObserver = DistributedNotificationCenter.default().addObserver(
+            forName: NSNotification.Name(kTISNotifySelectedKeyboardInputSourceChanged as String),
+            object: nil,
+            queue: .main
+        ) { _ in refresh() }
+    }
+
+    /// Takes a layout directly as well, so tests can resolve against a specific
+    /// keyboard layout instead of the one the machine happens to be running.
+    static func refresh(layoutData: Data? = commandLayoutData()) {
+        let resolved = layoutData.map { keyCodes(in: $0) } ?? [:]
+        lock.withLock { keyCodes = resolved }
+    }
+
+    static func keyCodes(in layoutData: Data) -> [QuitProtectionShortcut: Int64] {
+        var resolved: [QuitProtectionShortcut: Int64] = [:]
+        for code in UInt16(0)...127 {
+            guard let character = commandCharacter(for: code, layoutData: layoutData),
+                  let shortcut = QuitProtectionShortcut.allCases
+                      .first(where: { $0.character == character }),
+                  resolved[shortcut] == nil
+            else { continue }
+            resolved[shortcut] = Int64(code)
+            if resolved.count == QuitProtectionShortcut.allCases.count { break }
+        }
+        return resolved
+    }
+
+    /// An input method (Pinyin, Korean) carries no layout of its own; Command
+    /// shortcuts fall back to the ASCII-capable layout there, and so do we.
+    private static func commandLayoutData() -> Data? {
+        guard Thread.isMainThread else { return nil }
+        return unicodeLayoutData(TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue())
+            ?? unicodeLayoutData(
+                TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?.takeRetainedValue()
+            )
+    }
+
+    private static func unicodeLayoutData(_ source: TISInputSource?) -> Data? {
+        guard let source,
+              let layoutData = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData)
+        else { return nil }
+        return Unmanaged<CFData>.fromOpaque(layoutData).takeUnretainedValue() as Data
+    }
+
+    private static func commandCharacter(for code: UInt16, layoutData: Data) -> String? {
+        var deadKeyState: UInt32 = 0
+        var chars = [UniChar](repeating: 0, count: 4)
+        var length = 0
+        let status = layoutData.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) -> OSStatus in
+            guard let layout = bytes.bindMemory(to: UCKeyboardLayout.self).baseAddress
+            else { return OSStatus(paramErr) }
+            return UCKeyTranslate(layout, code, UInt16(kUCKeyActionDown),
+                                  UInt32((cmdKey >> 8) & 0xFF),
+                                  UInt32(LMGetKbdType()), OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                                  &deadKeyState, chars.count, &length, &chars)
+        }
+        guard status == noErr, length == 1 else { return nil }
+        return String(utf16CodeUnits: chars, count: length).lowercased()
     }
 }

--- a/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
+++ b/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
@@ -28,6 +28,7 @@ final class QuitProtectionService: ObservableObject {
     private var pendingExpiry: DispatchWorkItem?
     private var pending: Pending?
     private var swallowShortcut: QuitProtectionShortcut?
+    private var swallowTimestamp: UInt64 = 0
     private var frontmostBundleIdentifier: String?
     private var frontmostProcessIdentifier: pid_t?
     private let hud = QuitProtectionHUD()
@@ -82,6 +83,7 @@ final class QuitProtectionService: ObservableObject {
 
     private func start() {
         guard !isRunning else { return }
+        QuitProtectionKeyLayout.startObserving()
         guard installTap() else { return }
         isRunning = true
         let frontmost = NSWorkspace.shared.frontmostApplication
@@ -156,6 +158,9 @@ final class QuitProtectionService: ObservableObject {
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            // The events missed while the tap was off can include the key up
+            // that ends the swallow, so it cannot be trusted past this point.
+            swallowShortcut = nil
             cancelPending()
             let enabled = AppFeature.quitWindowProtection.isAvailable
                 && isEnabledForAnyShortcut
@@ -200,8 +205,11 @@ final class QuitProtectionService: ObservableObject {
 
         let shortcut = matchingShortcut(for: event)
 
-        if let swallowShortcut {
-            if shortcut == swallowShortcut || isRepeat {
+        if let swallow = swallowShortcut {
+            if !QuitProtectionSupport.swallowRemainsActive(startTimestamp: swallowTimestamp,
+                                                           currentTimestamp: now()) {
+                swallowShortcut = nil
+            } else if shortcut == swallow || isRepeat {
                 return nil
             }
         }
@@ -235,12 +243,14 @@ final class QuitProtectionService: ObservableObject {
         let option = flags.contains(.maskAlternate)
         let shift = flags.contains(.maskShift)
         let character = NSEvent(cgEvent: event)?.charactersIgnoringModifiers?.lowercased()
+        let commandKeyCode = QuitProtectionKeyLayout.commandKeyCode(for: shortcut)
 
         switch configuration.mode {
         case .hold:
             guard QuitProtectionSupport.isBaseShortcut(
                 keyCharacter: character,
                 keyCode: keyCode,
+                commandKeyCode: commandKeyCode,
                 command: command,
                 control: control,
                 option: option,
@@ -257,6 +267,7 @@ final class QuitProtectionService: ObservableObject {
             guard QuitProtectionSupport.isBaseShortcut(
                 keyCharacter: character,
                 keyCode: keyCode,
+                commandKeyCode: commandKeyCode,
                 command: command,
                 control: control,
                 option: option,
@@ -273,7 +284,7 @@ final class QuitProtectionService: ObservableObject {
                 ) {
                     let targetPid = pending.targetProcessIdentifier
                     cancelPending()
-                    swallowShortcut = shortcut
+                    beginSwallow(shortcut)
                     confirm(shortcut: shortcut, event: event, targetProcessIdentifier: targetPid)
                     return nil
                 }
@@ -286,6 +297,7 @@ final class QuitProtectionService: ObservableObject {
             if QuitProtectionSupport.isExtraShortcut(
                 keyCharacter: character,
                 keyCode: keyCode,
+                commandKeyCode: commandKeyCode,
                 command: command,
                 control: control,
                 option: option,
@@ -294,7 +306,7 @@ final class QuitProtectionService: ObservableObject {
                 extraModifier: configuration.extraModifier
             ) {
                 cancelPending()
-                swallowShortcut = shortcut
+                beginSwallow(shortcut)
                 confirm(shortcut: shortcut,
                         event: event,
                         targetProcessIdentifier: frontmostProcessIdentifier,
@@ -304,6 +316,7 @@ final class QuitProtectionService: ObservableObject {
             guard QuitProtectionSupport.isBaseShortcut(
                 keyCharacter: character,
                 keyCode: keyCode,
+                commandKeyCode: commandKeyCode,
                 command: command,
                 control: control,
                 option: option,
@@ -349,12 +362,12 @@ final class QuitProtectionService: ObservableObject {
     }
 
     private func handleFlagsChanged(_ event: CGEvent) {
+        guard !event.flags.contains(.maskCommand) else { return }
+        // Command coming up ends both waits: a confirmation cannot complete
+        // without it, and the keys the swallow covers cannot still be down.
+        swallowShortcut = nil
         guard pending != nil else { return }
-        let flags = event.flags
-        let commandHeld = flags.contains(.maskCommand)
-        if !commandHeld {
-            cancelPending()
-        }
+        cancelPending()
     }
 
     // MARK: Confirmation state
@@ -405,10 +418,19 @@ final class QuitProtectionService: ObservableObject {
         let event = pending.event
         let targetPid = pending.targetProcessIdentifier
 
-        swallowShortcut = shortcut
+        beginSwallow(shortcut)
         cancelPending()
 
         confirm(shortcut: shortcut, event: event, targetProcessIdentifier: targetPid)
+    }
+
+    /// Uptime nanoseconds rather than the event's own clock: a hold confirms
+    /// long after the event that started it, and the swallow begins here.
+    private func now() -> UInt64 { DispatchTime.now().uptimeNanoseconds }
+
+    private func beginSwallow(_ shortcut: QuitProtectionShortcut) {
+        swallowShortcut = shortcut
+        swallowTimestamp = now()
     }
 
     private func cancelPending() {
@@ -482,6 +504,7 @@ final class QuitProtectionService: ObservableObject {
         return QuitProtectionShortcut.allCases.first {
             QuitProtectionSupport.matchesKey(keyCharacter: character,
                                              keyCode: keyCode,
+                                             commandKeyCode: QuitProtectionKeyLayout.commandKeyCode(for: $0),
                                              shortcut: $0)
         }
     }

--- a/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
+++ b/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
@@ -233,12 +233,13 @@ final class QuitProtectionService: ObservableObject {
             return Unmanaged.passUnretained(event)
         }
 
-        if isRepeat {
+        let flags = event.flags
+        let command = flags.contains(.maskCommand)
+
+        if QuitProtectionSupport.dropsAutorepeat(isRepeat: isRepeat, command: command) {
             return nil
         }
 
-        let flags = event.flags
-        let command = flags.contains(.maskCommand)
         let control = flags.contains(.maskControl)
         let option = flags.contains(.maskAlternate)
         let shift = flags.contains(.maskShift)

--- a/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
+++ b/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
@@ -498,15 +498,25 @@ final class QuitProtectionService: ObservableObject {
 
     // MARK: Event helpers
 
+    /// Every key press and release on the machine reaches this, so the
+    /// character is read only on the path that still needs it. Where a layout
+    /// answered, matching is a key code comparison and the character is never
+    /// consulted; building it anyway cost an `NSEvent` and a layout
+    /// translation on each of those events.
     private func matchingShortcut(for event: CGEvent) -> QuitProtectionShortcut? {
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
-        let character = NSEvent(cgEvent: event)?.charactersIgnoringModifiers?.lowercased()
-        return QuitProtectionShortcut.allCases.first {
+        let resolved = QuitProtectionShortcut.allCases.map {
+            ($0, QuitProtectionKeyLayout.commandKeyCode(for: $0))
+        }
+        let character = resolved.contains { $0.1 == nil }
+            ? NSEvent(cgEvent: event)?.charactersIgnoringModifiers?.lowercased()
+            : nil
+        return resolved.first {
             QuitProtectionSupport.matchesKey(keyCharacter: character,
                                              keyCode: keyCode,
-                                             commandKeyCode: QuitProtectionKeyLayout.commandKeyCode(for: $0),
-                                             shortcut: $0)
-        }
+                                             commandKeyCode: $0.1,
+                                             shortcut: $0.0)
+        }?.0
     }
 
     private func isSynthetic(_ event: CGEvent) -> Bool {

--- a/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
+++ b/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
@@ -366,9 +366,6 @@ final class QuitProtectionService: ObservableObject {
 
     private func handleFlagsChanged(_ event: CGEvent) {
         guard !event.flags.contains(.maskCommand) else { return }
-        // Command coming up ends both waits: a confirmation cannot complete
-        // without it, and the keys the swallow covers cannot still be down.
-        swallowShortcut = nil
         guard pending != nil else { return }
         cancelPending()
     }

--- a/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
+++ b/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
@@ -83,7 +83,9 @@ final class QuitProtectionService: ObservableObject {
 
     private func start() {
         guard !isRunning else { return }
-        QuitProtectionKeyLayout.startObserving()
+        // Fills and follows the keycap cache the shortcut resolution reads.
+        // Idempotent; the app already starts it at launch.
+        GlobalShortcut.startObservingKeyboardLayout()
         guard installTap() else { return }
         isRunning = true
         let frontmost = NSWorkspace.shared.frontmostApplication
@@ -244,7 +246,7 @@ final class QuitProtectionService: ObservableObject {
         let option = flags.contains(.maskAlternate)
         let shift = flags.contains(.maskShift)
         let character = NSEvent(cgEvent: event)?.charactersIgnoringModifiers?.lowercased()
-        let commandKeyCode = QuitProtectionKeyLayout.commandKeyCode(for: shortcut)
+        let commandKeyCode = shortcut.commandKeyCode
 
         switch configuration.mode {
         case .hold:
@@ -506,9 +508,7 @@ final class QuitProtectionService: ObservableObject {
     /// translation on each of those events.
     private func matchingShortcut(for event: CGEvent) -> QuitProtectionShortcut? {
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
-        let resolved = QuitProtectionShortcut.allCases.map {
-            ($0, QuitProtectionKeyLayout.commandKeyCode(for: $0))
-        }
+        let resolved = QuitProtectionShortcut.allCases.map { ($0, $0.commandKeyCode) }
         let character = resolved.contains { $0.1 == nil }
             ? NSEvent(cgEvent: event)?.charactersIgnoringModifiers?.lowercased()
             : nil

--- a/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
+++ b/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
@@ -501,23 +501,15 @@ final class QuitProtectionService: ObservableObject {
 
     // MARK: Event helpers
 
-    /// Every key press and release on the machine reaches this, so the
-    /// character is read only on the path that still needs it. Where a layout
-    /// answered, matching is a key code comparison and the character is never
-    /// consulted; building it anyway cost an `NSEvent` and a layout
-    /// translation on each of those events.
     private func matchingShortcut(for event: CGEvent) -> QuitProtectionShortcut? {
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
-        let resolved = QuitProtectionShortcut.allCases.map { ($0, $0.commandKeyCode) }
-        let character = resolved.contains { $0.1 == nil }
-            ? NSEvent(cgEvent: event)?.charactersIgnoringModifiers?.lowercased()
-            : nil
-        return resolved.first {
+        let character = NSEvent(cgEvent: event)?.charactersIgnoringModifiers?.lowercased()
+        return QuitProtectionShortcut.allCases.first {
             QuitProtectionSupport.matchesKey(keyCharacter: character,
                                              keyCode: keyCode,
-                                             commandKeyCode: $0.1,
-                                             shortcut: $0.0)
-        }?.0
+                                             commandKeyCode: $0.commandKeyCode,
+                                             shortcut: $0)
+        }
     }
 
     private func isSynthetic(_ event: CGEvent) -> Bool {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21975,7 +21975,10 @@ struct MetricsTests {
         // back at the Latin letters, which is why the key that types \u{439} still quits.
         func quitProtectionKeyCodes(_ layoutID: String) -> [QuitProtectionShortcut: Int64]? {
             guard let data = testLayoutData(for: layoutID) else { return nil }
-            return QuitProtectionKeyLayout.keyCodes(in: data)
+            GlobalShortcut.refreshLayoutLabels(layoutData: data)
+            return QuitProtectionShortcut.allCases.reduce(into: [:]) {
+                $0[$1] = $1.commandKeyCode
+            }
         }
         if let us = quitProtectionKeyCodes("com.apple.keylayout.US") {
             expect(us[.quit] == 12 && us[.close] == 13,
@@ -22001,6 +22004,7 @@ struct MetricsTests {
             expect(french[.quit] == 0 && french[.close] == 6,
                    "French AZERTY moves Command-Q and Command-W to its own q and w keys")
         }
+        GlobalShortcut.refreshLayoutLabels()
 
         expect(QuitProtectionSupport.dropsAutorepeat(isRepeat: true, command: true),
                "a held Command-Q does not repeat into the app it is protecting")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21506,35 +21506,92 @@ struct MetricsTests {
                                                  exceptions: ["com.example.editor"]),
                "all-except scope protects an unselected bundle")
 
-        expect(QuitProtectionSupport.matchesKey(keyCharacter: "q", keyCode: 0,
-                                                shortcut: .quit),
-               "quit protection prefers the layout-resolved q character")
+        expect(QuitProtectionSupport.matchesKey(keyCharacter: "\u{439}", keyCode: 12,
+                                                commandKeyCode: 12, shortcut: .quit),
+               "a Cyrillic layout is protected on the key Command-Q quits from, "
+               + "which types \u{439} rather than q")
+        expect(!QuitProtectionSupport.matchesKey(keyCharacter: "'", keyCode: 12,
+                                                 commandKeyCode: 7, shortcut: .quit),
+               "a Dvorak layout leaves the key Command-Q does not quit from alone")
         expect(QuitProtectionSupport.matchesKey(keyCharacter: nil, keyCode: 13,
-                                                shortcut: .close),
-               "quit protection falls back to the W key code without a character")
+                                                commandKeyCode: nil, shortcut: .close),
+               "quit protection falls back to the W key code with neither a character nor a layout")
+        expect(QuitProtectionSupport.matchesKey(keyCharacter: "q", keyCode: 0,
+                                                commandKeyCode: nil, shortcut: .quit),
+               "quit protection falls back to the typed character without a layout")
         expect(QuitProtectionSupport.isBaseShortcut(keyCharacter: "q", keyCode: 12,
+                                                    commandKeyCode: 12,
                                                     command: true, control: false,
                                                     option: false, shift: false, shortcut: .quit),
                "plain Command-Q is recognized")
         expect(!QuitProtectionSupport.isBaseShortcut(keyCharacter: "q", keyCode: 12,
+                                                     commandKeyCode: 12,
                                                      command: true, control: false,
                                                      option: false, shift: true, shortcut: .quit),
                "Shift-Command-Q is not mistaken for plain Command-Q")
         expect(QuitProtectionSupport.isExtraShortcut(keyCharacter: "q", keyCode: 12,
+                                                     commandKeyCode: 12,
                                                      command: true, control: false,
                                                      option: false, shift: true,
                                                      shortcut: .quit, extraModifier: .shift),
                "Shift-Command-Q is recognized as an extra-modifier confirmation")
         expect(QuitProtectionSupport.isExtraShortcut(keyCharacter: "w", keyCode: 13,
+                                                     commandKeyCode: 13,
                                                      command: true, control: true,
                                                      option: false, shift: false,
                                                      shortcut: .close, extraModifier: .control),
                "Control-Command-W is recognized as an extra-modifier confirmation")
         expect(!QuitProtectionSupport.isExtraShortcut(keyCharacter: "q", keyCode: 12,
+                                                      commandKeyCode: 12,
                                                       command: true, control: false,
                                                       option: true, shift: false,
                                                       shortcut: .quit, extraModifier: .shift),
                "an unrelated modifier combination is not protected")
+
+        // Where each layout puts Command-Q and Command-W, read from the layouts
+        // the machine has installed. Non-Latin layouts point their Command table
+        // back at the Latin letters, which is why the key that types \u{439} still quits.
+        func quitProtectionKeyCodes(_ layoutID: String) -> [QuitProtectionShortcut: Int64]? {
+            guard let data = testLayoutData(for: layoutID) else { return nil }
+            return QuitProtectionKeyLayout.keyCodes(in: data)
+        }
+        if let us = quitProtectionKeyCodes("com.apple.keylayout.US") {
+            expect(us[.quit] == 12 && us[.close] == 13,
+                   "US layout keeps Command-Q and Command-W on their own keys")
+        }
+        if let russian = quitProtectionKeyCodes("com.apple.keylayout.Russian") {
+            expect(russian[.quit] == 12 && russian[.close] == 13,
+                   "a Cyrillic layout still quits and closes from the Latin Q and W keys")
+        }
+        if let greek = quitProtectionKeyCodes("com.apple.keylayout.Greek") {
+            expect(greek[.quit] == 12 && greek[.close] == 13,
+                   "a Greek layout still quits and closes from the Latin Q and W keys")
+        }
+        if let dvorak = quitProtectionKeyCodes("com.apple.keylayout.Dvorak") {
+            expect(dvorak[.quit] == 7 && dvorak[.close] == 43,
+                   "Dvorak moves Command-Q and Command-W to the keys it types q and w on")
+        }
+        if let dvorakCommand = quitProtectionKeyCodes("com.apple.keylayout.DVORAK-QWERTYCMD") {
+            expect(dvorakCommand[.quit] == 12 && dvorakCommand[.close] == 13,
+                   "the Dvorak layout that reverts to QWERTY under Command is followed there")
+        }
+        if let french = quitProtectionKeyCodes("com.apple.keylayout.French") {
+            expect(french[.quit] == 0 && french[.close] == 6,
+                   "French AZERTY moves Command-Q and Command-W to its own q and w keys")
+        }
+
+        expect(QuitProtectionSupport.swallowRemainsActive(
+            startTimestamp: 1_000_000_000,
+            currentTimestamp: 2_999_000_000
+        ), "the confirmation swallow covers the keys still held down")
+        expect(!QuitProtectionSupport.swallowRemainsActive(
+            startTimestamp: 1_000_000_000,
+            currentTimestamp: 3_000_000_001
+        ), "the confirmation swallow expires, so a lost key up cannot silence Command-Q for good")
+        expect(!QuitProtectionSupport.swallowRemainsActive(
+            startTimestamp: 1_000_000_000,
+            currentTimestamp: 999_999_999
+        ), "a clock that moved backwards releases the confirmation swallow")
 
         let quitProtectionKeys = [
             DefaultsKey.quitProtectionQuitEnabled,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21580,6 +21580,14 @@ struct MetricsTests {
                    "French AZERTY moves Command-Q and Command-W to its own q and w keys")
         }
 
+        expect(QuitProtectionSupport.dropsAutorepeat(isRepeat: true, command: true),
+               "a held Command-Q does not repeat into the app it is protecting")
+        expect(!QuitProtectionSupport.dropsAutorepeat(isRepeat: true, command: false),
+               "holding the Q or W key without Command still repeats with protection on, "
+               + "including the keys that type \u{439} and ; on layouts protection follows")
+        expect(!QuitProtectionSupport.dropsAutorepeat(isRepeat: false, command: true),
+               "the first Command-Q press is not dropped as a repeat")
+
         expect(QuitProtectionSupport.swallowRemainsActive(
             startTimestamp: 1_000_000_000,
             currentTimestamp: 2_999_000_000

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21983,6 +21983,14 @@ struct MetricsTests {
         if let us = quitProtectionKeyCodes("com.apple.keylayout.US") {
             expect(us[.quit] == 12 && us[.close] == 13,
                    "US layout keeps Command-Q and Command-W on their own keys")
+            // The digit row and the numeric keypad type the same character, in
+            // both tables and on every layout installed here, so the reverse
+            // map has to choose between two key codes. It answers with the
+            // lower one rather than with whichever the dictionary hands back,
+            // which is what the resolution it replaced did by scanning upwards.
+            expect(GlobalShortcut.layoutKeyCode(for: "1", usesCommand: true) == Int64(kVK_ANSI_1)
+                    && GlobalShortcut.layoutKeyCode(for: "1", usesCommand: false) == Int64(kVK_ANSI_1),
+                   "a character two keys type resolves to the lower key code, not the keypad")
         }
         if let russian = quitProtectionKeyCodes("com.apple.keylayout.Russian") {
             expect(russian[.quit] == 12 && russian[.close] == 13,


### PR DESCRIPTION
## Summary

Three fixes to the Command-Q / Command-W protection from #1200.

**Protection never engaged on a non-Latin keyboard layout.** Matching compared `charactersIgnoringModifiers` with "q" and "w". That character is the one the key types *without* Command, so a Russian layout reports "й" and a Greek one ";" for the very key that quits — no match, the event passed through untouched, and Command-Q quit the app with protection switched on and no feedback. The positional `fallbackKeyCode` never covered it: the character is non-nil for these presses, so that branch was unreachable.

Keyboard layouts carry a separate Command table, and it is the one the system resolves key equivalents through. `UCKeyTranslate` with `cmdKey` returns "q" for key code 12 on Russian and Greek, 7 on Dvorak — where Command-Q genuinely moves — and 12 on "Dvorak - QWERTY ⌘", which reverts to QWERTY exactly while Command is held. Matching now compares key codes and asks that question of the keycap cache in `GlobalShortcut`, which since #1226 holds both of the layout's tables for every key code, refreshes on the same `kTISNotifySelectedKeyboardInputSourceChanged` notification, and since #1220 already reads the ASCII-capable layout under an input method such as Pinyin. The cache only ever answered key code → label; the reverse question it now also answers is `GlobalShortcut.layoutKeyCode(for:usesCommand:)`, and `QuitProtectionShortcut.commandKeyCode` is that call. The typed character is left as the answer only where no layout has been read at all.

Rejected alternatives: falling back to the ANSI position (12/13) whenever the character misses fixes Cyrillic and Greek but claims ⌘' on Dvorak, where key code 12 is not Command-Q and confirming would terminate the app; gating that fallback on "the character is not ASCII" breaks on Greek, whose Q key types ";". Reading the layout needs no such guess.

**The post-confirmation swallow could latch forever.** `swallowShortcut` was set on confirmation and cleared only by a matching key up or by the feature being switched off. A key up can be lost: the tap is re-enabled after being disabled on timeout, a tap ahead of ours takes the event, the session switches user. From then on every Command-Q and Command-W was swallowed, and since the same branch also swallows `isRepeat`, so was every key's autorepeat — holding any letter produced a single character. Nothing the user could do restored either.

The swallow now ends at two more points: the tap being re-enabled after it was disabled (precisely the window where events go missing), and a two-second ceiling checked on the next key event.

Command coming up is deliberately not a release point, so `handleFlagsChanged` keeps `main`'s behaviour of ending only a pending confirmation there. Key ups are independent, so the keys the swallow covers can still be down when Command comes up, and Command first is the common order to let go. Clearing the swallow there would leave Q or W held with no swallow: the next autorepeat finds nothing to eat, `dropsAutorepeat` declines because Command is up, and the repeat passes through as a stray q or w into whatever app came forward. On `main` the swallow holds until the letter's key up and eats it, and that stays so here. The two-second ceiling already makes a lost key up recoverable, which was the only reason to release earlier.

**Holding the Q or W key with no Command produced one character and no repeat.** This is the second `isRepeat` in `handleKeyDown`, the one outside the swallow branch. It sat below the enabled and scope guards but above every modifier read, so with protection on it dropped the autorepeat of any key `matchingShortcut` resolved — and matching answers on the bare key, since the layout's Command table names a key code, not a chord. Following the layout carried that onto й and ц on Russian and ; and ς on Greek. The drop is now gated on Command (`QuitProtectionSupport.dropsAutorepeat`). Nothing below it acts without Command — both `isBaseShortcut` and `isExtraShortcut` require it — so a held Command-Q still cannot restart a hold or count as the second of a double press, which is what the drop exists for. Git history gives it no other purpose: it arrived unconditional in 4320c2e8 with the feature and was untouched by the audit pass in f25d1aa8, and nothing else in the tree reads it.

Deliberately unchanged: the `|| isRepeat` inside the swallow branch keeps its width — it is what stops the keys held through a confirmation from repeating into the app — and it is bounded by the two-second ceiling above rather than narrowed. The HUD and the settings surface are untouched.

## Verification

MacBook Air (Mac17,3), Apple M5, macOS 26.6.2 (25G83), Xcode 26.6 / Swift
6.3.3, self-built from this branch.

- `./build.sh --test` — `TESTS OK (9543 checks)` against the 9528 on `main`, so
  the 15 new assertions are the whole difference. The pair that fails whenever
  the machine's input source is an IME rather than a layout (`nil layout falls
  back to ANSI semicolon`, `App Switcher icon-row hints`) passed on this run;
  neither is touched by this change.
- `--test` compiles a whitelist that does not include
  `QuitProtectionService.swift`, so that file is covered by a `swiftc
  -typecheck` over the whole of `Sources/Vorssaint` against the same target and
  SDK the build uses, which reports no diagnostics.
- The six layout assertions were confirmed red before being trusted: with
  `GlobalShortcut.layoutKeyCode` returning nil, all six fail and the rest of the
  run is unchanged, so they are answering from the shared cache rather than
  passing on an unread layout.
- The tie-break the reverse map needs when two keys type one character — the
  digit row and the numeric keypad, on every layout and in both tables — is
  pinned to the lower key code and was confirmed red the same way: letting the
  higher one win fails that assertion alone.
- The three `dropsAutorepeat` assertions were confirmed red before being
  trusted: with the gate removed (`isRepeat` alone) `holding the Q or W key
  without Command still repeats with protection on` fails and the other two
  pass.

The layout assertions resolve Command-Q and Command-W against layout data read from the layouts installed on the machine — US 12/13, Russian 12/13, Greek 12/13, Dvorak 7/43, Dvorak-QWERTY ⌘ 12/13, French AZERTY 0/6 — plus the matcher on a Cyrillic press and the swallow's expiry, including a clock that moves backwards.

What I could not test: I have no machine set to a Cyrillic or Greek layout, so I have not pressed Command-Q there with the feature on; the layout claim rests on the layout data itself and on the unit assertions above. I also could not stage a lost key up — a tap disabled by timeout, or another tap taking the event — so the two release paths are covered by reading the state machine and by the expiry assertion, not by a live reproduction. The autorepeat gate is likewise asserted as a predicate, not by holding a key with the app running.

## Anything else

Nothing on the tracker reports any of the three defects: no issue describes a
layout on which the protection never engages, a swallow that does not end, or a
held key that stops repeating. #1047 is the nearest and is a different surface —
it reports the shortcut recorder capturing the physical key, is already labelled
fixed pending release, and predates this feature shipping.

#892 and its duplicate #1158 asked for the feature itself, and #1200 delivered
it without referencing either, so neither is on the fix track. They are
referenced here because on a Cyrillic or Greek layout what shipped never
engaged, so for those reporters the protection they asked for arrives with this
branch rather than with #1200. If that reads as the wrong PR to hang them on,
drop the lines — the feature request is #1200's to claim.

Refs #892
Refs #1158

