### PR TITLE
test: enumerate event-tap owners instead of listing six by hand

### DIFF
--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21758,12 +21758,18 @@ struct MetricsTests {
             let code = source.components(separatedBy: "\n")
                 .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
                 .joined(separator: "\n")
-            // A listen-only tap hands every event straight back, so a session
-            // that is off screen cannot swallow the keystrokes of the account
-            // on it, and the window server does not wait on the port. That is
-            // the whole reason these are excused, and it is re-derived from the
-            // source on every run: flip one to .defaultTap and it joins the
-            // gated set the same second, with nothing to remember.
+            // Releasing the port is asked of every owner, listen-only ones
+            // included: switching a tap off leaves the process holding it, and
+            // that is what the window server waits on. Nothing about handing
+            // events back changes who owns the port.
+            expect(code.contains("CFMachPortInvalidate"),
+                   "\(tapOwner) hands its tap back rather than only disabling it")
+            // The session gate is a different question, and a listen-only tap
+            // is genuinely excused from it: it returns every event unchanged,
+            // so a session that is off screen cannot swallow the keystrokes of
+            // the account on it. Re-derived from the source on every run --
+            // flip one to .defaultTap and it joins the gated set the same
+            // second, with nothing to remember.
             if code.contains(".listenOnly") && !code.contains(".defaultTap") { continue }
             if knownUngatedTaps[tapOwner] != nil { continue }
             expect(code.contains("SessionActivity.shared.onChange"),
@@ -21778,10 +21784,6 @@ struct MetricsTests {
             expect(code.contains("SessionActivitySupport.tapShouldRun(")
                     || code.contains("AXIsProcessTrusted()"),
                    "\(tapOwner) does not keep a modifying tap alive after Accessibility is lost")
-            // Switching a tap off leaves the process owning it, which is what
-            // the window server waits on; teardown must invalidate the port.
-            expect(code.contains("CFMachPortInvalidate"),
-                   "\(tapOwner) hands its tap back rather than only disabling it")
         }
         // A line that outlives its file stops naming a real gap and starts
         // excusing whatever moves in under that path.

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21758,10 +21758,15 @@ struct MetricsTests {
             let code = source.components(separatedBy: "\n")
                 .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
                 .joined(separator: "\n")
-            // Releasing the port is asked of every owner, listen-only ones
-            // included: switching a tap off leaves the process holding it, and
-            // that is what the window server waits on. Nothing about handing
-            // events back changes who owns the port.
+            // The reported gaps below are exempt from every check here,
+            // the port included: each is a named line waiting on its own fix,
+            // and asking a question the entry already answers turns the list
+            // into a wall of red that says nothing new.
+            if knownUngatedTaps[tapOwner] != nil { continue }
+            // Releasing the port is asked of every owner off that list,
+            // listen-only ones included: switching a tap off leaves the
+            // process holding it, and that is what the window server waits
+            // on. Nothing about handing events back changes who owns the port.
             expect(code.contains("CFMachPortInvalidate"),
                    "\(tapOwner) hands its tap back rather than only disabling it")
             // The session gate is a different question, and a listen-only tap
@@ -21771,7 +21776,6 @@ struct MetricsTests {
             // flip one to .defaultTap and it joins the gated set the same
             // second, with nothing to remember.
             if code.contains(".listenOnly") && !code.contains(".defaultTap") { continue }
-            if knownUngatedTaps[tapOwner] != nil { continue }
             expect(code.contains("SessionActivity.shared.onChange"),
                    "\(tapOwner) rebuilds its tap when the session comes back")
             let rearm = code.components(separatedBy: "tapDisabledByTimeout")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21698,34 +21698,96 @@ struct MetricsTests {
             encoding: .utf8)) ?? ""
         expect(mouseAccelerationSource.contains("SessionActivitySupport.isOnConsole("),
                "mouse acceleration shares the safe initial session-state fallback")
-        for tapOwner in ["Sources/Vorssaint/Services/ScrollInverter.swift",
-                         "Sources/Vorssaint/Services/SmoothScrollService.swift",
-                         "Sources/Vorssaint/Services/MouseNavigation/MouseNavigationService.swift",
-                         "Sources/Vorssaint/Services/MouseButtons/MouseButtonShortcutService.swift",
-                         "Sources/Vorssaint/Services/MiddleClick/MiddleClickService.swift",
-                         "Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift"] {
+        // The owners are read out of the tree, not listed here. A roster kept
+        // by hand is itself a membership list nobody maintains: the six names
+        // this loop used to carry were a sixth of the taps in the app, and the
+        // ones missing from it were exactly the ones that never joined the
+        // gate. Enumerating means the next person to call CGEvent.tapCreate
+        // cannot forget to register — there is nothing to register.
+        let tapOwnerFiles: [String] = {
+            guard let walker = FileManager.default.enumerator(atPath: "Sources") else { return [] }
+            var owners: [String] = []
+            for case let entry as String in walker where entry.hasSuffix(".swift") {
+                let path = "Sources/" + entry
+                guard let source = try? String(contentsOfFile: path, encoding: .utf8),
+                      source.contains("CGEvent.tapCreate") else { continue }
+                owners.append(path)
+            }
+            return owners.sorted()
+        }()
+        // An empty sweep would pass every check below in silence.
+        expect(tapOwnerFiles.count >= 20,
+               "the CGEvent.tapCreate sweep reaches the sources from the test's working directory")
+        // These taps were already outside the gate when the sweep replaced the
+        // roster, and none of them is exempt: the list is how they get reported
+        // rather than forgiven, so the enumeration can land without a rewrite
+        // of fourteen services in one change. Each value names the harm that
+        // stands while the line does. Nothing may be added — a tap written from
+        // now on follows the gate — and every fix deletes its line.
+        let knownUngatedTaps: [String: String] = [
+            "Sources/Vorssaint/Services/Audio/PreciseVolumeRollerService.swift":
+                "volume keys stay swallowed for the account switched in",
+            "Sources/Vorssaint/Services/Display/BrightnessService.swift":
+                "brightness keys stay swallowed for the account switched in",
+            "Sources/Vorssaint/Services/DockClick/DockClickService.swift":
+                "Dock clicks stall on the timeout of a switched-away session",
+            "Sources/Vorssaint/Services/Finder/FinderCutPaste.swift":
+                "Command-X in the other account's Finder reaches a dead tap first",
+            "Sources/Vorssaint/Services/Finder/FinderRenameService.swift":
+                "as FinderCutPaste, and its teardown also skips CFMachPortInvalidate",
+            "Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift":
+                "every keystroke of the account switched in pays the tap timeout",
+            "Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift":
+                "the radial trigger holds the mouse chain of a session it cannot serve",
+            "Sources/Vorssaint/Services/ShortcutRecordingTap.swift":
+                "a recorder left open across a switch re-arms into the other account",
+            "Sources/Vorssaint/Services/Snippets/TextSnippetService.swift":
+                "snippet expansion watches the other account's typing",
+            "Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift":
+                "the Super Key holds both a key and a mouse tap across the switch",
+            "Sources/Vorssaint/Services/Switcher/AppSwitcher.swift":
+                "the switcher keeps its Tab tap and never invalidates the port",
+            "Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift":
+                "two window-layout taps stay in the other account's key chain",
+            "Sources/Vorssaint/Services/WindowMaximizer.swift":
+                "the maximizer keeps its tap and never invalidates the port",
+        ]
+        for tapOwner in tapOwnerFiles {
             let source = (try? String(contentsOfFile: tapOwner, encoding: .utf8)) ?? ""
             expect(!source.isEmpty, "\(tapOwner) reads back for its session-switch check")
             let code = source.components(separatedBy: "\n")
                 .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
                 .joined(separator: "\n")
+            // A listen-only tap hands every event straight back, so a session
+            // that is off screen cannot swallow the keystrokes of the account
+            // on it, and the window server does not wait on the port. That is
+            // the whole reason these are excused, and it is re-derived from the
+            // source on every run: flip one to .defaultTap and it joins the
+            // gated set the same second, with nothing to remember.
+            if code.contains(".listenOnly") && !code.contains(".defaultTap") { continue }
+            if knownUngatedTaps[tapOwner] != nil { continue }
             expect(code.contains("SessionActivity.shared.onChange"),
                    "\(tapOwner) rebuilds its tap when the session comes back")
             let rearm = code.components(separatedBy: "tapDisabledByTimeout")
                 .dropFirst().first?.components(separatedBy: "return").first ?? ""
             expect(rearm.contains("SessionActivity.shared.isActive"),
                    "\(tapOwner) does not re-arm a disabled tap into a switched-away session")
-            if tapOwner.contains("MouseNavigation")
-                || tapOwner.contains("MouseButtonShortcut")
-                || tapOwner.contains("MiddleClick")
-                || tapOwner.contains("QuitProtection") {
-                expect(code.contains("AXIsProcessTrusted()"),
-                       "\(tapOwner) does not keep a modifying tap alive after Accessibility is lost")
-            }
+            // Either spelling of the permission half of the gate: the shared
+            // helper takes it as an argument, and the services that predate the
+            // helper ask the API directly.
+            expect(code.contains("SessionActivitySupport.tapShouldRun(")
+                    || code.contains("AXIsProcessTrusted()"),
+                   "\(tapOwner) does not keep a modifying tap alive after Accessibility is lost")
             // Switching a tap off leaves the process owning it, which is what
             // the window server waits on; teardown must invalidate the port.
             expect(code.contains("CFMachPortInvalidate"),
                    "\(tapOwner) hands its tap back rather than only disabling it")
+        }
+        // A line that outlives its file stops naming a real gap and starts
+        // excusing whatever moves in under that path.
+        for ungated in knownUngatedTaps.keys {
+            expect(tapOwnerFiles.contains(ungated),
+                   "the ungated-tap entry for \(ungated) still names a file that creates a tap")
         }
 
         // Disabling a tap and dropping the last Swift reference does not hand

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21758,17 +21758,6 @@ struct MetricsTests {
             let code = source.components(separatedBy: "\n")
                 .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
                 .joined(separator: "\n")
-            // The reported gaps below are exempt from every check here,
-            // the port included: each is a named line waiting on its own fix,
-            // and asking a question the entry already answers turns the list
-            // into a wall of red that says nothing new.
-            if knownUngatedTaps[tapOwner] != nil { continue }
-            // Releasing the port is asked of every owner off that list,
-            // listen-only ones included: switching a tap off leaves the
-            // process holding it, and that is what the window server waits
-            // on. Nothing about handing events back changes who owns the port.
-            expect(code.contains("CFMachPortInvalidate"),
-                   "\(tapOwner) hands its tap back rather than only disabling it")
             // The session gate is a different question, and a listen-only tap
             // is genuinely excused from it: it returns every event unchanged,
             // so a session that is off screen cannot swallow the keystrokes of
@@ -21776,6 +21765,7 @@ struct MetricsTests {
             // flip one to .defaultTap and it joins the gated set the same
             // second, with nothing to remember.
             if code.contains(".listenOnly") && !code.contains(".defaultTap") { continue }
+            if knownUngatedTaps[tapOwner] != nil { continue }
             expect(code.contains("SessionActivity.shared.onChange"),
                    "\(tapOwner) rebuilds its tap when the session comes back")
             let rearm = code.components(separatedBy: "tapDisabledByTimeout")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21734,7 +21734,7 @@ struct MetricsTests {
             "Sources/Vorssaint/Services/Finder/FinderCutPaste.swift":
                 "Command-X in the other account's Finder reaches a dead tap first",
             "Sources/Vorssaint/Services/Finder/FinderRenameService.swift":
-                "as FinderCutPaste, and its teardown also skips CFMachPortInvalidate",
+                "as FinderCutPaste, in the other account's Finder",
             "Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift":
                 "every keystroke of the account switched in pays the tap timeout",
             "Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift":
@@ -21746,11 +21746,11 @@ struct MetricsTests {
             "Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift":
                 "the Super Key holds both a key and a mouse tap across the switch",
             "Sources/Vorssaint/Services/Switcher/AppSwitcher.swift":
-                "the switcher keeps its Tab tap and never invalidates the port",
+                "the switcher keeps its Tab tap across the switch",
             "Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift":
-                "two window-layout taps stay in the other account's key chain",
+                "three window-layout taps stay in the other account's key chain",
             "Sources/Vorssaint/Services/WindowMaximizer.swift":
-                "the maximizer keeps its tap and never invalidates the port",
+                "the maximizer keeps its tap across the switch",
         ]
         for tapOwner in tapOwnerFiles {
             let source = (try? String(contentsOfFile: tapOwner, encoding: .utf8)) ?? ""


### PR DESCRIPTION
# Enumerate event-tap owners instead of listing six by hand

## Summary

The session-switch guard in `Tests/MetricsTests.swift` walked a hardcoded list
of six files. The app has twenty-four files that call `CGEvent.tapCreate`. So
the guard covered a quarter of the taps it was written for, and a service
adding a tap tomorrow inherited nothing — the list was itself a membership
roster nobody had a reason to update, which is the same failure the guard
exists to catch, one level up. The taps that never joined the session gate are
exactly the ones that were missing from the list.

The loop now reads its subjects out of `Sources/`: every `.swift` file
containing `CGEvent.tapCreate` is checked for the four things the guard already
asserted — `SessionActivity.shared.onChange`, `SessionActivity.shared.isActive`
between `tapDisabledByTimeout` and `return`, an Accessibility check, and
`CFMachPortInvalidate` on teardown. Registering is no longer optional because
there is nothing to register.

Two consequences of enumerating:

- Listen-only taps are excused from the session checks, and the excuse is
  re-derived from the source on every run rather than written down: a file whose
  tap is `.listenOnly` and never `.defaultTap` hands every event straight back,
  so an off-screen session cannot swallow the keystrokes of the account on
  screen. Change one to `.defaultTap` and it joins the gated set the same
  second.
- The permission half of the gate is now matched through either public spelling
  — `SessionActivitySupport.tapShouldRun(`, which takes it as an argument, or
  `AXIsProcessTrusted()` for the services that predate the helper. The old rule
  named four specific files because `ScrollInverter` asks through
  `Permissions.shared.accessibility`; that carve-out was a second hand-kept
  roster inside the first.

Thirteen services are outside the gate today. They are listed in
`knownUngatedTaps` with the harm each one does while its line stands, not with
a reason it is allowed — none of them is exempt. The list is how they get
reported rather than forgiven; rewriting fourteen services in the same change
that lands the enumeration is the kind of pull request that never gets read.
Nothing may be added to it, and each fix deletes its line. A separate check
fails if an entry stops naming a file that creates a tap, so a line cannot
outlive its subject and start excusing whatever moves in under that path.

Trade-offs:

- **Text-shape test rather than a unit test.** The tap owners need the event
  chain to run, so the proposition here is an absent one — "no file creates a
  tap outside the gate" — which is not reachable from a callable seam. That is
  what the existing comment on this block already says; enumerating strengthens
  a guard that had already picked the right tool.
- **The known-ungated list is a floor, not a ratchet.** A file on it that starts
  following the gate is not flagged for removal. A strict set-equality check
  would keep the list from rotting, but it would also break every in-flight
  branch that fixes one of these thirteen the moment either side merges. The
  cheap staleness check above covers the case that actually corrupts the guard.
- **The staleness check reads the path, not the prose.** It catches an entry
  whose file stops creating a tap. It cannot catch an entry whose *description*
  goes stale, which is what happened to three of them below. Linting the prose
  would be a second guard over a thirteen-line list; re-reading the list when a
  tap fix merges is cheaper.
- **Public symbols only.** Every needle is an exported symbol
  (`CGEvent.tapCreate`, `SessionActivity.shared.onChange`, `CFMachPortInvalidate`,
  `AXIsProcessTrusted`, `SessionActivitySupport.tapShouldRun`) so a rename inside
  a service cannot turn the guard red without changing behaviour. Comments are
  stripped before matching, so prose naming an API cannot answer for it.
- **No source file is touched.** The thirteen fixes are separate changes.

### Rebased onto #1225

This branch previously carried a `CFMachPortInvalidate` in `MusicLaunchBlocker`,
`AutoQuitService` and `DockPreviewService` — the three listen-only owners the
port check newly reached. #1225 (`f7d70935`) landed that call in all three, so
after the rebase the branch contributes none of them and the diff is one test
file.

Two things changed with it:

- Three `knownUngatedTaps` entries named a missing `CFMachPortInvalidate`
  alongside the session gap — `FinderRenameService`, `AppSwitcher`,
  `WindowMaximizer`. #1225 fixed the port in all three. Each entry is supposed to
  name the harm that stands while the line does, so the port half came off and
  the session gap stayed. The `WindowLayoutService` entry said "two" taps where
  the file has three, which you flagged earlier — corrected in the same commit.
  The remaining nine entries read the same as before: all thirteen still lack
  `SessionActivity.shared.onChange` on today's `main`.
- The per-owner port check is out of this loop (`61f04555`). #1225's own sweep in
  the same test asks every owner for the port, counted per tap rather than per
  file, with no exemption for the reported gaps — a strictly stronger question,
  and green. One caveat stays: this loop walks `Sources`, the port sweep walks
  `Sources/Vorssaint`, and `Package.swift`'s two other targets (`HIDEventSystem`,
  `VMStatisticsCompat`) create no tap today. A tap landing there would get the
  session questions here and never the port question. Same fact, two roots.

### The listen-only excuse, narrowed to the checks it can justify

Handing every event back is a reason to skip the *session* checks: an off-screen
session cannot swallow the keystrokes of the account on it. It is not a reason to
skip the port. Switching a tap off leaves the process owning it, which is what the
window server waits on, and that holds whether the tap modified anything or not.

The port is the sweep's question now, asked of every owner. This loop asks only
the session checks, and the listen-only excuse covers exactly those.

| owner | session checks asked here | port asked by #1225's sweep |
|---|---|---|
| in `knownUngatedTaps` | no | yes |
| listen-only, not on the list | no | yes |
| everything else | yes | yes |

## Verification

macOS 26, Apple silicon, own build from this branch, rebased onto `ea374e1e`.

```
./build.sh --test    TESTS OK (9562 checks) on this branch
                     TESTS OK (9528 checks) on a clean tree at origin/main
                     +45 checks, zero failures on either side
```

Both runs were green. The two input-source-dependent failures this repo sees on
some machines (`nil layout falls back to ANSI semicolon`, `App Switcher icon-row
hints…`) did not fire in either run on this machine.

Falsified the guard rather than only running it: added a throwaway
`Sources/Vorssaint/Services/ZZProbeTapService.swift` containing nothing but a
bare `.defaultTap` `CGEvent.tapCreate` and no teardown. Four assertions failed
against it without anyone registering it anywhere — the three per-owner checks by
that file's name, plus #1225's sweep reporting `1 taps, 0 invalidated` across 25
scanned owners. Deleted, back to `TESTS OK (9562 checks)`.

Re-derived the roster against today's `main` rather than trusting the version
written before #1225, #882 and #1219 merged: 24 tap owners, all under
`Sources/Vorssaint`, so the `>= 20` floor holds with four to spare; all 13
`knownUngatedTaps` paths still create a tap, so the staleness check passes; the
three listen-only exemptions are still exactly `MusicLaunchBlocker`,
`AutoQuitService` and `DockPreviewService`; and the eight owners that are neither
listed nor listen-only all pass every check, including `CleaningModeManager` and
`MouseClickDebounceService`, which the old six-name list never reached.

Still open from earlier review, both carried and neither touched here: the
re-arm slice reads only the first `tapDisabledByTimeout` site (`.dropFirst().first`),
and assertion 2 still greps for the literal `SessionActivity.shared.isActive`
rather than also accepting a lock-sampled `SessionActivitySupport.tapShouldRun`.
Both bite only once a `knownUngatedTaps` line is deleted, so they belong to the
branch that deletes it.

Not tested: nothing here runs a tap. The behaviour these assertions stand in
for — a tap handed back across a fast user switch — needs a second logged-in
account and was not exercised. The full `./build.sh` was not run. No source file
is changed, so there is nothing outside the `--test` compile whitelist to worry
about this time.

## Anything else

`RadialMenuService.swift` and `BrightnessService.swift` each have a branch in
flight adding the gate. Both are listed in `knownUngatedTaps` here; whichever
side merges second should delete the corresponding line. No ordering
dependency — the list is tolerant of a member that already complies.

#1233, #1234, #1235 and #1236 all currently report `mergeable=false` against
`main`, and the conflict is the same six-name list this change deletes. All
eleven files they touch are already named in `knownUngatedTaps`. Either ordering
resolves it — merging this last means taking this branch's side, as laid out
above; merging it first turns each of those four rebases into a deletion of the
matching `knownUngatedTaps` lines. Flagging only because the four are blocked
today and this is what unblocks them.

Refs #1153

