### PR TITLE
fix(taps): invalidate event tap ports on teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Vorssaint adds quit and close protections, expands screen text recognition, capt
 - Uninstallation now verifies that sleep was restored and asks for admin authorization if the passwordless restore fails, preventing closed-lid sleep prevention from remaining permanently disabled on the Mac. Thanks to @mugurc.
 - Screenshot quick preview no longer takes keyboard focus when presented, keeping keystrokes in the active app until the preview is clicked. Thanks to @iltonandrew.
 - Smooth Scroll and Scroll Inverter now step aside during fast user switching and resume on return, preventing background scroll stalls. Thanks to @iltonandrew.
+- Turning features on and off repeatedly no longer leaves unused keyboard and mouse listeners registered with the system for the rest of the session. Thanks to @PathGao.
 - Mouse navigation, button shortcuts and middle click now step aside outside the active login session or after Accessibility access is removed, preventing input stalls.
 - Focus follows mouse now leaves chosen apps alone and tracks the final pointer position during drags before changing focus.
 - Cleaning Mode now ends when its login session leaves the screen, preventing its input lock from affecting another active user.

--- a/Sources/Vorssaint/Services/Audio/MusicLaunchBlocker.swift
+++ b/Sources/Vorssaint/Services/Audio/MusicLaunchBlocker.swift
@@ -120,6 +120,7 @@ final class MusicLaunchBlocker: ObservableObject {
         if let mediaKeyTapSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), mediaKeyTapSource, .commonModes)
         }
+        CFMachPortInvalidate(tap)
         mediaKeyTapSource = nil
         mediaKeyTap = nil
     }

--- a/Sources/Vorssaint/Services/Audio/PreciseVolumeRollerService.swift
+++ b/Sources/Vorssaint/Services/Audio/PreciseVolumeRollerService.swift
@@ -37,6 +37,7 @@ final class PreciseVolumeRollerService: ObservableObject {
         if let source {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
         }
+        if let tap { CFMachPortInvalidate(tap) }
         tap = nil
         source = nil
         gate.reset()

--- a/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
+++ b/Sources/Vorssaint/Services/AutoQuit/AutoQuitService.swift
@@ -653,6 +653,7 @@ final class AutoQuitService: ObservableObject {
         if let closeRequestRunLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), closeRequestRunLoopSource, .commonModes)
         }
+        if let closeRequestTap { CFMachPortInvalidate(closeRequestTap) }
         closeRequestTap = nil
         closeRequestRunLoopSource = nil
     }

--- a/Sources/Vorssaint/Services/Display/BrightnessService.swift
+++ b/Sources/Vorssaint/Services/Display/BrightnessService.swift
@@ -694,6 +694,7 @@ final class BrightnessService: ObservableObject {
         if let keyTapSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), keyTapSource, .commonModes)
         }
+        CFMachPortInvalidate(tap)
         keyTapSource = nil
         keyTap = nil
     }
@@ -777,6 +778,7 @@ final class BrightnessService: ObservableObject {
             }
             CGEvent.tapEnable(tap: tap, enable: false)
             CFRunLoopRemoveSource(runLoop, source, .commonModes)
+            CFMachPortInvalidate(tap)
             if clearFunctionKeyThread() { installFunctionKeyTap() }
         }
     }

--- a/Sources/Vorssaint/Services/DockClick/DockClickService.swift
+++ b/Sources/Vorssaint/Services/DockClick/DockClickService.swift
@@ -111,6 +111,7 @@ final class DockClickService {
         if let runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
         }
+        if let tap { CFMachPortInvalidate(tap) }
         tap = nil
         runLoopSource = nil
         for (_, sweep) in pendingSweeps { sweep.cancel() }

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
@@ -345,6 +345,7 @@ final class DockPreviewService: ObservableObject {
         if let runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
         }
+        if let tap { CFMachPortInvalidate(tap) }
         tap = nil
         runLoopSource = nil
         cancelPendingHover()

--- a/Sources/Vorssaint/Services/Finder/FinderRenameService.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderRenameService.swift
@@ -131,6 +131,7 @@ final class FinderRenameService {
 
             CGEvent.tapEnable(tap: tap, enable: false)
             CFRunLoopRemoveSource(runLoop, source, .commonModes)
+            CFMachPortInvalidate(tap)
             if clearEventTapThread() { installTap() }
         }
     }

--- a/Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift
+++ b/Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift
@@ -186,6 +186,7 @@ final class KeyboardDebounceService: ObservableObject {
 
             CGEvent.tapEnable(tap: tap, enable: false)
             CFRunLoopRemoveSource(runLoop, source, .commonModes)
+            CFMachPortInvalidate(tap)
             eventLock.withLock {
                 state.reset()
             }

--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -380,6 +380,7 @@ final class AppSwitcher: ObservableObject {
 
             CGEvent.tapEnable(tap: tap, enable: false)
             CFRunLoopRemoveSource(runLoop, source, .commonModes)
+            CFMachPortInvalidate(tap)
             if clearEventTapThread() { installTap() }
         }
     }

--- a/Sources/Vorssaint/Services/WindowMaximizer.swift
+++ b/Sources/Vorssaint/Services/WindowMaximizer.swift
@@ -42,6 +42,7 @@ final class WindowMaximizer: ObservableObject {
         if let runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
         }
+        if let tap { CFMachPortInvalidate(tap) }
         tap = nil
         runLoopSource = nil
         pendingClick = nil

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21614,26 +21614,17 @@ struct MetricsTests {
         }
 
         // Disabling a tap and dropping the last Swift reference does not hand
-        // the port back. Measured on main: after tapEnable(false),
-        // CFRunLoopRemoveSource and setting the properties to nil, the mach
-        // port name still carries receive and send rights, and
-        // CGGetEventTapList still reports the tap against this process — one
-        // more per start/stop cycle, for the life of the process. Only
-        // CFMachPortInvalidate deregisters it, so the rule is the absence of a
-        // tap owner that never invalidates, not a list of the ones somebody
-        // noticed. Counted per tap, not per file: BrightnessService and
-        // SuperKeyService own two taps each and WindowLayoutService three, so
-        // one invalidate somewhere in the file must not answer for all of
-        // them. Comments are stripped first, as in the per-service check
-        // above, so prose naming the API cannot answer for it either. The
-        // owners the sweep actually found are counted and asserted, because a
-        // file with no literal `CGEvent.tapCreate` is skipped: move the call
-        // behind a helper and every owner drops out, leaving a loop that
-        // passes having checked nothing. A count above the tap count is not
-        // headroom either — MouseClickDebounceService's two invalidations are
-        // both on its one tap, so a second tap added there would pass for
-        // free; the rule catches a file that invalidates none of its taps, not
-        // one that misses a tap it already covers twice.
+        // the port back: CGGetEventTapList still reports the tap against this
+        // process, one more per start/stop cycle, for the life of the process.
+        // Only CFMachPortInvalidate deregisters it. Counted per tap rather than
+        // per file, because BrightnessService and SuperKeyService own two taps
+        // each and WindowLayoutService three, and on comment-stripped source,
+        // as in the per-service check above, so prose naming the API cannot
+        // answer for a missing call. A margin does not cover a tap added later:
+        // MouseClickDebounceService's two invalidations are both on its one
+        // tap. The owners reached are counted too, because a file with no
+        // literal CGEvent.tapCreate is skipped, so moving the call behind a
+        // helper would otherwise leave a sweep that passes having read nothing.
         var tapOwnersWithoutInvalidate: [String] = []
         var tapOwners = 0
         let tapOwnerSources = FileManager.default

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21351,7 +21351,11 @@ struct MetricsTests {
         // more per start/stop cycle, for the life of the process. Only
         // CFMachPortInvalidate deregisters it, so the rule is the absence of a
         // tap owner that never invalidates, not a list of the ones somebody
-        // noticed.
+        // noticed. Counted per tap, not per file: BrightnessService and
+        // SuperKeyService own two taps each and WindowLayoutService three, so
+        // one invalidate somewhere in the file must not answer for all of
+        // them. Comments are stripped first, as in the per-service check
+        // above, so prose naming the API cannot answer for it either.
         var tapOwnersWithoutInvalidate: [String] = []
         let tapOwnerSources = FileManager.default
             .enumerator(atPath: "Sources/Vorssaint")?
@@ -21359,10 +21363,15 @@ struct MetricsTests {
             .filter { $0.hasSuffix(".swift") && !$0.contains(" 2") } ?? []
         for file in tapOwnerSources.sorted() {
             guard let source = try? String(contentsOfFile: "Sources/Vorssaint/\(file)",
-                                           encoding: .utf8),
-                  source.contains("CGEvent.tapCreate") else { continue }
-            if !source.contains("CFMachPortInvalidate") {
-                tapOwnersWithoutInvalidate.append(file)
+                                           encoding: .utf8) else { continue }
+            let code = source.components(separatedBy: "\n")
+                .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+                .joined(separator: "\n")
+            let taps = code.components(separatedBy: "CGEvent.tapCreate").count - 1
+            guard taps > 0 else { continue }
+            let invalidations = code.components(separatedBy: "CFMachPortInvalidate").count - 1
+            if invalidations < taps {
+                tapOwnersWithoutInvalidate.append("\(file) (\(taps) taps, \(invalidations) invalidated)")
             }
         }
         expect(!tapOwnerSources.isEmpty && tapOwnersWithoutInvalidate.isEmpty,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21355,8 +21355,17 @@ struct MetricsTests {
         // SuperKeyService own two taps each and WindowLayoutService three, so
         // one invalidate somewhere in the file must not answer for all of
         // them. Comments are stripped first, as in the per-service check
-        // above, so prose naming the API cannot answer for it either.
+        // above, so prose naming the API cannot answer for it either. The
+        // owners the sweep actually found are counted and asserted, because a
+        // file with no literal `CGEvent.tapCreate` is skipped: move the call
+        // behind a helper and every owner drops out, leaving a loop that
+        // passes having checked nothing. A count above the tap count is not
+        // headroom either — MouseClickDebounceService's two invalidations are
+        // both on its one tap, so a second tap added there would pass for
+        // free; the rule catches a file that invalidates none of its taps, not
+        // one that misses a tap it already covers twice.
         var tapOwnersWithoutInvalidate: [String] = []
+        var tapOwners = 0
         let tapOwnerSources = FileManager.default
             .enumerator(atPath: "Sources/Vorssaint")?
             .compactMap { $0 as? String }
@@ -21369,13 +21378,15 @@ struct MetricsTests {
                 .joined(separator: "\n")
             let taps = code.components(separatedBy: "CGEvent.tapCreate").count - 1
             guard taps > 0 else { continue }
+            tapOwners += 1
             let invalidations = code.components(separatedBy: "CFMachPortInvalidate").count - 1
             if invalidations < taps {
                 tapOwnersWithoutInvalidate.append("\(file) (\(taps) taps, \(invalidations) invalidated)")
             }
         }
-        expect(!tapOwnerSources.isEmpty && tapOwnersWithoutInvalidate.isEmpty,
-               "every event tap owner invalidates its port on teardown: \(tapOwnersWithoutInvalidate)")
+        expect(tapOwners > 0 && tapOwnersWithoutInvalidate.isEmpty,
+               "every event tap owner invalidates its port on teardown, across "
+               + "\(tapOwners) scanned owners: \(tapOwnersWithoutInvalidate)")
 
         let mouseTapAppDelegateSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/App/AppDelegate.swift",

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21342,6 +21342,32 @@ struct MetricsTests {
             expect(code.contains("CFMachPortInvalidate"),
                    "\(tapOwner) hands its tap back rather than only disabling it")
         }
+
+        // Disabling a tap and dropping the last Swift reference does not hand
+        // the port back. Measured on main: after tapEnable(false),
+        // CFRunLoopRemoveSource and setting the properties to nil, the mach
+        // port name still carries receive and send rights, and
+        // CGGetEventTapList still reports the tap against this process — one
+        // more per start/stop cycle, for the life of the process. Only
+        // CFMachPortInvalidate deregisters it, so the rule is the absence of a
+        // tap owner that never invalidates, not a list of the ones somebody
+        // noticed.
+        var tapOwnersWithoutInvalidate: [String] = []
+        let tapOwnerSources = FileManager.default
+            .enumerator(atPath: "Sources/Vorssaint")?
+            .compactMap { $0 as? String }
+            .filter { $0.hasSuffix(".swift") && !$0.contains(" 2") } ?? []
+        for file in tapOwnerSources.sorted() {
+            guard let source = try? String(contentsOfFile: "Sources/Vorssaint/\(file)",
+                                           encoding: .utf8),
+                  source.contains("CGEvent.tapCreate") else { continue }
+            if !source.contains("CFMachPortInvalidate") {
+                tapOwnersWithoutInvalidate.append(file)
+            }
+        }
+        expect(!tapOwnerSources.isEmpty && tapOwnersWithoutInvalidate.isEmpty,
+               "every event tap owner invalidates its port on teardown: \(tapOwnersWithoutInvalidate)")
+
         let mouseTapAppDelegateSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/App/AppDelegate.swift",
             encoding: .utf8)) ?? ""


### PR DESCRIPTION
## Summary

Ten event tap owners switched their tap off on teardown but never handed the port back. `tapEnable(false)`, `CFRunLoopRemoveSource`, `tap = nil` — and the tap stays registered.

I assumed ARC covered this: `CGEvent.tapCreate` returns a `CFMachPort`, so dropping the last Swift reference should release the port and take the tap with it. It does not. Measured on `origin/main` with a probe that replicates the exact teardown these services use:

- The mach port name the `CFMachPort` wrapped still carries receive and send rights after the properties are nil'd; with `CFMachPortInvalidate` added, the same name reports `KERN_INVALID_NAME` immediately.
- `CGGetEventTapList` still reports the tap against the process, `enabled=false`, for the rest of the process's life. 20 start/stop cycles leave 20 registered taps and 20 leaked port names. With `CFMachPortInvalidate`, 20 cycles leave zero.
- Same numbers for `.defaultTap` and `.listenOnly`, and the same with no run loop source at all — so it is not the source holding the port. `CFGetRetainCount` on the `CFMachPort` reads 5 while the service holds one reference: the last Swift reference is nowhere near the last reference.

That means a tap owner accumulates one registration per enable/disable cycle, and every one of those cycles is user-reachable (each `syncWithPreferences()` on a settings change runs `stop()` then `start()`).

The fix is one line per teardown, placed where the thirteen services that already do this put it: after `tapEnable(false)` and `CFRunLoopRemoveSource`, before the property is cleared, and on the tap thread for the four threaded owners.

`Tests/MetricsTests.swift` gets the rule rather than a list: scan every file that calls `CGEvent.tapCreate` and require at least as many `CFMachPortInvalidate` calls as taps created, counted on comment-stripped source. The existing per-service assertion only covers the owners that also do session gating, so a new tap owner could be added tomorrow without tripping anything.

Counting per tap rather than per file matters for the three owners that create more than one: `BrightnessService` and `SuperKeyService` own two taps each and `WindowLayoutService` three, so a file-level check would let one invalidate answer for all of them. Stripping comments first matches the per-service check twenty-five lines above, which strips them so that prose naming the API cannot satisfy the rule. All 24 tap owners are green under the counted rule, and each of the three multi-tap files invalidates every tap it creates.

The sweep also has to say how much it read. A file with no literal `CGEvent.tapCreate` is skipped, so if the call ever moves behind a helper — the consolidation shape #937 and #938 describe — every owner drops out, the offender list stays empty and the check passes having read no tap owner at all. That is the same vacuous-scan failure being fixed on #1229, and it takes the same shape of fix: count the owners the sweep actually reached, assert that count above zero beside the empty offender list, and carry the number into the failure message. It reads 24 today.

The margin on `MouseClickDebounceService` — one tap, two invalidations — is not headroom. Both of its invalidations are on that one tap, in `stop()` and in `runEventTap()`'s exit path, so a second tap added to that file would pass for free. It is the only file on `main` where the counts diverge, and the comment now says so rather than leaving the number to be read as slack.

### What this does not change

The registered leftover is `enabled=false`. Whether the window server also *stalls* the front session on a disabled tap after fast user switching — the symptom in #1075 / #1153 — is not something I could measure: that needs two logged-in sessions. What is measured here is the registration and port leak, which holds regardless of fast user switching.

`MusicLaunchBlocker`, `AutoQuitService` and `DockPreviewService` are `.listenOnly` and were called out as out of scope for the stall mechanism. They are included anyway because the leak is identical and the guardrail is a rule about all tap owners, not about filter taps.

`QuitProtectionService` is not here because `f25d1aa8` already added its `CFMachPortInvalidate`. It was going to be this PR's one guardrail exception; the rebase made the exception unnecessary, so the guardrail ships with no allowances at all.

No session gating is added here. That is the per-service work #1153 describes and it belongs in its own PRs.

### Why this is one PR and not ten

+11 source lines, +35 test lines, no behavior branch — well under the +110 median, and every hunk is the same line for the same measured reason. The argument for splitting is reviewability, and there is nothing to review per file that is not already true of the first file.

Splitting would also make the guardrail worse. It can only land once, and it can only be green once every tap owner invalidates, so a split would have to ship it carrying a shrinking exception list — allowances that mean nothing except "not done yet", which is the exact shape the guardrail exists to prevent. Landing it together lets it ship with no exceptions.

## Verification

Mac17,3 (Apple M5), macOS 26.6.2 (25G83), self-built from source, release configuration.

```
./build.sh                     compiled clean, 0 warnings, 41.5 MB build/Vorssaint (run before the rebase)
./build/Vorssaint --selftest   SELFTEST OK
./build.sh --test              9470 checks, 2 failures
```

The two failures are `nil layout falls back to ANSI semicolon` and `App Switcher icon-row hints`. Both are outside this change: they read the machine's live input source, which is a Chinese IME here. Baseline for that claim is this branch's merge base `f25d1aa8`, run in a throwaway worktree on this machine: 9469 checks, the same 2 failures and nothing else. The scanned-owner assertion replaces the previous one rather than adding to the count, so the branch stays at 9470.

The guardrail was verified to bite rather than assumed to, once for each of the two shapes it now covers. Dropping one of `BrightnessService`'s two invalidations — the multi-tap shape a per-file check cannot see — produced:

```
every event tap owner invalidates its port on teardown: ["Services/Display/BrightnessService.swift (2 taps, 1 invalidated)"]
```

Commenting out the `WindowMaximizer` line, so the string is still in the raw file but not in the code, produced:

```
every event tap owner invalidates its port on teardown: ["Services/WindowMaximizer.swift (1 taps, 0 invalidated)"]
```

Both go green again when the line is restored, and the restored tree is back to the same 2 failures.

The scanned-owner assertion was bitten the same way, and the old one was bitten alongside it to show the difference. Changing the searched literal to `CGEvent.tapCreateViaHelper` — every owner disappearing behind a helper, in one edit — gives, on the assertion as it now stands:

```
every event tap owner invalidates its port on teardown, across 0 scanned owners: []
```

The same edit against the previous assertion, which guarded `!tapOwnerSources.isEmpty`, ran green: 9470 checks, 2 failures, the vacuous sweep passing unremarked. Restoring the literal returns the branch to green.

What I could not test:

- The fast-user-switching symptom itself. That needs two logged-in sessions; this machine has one.
- The full release compile of the ten service files **on the rebased tree**. `./build.sh --test` builds a hand-listed subset with `-Onone`, and most of these service files are not on that list, so locally they were only compiled by the full `./build.sh` run — which was made before the rebase onto `f25d1aa8`. The change is one added line per file with no new symbols, but the authoritative full compile of the final tree is CI's two jobs, not mine.
- Runtime behavior of the four threaded owners with a `stop()` racing the tap thread. The placement there is identical to what `TextSnippetService` and `SuperKeyService` already do, but I exercised it only through the probe.

## Anything else

Refs #1153

