### PR TITLE
fix(mixer): recognize the headphone jack by port id, not localized name

### DIFF
--- a/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
+++ b/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
@@ -13,7 +13,7 @@ struct MixerOutputDevice: Identifiable, Equatable {
     let uid: String
     let name: String
     let isDefault: Bool
-    let isHeadphones: Bool
+    let outputKind: MixerRoutingSupport.OutputDeviceKind
     let canBeDefaultOutput: Bool
     let canBeDefaultSystemOutput: Bool
     fileprivate let audioObjectID: AudioObjectID
@@ -510,7 +510,7 @@ final class AppVolumeMixer: ObservableObject {
                               uid: outputDevice.uid,
                               name: outputDevice.name,
                               isDefault: outputDevice.uid == device.uid,
-                              isHeadphones: outputDevice.isHeadphones,
+                              outputKind: outputDevice.outputKind,
                               canBeDefaultOutput: outputDevice.canBeDefaultOutput,
                               canBeDefaultSystemOutput: outputDevice.canBeDefaultSystemOutput,
                               audioObjectID: outputDevice.audioObjectID)
@@ -1089,24 +1089,36 @@ final class AppVolumeMixer: ObservableObject {
         lowerOnDisconnect: Bool,
         lowerToPercent: Int) -> LoweredOutputState {
         var state = state
-        if let nextDefaultUID,
-           nextOutputDevices.first(where: { $0.uid == nextDefaultUID })?.isHeadphones == true {
+        let newDefault = nextDefaultUID.flatMap { uid in
+            nextOutputDevices.first(where: { $0.uid == uid })
+        }
+        if let newDefault,
+           newDefault.outputKind.countsAsHeadphonesWhenDisconnected,
+           // Not the device this feature just lowered: putting its own volume
+           // back one refresh later would undo the lowering on the spot.
+           state.lastAutomaticLoweredOutputUID != newDefault.uid {
             state.lastAutomaticLoweredOutputUID = nil
-            // Headphones are back: the speakers get the volume they had before
-            // the disconnect lowered them.
+            // Headphones are (or may be) back: the speakers get the volume they
+            // had before the disconnect lowered them.
             state.loweredOutput = restoringLoweredOutputVolume(state.loweredOutput,
                                                                in: nextOutputDevices)
-            return state
+            if newDefault.outputKind.countsAsHeadphonesWhenTakingOver {
+                return state
+            }
+            // An unknown device may equally be a Bluetooth speaker inheriting a
+            // headphone volume, so the lowering below still gets to run on it.
         }
 
         guard lowerOnDisconnect,
               let previousDefaultUID,
               let previousDefault = previousOutputDevices.first(where: { $0.uid == previousDefaultUID }),
-              previousDefault.isHeadphones,
-              !nextOutputDevices.contains(where: { $0.uid == previousDefaultUID && $0.isHeadphones }),
+              previousDefault.outputKind.countsAsHeadphonesWhenDisconnected,
+              !nextOutputDevices.contains(where: {
+                  $0.uid == previousDefaultUID && $0.outputKind.countsAsHeadphonesWhenDisconnected
+              }),
               let nextDefaultUID,
-              let nextDefault = nextOutputDevices.first(where: { $0.uid == nextDefaultUID }),
-              !nextDefault.isHeadphones,
+              let nextDefault = newDefault,
+              !nextDefault.outputKind.countsAsHeadphonesWhenTakingOver,
               state.lastAutomaticLoweredOutputUID != nextDefaultUID else {
             return state
         }
@@ -1566,7 +1578,7 @@ final class AppVolumeMixer: ObservableObject {
                                              uid: uid,
                                              name: name,
                                              isDefault: uid == defaultUID,
-                                             isHeadphones: MixerRoutingSupport.outputLooksLikeHeadphones(
+                                             outputKind: MixerRoutingSupport.outputDeviceKind(
                                                 transportType: hasTransportType ? transportType : nil,
                                                 dataSourceID: dataSource?.id,
                                                 name: name,

--- a/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
+++ b/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
@@ -1559,15 +1559,12 @@ final class AppVolumeMixer: ObservableObject {
                 : uid
             guard name != "Vorssaint Mixer" else { continue }
             let dataSource = outputDataSource(for: deviceID)
-            var transportType: UInt32 = 0
-            let hasTransportType = read(deviceID, kAudioDevicePropertyTransportType, &transportType)
 
             devices.append(MixerOutputDevice(id: uid,
                                              uid: uid,
                                              name: name,
                                              isDefault: uid == defaultUID,
                                              isHeadphones: MixerRoutingSupport.outputLooksLikeHeadphones(
-                                                transportType: hasTransportType ? transportType : nil,
                                                 dataSourceID: dataSource?.id,
                                                 name: name,
                                                 uid: uid,

--- a/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
+++ b/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
@@ -13,7 +13,7 @@ struct MixerOutputDevice: Identifiable, Equatable {
     let uid: String
     let name: String
     let isDefault: Bool
-    let outputKind: MixerRoutingSupport.OutputDeviceKind
+    let isHeadphones: Bool
     let canBeDefaultOutput: Bool
     let canBeDefaultSystemOutput: Bool
     fileprivate let audioObjectID: AudioObjectID
@@ -510,7 +510,7 @@ final class AppVolumeMixer: ObservableObject {
                               uid: outputDevice.uid,
                               name: outputDevice.name,
                               isDefault: outputDevice.uid == device.uid,
-                              outputKind: outputDevice.outputKind,
+                              isHeadphones: outputDevice.isHeadphones,
                               canBeDefaultOutput: outputDevice.canBeDefaultOutput,
                               canBeDefaultSystemOutput: outputDevice.canBeDefaultSystemOutput,
                               audioObjectID: outputDevice.audioObjectID)
@@ -1089,36 +1089,24 @@ final class AppVolumeMixer: ObservableObject {
         lowerOnDisconnect: Bool,
         lowerToPercent: Int) -> LoweredOutputState {
         var state = state
-        let newDefault = nextDefaultUID.flatMap { uid in
-            nextOutputDevices.first(where: { $0.uid == uid })
-        }
-        if let newDefault,
-           newDefault.outputKind.countsAsHeadphonesWhenDisconnected,
-           // Not the device this feature just lowered: putting its own volume
-           // back one refresh later would undo the lowering on the spot.
-           state.lastAutomaticLoweredOutputUID != newDefault.uid {
+        if let nextDefaultUID,
+           nextOutputDevices.first(where: { $0.uid == nextDefaultUID })?.isHeadphones == true {
             state.lastAutomaticLoweredOutputUID = nil
-            // Headphones are (or may be) back: the speakers get the volume they
-            // had before the disconnect lowered them.
+            // Headphones are back: the speakers get the volume they had before
+            // the disconnect lowered them.
             state.loweredOutput = restoringLoweredOutputVolume(state.loweredOutput,
                                                                in: nextOutputDevices)
-            if newDefault.outputKind.countsAsHeadphonesWhenTakingOver {
-                return state
-            }
-            // An unknown device may equally be a Bluetooth speaker inheriting a
-            // headphone volume, so the lowering below still gets to run on it.
+            return state
         }
 
         guard lowerOnDisconnect,
               let previousDefaultUID,
               let previousDefault = previousOutputDevices.first(where: { $0.uid == previousDefaultUID }),
-              previousDefault.outputKind.countsAsHeadphonesWhenDisconnected,
-              !nextOutputDevices.contains(where: {
-                  $0.uid == previousDefaultUID && $0.outputKind.countsAsHeadphonesWhenDisconnected
-              }),
+              previousDefault.isHeadphones,
+              !nextOutputDevices.contains(where: { $0.uid == previousDefaultUID && $0.isHeadphones }),
               let nextDefaultUID,
-              let nextDefault = newDefault,
-              !nextDefault.outputKind.countsAsHeadphonesWhenTakingOver,
+              let nextDefault = nextOutputDevices.first(where: { $0.uid == nextDefaultUID }),
+              !nextDefault.isHeadphones,
               state.lastAutomaticLoweredOutputUID != nextDefaultUID else {
             return state
         }
@@ -1578,7 +1566,7 @@ final class AppVolumeMixer: ObservableObject {
                                              uid: uid,
                                              name: name,
                                              isDefault: uid == defaultUID,
-                                             outputKind: MixerRoutingSupport.outputDeviceKind(
+                                             isHeadphones: MixerRoutingSupport.outputLooksLikeHeadphones(
                                                 transportType: hasTransportType ? transportType : nil,
                                                 dataSourceID: dataSource?.id,
                                                 name: name,

--- a/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
+++ b/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
@@ -1141,9 +1141,17 @@ final class AppVolumeMixer: ObservableObject {
         return nil
     }
 
-    /// Teardown path only, and deliberately synchronous: `stopAll()` runs while
-    /// the app is quitting, so anything the mixer still owes the system has to
-    /// be handed back before the process goes away.
+    /// Synchronous because one of its two callers cannot wait: `AppDelegate`
+    /// calls `stopAll()` as the app quits, and a volume this feature lowered
+    /// has to be handed back before the process goes away.
+    ///
+    /// The other caller is `stop()`, which also runs when the mixer is simply
+    /// switched off in the hub. That one is on the main thread and reads and
+    /// writes the HAL, which `halQueue` above exists to keep off it — a device
+    /// mid-reconfiguration can hold either call for as long as the audio
+    /// daemon holds the device. Splitting the two paths means deciding what
+    /// happens if the app quits while an asynchronous restore is in flight, so
+    /// it is left as it is and described rather than quietly assumed.
     private func restoreLoweredOutputVolume() {
         loweredOutput = Self.restoringLoweredOutputVolume(loweredOutput, in: outputDevices)
     }

--- a/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
+++ b/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
@@ -1550,16 +1550,20 @@ final class AppVolumeMixer: ObservableObject {
                 ? nameRef as String
                 : uid
             guard name != "Vorssaint Mixer" else { continue }
-            let dataSourceName = outputDataSourceName(for: deviceID)
+            let dataSource = outputDataSource(for: deviceID)
+            var transportType: UInt32 = 0
+            let hasTransportType = read(deviceID, kAudioDevicePropertyTransportType, &transportType)
 
             devices.append(MixerOutputDevice(id: uid,
                                              uid: uid,
                                              name: name,
                                              isDefault: uid == defaultUID,
                                              isHeadphones: MixerRoutingSupport.outputLooksLikeHeadphones(
+                                                transportType: hasTransportType ? transportType : nil,
+                                                dataSourceID: dataSource?.id,
                                                 name: name,
                                                 uid: uid,
-                                                dataSourceName: dataSourceName),
+                                                dataSourceName: dataSource?.name),
                                              canBeDefaultOutput: canBeDefaultOutput,
                                              canBeDefaultSystemOutput: canBeDefaultSystemOutput,
                                              audioObjectID: deviceID))
@@ -1572,7 +1576,9 @@ final class AppVolumeMixer: ObservableObject {
         }
     }
 
-    private static func outputDataSourceName(for deviceID: AudioObjectID) -> String? {
+    /// The output port the device is currently using: its OSType id, which is
+    /// stable across languages, and the name HAL localizes for display.
+    private static func outputDataSource(for deviceID: AudioObjectID) -> (id: UInt32, name: String?)? {
         var dataSourceID: UInt32 = 0
         guard read(deviceID,
                    kAudioDevicePropertyDataSource,
@@ -1601,8 +1607,8 @@ final class AppVolumeMixer: ObservableObject {
                     &translation)
             }
         }
-        guard status == noErr else { return nil }
-        return nameRef as String
+        guard status == noErr else { return (dataSourceID, nil) }
+        return (dataSourceID, nameRef as String)
     }
 
     private static func hasOutputStreams(_ deviceID: AudioObjectID) -> Bool {

--- a/Sources/Vorssaint/Services/Audio/MixerRoutingSupport.swift
+++ b/Sources/Vorssaint/Services/Audio/MixerRoutingSupport.swift
@@ -278,27 +278,15 @@ enum MixerRoutingSupport {
     /// and headphones sharing one port — is recognized today by the data source
     /// name, and a port-first test would call it speakers.
     ///
-    /// - Parameters:
-    ///   - transportType: `kAudioDevicePropertyTransportType`, nil when unreadable.
-    ///   - dataSourceID: `kAudioDevicePropertyDataSource` on the output scope,
-    ///     nil when the device has no selectable port.
-    static func outputLooksLikeHeadphones(transportType: UInt32?,
-                                          dataSourceID: UInt32?,
+    /// - Parameter dataSourceID: `kAudioDevicePropertyDataSource` on the
+    ///   output scope, nil when the device has no selectable port.
+    static func outputLooksLikeHeadphones(dataSourceID: UInt32?,
                                           name: String,
                                           uid: String,
                                           dataSourceName: String?) -> Bool {
         // The built-in driver names its own headphone port, in a code that is
         // the same in every language. Nothing else can answer this.
         if dataSourceID == headphonesDataSourceID { return true }
-
-        // A display, a TV or an AirPlay receiver is never headphones, whatever
-        // it happens to be called.
-        switch transportType {
-        case kAudioDeviceTransportTypeHDMI, kAudioDeviceTransportTypeDisplayPort,
-             kAudioDeviceTransportTypeAirPlay:
-            return false
-        default: break
-        }
 
         // The word list, unchanged, so every device recognized today is still
         // recognized. A device it does not know is not headphones, as before.

--- a/Sources/Vorssaint/Services/Audio/MixerRoutingSupport.swift
+++ b/Sources/Vorssaint/Services/Audio/MixerRoutingSupport.swift
@@ -259,104 +259,50 @@ enum MixerRoutingSupport {
         return candidates[(index + 1) % candidates.count]
     }
 
-    /// Data source (port) codes the built-in audio driver reports through
-    /// `kAudioDevicePropertyDataSource`. They are the OSType constants from
-    /// IOKit's `IOAudioTypes.h` (`kIOAudioOutputPortSubType*`), so they read
-    /// the same on every Mac in every language — unlike the data source
-    /// *name*, which HAL localizes ("外置耳机", "Écouteurs externes").
-    static let headphonesDataSourceID: UInt32 = 0x6864_706e      // 'hdpn'
-    static let internalSpeakerDataSourceID: UInt32 = 0x6973_706b // 'ispk'
-    static let externalSpeakerDataSourceID: UInt32 = 0x6573_706b // 'espk'
+    /// The headphone port code the built-in audio driver reports through
+    /// `kAudioDevicePropertyDataSource`. It is the OSType constant from IOKit's
+    /// `IOAudioTypes.h` (`kIOAudioOutputPortSubTypeHeadphones`), so it reads the
+    /// same on every Mac in every language — unlike the data source *name*,
+    /// which HAL localizes ("外置耳机", "Écouteurs externes").
+    static let headphonesDataSourceID: UInt32 = 0x6864_706e // 'hdpn'
 
-    /// What an output device is, as far as the system will say.
+    /// Whether a disconnect of this device should count as "headphones came
+    /// off", which is what drives lowering the speaker volume.
     ///
-    /// Two states are not enough, because the answer is used on both sides of
-    /// a default-output handoff and the sides want opposite defaults for a
-    /// device nothing identified:
-    ///
-    /// - For the device that just went away, guessing "headphones" is the safe
-    ///   guess. Missing real headphones lets whatever takes over play at
-    ///   headphone volume, the accident the feature exists to prevent
-    ///   (issue #92); mistaking a speaker for headphones only lowers a volume
-    ///   the user can raise again and that is put back when the device returns.
-    /// - For the device that takes over, the same guess is the unsafe one: it
-    ///   is what suppresses the lowering. A Bluetooth speaker becoming the
-    ///   default is exactly the case the feature has to cover.
-    ///
-    /// So a transport that carries both kinds and reports no port is `unknown`
-    /// rather than either answer, and each side reads it its own way.
-    enum OutputDeviceKind: Equatable {
-        case headphones
-        case speakers
-        /// The system placed the device on a transport that carries both kinds
-        /// (Bluetooth) and gave no port id or recognizable name. CoreAudio has
-        /// no property that separates a Bluetooth headset from a Bluetooth
-        /// speaker — the Bluetooth class of device does, but that is IOBluetooth,
-        /// not the audio HAL.
-        case unknown
-
-        /// Read for the device that stopped being the default: did headphones
-        /// just come off? Unknown counts, because a missed pair of headphones
-        /// is the failure the feature exists to prevent.
-        var countsAsHeadphonesWhenDisconnected: Bool { self != .speakers }
-
-        /// Read for the device that just became the default: may it keep the
-        /// volume it inherited? Only a certain answer, because an unknown
-        /// device may be a speaker in the room.
-        var countsAsHeadphonesWhenTakingOver: Bool { self == .headphones }
-    }
-
-    /// What this output device is, for both sides of a handoff.
-    ///
-    /// The built-in speaker ports are matched positively rather than inferred,
-    /// and an unreadable port on a built-in device falls through to the name
-    /// list instead of being assumed to be the jack: a wrong guess on the
-    /// device taking over recreates the bug this protects against.
+    /// The port id is asked only where it can add an answer the word list does
+    /// not have, which is the headphone port: a jack the driver names in a
+    /// language the list cannot spell reads as headphones now. The speaker port
+    /// ids (`'ispk'`, `'espk'`) are deliberately not asked. They would only ever
+    /// repeat the "no" the list already gives, and asking them first would take
+    /// an answer away: a machine that reports its jack as `'espk'` — line-out
+    /// and headphones sharing one port — is recognized today by the data source
+    /// name, and a port-first test would call it speakers.
     ///
     /// - Parameters:
     ///   - transportType: `kAudioDevicePropertyTransportType`, nil when unreadable.
     ///   - dataSourceID: `kAudioDevicePropertyDataSource` on the output scope,
     ///     nil when the device has no selectable port.
-    static func outputDeviceKind(transportType: UInt32?,
-                                 dataSourceID: UInt32?,
-                                 name: String,
-                                 uid: String,
-                                 dataSourceName: String?) -> OutputDeviceKind {
-        // The built-in driver names its own port. This is the only answer that
-        // is authoritative, so it is asked first.
-        switch dataSourceID {
-        case headphonesDataSourceID: return .headphones
-        case internalSpeakerDataSourceID, externalSpeakerDataSourceID: return .speakers
-        default: break
-        }
+    static func outputLooksLikeHeadphones(transportType: UInt32?,
+                                          dataSourceID: UInt32?,
+                                          name: String,
+                                          uid: String,
+                                          dataSourceName: String?) -> Bool {
+        // The built-in driver names its own headphone port, in a code that is
+        // the same in every language. Nothing else can answer this.
+        if dataSourceID == headphonesDataSourceID { return true }
 
         // A display, a TV or an AirPlay receiver is never headphones, whatever
         // it happens to be called.
         switch transportType {
         case kAudioDeviceTransportTypeHDMI, kAudioDeviceTransportTypeDisplayPort,
              kAudioDeviceTransportTypeAirPlay:
-            return .speakers
+            return false
         default: break
         }
 
-        // For transports that carry both kinds and report no port — Bluetooth,
-        // USB and Thunderbolt interfaces, virtual and aggregate devices — the
-        // name list is all that is left. It only ever adds headphones the
-        // checks above did not claim.
-        if nameLooksLikeHeadphones(name: name, uid: uid, dataSourceName: dataSourceName) {
-            return .headphones
-        }
-
-        switch transportType {
-        case kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE:
-            // Could be either, and the name list is locale-dependent, so no
-            // answer is given rather than a wrong one.
-            return .unknown
-        default:
-            // Everything else keeps the old behaviour: a device the list does
-            // not know is not headphones.
-            return .speakers
-        }
+        // The word list, unchanged, so every device recognized today is still
+        // recognized. A device it does not know is not headphones, as before.
+        return nameLooksLikeHeadphones(name: name, uid: uid, dataSourceName: dataSourceName)
     }
 
     private static func nameLooksLikeHeadphones(name: String,

--- a/Sources/Vorssaint/Services/Audio/MixerRoutingSupport.swift
+++ b/Sources/Vorssaint/Services/Audio/MixerRoutingSupport.swift
@@ -268,58 +268,95 @@ enum MixerRoutingSupport {
     static let internalSpeakerDataSourceID: UInt32 = 0x6973_706b // 'ispk'
     static let externalSpeakerDataSourceID: UInt32 = 0x6573_706b // 'espk'
 
-    /// Whether a disconnect of this device should count as "headphones came
-    /// off", which is what drives lowering the speaker volume.
+    /// What an output device is, as far as the system will say.
     ///
-    /// The two mistakes are not equally bad for the device being disconnected:
-    /// missing real headphones lets the speakers take over at headphone
-    /// volume, the exact accident the feature exists to prevent, while
-    /// mistaking a speaker for headphones only lowers a volume the user can
-    /// raise again and that is restored when the device returns. So a
-    /// transport that carries both kinds resolves to "headphones".
+    /// Two states are not enough, because the answer is used on both sides of
+    /// a default-output handoff and the sides want opposite defaults for a
+    /// device nothing identified:
     ///
-    /// The device that takes over inverts that, though: calling it headphones
-    /// suppresses the lowering. That is why the two built-in speaker ports are
-    /// matched positively rather than inferred, and why an unreadable port on
-    /// a built-in device falls through to the name list instead of being
-    /// assumed to be the jack.
+    /// - For the device that just went away, guessing "headphones" is the safe
+    ///   guess. Missing real headphones lets whatever takes over play at
+    ///   headphone volume, the accident the feature exists to prevent
+    ///   (issue #92); mistaking a speaker for headphones only lowers a volume
+    ///   the user can raise again and that is put back when the device returns.
+    /// - For the device that takes over, the same guess is the unsafe one: it
+    ///   is what suppresses the lowering. A Bluetooth speaker becoming the
+    ///   default is exactly the case the feature has to cover.
+    ///
+    /// So a transport that carries both kinds and reports no port is `unknown`
+    /// rather than either answer, and each side reads it its own way.
+    enum OutputDeviceKind: Equatable {
+        case headphones
+        case speakers
+        /// The system placed the device on a transport that carries both kinds
+        /// (Bluetooth) and gave no port id or recognizable name. CoreAudio has
+        /// no property that separates a Bluetooth headset from a Bluetooth
+        /// speaker — the Bluetooth class of device does, but that is IOBluetooth,
+        /// not the audio HAL.
+        case unknown
+
+        /// Read for the device that stopped being the default: did headphones
+        /// just come off? Unknown counts, because a missed pair of headphones
+        /// is the failure the feature exists to prevent.
+        var countsAsHeadphonesWhenDisconnected: Bool { self != .speakers }
+
+        /// Read for the device that just became the default: may it keep the
+        /// volume it inherited? Only a certain answer, because an unknown
+        /// device may be a speaker in the room.
+        var countsAsHeadphonesWhenTakingOver: Bool { self == .headphones }
+    }
+
+    /// What this output device is, for both sides of a handoff.
+    ///
+    /// The built-in speaker ports are matched positively rather than inferred,
+    /// and an unreadable port on a built-in device falls through to the name
+    /// list instead of being assumed to be the jack: a wrong guess on the
+    /// device taking over recreates the bug this protects against.
     ///
     /// - Parameters:
     ///   - transportType: `kAudioDevicePropertyTransportType`, nil when unreadable.
     ///   - dataSourceID: `kAudioDevicePropertyDataSource` on the output scope,
     ///     nil when the device has no selectable port.
-    static func outputLooksLikeHeadphones(transportType: UInt32?,
-                                          dataSourceID: UInt32?,
-                                          name: String,
-                                          uid: String,
-                                          dataSourceName: String?) -> Bool {
+    static func outputDeviceKind(transportType: UInt32?,
+                                 dataSourceID: UInt32?,
+                                 name: String,
+                                 uid: String,
+                                 dataSourceName: String?) -> OutputDeviceKind {
         // The built-in driver names its own port. This is the only answer that
         // is authoritative, so it is asked first.
         switch dataSourceID {
-        case headphonesDataSourceID: return true
-        case internalSpeakerDataSourceID, externalSpeakerDataSourceID: return false
+        case headphonesDataSourceID: return .headphones
+        case internalSpeakerDataSourceID, externalSpeakerDataSourceID: return .speakers
         default: break
+        }
+
+        // A display, a TV or an AirPlay receiver is never headphones, whatever
+        // it happens to be called.
+        switch transportType {
+        case kAudioDeviceTransportTypeHDMI, kAudioDeviceTransportTypeDisplayPort,
+             kAudioDeviceTransportTypeAirPlay:
+            return .speakers
+        default: break
+        }
+
+        // For transports that carry both kinds and report no port — Bluetooth,
+        // USB and Thunderbolt interfaces, virtual and aggregate devices — the
+        // name list is all that is left. It only ever adds headphones the
+        // checks above did not claim.
+        if nameLooksLikeHeadphones(name: name, uid: uid, dataSourceName: dataSourceName) {
+            return .headphones
         }
 
         switch transportType {
         case kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE:
-            // Nothing in CoreAudio separates Bluetooth headphones from a
-            // Bluetooth speaker. Treated as headphones per the asymmetry above.
-            return true
-        case kAudioDeviceTransportTypeHDMI, kAudioDeviceTransportTypeDisplayPort,
-             kAudioDeviceTransportTypeAirPlay:
-            // A display, a TV or an AirPlay receiver is never headphones.
-            return false
-        default: break
+            // Could be either, and the name list is locale-dependent, so no
+            // answer is given rather than a wrong one.
+            return .unknown
+        default:
+            // Everything else keeps the old behaviour: a device the list does
+            // not know is not headphones.
+            return .speakers
         }
-
-        // Last resort, for transports that carry both kinds and report no port:
-        // USB and Thunderbolt interfaces, virtual and aggregate devices. The
-        // list only ever adds headphones the checks above did not claim, so a
-        // device it does not know still falls to "not headphones" — this is the
-        // one path that keeps the old locale-dependent behaviour, and it is
-        // reached only when the system itself gave no answer.
-        return nameLooksLikeHeadphones(name: name, uid: uid, dataSourceName: dataSourceName)
     }
 
     private static func nameLooksLikeHeadphones(name: String,

--- a/Sources/Vorssaint/Services/Audio/MixerRoutingSupport.swift
+++ b/Sources/Vorssaint/Services/Audio/MixerRoutingSupport.swift
@@ -259,9 +259,72 @@ enum MixerRoutingSupport {
         return candidates[(index + 1) % candidates.count]
     }
 
-    static func outputLooksLikeHeadphones(name: String,
+    /// Data source (port) codes the built-in audio driver reports through
+    /// `kAudioDevicePropertyDataSource`. They are the OSType constants from
+    /// IOKit's `IOAudioTypes.h` (`kIOAudioOutputPortSubType*`), so they read
+    /// the same on every Mac in every language — unlike the data source
+    /// *name*, which HAL localizes ("外置耳机", "Écouteurs externes").
+    static let headphonesDataSourceID: UInt32 = 0x6864_706e      // 'hdpn'
+    static let internalSpeakerDataSourceID: UInt32 = 0x6973_706b // 'ispk'
+    static let externalSpeakerDataSourceID: UInt32 = 0x6573_706b // 'espk'
+
+    /// Whether a disconnect of this device should count as "headphones came
+    /// off", which is what drives lowering the speaker volume.
+    ///
+    /// The two mistakes are not equally bad for the device being disconnected:
+    /// missing real headphones lets the speakers take over at headphone
+    /// volume, the exact accident the feature exists to prevent, while
+    /// mistaking a speaker for headphones only lowers a volume the user can
+    /// raise again and that is restored when the device returns. So a
+    /// transport that carries both kinds resolves to "headphones".
+    ///
+    /// The device that takes over inverts that, though: calling it headphones
+    /// suppresses the lowering. That is why the two built-in speaker ports are
+    /// matched positively rather than inferred, and why an unreadable port on
+    /// a built-in device falls through to the name list instead of being
+    /// assumed to be the jack.
+    ///
+    /// - Parameters:
+    ///   - transportType: `kAudioDevicePropertyTransportType`, nil when unreadable.
+    ///   - dataSourceID: `kAudioDevicePropertyDataSource` on the output scope,
+    ///     nil when the device has no selectable port.
+    static func outputLooksLikeHeadphones(transportType: UInt32?,
+                                          dataSourceID: UInt32?,
+                                          name: String,
                                           uid: String,
                                           dataSourceName: String?) -> Bool {
+        // The built-in driver names its own port. This is the only answer that
+        // is authoritative, so it is asked first.
+        switch dataSourceID {
+        case headphonesDataSourceID: return true
+        case internalSpeakerDataSourceID, externalSpeakerDataSourceID: return false
+        default: break
+        }
+
+        switch transportType {
+        case kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE:
+            // Nothing in CoreAudio separates Bluetooth headphones from a
+            // Bluetooth speaker. Treated as headphones per the asymmetry above.
+            return true
+        case kAudioDeviceTransportTypeHDMI, kAudioDeviceTransportTypeDisplayPort,
+             kAudioDeviceTransportTypeAirPlay:
+            // A display, a TV or an AirPlay receiver is never headphones.
+            return false
+        default: break
+        }
+
+        // Last resort, for transports that carry both kinds and report no port:
+        // USB and Thunderbolt interfaces, virtual and aggregate devices. The
+        // list only ever adds headphones the checks above did not claim, so a
+        // device it does not know still falls to "not headphones" — this is the
+        // one path that keeps the old locale-dependent behaviour, and it is
+        // reached only when the system itself gave no answer.
+        return nameLooksLikeHeadphones(name: name, uid: uid, dataSourceName: dataSourceName)
+    }
+
+    private static func nameLooksLikeHeadphones(name: String,
+                                                uid: String,
+                                                dataSourceName: String?) -> Bool {
         let haystack = [name, uid, dataSourceName ?? ""]
             .joined(separator: " ")
             .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: nil)

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarCatalog.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarCatalog.swift
@@ -544,7 +544,7 @@ enum CommandBarCatalog {
                     title: device.name,
                     subtitle: device.isDefault ? bar.soundOutputCurrent : bar.soundOutputSubtitle,
                     keywords: bar.soundOutputSubtitle,
-                    icon: .symbol(device.isHeadphones ? "headphones" : "hifispeaker"),
+                    icon: .symbol(device.outputKind == .speakers ? "hifispeaker" : "headphones"),
                     isActive: device.isDefault,
                     run: { _ in AppVolumeMixer.shared.setUniversalOutputDeviceUID(device.uid) }))
             }

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarCatalog.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarCatalog.swift
@@ -544,7 +544,7 @@ enum CommandBarCatalog {
                     title: device.name,
                     subtitle: device.isDefault ? bar.soundOutputCurrent : bar.soundOutputSubtitle,
                     keywords: bar.soundOutputSubtitle,
-                    icon: .symbol(device.outputKind == .speakers ? "hifispeaker" : "headphones"),
+                    icon: .symbol(device.isHeadphones ? "headphones" : "hifispeaker"),
                     isActive: device.isDefault,
                     run: { _ in AppVolumeMixer.shared.setUniversalOutputDeviceUID(device.uid) }))
             }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -6495,16 +6495,26 @@ struct MetricsTests {
             selectedUIDs: ["BuiltInSpeakerDevice"],
             availableUIDs: ["BuiltInSpeakerDevice"]) == nil,
                "sound output switcher does nothing when the only selected output is already current")
+        func outputKind(_ name: String,
+                        uid: String = "",
+                        transport: UInt32? = nil,
+                        dataSource: UInt32? = nil,
+                        dataSourceName: String? = nil) -> MixerRoutingSupport.OutputDeviceKind {
+            MixerRoutingSupport.outputDeviceKind(transportType: transport,
+                                                 dataSourceID: dataSource,
+                                                 name: name,
+                                                 uid: uid,
+                                                 dataSourceName: dataSourceName)
+        }
+        /// How the side of the handoff that lost its device reads the answer.
         func looksLikeHeadphones(_ name: String,
                                  uid: String = "",
                                  transport: UInt32? = nil,
                                  dataSource: UInt32? = nil,
                                  dataSourceName: String? = nil) -> Bool {
-            MixerRoutingSupport.outputLooksLikeHeadphones(transportType: transport,
-                                                          dataSourceID: dataSource,
-                                                          name: name,
-                                                          uid: uid,
-                                                          dataSourceName: dataSourceName)
+            outputKind(name, uid: uid, transport: transport,
+                       dataSource: dataSource, dataSourceName: dataSourceName)
+                .countsAsHeadphonesWhenDisconnected
         }
         expect(looksLikeHeadphones("AirPods Pro"),
                "AirPods are treated as headphones")
@@ -6544,6 +6554,30 @@ struct MetricsTests {
         expect(looksLikeHeadphones("Jabra Evolve2",
                                    transport: kAudioDeviceTransportTypeUSB),
                "USB falls back to the name list, which still knows common headsets")
+        // CoreAudio cannot separate a Bluetooth headset from a Bluetooth
+        // speaker, and the two sides of a handoff want opposite guesses for
+        // that: the device coming off should be assumed to be headphones, the
+        // device taking over must not be, or a Bluetooth speaker inherits the
+        // headphone volume it was meant to be protected from (issue #92).
+        expect(outputKind("Sennheiser HD 450BT",
+                          transport: kAudioDeviceTransportTypeBluetooth) == .unknown,
+               "a Bluetooth output the word list does not know is left unidentified")
+        expect(outputKind("AirPods Pro",
+                          transport: kAudioDeviceTransportTypeBluetooth) == .headphones,
+               "a Bluetooth output the word list knows is still headphones")
+        expect(outputKind("MacBook Air扬声器",
+                          uid: "BuiltInSpeakerDevice",
+                          transport: kAudioDeviceTransportTypeBuiltIn,
+                          dataSource: MixerRoutingSupport.internalSpeakerDataSourceID) == .speakers,
+               "a port the driver named is identified, not left unknown")
+        expect(MixerRoutingSupport.OutputDeviceKind.unknown.countsAsHeadphonesWhenDisconnected,
+               "an unidentified device that stops being the default counts as headphones coming off")
+        expect(!MixerRoutingSupport.OutputDeviceKind.unknown.countsAsHeadphonesWhenTakingOver,
+               "an unidentified device that becomes the default is still lowered")
+        expect(MixerRoutingSupport.OutputDeviceKind.headphones.countsAsHeadphonesWhenTakingOver,
+               "headphones becoming the default keep the volume they are given")
+        expect(!MixerRoutingSupport.OutputDeviceKind.speakers.countsAsHeadphonesWhenDisconnected,
+               "speakers going away are not a headphone disconnect")
         // Issue #256: some browsers' audio helpers answer for themselves, so
         // the mixer walks the parent chain to the nearest regular app.
         let helperParents: [pid_t: pid_t] = [500: 100, 100: 1, 700: 1,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -6495,26 +6495,55 @@ struct MetricsTests {
             selectedUIDs: ["BuiltInSpeakerDevice"],
             availableUIDs: ["BuiltInSpeakerDevice"]) == nil,
                "sound output switcher does nothing when the only selected output is already current")
-        expect(MixerRoutingSupport.outputLooksLikeHeadphones(name: "AirPods Pro",
-                                                             uid: "",
-                                                             dataSourceName: nil),
+        func looksLikeHeadphones(_ name: String,
+                                 uid: String = "",
+                                 transport: UInt32? = nil,
+                                 dataSource: UInt32? = nil,
+                                 dataSourceName: String? = nil) -> Bool {
+            MixerRoutingSupport.outputLooksLikeHeadphones(transportType: transport,
+                                                          dataSourceID: dataSource,
+                                                          name: name,
+                                                          uid: uid,
+                                                          dataSourceName: dataSourceName)
+        }
+        expect(looksLikeHeadphones("AirPods Pro"),
                "AirPods are treated as headphones")
-        expect(MixerRoutingSupport.outputLooksLikeHeadphones(name: "Built-in Output",
-                                                             uid: "",
-                                                             dataSourceName: "Headphones"),
+        expect(looksLikeHeadphones("Built-in Output", dataSourceName: "Headphones"),
                "wired headphone data source is treated as headphones")
-        expect(MixerRoutingSupport.outputLooksLikeHeadphones(name: "Sony WH-1000XM5",
-                                                             uid: "",
-                                                             dataSourceName: nil),
+        expect(looksLikeHeadphones("Sony WH-1000XM5"),
                "common Bluetooth headphone names are treated as headphones")
-        expect(!MixerRoutingSupport.outputLooksLikeHeadphones(name: "MacBook Pro Speakers",
-                                                              uid: "BuiltInSpeakerDevice",
-                                                              dataSourceName: nil),
+        expect(!looksLikeHeadphones("MacBook Pro Speakers", uid: "BuiltInSpeakerDevice"),
                "built-in speakers are not treated as headphones")
-        expect(!MixerRoutingSupport.outputLooksLikeHeadphones(name: "JBL Flip",
-                                                              uid: "",
-                                                              dataSourceName: nil),
+        expect(!looksLikeHeadphones("JBL Flip"),
                "Bluetooth speakers are not treated as headphones")
+        // The device name and the data source name HAL reports are localized,
+        // so the word list alone answers "no headphones here" on a Mac that is
+        // not running in English, and the disconnect never lowers the speakers.
+        // The port id is the same four-character code in every language.
+        expect(looksLikeHeadphones("MacBook Air",
+                                   uid: "BuiltInHeadphoneOutputDevice",
+                                   transport: kAudioDeviceTransportTypeBuiltIn,
+                                   dataSource: MixerRoutingSupport.headphonesDataSourceID,
+                                   dataSourceName: "外置耳机"),
+               "the headphone port id is recognized when its localized name matches no known word")
+        expect(!looksLikeHeadphones("MacBook Air扬声器",
+                                    uid: "BuiltInSpeakerDevice",
+                                    transport: kAudioDeviceTransportTypeBuiltIn,
+                                    dataSource: MixerRoutingSupport.internalSpeakerDataSourceID,
+                                    dataSourceName: "MacBook Air扬声器"),
+               "the built-in speaker port id is not treated as headphones")
+        expect(looksLikeHeadphones("Sennheiser HD 450BT",
+                                   transport: kAudioDeviceTransportTypeBluetooth),
+               "Bluetooth outputs the word list does not know are treated as headphones")
+        expect(!looksLikeHeadphones("Living Room Beats",
+                                    transport: kAudioDeviceTransportTypeAirPlay),
+               "an AirPlay receiver is not headphones even when its name matches the word list")
+        expect(!looksLikeHeadphones("Mi Monitor",
+                                    transport: kAudioDeviceTransportTypeDisplayPort),
+               "a DisplayPort monitor is not treated as headphones")
+        expect(looksLikeHeadphones("Jabra Evolve2",
+                                   transport: kAudioDeviceTransportTypeUSB),
+               "USB falls back to the name list, which still knows common headsets")
         // Issue #256: some browsers' audio helpers answer for themselves, so
         // the mixer walks the parent chain to the nearest regular app.
         let helperParents: [pid_t: pid_t] = [500: 100, 100: 1, 700: 1,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -6495,26 +6495,16 @@ struct MetricsTests {
             selectedUIDs: ["BuiltInSpeakerDevice"],
             availableUIDs: ["BuiltInSpeakerDevice"]) == nil,
                "sound output switcher does nothing when the only selected output is already current")
-        func outputKind(_ name: String,
-                        uid: String = "",
-                        transport: UInt32? = nil,
-                        dataSource: UInt32? = nil,
-                        dataSourceName: String? = nil) -> MixerRoutingSupport.OutputDeviceKind {
-            MixerRoutingSupport.outputDeviceKind(transportType: transport,
-                                                 dataSourceID: dataSource,
-                                                 name: name,
-                                                 uid: uid,
-                                                 dataSourceName: dataSourceName)
-        }
-        /// How the side of the handoff that lost its device reads the answer.
         func looksLikeHeadphones(_ name: String,
                                  uid: String = "",
                                  transport: UInt32? = nil,
                                  dataSource: UInt32? = nil,
                                  dataSourceName: String? = nil) -> Bool {
-            outputKind(name, uid: uid, transport: transport,
-                       dataSource: dataSource, dataSourceName: dataSourceName)
-                .countsAsHeadphonesWhenDisconnected
+            MixerRoutingSupport.outputLooksLikeHeadphones(transportType: transport,
+                                                          dataSourceID: dataSource,
+                                                          name: name,
+                                                          uid: uid,
+                                                          dataSourceName: dataSourceName)
         }
         expect(looksLikeHeadphones("AirPods Pro"),
                "AirPods are treated as headphones")
@@ -6539,12 +6529,18 @@ struct MetricsTests {
         expect(!looksLikeHeadphones("MacBook Air扬声器",
                                     uid: "BuiltInSpeakerDevice",
                                     transport: kAudioDeviceTransportTypeBuiltIn,
-                                    dataSource: MixerRoutingSupport.internalSpeakerDataSourceID,
+                                    dataSource: 0x6973_706b, // 'ispk'
                                     dataSourceName: "MacBook Air扬声器"),
-               "the built-in speaker port id is not treated as headphones")
-        expect(looksLikeHeadphones("Sennheiser HD 450BT",
-                                   transport: kAudioDeviceTransportTypeBluetooth),
-               "Bluetooth outputs the word list does not know are treated as headphones")
+               "a built-in speaker port is not treated as headphones")
+        // A shared line-out/headphone jack reports 'espk'. The word list is
+        // asked before the speaker port ids precisely so this machine keeps the
+        // answer it gets today.
+        expect(looksLikeHeadphones("Built-in Output",
+                                   uid: "BuiltInHeadphoneOutputDevice",
+                                   transport: kAudioDeviceTransportTypeBuiltIn,
+                                   dataSource: 0x6573_706b, // 'espk'
+                                   dataSourceName: "Headphones"),
+               "a jack reported as a speaker port is still headphones when the name says so")
         expect(!looksLikeHeadphones("Living Room Beats",
                                     transport: kAudioDeviceTransportTypeAirPlay),
                "an AirPlay receiver is not headphones even when its name matches the word list")
@@ -6554,30 +6550,9 @@ struct MetricsTests {
         expect(looksLikeHeadphones("Jabra Evolve2",
                                    transport: kAudioDeviceTransportTypeUSB),
                "USB falls back to the name list, which still knows common headsets")
-        // CoreAudio cannot separate a Bluetooth headset from a Bluetooth
-        // speaker, and the two sides of a handoff want opposite guesses for
-        // that: the device coming off should be assumed to be headphones, the
-        // device taking over must not be, or a Bluetooth speaker inherits the
-        // headphone volume it was meant to be protected from (issue #92).
-        expect(outputKind("Sennheiser HD 450BT",
-                          transport: kAudioDeviceTransportTypeBluetooth) == .unknown,
-               "a Bluetooth output the word list does not know is left unidentified")
-        expect(outputKind("AirPods Pro",
-                          transport: kAudioDeviceTransportTypeBluetooth) == .headphones,
-               "a Bluetooth output the word list knows is still headphones")
-        expect(outputKind("MacBook Air扬声器",
-                          uid: "BuiltInSpeakerDevice",
-                          transport: kAudioDeviceTransportTypeBuiltIn,
-                          dataSource: MixerRoutingSupport.internalSpeakerDataSourceID) == .speakers,
-               "a port the driver named is identified, not left unknown")
-        expect(MixerRoutingSupport.OutputDeviceKind.unknown.countsAsHeadphonesWhenDisconnected,
-               "an unidentified device that stops being the default counts as headphones coming off")
-        expect(!MixerRoutingSupport.OutputDeviceKind.unknown.countsAsHeadphonesWhenTakingOver,
-               "an unidentified device that becomes the default is still lowered")
-        expect(MixerRoutingSupport.OutputDeviceKind.headphones.countsAsHeadphonesWhenTakingOver,
-               "headphones becoming the default keep the volume they are given")
-        expect(!MixerRoutingSupport.OutputDeviceKind.speakers.countsAsHeadphonesWhenDisconnected,
-               "speakers going away are not a headphone disconnect")
+        expect(!looksLikeHeadphones("Sennheiser HD 450BT",
+                                    transport: kAudioDeviceTransportTypeBluetooth),
+               "a Bluetooth output the word list does not know keeps today's answer")
         // Issue #256: some browsers' audio helpers answer for themselves, so
         // the mixer walks the parent chain to the nearest regular app.
         let helperParents: [pid_t: pid_t] = [500: 100, 100: 1, 700: 1,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -6497,11 +6497,9 @@ struct MetricsTests {
                "sound output switcher does nothing when the only selected output is already current")
         func looksLikeHeadphones(_ name: String,
                                  uid: String = "",
-                                 transport: UInt32? = nil,
                                  dataSource: UInt32? = nil,
                                  dataSourceName: String? = nil) -> Bool {
-            MixerRoutingSupport.outputLooksLikeHeadphones(transportType: transport,
-                                                          dataSourceID: dataSource,
+            MixerRoutingSupport.outputLooksLikeHeadphones(dataSourceID: dataSource,
                                                           name: name,
                                                           uid: uid,
                                                           dataSourceName: dataSourceName)
@@ -6519,16 +6517,16 @@ struct MetricsTests {
         // The device name and the data source name HAL reports are localized,
         // so the word list alone answers "no headphones here" on a Mac that is
         // not running in English, and the disconnect never lowers the speakers.
-        // The port id is the same four-character code in every language.
+        // The port id is the same four-character code in every language. The
+        // uid here is deliberately one the word list cannot match, so this
+        // assertion reaches the port id and is red without it.
         expect(looksLikeHeadphones("MacBook Air",
-                                   uid: "BuiltInHeadphoneOutputDevice",
-                                   transport: kAudioDeviceTransportTypeBuiltIn,
+                                   uid: "BuiltInSpeakerDevice",
                                    dataSource: MixerRoutingSupport.headphonesDataSourceID,
                                    dataSourceName: "外置耳机"),
-               "the headphone port id is recognized when its localized name matches no known word")
+               "the headphone port id is recognized when neither the uid nor the localized name matches a known word")
         expect(!looksLikeHeadphones("MacBook Air扬声器",
                                     uid: "BuiltInSpeakerDevice",
-                                    transport: kAudioDeviceTransportTypeBuiltIn,
                                     dataSource: 0x6973_706b, // 'ispk'
                                     dataSourceName: "MacBook Air扬声器"),
                "a built-in speaker port is not treated as headphones")
@@ -6537,22 +6535,9 @@ struct MetricsTests {
         // answer it gets today.
         expect(looksLikeHeadphones("Built-in Output",
                                    uid: "BuiltInHeadphoneOutputDevice",
-                                   transport: kAudioDeviceTransportTypeBuiltIn,
                                    dataSource: 0x6573_706b, // 'espk'
                                    dataSourceName: "Headphones"),
                "a jack reported as a speaker port is still headphones when the name says so")
-        expect(!looksLikeHeadphones("Living Room Beats",
-                                    transport: kAudioDeviceTransportTypeAirPlay),
-               "an AirPlay receiver is not headphones even when its name matches the word list")
-        expect(!looksLikeHeadphones("Mi Monitor",
-                                    transport: kAudioDeviceTransportTypeDisplayPort),
-               "a DisplayPort monitor is not treated as headphones")
-        expect(looksLikeHeadphones("Jabra Evolve2",
-                                   transport: kAudioDeviceTransportTypeUSB),
-               "USB falls back to the name list, which still knows common headsets")
-        expect(!looksLikeHeadphones("Sennheiser HD 450BT",
-                                    transport: kAudioDeviceTransportTypeBluetooth),
-               "a Bluetooth output the word list does not know keeps today's answer")
         // Issue #256: some browsers' audio helpers answer for themselves, so
         // the mixer walks the parent chain to the nearest regular app.
         let helperParents: [pid_t: pid_t] = [500: 100, 100: 1, 700: 1,


### PR DESCRIPTION
## Summary

"Lower volume when headphones disconnect" decides what counts as headphones from a
hardcoded list of English words and brand names matched against the device name, its
UID and its data source name. One thing falls out of that and this change is about it:

- **The data source name is localized.** The built-in driver on this Mac reports its
  port as `MacBook Air扬声器`, not `MacBook Air Speakers` — I read it back from
  `kAudioDevicePropertyDataSourceNameForIDCFString`. The headphone port is named by the
  same mechanism, so on a Chinese, Japanese, Korean or Russian system it is a string the
  word list cannot contain. The disconnect branch is never entered, and unplugging wired
  headphones hands the speakers the volume the headphones were at. That is the accident
  the feature exists to prevent, and it fails silently — nothing tells the user the
  protection did not run.

The word list is unchanged, so a headphone it does not name (Sennheiser, AKG, most
third-party Bluetooth sets, USB headsets) is still missed. That is left as it is.

macOS answers the localized-name case directly and the code never asked.
`kAudioDevicePropertyDataSource` is read for the sole purpose of translating it into the
localized name that is then string-matched — the OSType it returns, which is what
identifies the port, is discarded on the next line.

`outputLooksLikeHeadphones` now takes the data source id, and asks in this order:

1. **Headphone port id** — `'hdpn'` is headphones
   (`kIOAudioOutputPortSubTypeHeadphones` in IOKit's `IOAudioTypes.h`). A four-character
   code, identical in every language. This is what fixes the localized-jack case.
2. **The word list**, unchanged, and it is still the answer for everything else. A device
   it does not know is not headphones, exactly as today.

### The speaker port ids are deliberately not asked

`'ispk'` and `'espk'` identify the speaker ports, and an earlier push of this branch asked
for them first and returned. That takes an answer away rather than adding one.

A Mac whose headphone jack and line-out share a single port reports that port as `'espk'`,
and there is hardware and there are drivers that do this. Today, on an English system, such
a jack is recognized through `dataSourceName == "Headphones"` and the disconnect protection
runs. With the port id asked first it returns `.speakers` before the word list is ever
consulted, and a path that works today stops working.

So only `'hdpn'` is asked ahead of the list. In the other direction the port id adds
nothing: "this is a speaker port" and "the word list did not recognize it" both come out
as *not headphones*, so there is no answer left to gain and one to lose. **Nothing the
current code recognizes is unrecognized after this change** — the one check placed ahead
of the list can only turn a *no* into a *yes*.

### Dropped: the transport-type check

Earlier pushes also read `kAudioDevicePropertyTransportType` and rejected HDMI, DisplayPort
and AirPlay ahead of the word list. That was the only place this branch answered *no* where
`main` answers *yes*, it was a new behaviour no device here can run once, and the
localized-jack fix does not depend on it. It is removed, with its assertions. If it is
wanted it should come as its own change with a device behind it.

### Not changed

The lowering arithmetic, `loweringOutputVolumeIfHeadphonesDisconnected` and its restore
branch, and the Command Bar glyph all read the same `isHeadphones` Bool they read on
`main`. This fixes the input that predicate is given, not what anything does with it. No
new user-facing text, so no localization work.

**Second commit, comment only, no behaviour change.** The synchronous restore
in `restoreLoweredOutputVolume` documented itself as reached only while the app
quits. It is also reached from `stop()`, which runs when the mixer is switched
off in the hub — on the main thread, reading and writing the HAL that
`halQueue` a few lines above exists to keep off it. Splitting the two callers
means deciding what happens if the app quits while an asynchronous restore is
in flight, which is a call for you rather than something to change quietly, so
the comment now describes both paths instead of asserting one.

## Verification

MacBook Air (Mac17,3), Apple M5, macOS 26.6.2 (25G83), Xcode 26.6, system
language Simplified Chinese, self-built from this branch.

```
./build.sh --test   9472 checks, 2 failing (below)
swiftc -typecheck   whole module, same target and SDK flags as the release build,
                    0 errors, 0 warnings
```

`AppVolumeMixer.swift` is not on `build.sh --test`'s source whitelist, so the type check
above is what compiled it locally; the release build is left to CI on both runners. I did
not run the full `./build.sh` here.

The two failures are `nil layout falls back to ANSI semicolon` (got the full-width `；`) and
`App Switcher icon-row hints describe default app and window shortcuts`. Both read the
machine's current input source rather than being given one, and this Mac has a Chinese IME
selected; neither touches audio or anything this branch changes. I did not run `--test` on
the base sha for a baseline this round, so I am describing them rather than calling them
pre-existing.

The `'hdpn'` assertion was confirmed red without the fix. Its earlier form used the uid
`BuiltInHeadphoneOutputDevice`, which the word list matches on its own (the haystack on
`main` is `[name, uid, dataSourceName ?? ""]` and `headphone` is a substring), so it never
reached the port id. It now uses `BuiltInSpeakerDevice` with the localized name `外置耳机`.
Deleting the `'hdpn'` check reds that assertion and only it (3 of 9472 failing, the two
IME ones plus it); restoring it is back to 2 of 9472.

The `'espk'` assertion was confirmed red before it was trusted: putting the speaker port
ids back ahead of the word list reds "a jack reported as a speaker port is still headphones
when the name says so", and only that assertion. Green again once removed.

### What the live measurement does and does not cover

I enumerated every output device on this Mac through the HAL and ran the predicate against
the live values:

| device | data source | available data sources | old answer | new answer |
|---|---|---|---|---|
| `BuiltInSpeakerDevice` (`MacBook Air扬声器`) | `'ispk'` | `'ispk'` only | not headphones | not headphones |
| DisplayPort monitor (`Mi Monitor`) | none | none | not headphones | not headphones |

**Both devices give the same answer before and after this change, so that run proves
nothing about the change itself.** What it does establish is narrower and worth having on
its own: `'ispk'` coming back from a live device matching the value in `IOAudioTypes.h` is
evidence that the HAL data source id really is the IOKit port subtype, and
`MacBook Air扬声器` coming back from `kAudioDevicePropertyDataSourceNameForIDCFString` is
the evidence that the name the current code matches on is localized. Those are the two
premises the change rests on; the change's own behaviour is not among the things this Mac
can show.

**What I could not test:** I have no headphones, Bluetooth audio device or USB interface to
attach, so every path where the new answer differs from the old one is covered by unit
assertions and header constants only, not by hardware.

Specifically unverified, and this is the whole of the new behaviour:

- **Whether this branch changes anything on the Mac it is written for.** The uid is not
  localized. If plugging headphones in makes a *separate* device whose uid is
  `BuiltInHeadphoneOutputDevice`, `main` already answers true through the uid on a Chinese
  system and this branch changes nothing on that Mac. The case it fixes is a built-in output
  that stays *one* device and switches its data source (`'ispk'` → `'hdpn'`) with the uid
  unchanged. With nothing plugged in, the speaker device here lists a single available data
  source, `'ispk'`, which is consistent with either layout: the driver only reports a port
  that is present. I could not observe which one this Mac has.
- **That the 3.5 mm jack reports `'hdpn'`.** The constant is
  `kIOAudioOutputPortSubTypeHeadphones` from IOKit's `IOAudioTypes.h`, and the same driver
  on this machine reports `'ispk'` for its speaker port, which is what makes it likely.
  But it is an inference, not an observation — I have never seen `'hdpn'` come back from
  this or any Mac. Apple documents the constants in the header; Apple does not document
  that CoreAudio's `kAudioDevicePropertyDataSource` returns IOAudioFamily port subtypes. If
  that inference is wrong, the localized-jack fix does not fire and the behaviour is today's.
- **The localized jack name on this machine**, for the same reason.

`loweringOutputVolumeIfHeadphonesDisconnected` is private and reads and writes the HAL, so
it has no unit assertions on this branch or on `main`; the predicate is what the new
assertions cover, and its wiring into that function is read off the code.

## Anything else

There is no bug report for this: the failure is silent, so it looks like nothing happening
rather than something going wrong. Referencing the issue the feature came from.

Refs #92
