### PR TITLE
fix: read shortcut key caps from the keyboard layout, not the input method

### DIFF
--- a/Sources/Vorssaint/Core/GlobalShortcut.swift
+++ b/Sources/Vorssaint/Core/GlobalShortcut.swift
@@ -550,12 +550,31 @@ struct GlobalShortcut: Equatable, Hashable {
         return derivedLayoutKeyLabel(for: code, layoutData: layoutData)
     }
 
+    /// The layout the keycaps are read from. An input method answers the
+    /// current-layout call with the companion layout it types through, and
+    /// Pinyin's turns ; , . [ ] \ ` into ；，。【】、· — what the method produces,
+    /// not what the keyboard says, and it moves with the method rather than
+    /// with the hardware. The ASCII capable layout under a method is the
+    /// physical keyboard, so the caps stay put. A plain layout is still asked
+    /// directly, which keeps AZERTY, QWERTZ and the non-Latin layouts showing
+    /// their own keys (issue #1047).
     private static func currentLayoutData() -> Data? {
-        guard Thread.isMainThread,
-              let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
+        guard Thread.isMainThread else { return nil }
+        let source = inputMethodIsActive
+            ? TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?.takeRetainedValue()
+            : TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue()
+        guard let source,
               let layoutData = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData)
         else { return nil }
         return Unmanaged<CFData>.fromOpaque(layoutData).takeUnretainedValue() as Data
+    }
+
+    private static var inputMethodIsActive: Bool {
+        guard let source = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue(),
+              let type = TISGetInputSourceProperty(source, kTISPropertyInputSourceType)
+        else { return false }
+        let value = Unmanaged<CFString>.fromOpaque(type).takeUnretainedValue() as String
+        return value != (kTISTypeKeyboardLayout as String)
     }
 
     private static func derivedLayoutKeyLabel(for code: UInt16,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -3858,6 +3858,24 @@ struct MetricsTests {
 
         GlobalShortcut.refreshLayoutLabels()
 
+        // Every assertion above compares labels the live input source produced,
+        // so on a Latin-layout Mac they all pass whichever source the keycaps
+        // are read from, and the one thing that made them wrong is invisible:
+        // an input method answers the current-layout call with the layout it
+        // types through, not the one printed on the keys. Pinned on the public
+        // symbols rather than on the private member holding them, so renaming
+        // it stays green and dropping the ASCII-capable lookup goes red.
+        let shortcutSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Core/GlobalShortcut.swift",
+            encoding: .utf8)) ?? ""
+        let shortcutCode = shortcutSource.split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(shortcutCode.contains("TISCopyCurrentASCIICapableKeyboardLayoutInputSource")
+                && shortcutCode.contains("TISCopyCurrentKeyboardInputSource")
+                && shortcutCode.contains("kTISPropertyInputSourceType"),
+               "keycaps come from the ASCII-capable layout while an input method is active")
+
         // The native full screen action, wired like the sixths: real strings,
         // a stable id, and no system-wide key claimed until someone asks.
         expect(WindowLayoutAction.allCases.contains(.fullScreen)


### PR DESCRIPTION
## Summary

Shortcut key caps were read from the input method's layout instead of the keyboard's.

`GlobalShortcut.currentLayoutData()` called `TISCopyCurrentKeyboardLayoutInputSource()`. When an input method is active, that API returns — as documented — the layout the *method* types through, not the one printed on the keys. Simplified Pinyin's companion layout is `com.apple.keylayout.PinyinKeyboard`, and it maps most punctuation to its full-width CJK forms.

Same key codes, same `derivedLayoutKeyLabel` logic, three layouts fed in as data:

| layout | `;` | `,` | `.` | `/` | `'` | `[` | `]` | `\` | `-` | `=` | `` ` `` |
|---|---|---|---|---|---|---|---|---|---|---|---|
| `PinyinKeyboard` | `；` | `，` | `。` | `/` | `'` | `【` | `】` | `、` | `-` | `=` | `·` |
| `ABC` / `US` | `;` | `,` | `.` | `/` | `'` | `[` | `]` | `\` | `-` | `=` | `` ` `` |
| `French` | `M` | `;` | `:` | `=` | `Ù` | `^` | `$` | `` ` `` | `)` | `-` | `<` |

**Seven keys are affected — `;` `,` `.` `[` `]` `\` and `` ` ``.** `/` `'` `-` `=` and every letter and digit are not. One defect, seven symptoms.

Because the cap is derived from the live input source, the same saved shortcut renders differently at different moments with no edit by the user. The app can cause that itself: the Super key's input-source cycling (`SuperKeyService.selectNextInputSource`) changes what those shortcut labels say in Settings, the menu panel, the Command Bar and the Radial Menu.

### What #1226 already covers, and what is left

#1226 landed after this PR was opened and after its review. It reads a Command combination off the layout's Command table, and Pinyin's Command table already prints ASCII, so **every Command shortcut is correct on `main` today** — including the App Switcher's `⌘\``, which this PR's earlier description used as its headline symptom. That example is stale and I have removed it.

What remains wrong is every combination *without* Command, which still reads the bare table of the input method's layout. Measured on `ed882cd3` with Simplified Pinyin active, by resolving the caps in code rather than by driving the UI:

| shortcut | `main` today | with this PR |
|---|---|---|
| `⌃⌥` + `` ` `` | `⌃⌥ ·` | ``⌃⌥ ` `` |
| `⌃⌥` + `;` | `⌃⌥ ；` | `⌃⌥ ;` |
| `⌃⌥` + `[` | `⌃⌥ 【` | `⌃⌥ [` |
| `⌘` + `` ` `` | ``⌘ ` `` (already right) | ``⌘ ` `` |

No shipped default is a punctuation key without Command — the `⌃⌥` defaults are letters, arrows and Return — so what is left reaches user-set combinations rather than the out-of-the-box App Switcher. The two fixes are orthogonal: #1226 picks the right table, this picks the right layout to read the tables out of. Under Pinyin the bare table is wrong whichever table #1226 selects.

### The fix

Read the ASCII-capable layout underneath when an input method is active; keep asking the current layout directly otherwise. The conditional is the part that matters: switching unconditionally to the ASCII-capable layout would regress a Russian user's `Ф` back to `A`, and would undo #1047 for AZERTY and QWERTZ. One guard in the single function every key-cap caller routes through.

### `matchesByCharacter`

An earlier version of this description said the match path was left desynchronized. That was wrong, and the review caught it. `matchesByCharacter` is the OR-fallback after `windowShortcut.matches` at both call sites (`AppSwitcher.swift:465` and `:658`), so the key-code arm already carries `⌘\`` on ANSI and the character arm never decides there. The character arm only fires on non-US layouts, and there the label now comes from the same layout the tap's event translates through. This change closes that desync rather than deferring it.

### The added assertion, and the two that were red

The description previously said two existing assertions were red on `main` and go green on this fix. That is no longer true of `main`: on `ed882cd3`, under a Chinese input method, the whole suite is green (9487 checks).

- `App Switcher icon-row hints describe default app and window shortcuts` was fixed by #1226 — `⌘\`` is a Command combination.
- `nil layout falls back to ANSI semicolon` was the review's second note: clearing the cache is only half the nil path, because on the main thread the next read derives live again, so it asserted "the live layout prints `;`". #1226 rewrote it to read the caps on a thread of its own — including the detail that `sync` would have run on the calling thread and stayed on main. Nothing left to do here. I had made the same change on this branch, measured it red with the ANSI fallback broken on purpose and green restored, then dropped it: it is the same idea as the one already on `main` and only produced a merge conflict. **The branch is unchanged from the commit that was reviewed.**

The one added assertion is what protects this change. Both of those behavioural assertions compare caps the live input source produced, so on a Latin-layout Mac they pass whichever source the caps are read from, including a revert to the original single call. The new assertion is pinned on the public TIS symbols (`TISCopyCurrentASCIICapableKeyboardLayoutInputSource`, `TISCopyCurrentKeyboardInputSource`, `kTISPropertyInputSourceType`) rather than on the private member holding them, so renaming that member stays green while dropping the ASCII-capable lookup goes red.

| state | input source | result |
|---|---|---|
| branch as pushed | Pinyin (`SCIM.ITABC`) | `TESTS OK (9400 checks)` |
| `currentLayoutData` reverted to the single original call | Pinyin (`SCIM.ITABC`) | `TESTS FAILED (2 of 9400)` — the new assertion and the icon-row hint |
| `currentLayoutData` reverted to the single original call | `com.apple.keylayout.ABC` | `TESTS FAILED (1 of 9400)` — only the new assertion; both layout assertions stayed green |
| branch merged onto `main` `ed882cd3` | Pinyin (`SCIM.ITABC`) | clean merge, `TESTS OK (9488 checks)` |

The third row is the argument for keeping it: with a Latin layout active the regression is invisible to every behavioural assertion in the suite.

Check count goes 9399 → 9400 on the branch.

### Other live input-source reads, checked

- `MouseNavigationKeys.keyStroke(for:)` — same API, correct as-is: it asks which key *types* a given character, which genuinely wants the live text-production layout.
- `SuperKeyService` — the input-source cycling feature itself.
- `AutoQuitService`, `TextSnippetService`, `AppSwitcher` `keyboardGetUnicodeString` — per-event translation, not key caps.

No other key-cap site consults the live source.

### Not changed

`CHANGELOG.md`. No refactoring, no renames.

## Verification

Mac17,3, Apple M5, macOS 26.6.2 (25G83), Xcode Command Line Tools, own build signed with the self-signed `Vorssaint Utils Signing` identity, single display, app language English, Simplified Pinyin active throughout.

```sh
./build.sh                     # 0 errors, 0 warnings; build/Vorssaint 41.5 MB
./build/Vorssaint --selftest
./build.sh --test              # TESTS OK (9400 checks)
```

Re-run for this update, all under Pinyin: `main` at `ed882cd3` on its own — `TESTS OK (9487 checks)`; this branch merged onto it — clean merge, `TESTS OK (9488 checks)`; the branch with the guard reverted — `TESTS FAILED (2 of 9400)`. The four-row cap table above came from temporary probe assertions on those two trees, which were removed again; both trees are untouched apart from the merge.

**A reviewer on a Latin-only Mac will not see this bug.** To reproduce, add Simplified Chinese Pinyin in System Settings, switch to it, then set any shortcut without Command to one of the seven punctuation keys and look at the cap: `⌃⌥ ；` instead of `⌃⌥ ;`. The three-layout table was produced by feeding layout data in code rather than by switching the system input source, so it can be re-derived on any Mac that has those layouts installed.

**What I could not test:** a real AZERTY, QWERTZ, Cyrillic or Ukelele-built custom layout as the *active system* layout — those paths are covered only by the existing in-code layout-data assertions, which pass. Japanese and Korean input methods take the same corrected branch as Pinyin but were not exercised, and whether `TISCopyCurrentASCIICapableKeyboardLayoutInputSource` returns the JIS layout rather than ABC on a Japanese keyboard is unverified. No runtime behaviour was checked: `./build.sh` cannot complete codesigning on this machine (`errSecInternalComponent` on `com.vorssaint.utils.fan-control`), so the compile and the `build/Vorssaint` binary are verified but no signed `.app` bundle was produced, and the change was never exercised in a running app.

## Anything else

Refs #1047
