### PR TITLE
fix(dock-click): decide and raise a window cycle from the same list

### DIFF
--- a/Sources/Vorssaint/Services/DockClick/DockClickService.swift
+++ b/Sources/Vorssaint/Services/DockClick/DockClickService.swift
@@ -231,7 +231,12 @@ final class DockClickService {
             }
             // Counted on the Space the user is looking at, the only windows
             // the raise can reach; the AX list above spans every Space.
-            let cycleCandidateCount = cycleEnabled
+            //
+            // Gated on the full precondition of the ladder's cycling branch,
+            // not just the setting: clicking a background app's icon is the
+            // common Dock click, and the count costs a window-server list plus
+            // an id resolve per window inside the event tap.
+            let cycleCandidateCount = cycleEnabled && frontmost && !windows.hasFullscreen
                 ? Self.cycleCandidates(pid: pid, windows: windows.unminimized).count
                 : 0
             let hasUnminimized = DockClickSupport.effectiveHasUnminimized(

--- a/Sources/Vorssaint/Services/DockClick/DockClickService.swift
+++ b/Sources/Vorssaint/Services/DockClick/DockClickService.swift
@@ -477,6 +477,11 @@ final class DockClickService {
     /// Minimize item (⌘M): one window per click, but the click works. This
     /// runs off the tap, so it can afford a longer leash than the tap-side
     /// window enumeration — busy JVMs routinely need it.
+    /// Menu items one Minimize All walk may read. The other menu walks in
+    /// this app stop at 600; an unbounded one here reads every item of every
+    /// menu the app has, at two or three cross-process reads each.
+    private static let minimizeMenuItemBudget = 600
+
     private static func handleMinimizeMenu(pid: pid_t) -> MinimizeMenuOutcome {
         let app = AXUIElementCreateApplication(pid)
         AXUIElementSetMessagingTimeout(app, 1.0)
@@ -487,12 +492,24 @@ final class DockClickService {
         var plainMinimize: AXUIElement?
         var minimizeAll: AXUIElement?
         var hasConflictingOptionM = false
-        // The Window menu sits near the end of the menu bar.
-        for barItem in topLevel.reversed() {
+        // Deliberately not stopped once both items are in hand. The blind
+        // ⌥⌘M this outcome may authorise would fire whatever else is bound to
+        // that combination, so `hasConflictingOptionM` is only trustworthy
+        // after the whole menu bar has been read. The cap below bounds the
+        // walk instead, and a walk that hits it reports the conflict it cannot
+        // rule out. The Window menu sits near the end, hence the reversal.
+        var visited = 0
+        var truncated = false
+        outer: for barItem in topLevel.reversed() {
             guard let menus = elementArray(barItem, kAXChildrenAttribute as String) else { continue }
             for menu in menus {
                 guard let items = elementArray(menu, kAXChildrenAttribute as String) else { continue }
                 for item in items {
+                    guard visited < Self.minimizeMenuItemBudget else {
+                        truncated = true
+                        break outer
+                    }
+                    visited += 1
                     let commandCharacter = stringAttribute(item, "AXMenuItemCmdChar")
                     let modifiers = intAttribute(item, "AXMenuItemCmdModifiers")
                     let isVerifiedMinimizeAll = DockClickSupport.isVerifiedMinimizeAll(
@@ -502,7 +519,12 @@ final class DockClickService {
                     )
                     if isVerifiedMinimizeAll, minimizeAll == nil {
                         minimizeAll = item
-                    } else if commandCharacter?.uppercased() == "M", modifiers == 2 {
+                    }
+                    // Independent of the capture above: a second verified
+                    // Minimize All used to fall through to this branch and
+                    // report the real item as the conflict.
+                    if !isVerifiedMinimizeAll,
+                       commandCharacter?.uppercased() == "M", modifiers == 2 {
                         hasConflictingOptionM = true
                     }
                     if commandCharacter?.uppercased() == "M",
@@ -526,7 +548,9 @@ final class DockClickService {
                 return .performed
             }
         }
-        return hasConflictingOptionM ? .shortcutUnsafe : .unavailable
+        // A truncated walk cannot vouch for the absence of another ⌥⌘M, and
+        // `.unavailable` is what authorises posting one blind.
+        return (hasConflictingOptionM || truncated) ? .shortcutUnsafe : .unavailable
     }
 
     private static func postMinimizeAllShortcut() {

--- a/Sources/Vorssaint/Services/DockClick/DockClickService.swift
+++ b/Sources/Vorssaint/Services/DockClick/DockClickService.swift
@@ -229,6 +229,11 @@ final class DockClickService {
                     windows = Self.standardWindows(pid: pid, timeout: 0.7)
                 }
             }
+            // Counted on the Space the user is looking at, the only windows
+            // the raise can reach; the AX list above spans every Space.
+            let cycleCandidateCount = cycleEnabled
+                ? Self.cycleCandidates(pid: pid, windows: windows.unminimized).count
+                : 0
             let hasUnminimized = DockClickSupport.effectiveHasUnminimized(
                 unminimizedCount: windows.unminimized.count,
                 minimizedCount: windows.minimized.count,
@@ -241,7 +246,7 @@ final class DockClickService {
                                              minimizeEnabled: minimizeEnabled,
                                              hideEnabled: hideEnabled,
                                              cycleWindowsEnabled: cycleEnabled,
-                                             unminimizedWindowCount: windows.unminimized.count,
+                                             cycleCandidateCount: cycleCandidateCount,
                                              ownsMinimize: ownsMinimize(pid: pid,
                                                                         minimized: windows.minimized))
         }
@@ -687,8 +692,8 @@ final class DockClickService {
         AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, kCFBooleanFalse)
     }
 
-    /// Cycles through an app's unminimized windows by raising the rearmost one
-    /// to the front, mimicking ⌘` (Command-Tilde) behavior.
+    /// Cycles through an app's windows on the current Space by raising the
+    /// rearmost one to the front, mimicking ⌘` (Command-Tilde) behavior.
     ///
     /// The rearmost window comes from the WindowServer's real z-order, not the
     /// AX windows array: that array keeps the focused window first, so
@@ -696,37 +701,34 @@ final class DockClickService {
     /// two frontmost windows and the rest are never visited. Raising the true
     /// rearmost window walks every window in round-robin order.
     private static func cycleWindows(pid: pid_t, windows: [AXUIElement]) {
-        guard windows.count > 1 else { return }
-
-        let rearWindow: AXUIElement
-        if let rear = rearmostByZOrder(pid: pid, windows: windows) {
-            rearWindow = rear
-        } else {
-            // No z-order available (window ids unresolved): the AX array is
-            // focused-first, so its last element is still the best rear guess.
-            rearWindow = windows[windows.count - 1]
-        }
+        let candidates = cycleCandidates(pid: pid, windows: windows)
+        // More than one only fails here when a window closed between the press
+        // and the release; the click was decided on the same list.
+        guard candidates.count > 1, let rearWindow = candidates.last else { return }
 
         AXUIElementPerformAction(rearWindow, kAXRaiseAction as CFString)
         let app = AXUIElementCreateApplication(pid)
+        // Runs on main, and a hung app would otherwise hold the focus write
+        // for the multi-second AX default with the menu bar and every panel
+        // frozen behind it.
+        AXUIElementSetMessagingTimeout(app, 0.35)
         AXUIElementSetAttributeValue(app, kAXFocusedWindowAttribute as CFString, rearWindow)
     }
 
-    /// The candidate that sits deepest in the WindowServer's front-to-back
-    /// on-screen list. Windows on other Spaces are not in that list, which is
+    /// The passed windows that the WindowServer currently lists on screen,
+    /// front to back. Windows on other Spaces are not in that list, which is
     /// wanted: cycling from the Dock must not yank the user across Spaces.
-    private static func rearmostByZOrder(pid: pid_t, windows: [AXUIElement]) -> AXUIElement? {
-        let orderedIDs = onScreenWindowIDs(pid: pid)
-        guard orderedIDs.count > 1 else { return nil }
-        var rear: (window: AXUIElement, depth: Int)?
-        for window in windows {
-            guard let id = AXWindowResolver.windowID(for: window),
-                  let depth = orderedIDs.firstIndex(of: id) else { continue }
-            if rear == nil || depth > rear!.depth {
-                rear = (window, depth)
-            }
-        }
-        return rear?.window
+    ///
+    /// Both the decision to cycle and the raise read this list. They used to
+    /// disagree — the decision counted every AX window, Spaces included, so a
+    /// Space holding one window still promised a rotation and the raise then
+    /// had to guess (issue #1204).
+    private static func cycleCandidates(pid: pid_t, windows: [AXUIElement]) -> [AXUIElement] {
+        let ids = windows.map { AXWindowResolver.windowID(for: $0) }
+        let indices = DockClickSupport.cycleCandidateIndices(
+            windowIDs: ids,
+            onScreenFrontToBack: onScreenWindowIDs(pid: pid))
+        return indices.map { windows[$0] }
     }
 
     // MARK: - Geometry

--- a/Sources/Vorssaint/Services/DockClick/DockClickSupport.swift
+++ b/Sources/Vorssaint/Services/DockClick/DockClickSupport.swift
@@ -181,6 +181,30 @@ enum DockClickSupport {
         unminimizedCount > 0 || (minimizedCount == 0 && windowServerSeesWindows)
     }
 
+    /// Which of the app's windows a cycling click can rotate through, as
+    /// indices into `windowIDs`, front to back.
+    ///
+    /// `windowIDs` are the app's unminimized windows in Accessibility order
+    /// (nil where the id could not be resolved); `onScreenFrontToBack` is the
+    /// window server's on-screen list, which holds only the Space the user is
+    /// looking at. A window parked on another Space therefore has no place in
+    /// the result and can never be raised.
+    ///
+    /// This is the single list behind both halves of the feature: `action`
+    /// only promises `.cycleWindows` when it holds more than one window, and
+    /// the raise takes its last element. Deciding from one set of windows and
+    /// raising from another is what made a Dock click either loop over two
+    /// windows forever or jump to a different desktop (issue #1204).
+    static func cycleCandidateIndices(windowIDs: [CGWindowID?],
+                                      onScreenFrontToBack: [CGWindowID]) -> [Int] {
+        var depths: [(index: Int, depth: Int)] = []
+        for (index, id) in windowIDs.enumerated() {
+            guard let id, let depth = onScreenFrontToBack.firstIndex(of: id) else { continue }
+            depths.append((index, depth))
+        }
+        return depths.sorted { $0.depth < $1.depth }.map(\.index)
+    }
+
     static func action(appIsFrontmost: Bool,
                        hasUnminimizedWindows: Bool,
                        hasMinimizedWindows: Bool,
@@ -189,10 +213,12 @@ enum DockClickSupport {
                        minimizeEnabled: Bool = true,
                        hideEnabled: Bool = false,
                        cycleWindowsEnabled: Bool = false,
-                       unminimizedWindowCount: Int = 0,
+                       cycleCandidateCount: Int = 0,
                        ownsMinimize: Bool = false) -> DockClickAction {
         guard !hasModifiers else { return .passThrough }
-        if cycleWindowsEnabled, appIsFrontmost, !hasFullscreenWindows, unminimizedWindowCount > 1 {
+        // Counted on the current Space only: a click must not advertise a
+        // rotation the raise cannot perform without changing desktops.
+        if cycleWindowsEnabled, appIsFrontmost, !hasFullscreenWindows, cycleCandidateCount > 1 {
             return .cycleWindows
         }
         if hideEnabled, appIsFrontmost { return .hide }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9701,7 +9701,7 @@ struct MetricsTests {
                                        hasModifiers: false,
                                        minimizeEnabled: true,
                                        cycleWindowsEnabled: true,
-                                       unminimizedWindowCount: 3) == .cycleWindows,
+                                       cycleCandidateCount: 3) == .cycleWindows,
                "dock click cycles instead of minimizing when both are on and there are windows to cycle")
         expect(DockClickSupport.action(appIsFrontmost: true,
                                        hasUnminimizedWindows: true,
@@ -9710,7 +9710,7 @@ struct MetricsTests {
                                        hasModifiers: false,
                                        minimizeEnabled: true,
                                        cycleWindowsEnabled: true,
-                                       unminimizedWindowCount: 1) == .minimize,
+                                       cycleCandidateCount: 1) == .minimize,
                "dock click still minimizes a single-window app with cycling on")
         expect(DockClickSupport.action(appIsFrontmost: true,
                                        hasUnminimizedWindows: true,
@@ -9719,7 +9719,7 @@ struct MetricsTests {
                                        hasModifiers: false,
                                        minimizeEnabled: false,
                                        cycleWindowsEnabled: true,
-                                       unminimizedWindowCount: 1) == .passThrough,
+                                       cycleCandidateCount: 1) == .passThrough,
                "cycling alone never minimizes a single-window app")
         expect(DockClickSupport.action(appIsFrontmost: true,
                                        hasUnminimizedWindows: true,
@@ -9785,7 +9785,7 @@ struct MetricsTests {
                                        minimizeEnabled: false,
                                        hideEnabled: true,
                                        cycleWindowsEnabled: false,
-                                       unminimizedWindowCount: 3) == .hide,
+                                       cycleCandidateCount: 3) == .hide,
                "hiding treats a multi-window app as one app when cycling is off")
         expect(DockClickSupport.action(appIsFrontmost: true,
                                        hasUnminimizedWindows: true,
@@ -9795,7 +9795,7 @@ struct MetricsTests {
                                        minimizeEnabled: false,
                                        hideEnabled: true,
                                        cycleWindowsEnabled: true,
-                                       unminimizedWindowCount: 3) == .cycleWindows,
+                                       cycleCandidateCount: 3) == .cycleWindows,
                "window cycling stays ahead of hiding when several windows are available")
         expect(DockClickSupport.action(appIsFrontmost: true,
                                        hasUnminimizedWindows: false,
@@ -9804,7 +9804,7 @@ struct MetricsTests {
                                        hasModifiers: false,
                                        minimizeEnabled: false,
                                        cycleWindowsEnabled: true,
-                                       unminimizedWindowCount: 0) == .passThrough,
+                                       cycleCandidateCount: 0) == .passThrough,
                "cycling alone never restores minimized windows")
         expect(DockClickSupport.action(appIsFrontmost: false,
                                        hasUnminimizedWindows: true,
@@ -9813,8 +9813,31 @@ struct MetricsTests {
                                        hasModifiers: false,
                                        minimizeEnabled: false,
                                        cycleWindowsEnabled: true,
-                                       unminimizedWindowCount: 3) == .passThrough,
+                                       cycleCandidateCount: 3) == .passThrough,
                "cycling lets the Dock activate apps that are not frontmost")
+        // Issue #1204's report: one app, four unminimized windows spread over
+        // three desktops, two of them on the desktop being looked at. The AX
+        // window list holds all four; the window server's on-screen list holds
+        // only the two.
+        let windowsAcrossDesktops: [CGWindowID?] = [1, 2, 3, 4]
+        expect(DockClickSupport.cycleCandidateIndices(windowIDs: windowsAcrossDesktops,
+                                                      onScreenFrontToBack: [1, 2]) == [0, 1],
+               "cycling only considers the windows on the desktop being looked at")
+        expect(DockClickSupport.cycleCandidateIndices(windowIDs: windowsAcrossDesktops,
+                                                      onScreenFrontToBack: [1, 2]).last == 1,
+               "the click raises the rearmost window of the current desktop")
+        expect(DockClickSupport.cycleCandidateIndices(windowIDs: windowsAcrossDesktops,
+                                                      onScreenFrontToBack: [2, 1]).last == 0,
+               "the next click raises the other one back, rotating in place")
+        expect(DockClickSupport.cycleCandidateIndices(windowIDs: windowsAcrossDesktops,
+                                                      onScreenFrontToBack: [3]).count == 1,
+               "a desktop holding one window offers nothing to cycle, so the click cannot jump to another desktop")
+        expect(DockClickSupport.cycleCandidateIndices(windowIDs: [1, 2, 3],
+                                                      onScreenFrontToBack: [3, 1, 2]).last == 1,
+               "three windows on one desktop rotate through all of them, not just the front two")
+        expect(DockClickSupport.cycleCandidateIndices(windowIDs: [nil, nil],
+                                                      onScreenFrontToBack: [1, 2]).isEmpty,
+               "windows whose ids cannot be resolved are never guessed at")
         expect(DockClickSupport.repeatDecision(lastAction: .cycleWindows, elapsed: 0.5) == .deriveFromState,
                "a repeated click after a cycle keeps cycling from live state")
         expect(DockClickSupport.repeatDecision(lastAction: .hide, elapsed: 0.5) == .deriveFromState,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9815,6 +9815,19 @@ struct MetricsTests {
                                        cycleWindowsEnabled: true,
                                        cycleCandidateCount: 3) == .passThrough,
                "cycling lets the Dock activate apps that are not frontmost")
+        // The two assertions above and below are what lets the service skip
+        // counting candidates unless the app is frontmost and has no
+        // fullscreen window: on those paths the ladder ignores the count, so
+        // paying for it inside the event tap buys nothing.
+        expect(DockClickSupport.action(appIsFrontmost: true,
+                                       hasUnminimizedWindows: true,
+                                       hasMinimizedWindows: false,
+                                       hasFullscreenWindows: true,
+                                       hasModifiers: false,
+                                       minimizeEnabled: true,
+                                       cycleWindowsEnabled: true,
+                                       cycleCandidateCount: 3) == .passThrough,
+               "cycling stays out of an app with a fullscreen window however many candidates there are")
         // Issue #1204's report: one app, four unminimized windows spread over
         // three desktops, two of them on the desktop being looked at. The AX
         // window list holds all four; the window server's on-screen list holds


### PR DESCRIPTION
## Summary

Clicking the Dock icon to cycle windows decided from one set of windows and
raised from another.

`DockClickSupport.action` reached `.cycleWindows` when the app had more than
one unminimized window in its Accessibility list, which spans every Space. The
raise then ranked those windows against the window server's on-screen list,
which holds only the Space you are looking at. Two sets, one question, and
nothing kept them in agreement, so the feature contradicted itself depending on
what the current desktop happened to hold:

- Two or more windows here: the rotation was correct but the click had already
  promised to reach windows it filtered out.
- One window here: the on-screen list had a single entry, the ranking gave up,
  and the fallback took the last element of the Accessibility array — a window
  that can live on another desktop. The click changed your desktop. That is the
  second half of #1204, and it was also the one path in this feature that
  crossed Spaces, directly against the comment sitting above it.

Both halves now read one list: the app's unminimized windows that the window
server currently reports on screen. `action` counts that list, the raise takes
its rearmost element, and the cross-Space fallback is gone. When the current
desktop holds a single window there is nothing to rotate, so the click falls
through the normal ladder to minimize, hide or the Dock's own behavior instead
of jumping somewhere. The selection is now a pure function,
`DockClickSupport.cycleCandidateIndices`, so it is covered by tests rather than
only reachable through live Accessibility calls.

The parameter that carried the count is renamed `cycleCandidateCount`. The old
name is what made the mismatch easy to write in the first place.

Cost on the event tap: one `CGWindowListCopyWindowInfo` and one window-id
resolve per unminimized window, and only on the clicks whose answer can use
it — window cycling on (off by default), the app already frontmost, and no
fullscreen window. Those are the exact three conditions of the ladder's cycling
branch, and `cycleCandidateCount` is read nowhere else in `action`, so on every
other click the count would have been discarded. Clicking a background app's
icon, the common Dock click, therefore pays nothing. Where the count is taken,
it is against the three Accessibility reads per window the same path already
does, and the elements come from `standardWindows`, so they already carry its
0.35 s messaging timeout.

**Which behavior this implements.** The report asks for the other one — a
rotation that walks every window of the app across all desktops — and that is a
deliberate no here, not an oversight:

- The settings caption for this option says the click rotates through the app's
  windows "like ⌘`", and it ships in 13 languages. macOS's own ⌘` ("Move focus
  to next window") stays on the current Space.
- The changelog entry that introduced the option describes it the same way:
  the Command backtick shortcut with the mouse.
- The same feature already refuses to cross Spaces elsewhere on purpose:
  fullscreen windows keep only the app-level hide action precisely so restoring
  their siblings cannot pull you to another Space.

Cross-Space cycling is a different feature, not a bug fix: it contradicts the
caption in 13 localizations and makes one Dock click able to change your
desktop with no way to see where it is going first. Tools that do reach across
Spaces — AltTab, and this project's own App Switcher — show you the windows and
let you pick one; a blind rotation is not the same interaction. If that is
wanted, it is a maintainer's call and a re-worded, re-translated caption, and
this patch is the right base for it: the Space filter is one pure function with
one caller.

**Second commit, the other half of this file's Minimize All path.** A second
verified Minimize All item fell through to the `else if` under the capture and
was recorded as a conflicting ⌥⌘M — the very flag that withholds the synthetic
shortcut this walk exists to authorise. The two checks are independent now.
The walk also had no item budget, unlike the three other menu walks in this
app, so it read every item of every menu at two or three cross-process reads
each; it stops at 600. It still does not stop early once both items are in
hand, and the comment now says why: `.unavailable` is what authorises posting
a blind ⌥⌘M, so the absence of another binding for that combination is only
established by reading the whole menu bar. A walk that hits the budget reports
the conflict it could not rule out instead.

Also fixed in passing: the focus write after the raise created its
`AXUIElementCreateApplication` without an `AXUIElementSetMessagingTimeout` —
the only app element in this file that had none. It runs on the main thread,
so a hung target app froze the menu bar and every panel for the multi-second
Accessibility default. It now uses the same 0.35 s leash as the rest.

Not touched: the minimize, restore and hide paths, the repeat/double-click
handling, and the decision ladder's order. Three behaviours change:

1. Which windows a cycling click considers, and whether it cycles at all when
   the current desktop holds one window.
2. An app whose windows never resolve to a window id no longer cycles at all.
   `_AXUIElementGetWindow` is what maps an AX element to the id the on-screen
   list is keyed by; when it fails for every window the candidate list is
   empty, so a click on such an app with three windows on the current desktop
   now falls through to minimize, hide or the Dock's own behavior. It used to
   guess the last element of the Accessibility array instead. This file already
   knows that app class — the 0.7 s retry above the count and the "busy JVM,
   SWT quirks" note further down exist for it. Taking the loss is the intended
   trade: the guess it replaces was a window picked by position in a list that
   is not ordered by depth and can sit on another desktop, which is the
   teleport in #1204. Cycling for those apps needs an id the window server will
   admit to, not a guess at one.
3. Whether a menu walk that found a real Minimize All still reports a conflict
   against itself.

## Verification

MacBook Air (`Mac17,3`), Apple M5, macOS 26.6.2 (25G83), Xcode 26.6, own build
from this branch, single display and a single Space.

```
./build.sh --test   9476 checks; 9469 on main, so the 7 new assertions are the difference
./build.sh          whole-module release compile, 0 errors, 0 warnings
```

The two failures in that run (`nil layout falls back to ANSI semicolon`,
`App Switcher icon-row hints`) fail identically on clean `main` here; both read
the machine's current input source, which is a Chinese IME. Neither is touched
by this change.

`DockClickService.swift` is not on `build.sh --test`'s source whitelist, so the
full `./build.sh` above is what compiled it locally. That run compiles the whole
module and the fan helper clean, then stops in the bundle-signing step:
`codesign` returns `errSecInternalComponent` for the fan-control helper against
this machine's self-signed identity. That is a local keychain condition on a
binary this change does not touch, after every Swift file was already compiled.
The signed bundle is left to CI on both runners.

Six of the new assertions cover #1204's exact topology — four unminimized
windows over three desktops, two of them on the current one — and check that the rotation
stays on those two, alternates between them, offers nothing to cycle on a
desktop holding one window, walks all three when three are present, and never
guesses at a window whose id will not resolve. The seventh pins the second half
of the condition that lets the service skip counting candidates: a fullscreen
window keeps `.cycleWindows` off the table however many candidates there are,
just as a non-frontmost app already does in the assertion above it. Both were
confirmed to go red when the matching term is removed from the branch.

**What I could not test.** The report's topology on real hardware. I have one
display and one Space, so I could not click a Dock icon with windows spread
over three desktops and watch what happens; the multi-Space behavior here is
argued from the window server's on-screen list and covered by the pure
function's tests, not observed. The two cases worth a maintainer's own Mac:

1. Two windows on the current desktop, more on others — repeated clicks must
   rotate those two and never change desktop.
2. One window on the current desktop, more on others — the click must now
   minimize (or hide, or do nothing, per settings) instead of switching
   desktop. This is the case that used to teleport.

Also untested: multiple displays with "Displays have separate Spaces" on, where
the on-screen list spans both screens. And an app whose window ids do not
resolve — behaviour 2 above is reasoned from the resolver, not watched on a
real SWT or JVM app.

## Anything else

Refs #1204
