### PR TITLE
fix(brightness): check the display fingerprint on every gamma write and hand the key taps back on a user switch

### DIFF
--- a/Sources/Vorssaint/Services/Display/BrightnessService.swift
+++ b/Sources/Vorssaint/Services/Display/BrightnessService.swift
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Vorssaint
 
 import AppKit
+import ApplicationServices
 import IOKit.graphics
 import ObjectiveC.runtime
 import os
@@ -41,12 +42,13 @@ struct BrightnessDisplay: Identifiable, Equatable {
 /// buttons use, addressed per display through its I2C service.
 ///
 /// While display control is off there are no display observers, services or
-/// I2C traffic. Keyboard light state is read only when Quick toggles opens.
-/// While display control is on, the standing resources are one screen change
-/// observer and a pair of wake observers, and no timers; everything else
-/// happens when a slider moves, a panel opens or the Mac wakes. All I2C work
-/// runs on a serial queue with the pacing displays need, and slider drags
-/// coalesce to the newest value per display.
+/// I2C traffic; the one standing subscription is the session-activity handler
+/// that hands the key taps back on a user switch. Keyboard light state is read
+/// only when Quick toggles opens. While display control is on, the standing
+/// resources add one screen change observer and a pair of wake observers, and
+/// no timers; everything else happens when a slider moves, a panel opens or
+/// the Mac wakes. All I2C work runs on a serial queue with the pacing displays
+/// need, and slider drags coalesce to the newest value per display.
 final class BrightnessService: ObservableObject {
     static let shared = BrightnessService()
 
@@ -95,8 +97,9 @@ final class BrightnessService: ObservableObject {
     /// protocol its own buttons use.
     private static let wakeSettleDelay: TimeInterval = 3
     /// Media-key tap, alive while pointer routing or the optional overlay is
-    /// on and Accessibility is granted. Its mask covers system-defined events
-    /// only, so ordinary typing never touches it.
+    /// on, Accessibility is granted and this login session is the one on
+    /// screen. Its mask covers system-defined events only, so ordinary typing
+    /// never touches it.
     private var keyTap: CFMachPort?
     private var keyTapSource: CFRunLoopSource?
     /// Second tap for keyboards that send brightness as an ordinary key
@@ -116,6 +119,11 @@ final class BrightnessService: ObservableObject {
     /// Whether the app's own overlay stands in for the system's, sampled with
     /// the tap so the tap thread never reads published state.
     private var overlayReplacesNativeOSD = false
+    /// `SessionActivitySupport.tapShouldRun`'s answer for the keystroke tap,
+    /// sampled for the same reason: the timeout re-arm runs on the tap thread,
+    /// and a tap put back into a session that is no longer on screen stalls
+    /// the account that is (issue #1075).
+    private var functionKeyTapShouldRun = false
     /// Codes whose press this app consumed, so the matching release is
     /// consumed as well and the system never sees half a key.
     private var swallowedKeyCodes = Set<Int>()
@@ -217,7 +225,16 @@ final class BrightnessService: ObservableObject {
     /// panel must not put the same slow monitor probe behind itself again.
     private var rebuildingTopology: BrightnessSupport.DisplayTopology?
 
-    private init() {}
+    private init() {
+        // A filter tap owned by a switched-away login session keeps its place
+        // in the chain, so the window server waits out the tap timeout on
+        // every event the account on screen sends (issue #1075). Hand both key
+        // taps back on resign and build them from preferences again on the
+        // way in.
+        SessionActivity.shared.onChange { [weak self] _ in
+            self?.syncKeyTap()
+        }
+    }
 
     func setKeyboardLightEnabled(_ enabled: Bool) {
         guard keyboardLightEnabled != nil, let keyboardLightBridge else { return }
@@ -434,10 +451,7 @@ final class BrightnessService: ObservableObject {
                 }
                 // A software-dimmed screen should return with its clean gamma
                 // before the saved dim level is reapplied by the rebuild.
-                if let baseline = self.gammaBaselines[display.id] {
-                    CGSetDisplayTransferByTable(display.id, baseline.count, baseline.red,
-                                                baseline.green, baseline.blue)
-                }
+                self.writeGammaBaseline(display.id, dimmedBy: nil)
             }
 
             // The gamma curve above is work-queue state; the reconfiguration
@@ -582,13 +596,11 @@ final class BrightnessService: ObservableObject {
         }
     }
 
-    /// Writes every remembered curve back, skipping any display number that
-    /// now belongs to a different monitor. Runs on the work queue.
+    /// Writes every remembered curve back, each one only to the monitor it was
+    /// read from (see `writeGammaBaseline`). Runs on the work queue.
     private func restoreAllGamma() {
-        for (id, baseline) in gammaBaselines
-        where Self.displayFingerprint(id) == baseline.fingerprint {
-            CGSetDisplayTransferByTable(id, baseline.count, baseline.red,
-                                        baseline.green, baseline.blue)
+        for id in gammaBaselines.keys {
+            guard writeGammaBaseline(id, dimmedBy: nil) else { continue }
             Self.log.log("restored gamma baseline for display \(id)")
         }
         gammaBaselines = [:]
@@ -645,9 +657,11 @@ final class BrightnessService: ObservableObject {
         let wantsBrightnessOSD = defaults.bool(
             forKey: DefaultsKey.brightnessOSDEnabled
         ) && brightnessOSDSupported
-        let wanted = running
-            && (wantsKeyRouting || wantsBrightnessOSD)
-            && Permissions.shared.accessibility
+        let wanted = SessionActivitySupport.tapShouldRun(
+            featureWanted: running && (wantsKeyRouting || wantsBrightnessOSD),
+            accessibilityGranted: AXIsProcessTrusted(),
+            sessionIsActive: SessionActivity.shared.isActive)
+        keyThreadLock.withLock { functionKeyTapShouldRun = wanted && wantsKeyRouting }
         if wanted { installKeyTap() } else { removeKeyTap() }
         // The plain key press path only earns its keystroke tap when the
         // pointer actually decides the target.
@@ -803,7 +817,13 @@ final class BrightnessService: ObservableObject {
     /// server and the route from behind the state lock.
     private func routeFunctionKey(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            let tap = keyThreadLock.withLock { shouldStopFunctionKeyThread ? nil : functionKeyTap }
+            // The gate the preference sync applied, asked again: a tap
+            // re-armed into a session that is no longer on screen stalls the
+            // one that is (issue #1075). Its answer was sampled with the tap,
+            // so nothing here reaches for main-thread state.
+            let tap = keyThreadLock.withLock {
+                functionKeyTapShouldRun && !shouldStopFunctionKeyThread ? functionKeyTap : nil
+            }
             if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
             return Unmanaged.passUnretained(event)
         }
@@ -968,7 +988,12 @@ final class BrightnessService: ObservableObject {
     /// Both halves are swallowed so the system never performs the same step.
     private func handleKeyEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let keyTap { CGEvent.tapEnable(tap: keyTap, enable: true) }
+            // Re-arming a tap handed back for a user switch puts the stall
+            // straight back on the account on screen, so the re-arm asks the
+            // same question the preference sync asks (issue #1075).
+            if SessionActivity.shared.isActive, let keyTap {
+                CGEvent.tapEnable(tap: keyTap, enable: true)
+            }
             return Unmanaged.passUnretained(event)
         }
         guard type.rawValue == CleaningSystemKeyEvent.systemDefinedEventTypeRawValue,
@@ -1590,21 +1615,35 @@ final class BrightnessService: ObservableObject {
         Self.log.log("captured gamma baseline for display \(id) [\(fingerprint, privacy: .public)], peak \(red[count - 1])")
     }
 
+    /// The one place a gamma curve is written. The remembered baseline reaches
+    /// the display only while the monitor behind that number is still the one
+    /// it was read from: numbers are handed out again after a reconnection and
+    /// the curves are deliberately kept across the gap, so a write that made
+    /// its own decision about the check would be free to put one monitor's
+    /// curve on another. A nil `factor` puts the untouched curve back. Work
+    /// queue only.
     @discardableResult
-    private func applySoftwareDim(_ id: CGDirectDisplayID, value: Double) -> Bool {
+    private func writeGammaBaseline(_ id: CGDirectDisplayID, dimmedBy factor: CGGammaValue?) -> Bool {
         guard let baseline = gammaBaselines[id],
               baseline.fingerprint == Self.displayFingerprint(id) else { return false }
+        let channel = { (values: [CGGammaValue]) -> [CGGammaValue] in
+            guard let factor else { return values }
+            return BrightnessSupport.scaledGammaTable(values, factor: factor)
+        }
+        return CGSetDisplayTransferByTable(id, baseline.count,
+                                           channel(baseline.red), channel(baseline.green),
+                                           channel(baseline.blue)) == .success
+    }
+
+    @discardableResult
+    private func applySoftwareDim(_ id: CGDirectDisplayID, value: Double) -> Bool {
         if value >= 0.999 {
-            let restored = CGSetDisplayTransferByTable(id, baseline.count, baseline.red,
-                                                       baseline.green, baseline.blue) == .success
+            let restored = writeGammaBaseline(id, dimmedBy: nil)
             if restored { dimmedDisplays.remove(id) }
             return restored
         }
-        let factor = BrightnessSupport.softwareDimFactor(for: value)
-        let red = BrightnessSupport.scaledGammaTable(baseline.red, factor: factor)
-        let green = BrightnessSupport.scaledGammaTable(baseline.green, factor: factor)
-        let blue = BrightnessSupport.scaledGammaTable(baseline.blue, factor: factor)
-        let applied = CGSetDisplayTransferByTable(id, baseline.count, red, green, blue) == .success
+        let applied = writeGammaBaseline(
+            id, dimmedBy: BrightnessSupport.softwareDimFactor(for: value))
         if applied { dimmedDisplays.insert(id) }
         return applied
     }

--- a/Sources/Vorssaint/Services/Display/BrightnessService.swift
+++ b/Sources/Vorssaint/Services/Display/BrightnessService.swift
@@ -119,11 +119,6 @@ final class BrightnessService: ObservableObject {
     /// Whether the app's own overlay stands in for the system's, sampled with
     /// the tap so the tap thread never reads published state.
     private var overlayReplacesNativeOSD = false
-    /// `SessionActivitySupport.tapShouldRun`'s answer for the keystroke tap,
-    /// sampled for the same reason: the timeout re-arm runs on the tap thread,
-    /// and a tap put back into a session that is no longer on screen stalls
-    /// the account that is (issue #1075).
-    private var functionKeyTapShouldRun = false
     /// Codes whose press this app consumed, so the matching release is
     /// consumed as well and the system never sees half a key.
     private var swallowedKeyCodes = Set<Int>()
@@ -661,7 +656,6 @@ final class BrightnessService: ObservableObject {
             featureWanted: running && (wantsKeyRouting || wantsBrightnessOSD),
             accessibilityGranted: AXIsProcessTrusted(),
             sessionIsActive: SessionActivity.shared.isActive)
-        keyThreadLock.withLock { functionKeyTapShouldRun = wanted && wantsKeyRouting }
         if wanted { installKeyTap() } else { removeKeyTap() }
         // The plain key press path only earns its keystroke tap when the
         // pointer actually decides the target.
@@ -817,14 +811,14 @@ final class BrightnessService: ObservableObject {
     /// server and the route from behind the state lock.
     private func routeFunctionKey(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            // The gate the preference sync applied, asked again: a tap
-            // re-armed into a session that is no longer on screen stalls the
-            // one that is (issue #1075). Its answer was sampled with the tap,
-            // so nothing here reaches for main-thread state.
-            let tap = keyThreadLock.withLock {
-                functionKeyTapShouldRun && !shouldStopFunctionKeyThread ? functionKeyTap : nil
+            // Re-arming into a session that is no longer on screen puts the
+            // stall the tap was handed back to avoid straight back on the
+            // account that is (issue #1075), so the re-arm asks the same
+            // question the preference sync asks.
+            let tap = keyThreadLock.withLock { shouldStopFunctionKeyThread ? nil : functionKeyTap }
+            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let tap {
+                CGEvent.tapEnable(tap: tap, enable: true)
             }
-            if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
             return Unmanaged.passUnretained(event)
         }
         guard type == .keyDown || type == .keyUp else {

--- a/Sources/Vorssaint/Services/Display/BrightnessService.swift
+++ b/Sources/Vorssaint/Services/Display/BrightnessService.swift
@@ -754,7 +754,7 @@ final class BrightnessService: ObservableObject {
             keyThreadLock.withLock { functionKeyRunLoop = runLoop }
             let stopBeforeCreating = keyThreadLock.withLock { shouldStopFunctionKeyThread }
             guard !stopBeforeCreating else {
-                if clearFunctionKeyThread() { installFunctionKeyTap() }
+                if clearFunctionKeyThread() { restartFunctionKeyTapOnMain() }
                 return
             }
             let mask = CGEventMask(1 << CGEventType.keyDown.rawValue)
@@ -787,8 +787,25 @@ final class BrightnessService: ObservableObject {
             CGEvent.tapEnable(tap: tap, enable: false)
             CFRunLoopRemoveSource(runLoop, source, .commonModes)
             CFMachPortInvalidate(tap)
-            if clearFunctionKeyThread() { installFunctionKeyTap() }
+            if clearFunctionKeyThread() { restartFunctionKeyTapOnMain() }
         }
+    }
+
+    /// Runs on the tap thread once its run loop has stopped. A restart that
+    /// `installFunctionKeyTap` left pending goes back through `syncKeyTap`
+    /// instead of straight to `installFunctionKeyTap`: the session flag is
+    /// written on the main thread, and a tap rebuilt into a session that is no
+    /// longer on screen stalls the account that is (issue #1153). Same shape as
+    /// `KeyboardDebounceService.restartTapOnMain`.
+    private func restartFunctionKeyTapOnMain() {
+        DispatchQueue.main.async { [weak self] in self?.syncKeyTap() }
+    }
+
+    /// Puts the keystroke tap back after the window server disabled it, unless
+    /// a stop is already on its way and the port is about to go. Main thread.
+    private func rearmDisabledFunctionKeyTap() {
+        let tap = keyThreadLock.withLock { shouldStopFunctionKeyThread ? nil : functionKeyTap }
+        if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
     }
 
     private func clearFunctionKeyThread() -> Bool {
@@ -813,11 +830,19 @@ final class BrightnessService: ObservableObject {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             // Re-arming into a session that is no longer on screen puts the
             // stall the tap was handed back to avoid straight back on the
-            // account that is (issue #1075), so the re-arm asks the same
-            // question the preference sync asks.
-            let tap = keyThreadLock.withLock { shouldStopFunctionKeyThread ? nil : functionKeyTap }
-            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let tap {
-                CGEvent.tapEnable(tap: tap, enable: true)
+            // account that is (issue #1075). The flag that answers that is
+            // written on the main thread while this callback runs on the tap's
+            // own thread, so the question is asked where the answer lives.
+            // Accessibility is asked there for the same reason as in the sync:
+            // this tap modifies events, so a revoked grant has to end it rather
+            // than put it back. A refused re-arm goes to the sync to be
+            // stopped, so the tap is not left disabled with its thread still up.
+            DispatchQueue.main.async { [weak self] in
+                if SessionActivity.shared.isActive, AXIsProcessTrusted() {
+                    self?.rearmDisabledFunctionKeyTap()
+                } else {
+                    self?.syncKeyTap()
+                }
             }
             return Unmanaged.passUnretained(event)
         }
@@ -984,9 +1009,14 @@ final class BrightnessService: ObservableObject {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             // Re-arming a tap handed back for a user switch puts the stall
             // straight back on the account on screen, so the re-arm asks the
-            // same question the preference sync asks (issue #1075).
-            if SessionActivity.shared.isActive, let keyTap {
+            // same question the preference sync asks (issue #1075). This tap
+            // swallows events, so a revoked Accessibility grant ends it too.
+            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let keyTap {
                 CGEvent.tapEnable(tap: keyTap, enable: true)
+            } else {
+                // Invalidating the port from its own callback stack is unsafe;
+                // finish this callback fail-open, then release the tap.
+                DispatchQueue.main.async { [weak self] in self?.syncKeyTap() }
             }
             return Unmanaged.passUnretained(event)
         }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -14142,6 +14142,19 @@ struct MetricsTests {
         expect(!brightnessWorkQueueHalf.isEmpty && !brightnessWorkQueueCode.contains("NSScreen"),
                "the brightness work queue resolves display names without touching NSScreen")
 
+        // A remembered gamma curve belongs to the monitor it was read from,
+        // never to whatever inherits its display number after a reconnection,
+        // and the curves are deliberately kept across that gap. The check
+        // cannot live at each write site: four of them existed and one had
+        // been left without it. Funnelling every write through the one helper
+        // that checks is what the count below holds in place.
+        let brightnessCode = brightnessSource
+            .components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(brightnessCode.components(separatedBy: "CGSetDisplayTransferByTable").count - 1 == 1,
+               "every gamma write goes through the one helper that checks the display fingerprint")
+
         let ddcWrite = BrightnessSupport.writePacket(code: 0x10, value: 0x1234)
         let expectedDDCWrite: [UInt8] = [0x84, 0x03, 0x10, 0x12, 0x34, 0x8E]
         expect(ddcWrite == expectedDDCWrite,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -14154,6 +14154,36 @@ struct MetricsTests {
             .joined(separator: "\n")
         expect(brightnessCode.components(separatedBy: "CGSetDisplayTransferByTable").count - 1 == 1,
                "every gamma write goes through the one helper that checks the display fingerprint")
+        // Both key taps re-arm after a window-server timeout the way the gated
+        // tap owners do. The session flag is written on the main thread, so
+        // the keystroke tap's callback (its own thread) hops there before
+        // asking; a re-arm that is refused hands the tap to syncKeyTap to be
+        // stopped instead of leaving it disabled with the thread still up.
+        let brightnessRearms = brightnessCode.components(separatedBy: "tapDisabledByTimeout")
+            .dropFirst()
+            .map { $0.components(separatedBy: "return Unmanaged").first ?? "" }
+        expect(brightnessRearms.count == 2
+               && brightnessRearms.allSatisfy {
+                   $0.contains("SessionActivity.shared.isActive") && $0.contains("AXIsProcessTrusted()")
+                       && $0.contains("DispatchQueue.main.async") && $0.contains("syncKeyTap()")
+               },
+               "both brightness key taps ask the session and Accessibility on the main thread "
+               + "before re-arming, and hand a refused tap to the sync")
+        let functionKeyRearm = brightnessCode.components(separatedBy: "private func routeFunctionKey(").last?
+            .components(separatedBy: "return Unmanaged").first ?? ""
+        let functionKeyHop = functionKeyRearm.range(of: "DispatchQueue.main.async")
+        let functionKeyAsk = functionKeyRearm.range(of: "SessionActivity.shared.isActive")
+        expect(functionKeyHop != nil && functionKeyAsk != nil
+               && functionKeyHop!.lowerBound < functionKeyAsk!.lowerBound,
+               "the keystroke tap's re-arm asks the session flag on the main thread, not on its own")
+        // A restart pending at the tap thread's tail goes through the same
+        // gate instead of straight back to install.
+        let functionKeyRestart = brightnessCode.components(separatedBy: "private func restartFunctionKeyTapOnMain")
+            .dropFirst().first?.components(separatedBy: "\n    }").first ?? ""
+        expect(!brightnessCode.contains("clearFunctionKeyThread() { installFunctionKeyTap() }")
+               && functionKeyRestart.contains("DispatchQueue.main.async")
+               && functionKeyRestart.contains("syncKeyTap"),
+               "a pending keystroke-tap restart goes back through syncKeyTap on the main thread")
 
         let ddcWrite = BrightnessSupport.writePacket(code: 0x10, value: 0x1234)
         let expectedDDCWrite: [UInt8] = [0x84, 0x03, 0x10, 0x12, 0x34, 0x8E]


### PR DESCRIPTION
## Summary

Two fixes in `BrightnessService`, both cases of a rule the file already had and
one place that did not follow it.

**A gamma curve could be written to the wrong monitor.** `GammaTable` carries a
`fingerprint` for one reason, written at its declaration: display numbers are
handed out again after a reconnection, so the fingerprint is what stops one
monitor's curve from being written to another. The remembered curves are
deliberately kept across a disconnection — a hub renegotiating or a cable
settling must not force a fresh reading from a screen that is still dimmed — so
"this number now belongs to a different monitor" is a state the code expects to
be in. Four places wrote a curve; three checked the fingerprint first and the
fourth, the restore that runs just before a display is switched off, took the
table by display number and wrote it.

Rather than add the missing check, the write itself now owns it. There is one
private `writeGammaBaseline(_:dimmedBy:)`, it looks the baseline up and compares
the fingerprint before it writes, and it is the only place in the file that
calls `CGSetDisplayTransferByTable`. The three callers no longer hold a raw
table to write, so the check is not something a call site can forget: restoring
and dimming are the same write with and without a scale factor. A test pins the
call count at one, so a future write that goes around the helper fails rather
than silently reintroducing the case.

Considered and not taken: adding the fingerprint comparison at the fourth site.
It fixes the reported instance and leaves the next writer free to repeat it —
which is what had already happened three writes in. Also considered: dropping
the curve for a display number whose monitor changed. That is the behaviour the
"kept across the gap" comment exists to prevent.

`dimmedDisplays` is deliberately left holding the display through that restore.
The rebuild reads it as `appliedByApp` to decide whether the saved dim comes
back when the display returns, which is what the surrounding comment asks for.

**Both brightness key taps stayed armed through a fast user switch.** `#1153`
names this service twice. The session-defined tap and the keystroke tap were
built from `running && preferences && Accessibility`, with no session term, and
`BrightnessService` never subscribed to `SessionActivity`, so a switch left both
taps in the event chain. The window server then routes the front account's
events through a process that cannot answer and waits out the tap timeout on
each one. The keystroke tap is the worse of the two: its mask is `keyDown |
keyUp`, so every keystroke in the session goes through it.

The wiring now follows `MouseNavigationService`: subscribe in `init`, route the
install decision through `SessionActivitySupport.tapShouldRun`, ask again before
a timeout re-arm, and invalidate the mach port on teardown rather than only
disabling it — a disabled tap the process still owns is still a tap the window
server owns a reference to.

The keystroke tap runs its callback on a thread of its own rather than on the
main run loop — that is why it exists separately, since waiting on the main run
loop is what made typing stutter once already. An earlier revision read
`SessionActivity.shared.isActive` on that thread, the way
`MouseClickDebounceService` did at the time. The session-tap branches that
landed since (#1234, #1235, #1236) settled three rules for a re-arm, and this
branch now follows them:

- The re-arm decision is made on the thread that writes the answer. The
  session flag is written on the main thread, so `routeFunctionKey` hops there
  with `DispatchQueue.main.async` and asks `SessionActivity.shared.isActive`
  and `AXIsProcessTrusted()` from that block; `handleKeyEvent` already runs on
  the main run loop and asks in place. Both are modifying taps, so both ask
  Accessibility, not only the session.
- A refused re-arm goes to `syncKeyTap` instead of leaving the tap disabled
  with its thread still up. The sync then stops it for good, or rebuilds it,
  from the same gate the preference sync uses. `handleKeyEvent` defers that
  hop, since invalidating a port from its own callback stack is unsafe.
- A restart pending at the tap thread's tail goes through that gate too.
  The two `if clearFunctionKeyThread() { installFunctionKeyTap() }` tails
  became `restartFunctionKeyTapOnMain()`, the shape of
  `KeyboardDebounceService.restartTapOnMain`: hop to the main thread, call
  `syncKeyTap`.

`Permissions.shared.accessibility` (a cached published value) became
`AXIsProcessTrusted()` in that decision, matching the four other services whose
taps modify events.

### Dropped from this branch: a sampled `functionKeyTapShouldRun`

An earlier revision kept the gate's answer in a `functionKeyTapShouldRun` field
and re-armed on `functionKeyTapShouldRun && !shouldStopFunctionKeyThread`.
`syncKeyTap` set it to `wanted && wantsKeyRouting`, which is the same expression,
three lines down, that chooses between `installFunctionKeyTap()` — which sets
`shouldStopFunctionKeyThread = false` — and `removeFunctionKeyTap()`. On every
path `syncKeyTap` drives, the conjunction said exactly what
`!shouldStopFunctionKeyThread` already said, and it added a way to go stale: the
two re-installs inside `runFunctionKeyTap`'s
`if clearFunctionKeyThread() { installFunctionKeyTap() }` never set it.

## Verification

MacBook, macOS 26, `MacOSX26.sdk`.

Rebased on `main`. Full `./build.sh`: exit 0, no warnings.
`./build.sh --test` → `TESTS OK (9602 checks)`, no failures.

The gamma guardrail was checked by breaking what it guards: reintroducing the
raw unchecked `CGSetDisplayTransferByTable` at the toggle site turns it red,
and it goes green again on restore. The three re-arm assertions (both taps ask
session and Accessibility on the main thread and hand a refusal to the sync;
the keystroke tap's hop precedes its read; no thread tail goes around the
gate) were written before the code and ran red first
(`TESTS FAILED (3 of 9602)`).

**Not tested.** There is one login session on this machine, so the fast user
switching behaviour is reasoned from the shared mechanism `#1153` describes, not
measured — same caveat the issue carries. No second monitor here either, so the
gamma path was not exercised against real hardware: a software-dimmed display,
switched off and back on with a different monitor taking its display number, is
the case the fix is about and it has not been reproduced.

## Anything else

Refs #1153


#301 reports an external display blacking out, sometimes while the brightness slider is
moving, recoverable only by unplugging the hub. The gamma half of this branch is one way
that can happen: a display number handed out again after a reconnection let the
pre-switch-off restore write a dimmed baseline to whichever monitor now holds the number.
#836 attributes #301 to DDC renegotiation, which this branch does not touch, so this is
an additional candidate path and not the fix that issue is waiting for.

Refs #301

