### PR TITLE
chore(clipboard): drop the unused single-entry delete alias

### DIFF
--- a/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
+++ b/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
@@ -452,10 +452,6 @@ final class ClipboardHistoryService: ObservableObject {
         save()
     }
 
-    func removeSelectedQuickEntry() {
-        removeSelectedQuickEntries()
-    }
-
     /// Where the pointer sat when the keyboard last moved the selection. Rows
     /// scrolling under a still pointer report hover, and hover would otherwise
     /// take the preview back from the row the arrow keys chose.


### PR DESCRIPTION
## Summary

Removes `ClipboardHistoryService.removeSelectedQuickEntry()`, a three-line wrapper that
nothing calls and whose name states the opposite of what it does.

`bb612b17` added multi-selection deletion and moved every call site to
`removeSelectedQuickEntries()`. The singular wrapper was left behind, forwarding to the
plural one. So the name promises "delete the selected entry" while the body deletes the
whole batch — `removeSelectedQuickEntries()` resolves its targets through
`quickEntriesForPrimaryAction()`, which returns the full batch selection when one exists.

Two ways to resolve that in this one symbol: give the singular name a real singular body,
or delete it. Deleting is the right one — a genuinely single-entry delete has no caller
asking for it, and the batch path is already the behaviour the UI wants. Adding one would
be speculative API, and keeping the current wrapper keeps a name that lies.

Scope: this removes one unreachable symbol. It does not fix the singular-name-plural-body
shape in general — see **Anything else** for the two live methods that still have it.

No behaviour change: nothing referenced the symbol, so nothing was rerouted.

**Not changed:** the `⌥⌫` / `⌘⌫` bindings still delete the whole selection. That is
deliberate — `bb612b17`'s changelog entry describes exactly that ("supports
Command-Delete and Option-Delete to remove selected items at once"). This PR only removes
unreachable code.

**Not changed:** `CHANGELOG.md`.

## Verification

MacBook (Mac17,3, Apple M5), macOS 26.6.2 (25G83), Swift 6.3.3, self-built from this
branch — not a release build.

Zero callers, checked before deleting rather than inferred from reading:

- `grep -rn "removeSelectedQuickEntry\b" Sources Tests` — one hit, the definition line
  itself. The only other occurrences of the stem in the repo are `removeSelectedQuickEntries`
  (`ClipboardQuickPanelView.swift:232`, `ClipboardHistoryService.swift:443` definition,
  `:1212` key handler).
- Repo-wide search for the name as a string literal: no hits, so it is not reached through
  `#selector`, `NSSelectorFromString`, or KVC. `ClipboardHistoryService` is a
  `final class ... ObservableObject` with no protocol requiring the symbol.

Commands:

- `./build.sh` — full `-O` build, 0 warnings, 0 errors; 43,537,688-byte `build/Vorssaint` produced
- `./build/Vorssaint --selftest` — `SELFTEST OK`
- `./build.sh --test` — `TESTS OK (9399 checks)` against this branch's base `b0dde656`; this PR adds no assertions

**What I could not test:** nothing behavioural — the removed code had no reachable path to
exercise. No new test was added; deleting unreachable code leaves no proposition to assert.
Note that `ClipboardHistoryService.swift` is not in `build.sh --test`'s source whitelist, so
the full `./build.sh` above is the only compile gate this change actually passes through.

## Anything else

The same shape — a singular name whose body acts on the whole batch — is still live in two
methods on `ClipboardHistoryService`, and both have callers, so neither is touched here:

- `copySelectedQuickEntry()` (`:417`) — called from `ClipboardQuickPanelView.swift:225`
  (footer paste button), `:510` (click on an already-selected row), and the key handler at
  `ClipboardHistoryService.swift:1183` (plain `⏎`).
- `copySelectedQuickEntryOnly()` (`:427`) — called from `ClipboardQuickPanelView.swift:229`
  (footer copy button) and the key handler at `ClipboardHistoryService.swift:1179` (`⇧⏎`)
  and `:1195` (`⌘C`).

Both resolve targets through the same `quickEntriesForPrimaryAction()` (`:1299`) and fan
out to `copyQuickEntries` / `copyOnlyQuickEntries` when the batch holds more than one
entry. Their behaviour is what the UI wants; only the names are singular. Renaming live
methods with six call sites is a separate change and does not belong in a dead-code
removal, so it is deliberately left out of this PR rather than overlooked.
