### PR TITLE
fix(shortcuts): read keycaps from the layout's Command table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project are documented here. The format follows
 ## [Unreleased]
 
 ### Summary
-Vorssaint adds quit and close protections, expands screen text recognition, capture magnifier, clipboard, Super key, Dock Preview, App Switcher, Window Layout, mouse controls and snippet controls, broadens app update and safe cleanup discovery, and hardens Command Bar shortcut capture, permission guide recovery, input session switching, Accessibility timeouts, Volume Mixer audio rendering, helper process attribution and teardown, Super key shutdown, process termination, update and uninstallation teardown, window handling, pasteboard restoration, sensor selection, Cleaning Mode unlock and favicon downloads. It also improves mouse scrolling feel, disk space and system monitor metrics, Settings, Scratchpad, Screenshot Editor, floating panels and several menu bar behaviors.
+Vorssaint adds quit and close protections, expands screen text recognition, capture magnifier, clipboard, Super key, Dock Preview, App Switcher, Window Layout, mouse controls and snippet controls, broadens app update and safe cleanup discovery, and hardens shortcut capture and key caps, permission guide recovery, input session switching, Accessibility timeouts, Volume Mixer audio rendering, helper process attribution and teardown, Super key shutdown, process termination, update and uninstallation teardown, window handling, pasteboard restoration, sensor selection, Cleaning Mode unlock and favicon downloads. It also improves mouse scrolling feel, disk space and system monitor metrics, Settings, Scratchpad, Screenshot Editor, floating panels and several menu bar behaviors.
 
 ### Added
 - Settings now includes optional protections for Command-Q and Command-W with customizable hold duration, double press, extra modifier requirements and per-app scopes. Thanks to @RuanMD.
@@ -44,7 +44,7 @@ Vorssaint adds quit and close protections, expands screen text recognition, capt
 - The Command Bar capture card now records Command Q instead of ignoring it. Thanks to @arsarsars1 and @jtprogru.
 - Volume Mixer now attributes helper audio processes whose system responsibility report is detached to their parent app, ensuring browsers and sandboxed communication apps are controllable.
 - Quit on close now captures windows created asynchronously after launch or on activation, ensuring apps that load their windows after process startup are quit when their last window is closed.
-- Shortcut fields and key display now read key caps from the active keyboard layout, so non-QWERTY layouts such as AZERTY display the keys actually pressed.
+- Shortcut fields and key displays now follow the active keyboard layout, including Command-specific mappings, so they show the keys actually pressed. Thanks to @PathGao.
 - The Uninstaller and Cleaner leftover scans now accept two-component bundle identifiers, allowing apps with two-part domain names to be selected and cleaned.
 - The permission guide card now offers a start-over option when an entry left by an earlier app build is stuck on in System Settings, and adds a relaunch button once Screen Recording is granted. Thanks to @andreisuslov.
 - Uninstallation now verifies that sleep was restored and asks for admin authorization if the passwordless restore fails, preventing closed-lid sleep prevention from remaining permanently disabled on the Mac. Thanks to @mugurc.

--- a/Sources/Vorssaint/Core/GlobalShortcut.swift
+++ b/Sources/Vorssaint/Core/GlobalShortcut.swift
@@ -431,7 +431,8 @@ struct GlobalShortcut: Equatable, Hashable {
         case kVK_F19: return "F19"
         case kVK_F20: return "F20"
         default:
-            if let label = Self.layoutKeyLabel(for: keyCode) {
+            if let label = Self.layoutKeyLabel(for: keyCode,
+                                               usesCommand: modifiers.contains(.command)) {
                 return label
             }
             return Self.fallbackAnsiKeyLabel(for: keyCode)
@@ -496,23 +497,41 @@ struct GlobalShortcut: Equatable, Hashable {
     /// so keys the static table does not know (ISO and JIS extras) still get a
     /// real cap. Returns nil for anything unprintable, keeping those invalid.
     ///
+    /// `usesCommand` picks which of the layout's two tables to read, because a
+    /// keycap is a promise about a whole combination, not about the key alone.
+    /// macOS resolves a Command combination through the layout's Command
+    /// table, and the two tables disagree on every layout that types a
+    /// non-Latin script: on Russian and on Greek the key at keycode 12 types
+    /// something else bare and still answers Command-Q, Simplified Pinyin's
+    /// semicolon key types a full-width semicolon bare and a plain one under
+    /// Command, and DVORAK-QWERTYCMD exists for nothing but this difference.
+    /// Reading the bare table for a Command shortcut prints a cap the user
+    /// cannot press. Combinations without Command keep the bare table, which
+    /// is what they actually fire on.
+    ///
     /// Answered from the cache: deriving a label asks Text Input Services,
     /// which traps the process off the main thread, and the Switcher's tap
     /// asks for one on every key from its own (issue #578).
-    private static func layoutKeyLabel(for keyCode: Int64) -> String? {
-        if let cached = (layoutLabelLock.withLock { layoutLabels[keyCode] }) {
+    private static func layoutKeyLabel(for keyCode: Int64, usesCommand: Bool) -> String? {
+        let cacheKey = LayoutLabelKey(keyCode: keyCode, usesCommand: usesCommand)
+        if let cached = (layoutLabelLock.withLock { layoutLabels[cacheKey] }) {
             return cached
         }
         if Thread.isMainThread {
-            let label = derivedLayoutKeyLabel(for: keyCode)
-            layoutLabelLock.withLock { layoutLabels[keyCode] = label }
+            let label = derivedLayoutKeyLabel(for: keyCode, usesCommand: usesCommand)
+            layoutLabelLock.withLock { layoutLabels[cacheKey] = label }
             return label
         }
         return nil
     }
 
+    private struct LayoutLabelKey: Hashable {
+        let keyCode: Int64
+        let usesCommand: Bool
+    }
+
     private static let layoutLabelLock = NSLock()
-    private static var layoutLabels: [Int64: String] = [:]
+    private static var layoutLabels: [LayoutLabelKey: String] = [:]
     private static var keyboardLayoutObserver: AnyObject?
 
     /// Starts observing system keyboard layout changes so the keycap cache stays
@@ -534,20 +553,26 @@ struct GlobalShortcut: Equatable, Hashable {
             layoutLabelLock.withLock { layoutLabels.removeAll() }
             return
         }
-        var labels: [Int64: String] = [:]
+        var labels: [LayoutLabelKey: String] = [:]
         for keyCode in UInt16(0)...127 {
-            if let label = derivedLayoutKeyLabel(for: keyCode, layoutData: layoutData) {
-                labels[Int64(keyCode)] = label
+            for usesCommand in [false, true] {
+                if let label = derivedLayoutKeyLabel(for: keyCode,
+                                                     layoutData: layoutData,
+                                                     usesCommand: usesCommand) {
+                    labels[LayoutLabelKey(keyCode: Int64(keyCode),
+                                          usesCommand: usesCommand)] = label
+                }
             }
         }
         layoutLabelLock.withLock { layoutLabels = labels }
     }
 
-    private static func derivedLayoutKeyLabel(for keyCode: Int64) -> String? {
+    private static func derivedLayoutKeyLabel(for keyCode: Int64,
+                                              usesCommand: Bool) -> String? {
         guard let code = UInt16(exactly: keyCode),
               let layoutData = currentLayoutData()
         else { return nil }
-        return derivedLayoutKeyLabel(for: code, layoutData: layoutData)
+        return derivedLayoutKeyLabel(for: code, layoutData: layoutData, usesCommand: usesCommand)
     }
 
     private static func currentLayoutData() -> Data? {
@@ -559,14 +584,18 @@ struct GlobalShortcut: Equatable, Hashable {
     }
 
     private static func derivedLayoutKeyLabel(for code: UInt16,
-                                              layoutData: Data) -> String? {
+                                              layoutData: Data,
+                                              usesCommand: Bool) -> String? {
         var deadKeyState: UInt32 = 0
         var chars = [UniChar](repeating: 0, count: 4)
         var length = 0
+        // UCKeyTranslate wants the modifier state already shifted down out of
+        // the Carbon event's high byte.
+        let modifierState = usesCommand ? UInt32((cmdKey >> 8) & 0xFF) : 0
         let status = layoutData.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) -> OSStatus in
             guard let layout = bytes.bindMemory(to: UCKeyboardLayout.self).baseAddress
             else { return OSStatus(paramErr) }
-            return UCKeyTranslate(layout, code, UInt16(kUCKeyActionDisplay), 0,
+            return UCKeyTranslate(layout, code, UInt16(kUCKeyActionDisplay), modifierState,
                                   UInt32(LMGetKbdType()), OptionBits(kUCKeyTranslateNoDeadKeysBit),
                                   &deadKeyState, chars.count, &length, &chars)
         }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -3850,11 +3850,55 @@ struct MetricsTests {
             expectEqual(usSemi.displayString, "⌃⌥⌘ ;", "US layout resolves physical semicolon key as semicolon")
         }
 
+        // A keycap names a combination, not a key, and macOS resolves a Command
+        // combination through the layout's Command table. Layouts that type a
+        // non-Latin script answer differently there than they do bare, and
+        // DVORAK-QWERTYCMD exists for nothing but that difference, so both
+        // tables have to come out of the same layout.
+        if let russianData = testLayoutData(for: "com.apple.keylayout.Russian") {
+            GlobalShortcut.refreshLayoutLabels(layoutData: russianData)
+            let russianCommandQ = GlobalShortcut(keyCode: Int64(kVK_ANSI_Q), modifiers: layoutTestModifiers)
+            let russianBareQ = GlobalShortcut(keyCode: Int64(kVK_ANSI_Q), modifiers: [.control, .option])
+            expectEqual(russianCommandQ.displayString, "⌃⌥⌘Q",
+                        "Russian reads a Command shortcut off the layout's Command table")
+            expectEqual(russianBareQ.displayString, "⌃⌥Й",
+                        "Russian reads a shortcut without Command off the character the key types")
+        }
+
+        if let dvorakCommandData = testLayoutData(for: "com.apple.keylayout.DVORAK-QWERTYCMD") {
+            GlobalShortcut.refreshLayoutLabels(layoutData: dvorakCommandData)
+            let dvorakCommandSemi = GlobalShortcut(keyCode: Int64(kVK_ANSI_Semicolon),
+                                                   modifiers: layoutTestModifiers)
+            let dvorakBareSemi = GlobalShortcut(keyCode: Int64(kVK_ANSI_Semicolon),
+                                                modifiers: [.control, .option])
+            expectEqual(dvorakCommandSemi.displayString, "⌃⌥⌘ ;",
+                        "Dvorak with QWERTY Command keeps Command shortcuts on the QWERTY cap")
+            expectEqual(dvorakBareSemi.displayString, "⌃⌥S",
+                        "Dvorak with QWERTY Command keeps the rest on the Dvorak cap")
+        }
+
+        // The ANSI table answers when no layout can be read at all. On a live
+        // system that is a caller off the main thread meeting a cold cache:
+        // Text Input Services cannot be asked from there, so nothing derives a
+        // cap and nothing warms the entry either.
         GlobalShortcut.refreshLayoutLabels(layoutData: nil)
-        let fallbackM = GlobalShortcut(keyCode: Int64(kVK_ANSI_M), modifiers: layoutTestModifiers)
-        let fallbackSemi = GlobalShortcut(keyCode: Int64(kVK_ANSI_Semicolon), modifiers: layoutTestModifiers)
-        expectEqual(fallbackM.displayString, "⌃⌥⌘M", "nil layout falls back to ANSI M")
-        expectEqual(fallbackSemi.displayString, "⌃⌥⌘ ;", "nil layout falls back to ANSI semicolon")
+        var coldCacheCaps: [String] = []
+        let coldCacheDone = DispatchSemaphore(value: 0)
+        // A thread of its own, not `sync`: dispatch runs a synchronous block on
+        // whichever thread called it, so `sync` would still be the main thread
+        // and would reach Text Input Services after all.
+        Thread {
+            coldCacheCaps = [
+                GlobalShortcut(keyCode: Int64(kVK_ANSI_M), modifiers: layoutTestModifiers).displayString,
+                GlobalShortcut(keyCode: Int64(kVK_ANSI_Semicolon), modifiers: layoutTestModifiers).displayString,
+            ]
+            coldCacheDone.signal()
+        }.start()
+        coldCacheDone.wait()
+        expectEqual(coldCacheCaps.first ?? "", "⌃⌥⌘M",
+                    "a cold cache off the main thread falls back to ANSI M")
+        expectEqual(coldCacheCaps.last ?? "", "⌃⌥⌘ ;",
+                    "a cold cache off the main thread falls back to ANSI semicolon")
 
         GlobalShortcut.refreshLayoutLabels()
 


### PR DESCRIPTION
## Summary

Shortcut keycaps asked the keyboard layout the wrong question. `derivedLayoutKeyLabel` called `UCKeyTranslate` with a modifier state of `0`, which means "what does this key type when pressed on its own". But a cap in a shortcut field describes a whole combination, and macOS resolves a Command combination through the layout's **Command table** instead. Wherever the two tables disagree, the app printed a cap the user cannot press.

Measured here against the layout data macOS ships, key codes 12 and 41:

| layout | bare | Command table |
|---|---|---|
| Russian | `й` / `ж` | `q` / `;` |
| Greek | `;` / `΄` | `q` / `;` |
| Simplified Pinyin | `q` / `；` (full width) | `q` / `;` |
| DVORAK-QWERTYCMD | `'` / `s` | `q` / `;` |
| US, French, German, ABNT2 | unchanged | unchanged |

The two tables differ on layouts for Russian, Japanese, Korean, Simplified Chinese, Traditional Chinese and Hong Kong Chinese — six of the thirteen languages this app ships — plus `DVORAK-QWERTYCMD`, a layout whose whole reason to exist is that Command goes to the QWERTY position.

The fix keeps the direction `7d6ecfea` set, that caps follow the active layout, and changes only which of the layout's two tables is read: the Command table when the combination carries Command, the bare table otherwise. A shortcut on ⌃⌥ alone is not remapped by macOS, so the Command table would be the wrong answer for it. The cap cache is therefore keyed by key code **and** whether the combination uses Command, and `refreshLayoutLabels` fills both halves.

Alternatives considered and rejected:

- **Always read the Command table.** One table, smaller diff, but every non-Command shortcut would then lie on Russian, Greek and Pinyin, where the user really does press the key that types `й`. That trades one wrong answer for another.
- **Pin the caps to ANSI.** Makes the tests deterministic by undoing `7d6ecfea`, which was a deliberate decision. A German user would be back to reading `;` for the Ö key.
- **Relax the assertions.** The failing assertion was reporting a real defect, not a flake.

### What this does not change

No public contract moves: no storage format, no registered defaults, no registration or matching path. Caps change only on layouts where they were already wrong.

`refreshLayoutLabels(layoutData: nil)` is deliberately left alone, because it is a **different** defect. It clears the cache, and the next main-thread lookup silently re-derives from the live system layout, so the state "no layout data" is unreachable in the running app. Making it reachable means giving the cache an explicit "no layout" mode, which changes what happens when Text Input Services is briefly unavailable during launch — a separate risk that should not ride along on a keycap fix. Its assertion has been moved onto the path where the ANSI fallback genuinely is reachable, a caller off the main thread meeting a cold cache, which is what the Switcher's key tap does.

Worth flagging for merge order: PR #1218 adds `QuitProtectionKeyLayout.commandCharacter`, a second reader of the same Command table over the same Carbon call. It is deliberately untouched here, since it is still open and editing it would collide. After both land there will be two, and you may want one of them to own it.

## Verification

MacBook Pro (`Mac17,3`), macOS 26.6.2 (25G83), locally built from this branch, rebased onto `f25d1aa8`.

```
./build.sh --test → TESTS OK (9473 checks)
```

Run with **Simplified Pinyin** active (`com.apple.inputmethod.SCIM.ITABC`, keyboard layout `com.apple.keylayout.PinyinKeyboard`), which is where this reproduces. On unmodified `main` under that input source the suite fails two assertions, and both are this one defect:

```
- nil layout falls back to ANSI semicolon: got "⌃⌥⌘ ；", expected "⌃⌥⌘ ;"
- App Switcher icon-row hints describe default app and window shortcuts
```

The second is the Switcher's window hint, ⌘ plus the backtick key, which on this layout types `·` bare and `` ` `` under Command. Reverting only `GlobalShortcut.swift` to `main` while keeping the new tests reproduces both, plus the two new Command-table assertions, and restoring it turns all four green. Also green with ABC active, which is the point: the new assertions read explicit layout data from `TISCreateInputSourceList`, never the tester's active input source.

The ANSI-fallback assertion was checked the same way, by breaking `fallbackAnsiKeyLabel`'s semicolon entry and confirming it goes red. It did not, at first: `DispatchQueue.global().sync` runs its block on the calling thread, so the original "off the main thread" reading was still on the main thread and quietly reached Text Input Services. It now uses a thread of its own.

**What I could not test:** no physical Russian, Greek, Japanese, Korean or Dvorak-QWERTY⌘ keyboard here, so caps on those layouts are verified against the layout data macOS ships rather than against a keyboard someone is typing on. The Command-table difference itself is measured, not assumed. I did not exercise the Switcher's live key tap under a non-Latin layout, and I have left the full `-O` build and the zero-warning check to CI, which runs it on both `macos-15` and `macos-26`.

## Anything else

Refs #1047

That report covers both which key a shortcut fires on and what the field prints. This change is the label half, and only for layouts whose Command table differs from their bare table. The registration and matching side is untouched.
