### PR TITLE
fix(shelf): keep the saved shelf when its store fails to decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project are documented here. The format follows
 ## [Unreleased]
 
 ### Summary
-Vorssaint adds quit and close protections, expands screen text recognition, capture magnifier, clipboard, Super key, Dock Preview, App Switcher, Window Layout, mouse controls, snippet controls and the disk image installer, broadens app update and safe cleanup discovery, and hardens shortcut capture and key caps, permission guide recovery, input session switching, Accessibility timeouts, Volume Mixer audio rendering, helper process attribution and teardown, Super key shutdown, process termination, update and uninstallation teardown, window handling and shared on-screen parsing, pasteboard restoration, sensor selection, Cleaning Mode unlock, favicon downloads, the What's New showcase video download and stopping a recording. It also improves mouse scrolling feel, disk space and system monitor metrics, Command Bar responsiveness, Settings, Scratchpad, Screenshot Editor, floating panels and several menu bar behaviors.
+Vorssaint adds quit and close protections, expands screen text recognition, capture magnifier, clipboard, Super key, Dock Preview, App Switcher, Window Layout, mouse controls, snippet controls and the disk image installer, broadens app update and safe cleanup discovery, and hardens shortcut capture and key caps, permission guide recovery, input session switching, Accessibility timeouts, Volume Mixer audio rendering, helper process attribution and teardown, Super key shutdown, process termination, update and uninstallation teardown, window handling and shared on-screen parsing, pasteboard restoration, the docked shelf's saved items, sensor selection, Cleaning Mode unlock, favicon downloads, the What's New showcase video download and stopping a recording. It also improves mouse scrolling feel, disk space and system monitor metrics, Command Bar responsiveness, Settings, Scratchpad, Screenshot Editor, floating panels and several menu bar behaviors.
 
 ### Added
 - Settings now includes optional protections for Command-Q and Command-W with customizable hold duration, double press, extra modifier requirements and per-app scopes. Thanks to @RuanMD.
@@ -86,6 +86,7 @@ Vorssaint adds quit and close protections, expands screen text recognition, capt
 - Text snippets now keep their trigger buffer when typed on the macOS Accessibility Keyboard. Thanks to @fermincasagrande.
 - Dock click actions and previews now stay behind fullscreen content and sample high-rate pointer movement without overloading the hover tap. Thanks to @iltonandrew.
 - Clipboard history now trims against the encoded file size before saving, preventing its store from becoming unreadable.
+- The docked shelf now keeps its saved items and the text and images it stored for them when its saved list cannot be read completely, instead of clearing the shelf and deleting those files. Thanks to @PathGao.
 - Kill Process now sorts consistently and revalidates the exact process before terminating it, preventing a recycled process identifier from targeting a different process.
 - Music launch blocking now fails open when its media-key listener is unavailable.
 - Radial Menu favicon downloads now stay on the link origin and reject cross-origin redirects, oversized payloads and unsafe image dimensions.

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -201,15 +201,6 @@ final class ShelfService: ObservableObject {
     /// as a content drag (issue #240).
     private var sawGestureStart = false
     private var dragBeganInDock = false
-    /// Dragged events spent re-asking whether this gesture started in the
-    /// Dock, capped so a long drag does not pay for the answer at event rate.
-    private var dockOriginProbes = 0
-    private static let dockOriginProbeLimit = 5
-    /// One gesture's answer to "does the drag pasteboard hold something the
-    /// Shelf can keep", remembered against the change count that produced it.
-    /// The contents cannot change while the count stands still, so enumerating
-    /// them once per gesture is enough.
-    private var droppableContentAnswer: (changeCount: Int, hasContent: Bool)?
     private var dragSourceBundleIdentifier: String?
     private var activeInternalDragIDs: [UUID] = []
     private var internalDragWasMerged = false
@@ -432,15 +423,7 @@ final class ShelfService: ObservableObject {
                 if !self.sawGestureStart {
                     self.beginDragGesture(with: event)
                 }
-                // Where the gesture started is settled at `beginDragGesture`;
-                // re-asking costs a window-list copy plus a running-app lookup
-                // on every dragged event. A Dock stack whose mouse-down never
-                // reached the monitor can still surface its window number a
-                // few events late, so keep asking for a short while.
-                if !self.dragBeganInDock, self.dockOriginProbes < Self.dockOriginProbeLimit {
-                    self.dockOriginProbes += 1
-                    self.dragBeganInDock = self.eventBelongsToDock(event)
-                }
+                self.dragBeganInDock = self.dragBeganInDock || self.eventBelongsToDock(event)
                 let defaults = UserDefaults.standard
                 if defaults.bool(forKey: DefaultsKey.shelfShakeToOpen) {
                     self.handleDrag(event)
@@ -511,19 +494,11 @@ final class ShelfService: ObservableObject {
 
     private func isContentDragActive() -> Bool {
         let pasteboard = NSPasteboard(name: .drag)
-        let changeCount = pasteboard.changeCount
         return ShelfInteractionSupport.isContentDrag(
             baselineChangeCount: dragBaselineChangeCount,
-            changeCount: changeCount,
+            changeCount: pasteboard.changeCount,
             beganInDock: dragBeganInDock,
-            hasDroppableContent: {
-                if let answer = droppableContentAnswer, answer.changeCount == changeCount {
-                    return answer.hasContent
-                }
-                let hasContent = pasteboardHasDroppableContent(pasteboard)
-                droppableContentAnswer = (changeCount, hasContent)
-                return hasContent
-            })
+            hasDroppableContent: { pasteboardHasDroppableContent(pasteboard) })
     }
 
     /// Opens a gesture at its first observed event: the mouse-down when it
@@ -532,7 +507,6 @@ final class ShelfService: ObservableObject {
     private func beginDragGesture(with event: NSEvent) {
         sawGestureStart = true
         dragBaselineChangeCount = NSPasteboard(name: .drag).changeCount
-        dockOriginProbes = 0
         dragBeganInDock = eventBelongsToDock(event)
         dragSourceBundleIdentifier = sourceBundleIdentifier(for: event)
     }

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -2027,9 +2027,11 @@ final class ShelfService: ObservableObject {
     /// thumbnails touch the disk, and this runs at launch), merges it with
     /// anything added in the meantime, then sweeps payload files that lost
     /// their item (crash between write and save, or dropped at sanitizing).
-    /// A blob that will not decode at all restores nothing and skips both the
-    /// save-back and the sweep: it is a store this build cannot read, not a
-    /// shelf the user emptied.
+    /// A blob this build cannot read whole — one that will not decode at all,
+    /// and one that decoded with entries dropped — skips both the save-back
+    /// and the sweep: it is a store this build cannot read, not a shelf the
+    /// user emptied, and the entries it dropped still own payload files that
+    /// the blob it kept still points at.
     private func restoreItems() {
         let sweepCutoff = Date()
         let data = UserDefaults.standard.data(forKey: DefaultsKey.shelfItems)
@@ -2041,9 +2043,9 @@ final class ShelfService: ObservableObject {
             // NSWorkspace and SF Symbols, which are only safe on the main
             // thread, so that step waits for the hop below.
             var sanitized: [ShelfPersistedItem] = []
-            var storeUnreadable = false
-            switch ShelfPersistenceSupport.load(data) {
-            case let .items(decoded):
+            let store = ShelfPersistenceSupport.load(data)
+            switch store {
+            case let .items(decoded), let .partial(decoded):
                 sanitized = ShelfPersistenceSupport.sanitized(decoded, fileExists: { path in
                     if FileManager.default.fileExists(atPath: path) { return true }
                     // A file on an unmounted volume is not gone: the app can
@@ -2056,7 +2058,7 @@ final class ShelfService: ObservableObject {
                     return false
                 }, resolveBookmark: Self.resolvedBookmarkPath)
             case .unreadable:
-                storeUnreadable = true
+                break
             }
             DispatchQueue.main.async {
                 let restored = sanitized.compactMap { self.restoredItem(from: $0) }
@@ -2072,11 +2074,14 @@ final class ShelfService: ObservableObject {
                     self.items = keptRestored + self.items
                     self.startContentThumbnails(for: keptRestored)
                 }
-                // A store this build cannot read is not an empty shelf.
-                // Saving over it and sweeping the payload files it still
-                // references would turn one bad blob into permanent loss, so
-                // both wait for a launch that can read it again.
-                guard !storeUnreadable else { return }
+                // A store this build could not read whole is not an empty
+                // shelf, and it is not the shelf either. Saving over it and
+                // sweeping the payload files it still references would turn
+                // entries this build cannot read into permanent loss — the
+                // dropped entry's file is still there and still referenced,
+                // unlike a `sanitized` drop, whose file is gone by definition.
+                // Both wait for a launch that can read the store again.
+                guard case .items = store else { return }
                 if ShelfPersistenceSupport.needsPersistAfterRestore(
                     restoredIsEmpty: restored.isEmpty,
                     liveItemCount: liveItemCount) {

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -2001,6 +2001,9 @@ final class ShelfService: ObservableObject {
     /// thumbnails touch the disk, and this runs at launch), merges it with
     /// anything added in the meantime, then sweeps payload files that lost
     /// their item (crash between write and save, or dropped at sanitizing).
+    /// A blob that will not decode at all restores nothing and skips both the
+    /// save-back and the sweep: it is a store this build cannot read, not a
+    /// shelf the user emptied.
     private func restoreItems() {
         let sweepCutoff = Date()
         let data = UserDefaults.standard.data(forKey: DefaultsKey.shelfItems)
@@ -2012,8 +2015,9 @@ final class ShelfService: ObservableObject {
             // NSWorkspace and SF Symbols, which are only safe on the main
             // thread, so that step waits for the hop below.
             var sanitized: [ShelfPersistedItem] = []
-            if let data,
-               let decoded = try? JSONDecoder().decode([ShelfPersistedItem].self, from: data) {
+            var storeUnreadable = false
+            switch ShelfPersistenceSupport.load(data) {
+            case let .items(decoded):
                 sanitized = ShelfPersistenceSupport.sanitized(decoded, fileExists: { path in
                     if FileManager.default.fileExists(atPath: path) { return true }
                     // A file on an unmounted volume is not gone: the app can
@@ -2025,6 +2029,8 @@ final class ShelfService: ObservableObject {
                     }
                     return false
                 }, resolveBookmark: Self.resolvedBookmarkPath)
+            case .unreadable:
+                storeUnreadable = true
             }
             DispatchQueue.main.async {
                 let restored = sanitized.compactMap { self.restoredItem(from: $0) }
@@ -2040,6 +2046,11 @@ final class ShelfService: ObservableObject {
                     self.items = keptRestored + self.items
                     self.startContentThumbnails(for: keptRestored)
                 }
+                // A store this build cannot read is not an empty shelf.
+                // Saving over it and sweeping the payload files it still
+                // references would turn one bad blob into permanent loss, so
+                // both wait for a launch that can read it again.
+                guard !storeUnreadable else { return }
                 if ShelfPersistenceSupport.needsPersistAfterRestore(
                     restoredIsEmpty: restored.isEmpty,
                     liveItemCount: liveItemCount) {

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -201,6 +201,15 @@ final class ShelfService: ObservableObject {
     /// as a content drag (issue #240).
     private var sawGestureStart = false
     private var dragBeganInDock = false
+    /// Dragged events spent re-asking whether this gesture started in the
+    /// Dock, capped so a long drag does not pay for the answer at event rate.
+    private var dockOriginProbes = 0
+    private static let dockOriginProbeLimit = 5
+    /// One gesture's answer to "does the drag pasteboard hold something the
+    /// Shelf can keep", remembered against the change count that produced it.
+    /// The contents cannot change while the count stands still, so enumerating
+    /// them once per gesture is enough.
+    private var droppableContentAnswer: (changeCount: Int, hasContent: Bool)?
     private var dragSourceBundleIdentifier: String?
     private var activeInternalDragIDs: [UUID] = []
     private var internalDragWasMerged = false
@@ -423,7 +432,15 @@ final class ShelfService: ObservableObject {
                 if !self.sawGestureStart {
                     self.beginDragGesture(with: event)
                 }
-                self.dragBeganInDock = self.dragBeganInDock || self.eventBelongsToDock(event)
+                // Where the gesture started is settled at `beginDragGesture`;
+                // re-asking costs a window-list copy plus a running-app lookup
+                // on every dragged event. A Dock stack whose mouse-down never
+                // reached the monitor can still surface its window number a
+                // few events late, so keep asking for a short while.
+                if !self.dragBeganInDock, self.dockOriginProbes < Self.dockOriginProbeLimit {
+                    self.dockOriginProbes += 1
+                    self.dragBeganInDock = self.eventBelongsToDock(event)
+                }
                 let defaults = UserDefaults.standard
                 if defaults.bool(forKey: DefaultsKey.shelfShakeToOpen) {
                     self.handleDrag(event)
@@ -494,11 +511,19 @@ final class ShelfService: ObservableObject {
 
     private func isContentDragActive() -> Bool {
         let pasteboard = NSPasteboard(name: .drag)
+        let changeCount = pasteboard.changeCount
         return ShelfInteractionSupport.isContentDrag(
             baselineChangeCount: dragBaselineChangeCount,
-            changeCount: pasteboard.changeCount,
+            changeCount: changeCount,
             beganInDock: dragBeganInDock,
-            hasDroppableContent: { pasteboardHasDroppableContent(pasteboard) })
+            hasDroppableContent: {
+                if let answer = droppableContentAnswer, answer.changeCount == changeCount {
+                    return answer.hasContent
+                }
+                let hasContent = pasteboardHasDroppableContent(pasteboard)
+                droppableContentAnswer = (changeCount, hasContent)
+                return hasContent
+            })
     }
 
     /// Opens a gesture at its first observed event: the mouse-down when it
@@ -507,6 +532,7 @@ final class ShelfService: ObservableObject {
     private func beginDragGesture(with event: NSEvent) {
         sawGestureStart = true
         dragBaselineChangeCount = NSPasteboard(name: .drag).changeCount
+        dockOriginProbes = 0
         dragBeganInDock = eventBelongsToDock(event)
         dragSourceBundleIdentifier = sourceBundleIdentifier(for: event)
     }

--- a/Sources/Vorssaint/Services/Shelf/ShelfSupport.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfSupport.swift
@@ -494,9 +494,15 @@ private struct FailableShelfPersistedItem: Decodable {
 /// that empty list back and sweeping the payload files behind it turns one
 /// bad blob into permanent loss.
 enum ShelfStoreLoad: Equatable {
-    /// No blob yet (first launch), or a blob that decoded to a list —
-    /// possibly an empty one, which is a shelf the user emptied.
+    /// No blob yet (first launch), or a blob that decoded whole — possibly to
+    /// an empty list, which is a shelf the user emptied.
     case items([ShelfPersistedItem])
+    /// A blob that decoded, but with entries this build could not read: an
+    /// unknown kind written by a newer build, at the top level or inside a
+    /// batch. Those entries still own payload files in the shelf's own
+    /// directory, and the blob still points at them, so their files must
+    /// survive to the launch that can read the store again.
+    case partial([ShelfPersistedItem])
     /// A blob that is not a shelf list at all. Leave it, and the payload
     /// files it still references, alone until the next launch.
     case unreadable
@@ -513,7 +519,8 @@ enum ShelfPersistenceSupport {
     /// answer for, so "the blob did not decode" cannot quietly become "the
     /// shelf is empty" the way decoding the array outright does. Entries are
     /// lossy on their own: one with an unknown kind or a missing required
-    /// field drops itself instead of taking the rest with it.
+    /// field drops itself instead of taking the rest with it, and a list that
+    /// lost an entry that way comes back as `.partial`, not `.items`.
     static func load(_ data: Data?) -> ShelfStoreLoad {
         guard let data else { return .items([]) }
         guard let decoded = try? JSONDecoder().decode([FailableShelfPersistedItem].self,
@@ -522,7 +529,24 @@ enum ShelfPersistenceSupport {
         // A stored list where nothing survived is a shelf this build cannot
         // read (a downgrade past a format change), not one the user emptied.
         if !decoded.isEmpty, items.isEmpty { return .unreadable }
-        return .items(items)
+        // Counted rather than read off `decoded.count`: an entry can also drop
+        // itself inside a batch, and its payload file is as real as a top-level
+        // one's. The blob kept still points at every dropped entry's file.
+        let stored = storedEntryCount(try? JSONSerialization.jsonObject(with: data))
+        return stored == readEntryCount(items) ? .items(items) : .partial(items)
+    }
+
+    /// Entries the blob describes at every depth, readable or not.
+    private static func storedEntryCount(_ json: Any?) -> Int {
+        guard let entries = json as? [Any] else { return 0 }
+        return entries.reduce(0) { total, entry in
+            total + 1 + storedEntryCount((entry as? [String: Any])?["children"])
+        }
+    }
+
+    /// Entries this build read at every depth.
+    private static func readEntryCount(_ items: [ShelfPersistedItem]) -> Int {
+        items.reduce(0) { $0 + 1 + readEntryCount($1.children ?? []) }
     }
 
     static func boundedLiveText(_ text: String) -> String? {

--- a/Sources/Vorssaint/Services/Shelf/ShelfSupport.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfSupport.swift
@@ -456,12 +456,74 @@ struct ShelfPersistedItem: Codable, Equatable {
     }
 }
 
+// The custom decoder lives in an extension so the memberwise initializer
+// stays synthesized. It tolerates blobs written by other versions: absent
+// fields fall back to their defaults, and an unknown kind fails just this
+// item, which the lossy array decode in `ShelfPersistenceSupport.load` then
+// drops instead of losing the whole shelf.
+extension ShelfPersistedItem {
+    private enum CodingKeys: String, CodingKey {
+        case id, kind, title, text, url, path, bookmark, children
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(id: try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID(),
+                  kind: try container.decode(Kind.self, forKey: .kind),
+                  title: try container.decodeIfPresent(String.self, forKey: .title) ?? "",
+                  text: try container.decodeIfPresent(String.self, forKey: .text),
+                  url: try container.decodeIfPresent(String.self, forKey: .url),
+                  path: try container.decodeIfPresent(String.self, forKey: .path),
+                  bookmark: try container.decodeIfPresent(Data.self, forKey: .bookmark),
+                  children: try container.decodeIfPresent([FailableShelfPersistedItem].self, forKey: .children)?
+                      .compactMap(\.value))
+    }
+}
+
+private struct FailableShelfPersistedItem: Decodable {
+    let value: ShelfPersistedItem?
+
+    init(from decoder: Decoder) throws {
+        value = try? ShelfPersistedItem(from: decoder)
+    }
+}
+
+/// What the saved shelf blob turned out to be. The outcomes are kept apart
+/// because they need opposite handling, and collapsing them into a plain
+/// item list is what lets a decode failure pass for an empty shelf: writing
+/// that empty list back and sweeping the payload files behind it turns one
+/// bad blob into permanent loss.
+enum ShelfStoreLoad: Equatable {
+    /// No blob yet (first launch), or a blob that decoded to a list —
+    /// possibly an empty one, which is a shelf the user emptied.
+    case items([ShelfPersistedItem])
+    /// A blob that is not a shelf list at all. Leave it, and the payload
+    /// files it still references, alone until the next launch.
+    case unreadable
+}
+
 enum ShelfPersistenceSupport {
     /// Ceilings so a stale or hand-edited blob cannot balloon startup: the
     /// shelf is a hand-curated surface, not an archive.
     static let maxLeaves = 200
     static let maxTextLength = 200_000
     static let maxDepth = 4
+
+    /// The only way into the saved shelf. Callers get a case they have to
+    /// answer for, so "the blob did not decode" cannot quietly become "the
+    /// shelf is empty" the way decoding the array outright does. Entries are
+    /// lossy on their own: one with an unknown kind or a missing required
+    /// field drops itself instead of taking the rest with it.
+    static func load(_ data: Data?) -> ShelfStoreLoad {
+        guard let data else { return .items([]) }
+        guard let decoded = try? JSONDecoder().decode([FailableShelfPersistedItem].self,
+                                                      from: data) else { return .unreadable }
+        let items = decoded.compactMap(\.value)
+        // A stored list where nothing survived is a shelf this build cannot
+        // read (a downgrade past a format change), not one the user emptied.
+        if !decoded.isEmpty, items.isEmpty { return .unreadable }
+        return .items(items)
+    }
 
     static func boundedLiveText(_ text: String) -> String? {
         let bounded = String(text.prefix(maxTextLength))

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -16494,8 +16494,11 @@ struct MetricsTests {
                 if !pinned { unpinnedBorderlessMenus.append("\(file):\(index + 1)") }
             }
         }
-        expect(unpinnedBorderlessMenus.isEmpty,
-               "every borderless menu keeps its own size: \(unpinnedBorderlessMenus)")
+        // The file count is part of the rule: an enumerator that finds nothing
+        // would leave the list empty and pass while checking no menu at all.
+        expect(!uiFiles.isEmpty && unpinnedBorderlessMenus.isEmpty,
+               "every borderless menu keeps its own size, across \(uiFiles.count) "
+               + "scanned files: \(unpinnedBorderlessMenus)")
 
         // `waitUntilAllOperationsAreFinished` has no deadline, and the window
         // walk that used it runs on the main thread while its operations run on
@@ -21575,9 +21578,9 @@ struct MetricsTests {
                          "\(language.rawValue) quit protection modifier HUD format")
         }
 
-        // Loading the saved shelf keeps "nothing saved", "decoded to a list"
-        // and "will not decode" apart. Only the first two describe a shelf
-        // that may be saved over.
+        // Loading the saved shelf keeps "nothing saved", "decoded whole",
+        // "decoded with entries dropped" and "will not decode" apart. Only a
+        // store read whole may be saved over and swept behind.
         expect(ShelfPersistenceSupport.load(nil) == .items([]),
                "no saved shelf blob restores as an empty shelf")
         expect(ShelfPersistenceSupport.load(Data("[]".utf8)) == .items([]),
@@ -21589,20 +21592,40 @@ struct MetricsTests {
 
         // One bad entry drops only itself: an unknown kind (written by a newer
         // build) and a missing optional field must not cost the whole shelf.
+        // The list that comes back is `.partial`, never `.items`: the dropped
+        // entry's payload file is still on disk and the blob still points at
+        // it, so the caller must not save over the store or sweep behind it.
         let mixedShelfBlob = Data("""
         [{"id":"8B3E1C2A-0000-4000-8000-000000000001","kind":"text","title":"keep","text":"body"},
          {"id":"8B3E1C2A-0000-4000-8000-000000000002","kind":"telepathy","title":"unknown kind"},
          {"kind":"link","title":"no id","url":"https://example.com"}]
         """.utf8)
         var mixedShelfTitles: [String] = []
-        if case let .items(loaded) = ShelfPersistenceSupport.load(mixedShelfBlob) {
+        if case let .partial(loaded) = ShelfPersistenceSupport.load(mixedShelfBlob) {
             mixedShelfTitles = loaded.map(\.title)
         }
         expect(mixedShelfTitles == ["keep", "no id"],
-               "an entry with an unknown kind drops itself, found \(mixedShelfTitles)")
+               "an entry with an unknown kind drops itself and the rest load as "
+               + "partial, found \(mixedShelfTitles)")
         expect(ShelfPersistenceSupport.load(Data(#"[{"kind":"telepathy"}]"#.utf8)) == .unreadable,
                "a stored list where no entry survives is unreadable, not empty")
 
+        let wholeShelfBlob = Data("""
+        [{"id":"8B3E1C2A-0000-4000-8000-000000000007","kind":"text","title":"a","text":"a"},
+         {"id":"8B3E1C2A-0000-4000-8000-000000000008","kind":"batch","title":"pile","children":[
+           {"id":"8B3E1C2A-0000-4000-8000-000000000009","kind":"text","title":"b","text":"b"}]}]
+        """.utf8)
+        var wholeShelfTitles: [String] = []
+        if case let .items(loaded) = ShelfPersistenceSupport.load(wholeShelfBlob) {
+            wholeShelfTitles = loaded.map(\.title)
+        }
+        expect(wholeShelfTitles == ["a", "pile"],
+               "a store every entry of which decodes loads whole, found \(wholeShelfTitles)")
+
+        // A child that drops itself costs its payload file the same way a
+        // top-level entry does, so the depth it sits at must not change the
+        // answer: the batch survives with its readable children, and the load
+        // is still partial.
         let batchShelfBlob = Data("""
         [{"id":"8B3E1C2A-0000-4000-8000-000000000003","kind":"batch","title":"pile","children":[
            {"id":"8B3E1C2A-0000-4000-8000-000000000004","kind":"text","title":"a","text":"a"},
@@ -21610,29 +21633,55 @@ struct MetricsTests {
            {"id":"8B3E1C2A-0000-4000-8000-000000000006","kind":"text","title":"c","text":"c"}]}]
         """.utf8)
         var batchShelfChildTitles: [String] = []
-        if case let .items(loaded) = ShelfPersistenceSupport.load(batchShelfBlob) {
+        if case let .partial(loaded) = ShelfPersistenceSupport.load(batchShelfBlob) {
             batchShelfChildTitles = (loaded.first?.children ?? []).map(\.title)
         }
         expect(batchShelfChildTitles == ["a", "c"],
-               "a bad child drops itself and its batch survives, found \(batchShelfChildTitles)")
+               "a bad child drops itself, its batch survives and the store loads as "
+               + "partial, found \(batchShelfChildTitles)")
+
+        // The sweep decision lives in ShelfService, which `--test` does not
+        // compile, so it is pinned by shape: restore may reach the payload
+        // sweep only past the guard that a store read whole has to pass. A
+        // `.partial` store's dropped entries still own files in that
+        // directory, and the blob it kept still points at them.
+        let restoreItemsBody = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Shelf/ShelfService.swift",
+            encoding: .utf8)) ?? "")
+            .components(separatedBy: "private func restoreItems()")
+            .dropFirst().first?
+            .components(separatedBy: "\n    private func ").first ?? ""
+        let pastRestoreGuard = restoreItemsBody
+            .components(separatedBy: "guard case .items = store else { return }")
+        expect(pastRestoreGuard.count == 2
+                && !pastRestoreGuard[0].contains("sweepOwnedFiles(")
+                && pastRestoreGuard[1].contains("sweepOwnedFiles("),
+               "restore sweeps the shelf's payload files only for a store it read whole")
 
         // Guards the class, not the one instance that emptied shelves: the
         // saved blob may only be read through `load`, which hands the caller a
         // `.unreadable` case it has to answer for. A bare array decode brings
         // back the all-or-nothing form, where any single bad entry restores an
         // empty shelf that is then written back over the real one.
+        // The scan has to report how many files it read: an enumerator that
+        // finds nothing (the tests run from somewhere other than the repo
+        // root) leaves the list empty, and a rule checked against no files at
+        // all passes while guarding nothing.
         var rawShelfStoreDecoders: [String] = []
+        var scannedShelfStoreFiles = 0
         if let sources = FileManager.default.enumerator(atPath: "Sources") {
             for case let path as String in sources where path.hasSuffix(".swift") {
                 let text = (try? String(contentsOfFile: "Sources/" + path, encoding: .utf8)) ?? ""
+                scannedShelfStoreFiles += 1
                 if text.contains("decode([ShelfPersistedItem]") {
                     rawShelfStoreDecoders.append((path as NSString).lastPathComponent)
                 }
             }
         }
-        expect(rawShelfStoreDecoders.isEmpty,
+        expect(scannedShelfStoreFiles > 0 && rawShelfStoreDecoders.isEmpty,
                "the saved shelf is read only through ShelfPersistenceSupport.load, "
-               + "found a bare decode in \(rawShelfStoreDecoders.sorted())")
+               + "found a bare decode in \(rawShelfStoreDecoders.sorted()) "
+               + "across \(scannedShelfStoreFiles) scanned files")
 
         if failures.isEmpty {
             print("TESTS OK (\(checks) checks)")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -7875,6 +7875,19 @@ struct MetricsTests {
             expect(false, "shelf items must encode and decode")
         }
 
+        // Every field at once, none left at its default. `CodingKeys` is written
+        // out by hand next to the stored properties, and a property missing from
+        // it is silently dropped by both the custom decoder and the synthesized
+        // encoder, so a ninth field added without a case would stop being saved
+        // and read with nothing else complaining.
+        let shelfFullItem = ShelfPersistedItem(id: UUID(), kind: .file, title: "t", text: "x",
+                                               url: "https://example.com/u", path: "/tmp/p",
+                                               bookmark: Data([1]), children: [])
+        let shelfFullRound = (try? JSONEncoder().encode(shelfFullItem))
+            .flatMap { try? JSONDecoder().decode(ShelfPersistedItem.self, from: $0) }
+        expect(shelfFullRound == shelfFullItem,
+               "every persisted shelf field survives an encode and decode round trip")
+
         expect(ShelfPersistenceSupport.sanitized([shelfFile, shelfText, shelfLink]) { _ in true }
                    == [shelfFile, shelfText, shelfLink],
                "healthy shelf items pass sanitizing untouched")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21575,6 +21575,65 @@ struct MetricsTests {
                          "\(language.rawValue) quit protection modifier HUD format")
         }
 
+        // Loading the saved shelf keeps "nothing saved", "decoded to a list"
+        // and "will not decode" apart. Only the first two describe a shelf
+        // that may be saved over.
+        expect(ShelfPersistenceSupport.load(nil) == .items([]),
+               "no saved shelf blob restores as an empty shelf")
+        expect(ShelfPersistenceSupport.load(Data("[]".utf8)) == .items([]),
+               "a saved empty shelf restores as an empty shelf")
+        expect(ShelfPersistenceSupport.load(Data("not json".utf8)) == .unreadable,
+               "an unreadable shelf blob is not an empty shelf")
+        expect(ShelfPersistenceSupport.load(Data(#"{"items":[]}"#.utf8)) == .unreadable,
+               "a shelf blob that is not a list is not an empty shelf")
+
+        // One bad entry drops only itself: an unknown kind (written by a newer
+        // build) and a missing optional field must not cost the whole shelf.
+        let mixedShelfBlob = Data("""
+        [{"id":"8B3E1C2A-0000-4000-8000-000000000001","kind":"text","title":"keep","text":"body"},
+         {"id":"8B3E1C2A-0000-4000-8000-000000000002","kind":"telepathy","title":"unknown kind"},
+         {"kind":"link","title":"no id","url":"https://example.com"}]
+        """.utf8)
+        var mixedShelfTitles: [String] = []
+        if case let .items(loaded) = ShelfPersistenceSupport.load(mixedShelfBlob) {
+            mixedShelfTitles = loaded.map(\.title)
+        }
+        expect(mixedShelfTitles == ["keep", "no id"],
+               "an entry with an unknown kind drops itself, found \(mixedShelfTitles)")
+        expect(ShelfPersistenceSupport.load(Data(#"[{"kind":"telepathy"}]"#.utf8)) == .unreadable,
+               "a stored list where no entry survives is unreadable, not empty")
+
+        let batchShelfBlob = Data("""
+        [{"id":"8B3E1C2A-0000-4000-8000-000000000003","kind":"batch","title":"pile","children":[
+           {"id":"8B3E1C2A-0000-4000-8000-000000000004","kind":"text","title":"a","text":"a"},
+           {"id":"8B3E1C2A-0000-4000-8000-000000000005","kind":"telepathy","title":"b"},
+           {"id":"8B3E1C2A-0000-4000-8000-000000000006","kind":"text","title":"c","text":"c"}]}]
+        """.utf8)
+        var batchShelfChildTitles: [String] = []
+        if case let .items(loaded) = ShelfPersistenceSupport.load(batchShelfBlob) {
+            batchShelfChildTitles = (loaded.first?.children ?? []).map(\.title)
+        }
+        expect(batchShelfChildTitles == ["a", "c"],
+               "a bad child drops itself and its batch survives, found \(batchShelfChildTitles)")
+
+        // Guards the class, not the one instance that emptied shelves: the
+        // saved blob may only be read through `load`, which hands the caller a
+        // `.unreadable` case it has to answer for. A bare array decode brings
+        // back the all-or-nothing form, where any single bad entry restores an
+        // empty shelf that is then written back over the real one.
+        var rawShelfStoreDecoders: [String] = []
+        if let sources = FileManager.default.enumerator(atPath: "Sources") {
+            for case let path as String in sources where path.hasSuffix(".swift") {
+                let text = (try? String(contentsOfFile: "Sources/" + path, encoding: .utf8)) ?? ""
+                if text.contains("decode([ShelfPersistedItem]") {
+                    rawShelfStoreDecoders.append((path as NSString).lastPathComponent)
+                }
+            }
+        }
+        expect(rawShelfStoreDecoders.isEmpty,
+               "the saved shelf is read only through ShelfPersistenceSupport.load, "
+               + "found a bare decode in \(rawShelfStoreDecoders.sorted())")
+
         if failures.isEmpty {
             print("TESTS OK (\(checks) checks)")
             exit(0)


### PR DESCRIPTION
## Summary

### A store that failed to decode emptied the shelf and deleted its files

`restoreItems` read the saved blob with `try? JSONDecoder().decode([ShelfPersistedItem].self, from: data)`, which is all-or-nothing: `id`, `kind` and `title` are non-optional and `Kind` is a strict raw-value enum, so one entry with a missing field or a kind written by a newer build threw and left the restored list empty. Two irreversible things then ran on that empty list — `needsPersistAfterRestore(restoredIsEmpty: true, …)` saved it back over the real store, and `sweepOwnedFiles(keeping: [])` deleted every file in the shelf's own payload directory older than the launch cutoff. One entry this build could not read cost the whole shelf, including the pasted images and text it had written to disk itself.

Fixed at the shape, not at the one call site:

- `ShelfPersistedItem` decodes through a `FailableShelfPersistedItem` wrapper, the construct `RadialMenuSupport` already uses for menu items and profiles. A bad entry drops itself and the rest of the list survives, at any nesting depth.
- `ShelfPersistenceSupport.load(_:)` is the only way into the store and returns `ShelfStoreLoad`, not an array. `.unreadable` is a case the caller has to answer for, so "the blob did not decode" can no longer pass for "the shelf is empty". A blob that decoded to a list where nothing survived counts as unreadable too: that is a downgrade past a format change, not a shelf the user emptied.
- A blob that decoded with entries missing is `.partial`, its own case. An entry that dropped itself still owns its payload file in the shelf's directory, and the blob that survived still points at that file, so a `.partial` store is treated like `.unreadable`: no save-back, no sweep. The drop is counted at every depth, not off the top-level `decoded.count`, because a child of a batch owns a payload file the same way a top-level entry does. This is unlike a `sanitized` drop, whose file is already gone by definition and whose sweep is the point.
- Restore therefore reaches the save-back and the sweep only for a store it read whole.

Four states are now distinct where they used to be one: no blob at all (first launch), a blob that decoded whole (possibly to an empty list — a shelf the user emptied, and safe to save over), a blob that decoded with entries dropped, and a blob that does not decode at all. Only the first two may be written over and swept behind.

`ShelfPersistedItem` writes its eight `CodingKeys` by hand next to eight stored properties, and a ninth added without a case is invisible in both directions at once: the synthesized encoder has no key to write it under, and the hand-written `init(from:)` never reads it back. The round trip already in the suite could not see that — every item it encodes leaves `bookmark` and `children` at their defaults, so a field that never survives compares equal anyway. A second round trip encodes one item with all eight fields set to non-default values and compares the decoded item against it.

### Tradeoffs

- Considered guarding only the `restoreItems` call site with `data != nil && decoded == nil`. Rejected: it leaves the all-or-nothing decode expressible, so the next reader of the store writes the same bug. An enum makes the failure a case the compiler forces a caller to handle.
- Considered making the bare decode impossible outright. It cannot be — `ShelfPersistedItem` has to stay `Decodable` for the failable wrapper to work — so the nearest available guard is a source-shape check in the tests that no file under `Sources/` decodes the array directly. It keys off the persisted type's name, which is a rename away from going quiet; that is the weaker half of this change. It now also reports how many files it read and fails on zero, so a run from outside the repo root cannot pass it by scanning nothing.
- Considered saving a repaired list when only some entries were unreadable. Not done, and now the payload files behind those entries survive too: rewriting the store would make a downgrade lossy, and sweeping behind it would make it permanent.
- `restoreCompleted` still flips to true on an unreadable or partial store, so a drop or a delete the user makes afterwards does save over it. Blocking saves outright would leave the shelf silently read-only. What that later save cannot do any more is take the dropped entries' files with it in the same launch.
- The full-field round trip is only as wide as the instance it encodes. It catches a ninth field when that instance sets it to something other than its default, which is what the comment beside it asks the next reader to do; a ninth field left at its default in the test still passes. Making it independent of that would need reflection over the stored properties, a different check that is not in here.
- Not touched here: the `maxLeaves` ceiling drops restored items past 200 leaves and then sweeps their payload files, which is the same trade on a store too large rather than one too new. It predates this change and is left as it is.
- Not touched here either: restore still builds each item's icon with `NSWorkspace.icon(forFile:)` and its bookmark with `url.bookmarkData()` on the main thread, once per restored item, up to 200 — and `sanitized` deliberately keeps items on unmounted volumes, which are the paths most likely to make LaunchServices wait. Deferring those needs a placeholder icon and a second async patch channel, and it changes what launch looks like; that belongs in its own change.

## Verification

macOS 26.x on Apple silicon.

- `./build.sh --test`: `TESTS FAILED (2 of 9480)`, and both are the pre-existing pair (`nil layout falls back to ANSI semicolon`, `App Switcher icon-row hints…`) that read the machine's current input source and flip with the active input method. They fail the same way on `origin/main` at `f25d1aa8` on this machine.
- `swiftc -typecheck` over the whole `Sources/Vorssaint` set, with the target, SDK and compat flags `build.sh` compiles with: clean, no diagnostics. `ShelfService.swift` is not in the `--test` file list, so this is the only thing here that reads it. The full `./build.sh` release compile finished with no warnings on the previous head of this branch; what changed in that file since is a removal, restoring the line already on `main`.
- Every check here was confirmed red before being trusted, in one run with the fixes broken on purpose. Making `load` return `.items` instead of `.partial` reddened both partial checks (`found []`). Replacing the restore guard with one that lets everything but `.unreadable` through reddened the source-shape pin on `restoreItems`. Pointing the two directory scans at a path that does not exist reddened both on their file counts (`across 0 scanned files`) where before the fix they passed on an empty scan. All four were restored and are green. The new round trip was seen red the same way: adding a ninth stored property to `ShelfPersistedItem` without a `CodingKeys` case, and setting it on the encoded item, failed that check and nothing else.
- The unreadable, partial and whole-store paths were driven through `ShelfPersistenceSupport.load` in the unit tests, including a batch whose child has a kind this build does not know.

What was not tested: the sweep itself never ran in a test — `ShelfService` is not in the `--test` set, so the rule that restore reaches `sweepOwnedFiles` only past the whole-store guard is pinned by source shape, not by executing it. No real `shelfItems` blob was corrupted and no app was relaunched against it, and no payload file was watched surviving a downgrade on disk. No second login session, no external or network volume mounted to exercise the unmounted-volume branch, and no multi-display or multi-Space layout.

## Anything else

The drag half that was on this branch has been taken back off it. `dockOriginProbeLimit = 5` narrowed "ask on every dragged event" to "ask at most five times past the start" on the strength of one line of reasoning — that five events is 40–80 ms — with nothing measuring when a Dock stack actually surfaces its window number, and no list of the gestures the old code recognised that the new one does not. `dragBeganInDock` feeds `ShelfInteractionSupport.isContentDrag(beganInDock:)`, so a number guessed too low is a user-visible regression on Dock drags, and no check here covers it. The pasteboard-answer memo beside it is clean on its own — `NSPasteboard.changeCount` is documented, and it takes one full pasteboard enumeration per caller per event down to one per gesture — but it is the same half of the branch, and it is worth a real before-and-after count of its own rather than a ride in behind the restore fix. Both are now #1265, where the guessed five has a section of its own.

One unrelated test carried the same vacuous-scan bug as the new source-shape guard and is fixed in the same commit: the borderless-menu rule enumerated `Sources/Vorssaint/UI` and passed on an empty list. It now requires the scan to have read at least one file, the way the `waitUntilAllOperationsAreFinished` and application-role scans beside it already did.

Refs #162