### PR TITLE
perf(radial-menu): keep the side-button tap cheap

### DIFF
--- a/Sources/Vorssaint/Services/MouseNavigation/MouseNavigationService.swift
+++ b/Sources/Vorssaint/Services/MouseNavigation/MouseNavigationService.swift
@@ -211,7 +211,8 @@ final class MouseNavigationService: ObservableObject {
         // other side button keeps navigating. While the shortcut capture row
         // is listening, every press belongs to it, including a button with no
         // mapping yet, or the capture could never see the button it is asked
-        // to watch for.
+        // to watch for. Both claims are asked again on every Drag of a held
+        // side button, so both have to stay cheap.
         if RadialMenuSupport.claimsMouseButton(buttonNumber)
             || MouseButtonShortcutSupport.claimsButton(buttonNumber)
             || MouseButtonShortcutService.isCaptureActive {

--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
@@ -72,7 +72,14 @@ final class RadialMenuService: ObservableObject {
     private var activationObserver: NSObjectProtocol?
     private var promptedForAccessibility = false
 
-    private init() {}
+    private init() {
+        // A filter tap owned by a switched-away login session stalls input in
+        // the session on screen. Hand the mouse tap back on resign and build
+        // it again from preferences when this session comes back.
+        SessionActivity.shared.onChange { [weak self] _ in
+            self?.syncMouseTap()
+        }
+    }
 
     var sessionActive: Bool { !stack.isEmpty }
 
@@ -128,16 +135,28 @@ final class RadialMenuService: ObservableObject {
     // app under the pointer; alive only while a button is configured, torn
     // down with the feature)
 
-    private func syncMouseTap(profiles: [RadialMenuProfile]? = nil) {
+    /// Whether the button tap has a job right now. The capture row needs it
+    /// even with the feature switched off, so it can tell a button this app
+    /// cannot see from one that is simply set to something else.
+    private func mouseTapWanted(profiles: [RadialMenuProfile]?) -> Bool {
         let defaults = UserDefaults.standard
-        let currentProfiles = profiles ?? RadialMenuSupport.decodeProfiles(
+        let hasAnyButton = profiles.map { list in
+            list.contains { RadialMenuMouseTrigger.sanitized($0.mouseButton).buttonNumber != nil }
+        } ?? !RadialMenuSupport.claimedMouseButtons(
             defaults.data(forKey: DefaultsKey.radialMenuProfiles),
             defaults: defaults
-        )
-        let hasAnyButton = currentProfiles.contains {
-            RadialMenuMouseTrigger.sanitized($0.mouseButton).buttonNumber != nil
-        }
-        guard hasAnyButton || isReportingMouseButtons else {
+        ).isEmpty
+        let enabled = AppFeature.radialMenu.isAvailable
+            && defaults.bool(forKey: DefaultsKey.radialMenuEnabled)
+        return (hasAnyButton && enabled) || isReportingMouseButtons
+    }
+
+    private func syncMouseTap(profiles: [RadialMenuProfile]? = nil) {
+        guard SessionActivitySupport.tapShouldRun(
+            featureWanted: mouseTapWanted(profiles: profiles),
+            accessibilityGranted: AXIsProcessTrusted(),
+            sessionIsActive: SessionActivity.shared.isActive
+        ) else {
             tearDownMouseTap()
             return
         }
@@ -146,7 +165,7 @@ final class RadialMenuService: ObservableObject {
         if let mouseTap, !CGEvent.tapIsEnabled(tap: mouseTap) {
             tearDownMouseTap()
         }
-        guard mouseTap == nil, AXIsProcessTrusted() else { return }
+        guard mouseTap == nil else { return }
         let mask = (CGEventMask(1) << CGEventType.otherMouseDown.rawValue)
             | (CGEventMask(1) << CGEventType.otherMouseUp.rawValue)
         guard let tap = CGEvent.tapCreate(
@@ -184,7 +203,18 @@ final class RadialMenuService: ObservableObject {
 
     private func handleMouseTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let mouseTap { CGEvent.tapEnable(tap: mouseTap, enable: true) }
+            let shouldRearm = SessionActivitySupport.tapShouldRun(
+                featureWanted: mouseTapWanted(profiles: nil),
+                accessibilityGranted: AXIsProcessTrusted(),
+                sessionIsActive: SessionActivity.shared.isActive
+            )
+            if shouldRearm, let mouseTap {
+                CGEvent.tapEnable(tap: mouseTap, enable: true)
+            } else {
+                // Invalidating the port from its own callback stack is unsafe;
+                // finish this callback fail-open, then release the tap.
+                DispatchQueue.main.async { [weak self] in self?.syncMouseTap() }
+            }
             return Unmanaged.passUnretained(event)
         }
         let pressed = Int(event.getIntegerValueField(.mouseEventButtonNumber))
@@ -202,17 +232,17 @@ final class RadialMenuService: ObservableObject {
             lastMouseButtonSeen = pressed
         }
         let defaults = UserDefaults.standard
-        let profiles = RadialMenuSupport.decodeProfiles(
+        let button = Int64(pressed)
+        // Every press and release of every extra button lands here, so the
+        // cheap question comes first: the wheels themselves are decoded only
+        // once a press turns out to be a summoner, and only to open one.
+        guard RadialMenuSupport.claimedMouseButtons(
             defaults.data(forKey: DefaultsKey.radialMenuProfiles),
             defaults: defaults
-        )
-        guard let matchingProfile = profiles.first(where: {
-            RadialMenuMouseTrigger.sanitized($0.mouseButton).buttonNumber == Int64(pressed)
-        }) else {
+        ).contains(button) else {
             return Unmanaged.passUnretained(event)
         }
 
-        let button = Int64(pressed)
         // The source lives on the main run loop, so this already runs on
         // main; acting synchronously keeps a quick click ordered (the down
         // opens the wheel before its own up arrives). The claimed button is
@@ -221,6 +251,15 @@ final class RadialMenuService: ObservableObject {
         // caption promises exactly that).
         if type == .otherMouseDown {
             if !sessionActive {
+                let profiles = RadialMenuSupport.decodeProfiles(
+                    defaults.data(forKey: DefaultsKey.radialMenuProfiles),
+                    defaults: defaults
+                )
+                guard let matchingProfile = profiles.first(where: {
+                    RadialMenuMouseTrigger.sanitized($0.mouseButton).buttonNumber == button
+                }) else {
+                    return Unmanaged.passUnretained(event)
+                }
                 beginSession(for: matchingProfile, hold: false, heldButton: button)
             } else if !holdPhase {
                 endSession()

--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
@@ -72,18 +72,7 @@ final class RadialMenuService: ObservableObject {
     private var activationObserver: NSObjectProtocol?
     private var promptedForAccessibility = false
 
-    private init() {
-        // A filter tap owned by a switched-away login session stalls input in
-        // the session on screen. Hand the mouse tap back on resign and build
-        // it again from preferences when this session comes back.
-        // The session goes with it: the tap is what ends a held wheel, so a
-        // wheel still open when the tap is handed back would never see its
-        // release and would come back stuck in hold phase.
-        SessionActivity.shared.onChange { [weak self] active in
-            if !active { self?.endSession() }
-            self?.syncMouseTap()
-        }
-    }
+    private init() {}
 
     var sessionActive: Bool { !stack.isEmpty }
 
@@ -139,28 +128,18 @@ final class RadialMenuService: ObservableObject {
     // app under the pointer; alive only while a button is configured, torn
     // down with the feature)
 
-    /// Whether the button tap has a job right now. The capture row needs it
-    /// even with the feature switched off, so it can tell a button this app
-    /// cannot see from one that is simply set to something else.
-    private func mouseTapWanted(profiles: [RadialMenuProfile]?) -> Bool {
+    private func syncMouseTap(profiles: [RadialMenuProfile]? = nil) {
         let defaults = UserDefaults.standard
+        // Asked of the stored buttons alone when the caller has no profiles in
+        // hand: this only needs to know whether any wheel is bound to a button,
+        // and the full decode pays for every item and icon to answer it.
         let hasAnyButton = profiles.map { list in
             list.contains { RadialMenuMouseTrigger.sanitized($0.mouseButton).buttonNumber != nil }
         } ?? !RadialMenuSupport.claimedMouseButtons(
             defaults.data(forKey: DefaultsKey.radialMenuProfiles),
             defaults: defaults
         ).isEmpty
-        let enabled = AppFeature.radialMenu.isAvailable
-            && defaults.bool(forKey: DefaultsKey.radialMenuEnabled)
-        return (hasAnyButton && enabled) || isReportingMouseButtons
-    }
-
-    private func syncMouseTap(profiles: [RadialMenuProfile]? = nil) {
-        guard SessionActivitySupport.tapShouldRun(
-            featureWanted: mouseTapWanted(profiles: profiles),
-            accessibilityGranted: AXIsProcessTrusted(),
-            sessionIsActive: SessionActivity.shared.isActive
-        ) else {
+        guard hasAnyButton || isReportingMouseButtons else {
             tearDownMouseTap()
             return
         }
@@ -169,7 +148,7 @@ final class RadialMenuService: ObservableObject {
         if let mouseTap, !CGEvent.tapIsEnabled(tap: mouseTap) {
             tearDownMouseTap()
         }
-        guard mouseTap == nil else { return }
+        guard mouseTap == nil, AXIsProcessTrusted() else { return }
         let mask = (CGEventMask(1) << CGEventType.otherMouseDown.rawValue)
             | (CGEventMask(1) << CGEventType.otherMouseUp.rawValue)
         guard let tap = CGEvent.tapCreate(
@@ -207,18 +186,7 @@ final class RadialMenuService: ObservableObject {
 
     private func handleMouseTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            let shouldRearm = SessionActivitySupport.tapShouldRun(
-                featureWanted: mouseTapWanted(profiles: nil),
-                accessibilityGranted: AXIsProcessTrusted(),
-                sessionIsActive: SessionActivity.shared.isActive
-            )
-            if shouldRearm, let mouseTap {
-                CGEvent.tapEnable(tap: mouseTap, enable: true)
-            } else {
-                // Invalidating the port from its own callback stack is unsafe;
-                // finish this callback fail-open, then release the tap.
-                DispatchQueue.main.async { [weak self] in self?.syncMouseTap() }
-            }
+            if let mouseTap { CGEvent.tapEnable(tap: mouseTap, enable: true) }
             return Unmanaged.passUnretained(event)
         }
         let pressed = Int(event.getIntegerValueField(.mouseEventButtonNumber))

--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
@@ -255,12 +255,16 @@ final class RadialMenuService: ObservableObject {
                     defaults.data(forKey: DefaultsKey.radialMenuProfiles),
                     defaults: defaults
                 )
-                guard let matchingProfile = profiles.first(where: {
+                // The guard above already claimed the click, and the release
+                // will be swallowed to match it. A profile the full decode
+                // drops but the cheap read keeps (a corrupt blob) therefore
+                // opens no wheel and still costs the app under the pointer
+                // nothing: never one half of a click.
+                if let matchingProfile = profiles.first(where: {
                     RadialMenuMouseTrigger.sanitized($0.mouseButton).buttonNumber == button
-                }) else {
-                    return Unmanaged.passUnretained(event)
+                }) {
+                    beginSession(for: matchingProfile, hold: false, heldButton: button)
                 }
-                beginSession(for: matchingProfile, hold: false, heldButton: button)
             } else if !holdPhase {
                 endSession()
             }

--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
@@ -76,7 +76,11 @@ final class RadialMenuService: ObservableObject {
         // A filter tap owned by a switched-away login session stalls input in
         // the session on screen. Hand the mouse tap back on resign and build
         // it again from preferences when this session comes back.
-        SessionActivity.shared.onChange { [weak self] _ in
+        // The session goes with it: the tap is what ends a held wheel, so a
+        // wheel still open when the tap is handed back would never see its
+        // release and would come back stuck in hold phase.
+        SessionActivity.shared.onChange { [weak self] active in
+            if !active { self?.endSession() }
             self?.syncMouseTap()
         }
     }

--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuSupport.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuSupport.swift
@@ -105,6 +105,19 @@ private struct FailableRadialMenuProfile: Decodable {
     }
 }
 
+/// A profile read for its mouse button alone: the question the event taps ask,
+/// answered without walking the items or decoding the icons they carry.
+private struct RadialMenuProfileButton: Decodable {
+    let mouseButton: String?
+
+    private enum CodingKeys: String, CodingKey { case mouseButton }
+
+    init(from decoder: Decoder) throws {
+        let container = try? decoder.container(keyedBy: CodingKeys.self)
+        mouseButton = (try? container?.decodeIfPresent(String.self, forKey: .mouseButton)) ?? nil
+    }
+}
+
 /// Curated starter presets when creating new profiles.
 enum RadialMenuProfilePreset: String, CaseIterable, Identifiable {
     case general, media, tools, windowLayout, quickToggles, blank
@@ -422,9 +435,11 @@ extension RadialMenuSupport {
     }
 
     /// Whether the radial menu currently owns this extra button as its
-    /// summoner. Mouse navigation asks this from its own tap and lets a
-    /// claimed button through; pure defaults reads, so asking never wakes
-    /// the radial menu service.
+    /// summoner. Mouse navigation and the mouse button shortcuts both ask
+    /// this from inside their own tap callbacks, on every event of a
+    /// side-button gesture, so it reads defaults and the stored buttons only:
+    /// never the items, and never `decodeProfiles`, which decodes their
+    /// custom icons. Asking never wakes the radial menu service.
     static func claimsMouseButton(_ button: Int64) -> Bool {
         claimsMouseButton(button, defaults: .standard)
     }
@@ -432,10 +447,8 @@ extension RadialMenuSupport {
     static func claimsMouseButton(_ button: Int64, defaults: UserDefaults) -> Bool {
         guard defaults.bool(forKey: AppFeature.radialMenu.availabilityKey),
               defaults.bool(forKey: DefaultsKey.radialMenuEnabled) else { return false }
-        let profiles = decodeProfiles(defaults.data(forKey: DefaultsKey.radialMenuProfiles), defaults: defaults)
-        return profiles.contains {
-            RadialMenuMouseTrigger.sanitized($0.mouseButton).buttonNumber == button
-        }
+        return claimedMouseButtons(defaults.data(forKey: DefaultsKey.radialMenuProfiles),
+                                   defaults: defaults).contains(button)
     }
 }
 
@@ -699,9 +712,31 @@ enum RadialMenuSupport {
         }
     }
 
+    /// The mouse buttons the wheel is bound to right now, decoded from the
+    /// stored buttons alone.
+    ///
+    /// This is the question the event taps ask, so it must stay cheap:
+    /// `decodeProfiles` answers it too, but only by paying for every item on
+    /// every wheel. The legacy fallback is the same one it migrates from, so
+    /// the two answers cannot drift apart for a user who has not saved a
+    /// profile yet.
+    static func claimedMouseButtons(_ data: Data?, defaults: UserDefaults = .standard) -> [Int64] {
+        if let data, let decoded = try? JSONDecoder().decode([RadialMenuProfileButton].self, from: data) {
+            return decoded.compactMap { RadialMenuMouseTrigger.sanitized($0.mouseButton).buttonNumber }
+        }
+        let legacy = RadialMenuMouseTrigger.sanitized(
+            defaults.string(forKey: DefaultsKey.radialMenuMouseButton))
+        return legacy.buttonNumber.map { [$0] } ?? []
+    }
+
     /// Decodes profiles from JSON blob. If missing, checks for legacy
     /// items / shortcut / mouse button to migrate existing users, or creates
     /// the starter profile.
+    ///
+    /// Walks every item on every wheel and decodes each custom icon (up to
+    /// `RadialMenuFaviconFetcher.maxStoredIconBytes` of PNG apiece), so it
+    /// belongs to settings and session start, never to an event-tap callback.
+    /// A callback that only needs the summoner wants `claimedMouseButtons`.
     static func decodeProfiles(_ data: Data?, defaults: UserDefaults = .standard) -> [RadialMenuProfile] {
         if let data, let decoded = try? JSONDecoder().decode([FailableRadialMenuProfile].self, from: data) {
             let sanitized = sanitizedProfiles(decoded.compactMap(\.value))

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15282,6 +15282,17 @@ struct MetricsTests {
             .components(separatedBy: "private func hotkeyPressed").first ?? ""
         expect(!radialClaimedClick.isEmpty && !radialClaimedClick.contains("passUnretained"),
                "a claimed side button keeps both halves of its click whatever the full decode says")
+
+        // The tap is the only thing that ends a button-held wheel, so handing
+        // it back on resign has to end the session too; a wheel left open
+        // across the switch would come back in hold phase with no release
+        // coming for it.
+        let radialSessionResign = radialServiceCode
+            .components(separatedBy: "SessionActivity.shared.onChange")
+            .dropFirst().first?
+            .components(separatedBy: "var sessionActive").first ?? ""
+        expect(radialSessionResign.contains("endSession()"),
+               "the radial menu ends its session when the mouse tap is handed back on resign")
         expect(RadialMenuFaviconFetcher.faviconURL(
             for: "https://example.com:8443/path?q=1#part")?.absoluteString
                 == "https://example.com:8443/favicon.ico"

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15282,17 +15282,6 @@ struct MetricsTests {
             .components(separatedBy: "private func hotkeyPressed").first ?? ""
         expect(!radialClaimedClick.isEmpty && !radialClaimedClick.contains("passUnretained"),
                "a claimed side button keeps both halves of its click whatever the full decode says")
-
-        // The tap is the only thing that ends a button-held wheel, so handing
-        // it back on resign has to end the session too; a wheel left open
-        // across the switch would come back in hold phase with no release
-        // coming for it.
-        let radialSessionResign = radialServiceCode
-            .components(separatedBy: "SessionActivity.shared.onChange")
-            .dropFirst().first?
-            .components(separatedBy: "var sessionActive").first ?? ""
-        expect(radialSessionResign.contains("endSession()"),
-               "the radial menu ends its session when the mouse tap is handed back on resign")
         expect(RadialMenuFaviconFetcher.faviconURL(
             for: "https://example.com:8443/path?q=1#part")?.absoluteString
                 == "https://example.com:8443/favicon.ico"

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15265,6 +15265,23 @@ struct MetricsTests {
                 == [MouseButtonShortcutSupport.forwardButtonNumber],
                "claimed mouse buttons fall back to the legacy button key like the full decode")
         legacyButtonDefaults.removePersistentDomain(forName: "com.vorssaint.tests.radialLegacyButton")
+
+        // The cheap read and the full decode can disagree on a corrupt blob,
+        // so only one of them may decide whether the click is passed on: once
+        // the button is claimed, nothing past that point hands an event back,
+        // or the down and the up split.
+        let radialServiceCode = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift",
+            encoding: .utf8)) ?? "")
+            .components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        let radialClaimedClick = radialServiceCode
+            .components(separatedBy: "if type == .otherMouseDown {")
+            .dropFirst().first?
+            .components(separatedBy: "private func hotkeyPressed").first ?? ""
+        expect(!radialClaimedClick.isEmpty && !radialClaimedClick.contains("passUnretained"),
+               "a claimed side button keeps both halves of its click whatever the full decode says")
         expect(RadialMenuFaviconFetcher.faviconURL(
             for: "https://example.com:8443/path?q=1#part")?.absoluteString
                 == "https://example.com:8443/favicon.ico"

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15237,6 +15237,34 @@ struct MetricsTests {
         expect(samplePNG.map { RadialMenuFaviconFetcher.sourceDimensionsAreSafe($0) } == true
                && !RadialMenuFaviconFetcher.sourceDimensionsAreSafe(Data("not an image".utf8)),
                "favicon decoding accepts bounded images and rejects invalid payloads")
+
+        // The event taps read the cheap answer on every side-button event, so
+        // it has to agree with the full decode, custom icons and all.
+        let iconProfile = RadialMenuProfile(
+            name: "Icons",
+            mouseButton: RadialMenuMouseTrigger.button(6).rawValue,
+            items: [RadialMenuItem(kind: .app,
+                                   payload: "/Applications/Safari.app",
+                                   customIconData: samplePNG)]
+        )
+        let iconProfilesData = RadialMenuSupport.encodeProfiles([iconProfile, profileA])
+        let fullyDecodedButtons = RadialMenuSupport.decodeProfiles(iconProfilesData)
+            .compactMap { RadialMenuMouseTrigger.sanitized($0.mouseButton).buttonNumber }
+        expect(fullyDecodedButtons == [6, MouseButtonShortcutSupport.backButtonNumber]
+                && RadialMenuSupport.claimedMouseButtons(iconProfilesData) == fullyDecodedButtons,
+               "claimed mouse buttons read without the items match the full profile decode")
+
+        let legacyButtonDefaults = UserDefaults(suiteName: "com.vorssaint.tests.radialLegacyButton")!
+        legacyButtonDefaults.removePersistentDomain(forName: "com.vorssaint.tests.radialLegacyButton")
+        legacyButtonDefaults.set(RadialMenuMouseTrigger.forward.rawValue,
+                                 forKey: DefaultsKey.radialMenuMouseButton)
+        expect(RadialMenuSupport.claimedMouseButtons(nil, defaults: legacyButtonDefaults)
+                == [MouseButtonShortcutSupport.forwardButtonNumber]
+                && RadialMenuSupport.claimedMouseButtons(Data("not profiles".utf8),
+                                                         defaults: legacyButtonDefaults)
+                == [MouseButtonShortcutSupport.forwardButtonNumber],
+               "claimed mouse buttons fall back to the legacy button key like the full decode")
+        legacyButtonDefaults.removePersistentDomain(forName: "com.vorssaint.tests.radialLegacyButton")
         expect(RadialMenuFaviconFetcher.faviconURL(
             for: "https://example.com:8443/path?q=1#part")?.absoluteString
                 == "https://example.com:8443/favicon.ico"


### PR DESCRIPTION
## Summary

Every side-button event ran a full profile decode.

`RadialMenuSupport.claimsMouseButton` and the wheel's own tap callback both answered
"which button opens the wheel?" by calling `decodeProfiles`, which reads the stored blob,
JSON-decodes every profile with all of its items, and then runs `NSImage(data:)` over
every custom icon it finds — up to `maxStoredIconBytes` (64 KB) of PNG per item, up to 12
items per wheel, per profile. Three tap callbacks ask that question:
`MouseNavigationService`'s HID tap (whose mask includes `.otherMouseDragged`, so it asks
on every event of a held-button drag), `MouseButtonShortcutService`'s tap on every
`.otherMouseDown`, and the radial menu's own tap on every press and release. Holding a
side button and moving the mouse therefore ran the whole decode at the mouse's event
rate, synchronously in the callbacks, on the main run loop — where overrunning the tap
timeout costs dropped events.

The buttons are now decoded on their own: `RadialMenuSupport.claimedMouseButtons` reads
the same blob through a `Decodable` that has one field, `mouseButton`, so the items and
their icons are never touched. It keeps the same legacy single-button fallback
`decodeProfiles` migrates from, so the two answers cannot drift for a user who has not
saved a profile yet. `claimsMouseButton` routes through it, which fixes all three callers
at once; the wheel's tap decodes the profiles only after a press has matched a summoner
and only to open the wheel; and `syncMouseTap` uses it when its caller has no profiles in
hand. `decodeProfiles` keeps its name and its callers, and gains a note on the cost and
on what to call from a callback instead; `claimsMouseButton`'s doc comment claimed "pure
defaults reads", which had not been true since profiles landed, and now says what it
does.

Splitting the question in two let the two answers disagree inside one click, and the
first revision of this branch let that disagreement reach the app under the pointer. A
profile that keeps a valid `mouseButton` but fails the full decode — a bad `color`, a
non-array `items` — is dropped by `sanitizedProfiles` and kept by the one-field read. The
press took the early `return Unmanaged.passUnretained(event)` that guarded `beginSession`,
while its release fell past that branch to `return nil`, so the app got half a click,
which the comment right above promises never happens. Only the cheap read decides that
now: the profile match no longer returns, it only decides whether a wheel opens, so a
press whose wheel cannot be decoded opens nothing and is still swallowed with its
release. The `guard` became an `if let` for that reason.

Trade-offs:

- A cache of the claimed buttons with invalidation on defaults change would also have
  removed the cost, but it adds state to keep correct across profile edits, migration and
  the capture row. Decoding one small field is already cheap enough that there is nothing
  left to cache.
- Renaming `decodeProfiles` to something that says what it costs would make the wrong
  call harder to write, at five call sites plus tests and a conflict with every other
  branch that touches the file. The doc comment says it instead.

### Split out: the session gate

This branch also handed the tap back across a fast user switch. That half is now #1270.
It references a different issue (#1153, not #1045), shares no premise with the decode,
and carries a **Not tested** note this half does not — there is no second logged-in
account here. It went out whole: the `SessionActivity.shared.onChange` registration with
its `endSession()`, the `SessionActivitySupport.tapShouldRun` wrapper around the sync
gate, the feature check that wrapper needed, the re-arm's session question, and the
assertion for the resign path. `AXIsProcessTrusted()` is back where `main` has it, in the
tap-creation guard.

## Verification

MacBook Pro (Apple silicon), macOS 26. Rebased onto `main` at `a952b829`.

```
./build.sh --test      TESTS OK (9537 checks)
swiftc -typecheck      exit 0, whole module
```

`RadialMenuService.swift` is outside the `--test` compile whitelist, so the whole of
`Sources/Vorssaint/**` was type-checked separately with the build's own target and SDK
(`arm64-apple-macosx14.0`, `MacOSX26.sdk`, plus the two `-I` compat paths). The full
`./build.sh` was not run: with the signing keychain locked, `codesign` blocks on an
unlock dialog.

Three assertions cover this half. Two are behavioural and run against the real decoders:
the cheap read agrees with the full decode on a profile set that carries a custom icon,
and it falls back to the legacy single-button key exactly where the full decode does,
both for a missing blob and for a corrupt one. The third is a source-shape check on
`handleMouseTap`, because that path is private, takes a live `CGEvent` and cannot be
called from a test: once the cheap read has claimed the button, nothing past that point
hands an event back, which is what keeps the down and the up together.

**Not tested.** The event-rate cost is read off the code path — no instrumented profile
with custom icons was timed, so the improvement is "the decode no longer happens", not a
measured millisecond figure. The half-click path itself was not reproduced with a live
corrupt blob and a real side button.

## Anything else

`MouseNavigationService.handle` asks `RadialMenuSupport.claimsMouseButton`,
`MouseButtonShortcutSupport.claimsButton` and `MouseButtonShortcutService.isCaptureActive`
again on every event of a gesture, including the release, so a claim that changes while a
side button is held can split a click there too. That is on `main` already and
independent of this branch, so it is left alone here. `MouseButtonShortcutService`,
`MiddleClickService` and `DockClickService` all record what the press decided and let the
release follow it, so none of them has the shape.

#1045 reports mouse clicks dropped at random in a full-screen game, coming back after a
few seconds, with "three finger click acts as middle click" switched on. That is the
shape of a filter tap overrunning the tap timeout and being disabled by the window
server, and `MouseNavigationService`'s HID tap — whose mask includes
`.otherMouseDragged` — is one of the three callbacks that ran the full profile decode on
every event of a held-button drag. Linked as a candidate cause, not a confirmed one:
that report has not been retested, and #836 asks the reporter for a Dock-clicks-only
retest first.

Refs #1045
