### PR TITLE
fix(build): only count signing identities that can actually sign

### DIFF
--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21280,10 +21280,12 @@ struct MetricsTests {
         // before signing. The needle is the invocation at the start of a
         // command line: the ad-hoc fallback's advice string also names the
         // script, and must not satisfy this check.
-        let runsSigningSetup = buildScript.components(separatedBy: "\n").contains {
+        let invokesSigningSetup: (String) -> Bool = {
             $0.range(of: #"^\s*(if\s+!?\s*)?\./Tools/setup-signing\.sh"#,
                      options: .regularExpression) != nil
         }
+        let runsSigningSetup = buildScript.components(separatedBy: "\n")
+            .contains(where: invokesSigningSetup)
         expect(runsSigningSetup,
                "an identity-less Developer build invokes Tools/setup-signing.sh itself")
 
@@ -21329,32 +21331,59 @@ struct MetricsTests {
         // time where it creates it, so a file-wide search answers yes with the
         // probe's own unlock deleted — and then the first signing build after
         // a reboot is back on the SecurityAgent dialog this branch removes.
-        for (script, lines, probeName) in
-            [("build.sh", buildScriptLines, "legacy_identity_installed"),
-             ("Tools/setup-signing.sh", signingSetupLines, "identity_can_sign")] {
+        for (script, lines, probeName, verdict) in
+            [("build.sh", buildScriptLines, "legacy_identity_installed",
+              "LEGACY_IDENTITY_USABLE=yes"),
+             ("Tools/setup-signing.sh", signingSetupLines, "identity_can_sign", "signed=0")] {
+            // Once, not at least once: a second definition later in the file is
+            // the one the shell runs, and everything below here reads the first.
+            let definitions = lines.filter {
+                $0.trimmingCharacters(in: .whitespaces).hasPrefix("\(probeName)() {")
+            }
+            expect(definitions.count == 1,
+                   "\(script) defines \(probeName)() exactly once, found \(definitions.count)")
             let probe = probeBody(lines, probeName)
             expect(!probe.isEmpty, "\(script) still defines \(probeName)()")
             let probeCode = probe.joined(separator: "\n")
+            let namedQueries = lines
+                .filter { $0.contains("find-identity") }
+                .filter { $0.contains("$LEGACY_IDENTITY") || $0.contains("$IDENTITY") }
             let identityQueries = probe
                 .filter { $0.contains("find-identity") }
                 .filter { $0.contains("$LEGACY_IDENTITY") || $0.contains("$IDENTITY") }
             expect(!identityQueries.isEmpty,
                    "\(script)'s \(probeName) still looks the stable identity up by name")
+            // Presence is not the whole guarantee. The defect this branch fixes
+            // was call sites deciding off the raw listing, copy-pasted five
+            // times; a sixth added beside the probe leaves the probe intact and
+            // brings the bug straight back. The listing may be asked for this
+            // identity only where the answer is then handed to codesign.
+            expect(namedQueries.count == identityQueries.count,
+                   "\(script) asks find-identity for the stable identity only inside "
+                    + "\(probeName), found \(namedQueries.count - identityQueries.count) "
+                    + "such lookup(s) outside it")
             // This one stays file-wide on purpose: it forbids a spelling
             // rather than requiring a line, and -v against this identity is
             // wrong wherever it is written.
-            let trustQueries = lines
-                .filter { $0.contains("find-identity") }
-                .filter { $0.contains("$LEGACY_IDENTITY") || $0.contains("$IDENTITY") }
-                .filter { $0.contains("-v") }
+            let trustQueries = namedQueries.filter { $0.contains("-v") }
             expect(trustQueries.isEmpty,
                    "\(script) looks the self-signed identity up without asking find-identity "
                     + "for valid identities only, found \(trustQueries.count) that do")
             expect(probeCode.contains("unlock-keychain -p"),
                    "\(script)'s \(probeName) unlocks the dedicated signing keychain itself")
-            expect(probeCode.contains("codesign --force --sign"),
-                   "\(script)'s \(probeName) asks codesign whether the identity can sign "
-                    + "before relying on it")
+            // Requiring the codesign call is not enough by itself: a line
+            // setting the verdict unconditionally leaves the call in place and
+            // answers yes without it. Exactly one call, exactly one verdict,
+            // and the verdict no earlier than the call it is meant to read.
+            let signingProbes = probe.indices.filter {
+                probe[$0].contains("codesign --force --sign")
+            }
+            let verdicts = probe.indices.filter { probe[$0].contains(verdict) }
+            expect(signingProbes.count == 1 && verdicts.count == 1
+                    && verdicts[0] >= signingProbes[0],
+                   "\(script)'s \(probeName) reaches `\(verdict)` only through asking codesign "
+                    + "whether the identity can sign, found \(signingProbes.count) call(s) and "
+                    + "\(verdicts.count) verdict line(s)")
             // zsh keeps `status` as a second name for $?, and it is read-only:
             // `local status=1` aborts the script on the first call to the
             // function that declares it, so the probe never runs at all.
@@ -21375,37 +21404,47 @@ struct MetricsTests {
         // then goes true and the unlock is skipped without a word, leaving
         // codesign to meet a locked keychain and raise the SecurityAgent
         // dialog. Pin both values against each other, not just the call.
-        let shellLiteral: (String, [String]) -> String? = { name, lines in
+        // Every assignment, not the first: reading one and comparing it would
+        // pass a second assignment added below it, and the shell obeys the last
+        // one to run. So the value has to be written exactly once per script.
+        let shellLiterals: (String, [String]) -> [String] = { name, lines in
             lines.compactMap { line -> String? in
                 let trimmed = line.trimmingCharacters(in: .whitespaces)
                 guard trimmed.hasPrefix("\(name)=\"") else { return nil }
                 return String(trimmed.dropFirst(name.count + 2).prefix { $0 != "\"" })
-            }.first
+            }
         }
         for (what, inBuildScript, inSetupScript) in
             [("password", "LEGACY_KEYCHAIN_PASSWORD", "KCPASS"),
              ("path", "LEGACY_KEYCHAIN", "KC")] {
-            let fromBuild = shellLiteral(inBuildScript, buildScriptLines)
-            let fromSetup = shellLiteral(inSetupScript, signingSetupLines)
-            expect(fromBuild?.isEmpty == false && fromBuild == fromSetup,
+            let fromBuild = shellLiterals(inBuildScript, buildScriptLines)
+            let fromSetup = shellLiterals(inSetupScript, signingSetupLines)
+            expect(fromBuild.count == 1 && fromBuild.first?.isEmpty == false
+                    && fromBuild == fromSetup,
                    "build.sh's \(inBuildScript) and Tools/setup-signing.sh's \(inSetupScript) "
-                    + "are the same signing keychain \(what), found \(fromBuild ?? "none") "
-                    + "and \(fromSetup ?? "none")")
+                    + "are each assigned once and name the same signing keychain \(what), "
+                    + "found \(fromBuild) and \(fromSetup)")
         }
 
         // The signing probe is asked once and cached. Running the repair is the
         // only thing that changes its answer, so the cache has to be dropped
         // there: otherwise --dev creates a working identity and then signs the
         // build ad-hoc off the "no" recorded a moment earlier.
-        if let repair = buildScriptLines.firstIndex(where: { $0.contains("Tools/setup-signing.sh") }) {
+        // Every invocation, located the same way runsSigningSetup locates one:
+        // a bare substring also matches the ad-hoc fallback's advice string,
+        // which names the script and repairs nothing. And a second repair site
+        // added later is the same bug again, so each one carries its own reset.
+        let repairs = buildScriptLines.indices.filter { invokesSigningSetup(buildScriptLines[$0]) }
+        expect(!repairs.isEmpty,
+               "build.sh still runs Tools/setup-signing.sh when no identity is usable")
+        for repair in repairs {
             let afterRepair = Array(buildScriptLines[(repair + 1)...])
             let nextRead = afterRepair.firstIndex { $0.contains("legacy_identity_installed") }
                 ?? afterRepair.count
             expect(afterRepair[..<nextRead].contains { $0.contains("LEGACY_IDENTITY_USABLE=\"\"") },
-                   "build.sh clears the cached identity verdict after running the repair, "
+                   "build.sh clears the cached identity verdict after running the repair at "
+                    + "`\(buildScriptLines[repair].trimmingCharacters(in: .whitespaces))`, "
                     + "before anything reads it again")
-        } else {
-            expect(false, "build.sh still runs Tools/setup-signing.sh when no identity is usable")
         }
 
         // The setup script must run against the stock /usr/bin/openssl, which

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21280,12 +21280,10 @@ struct MetricsTests {
         // before signing. The needle is the invocation at the start of a
         // command line: the ad-hoc fallback's advice string also names the
         // script, and must not satisfy this check.
-        let invokesSigningSetup: (String) -> Bool = {
+        let runsSigningSetup = buildScript.components(separatedBy: "\n").contains {
             $0.range(of: #"^\s*(if\s+!?\s*)?\./Tools/setup-signing\.sh"#,
                      options: .regularExpression) != nil
         }
-        let runsSigningSetup = buildScript.components(separatedBy: "\n")
-            .contains(where: invokesSigningSetup)
         expect(runsSigningSetup,
                "an identity-less Developer build invokes Tools/setup-signing.sh itself")
 
@@ -21315,75 +21313,29 @@ struct MetricsTests {
         // setup-signing.sh knows.
         let buildScriptLines = buildScript.components(separatedBy: "\n")
             .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#") }
-        // The lines of a top-level shell function, closing brace at column 0.
-        let probeBody: ([String], String) -> [String] = { lines, name in
-            guard let start = lines.firstIndex(where: {
-                $0.trimmingCharacters(in: .whitespaces).hasPrefix("\(name)() {")
-            }) else { return [] }
-            let rest = lines[(start + 1)...]
-            guard let end = rest.firstIndex(of: "}") else { return [] }
-            return Array(rest[..<end])
-        }
-        // Asserted per script, not over the pair: a union is satisfied by one
-        // surviving line in either file, so deleting the lookup out of
-        // setup-signing.sh would pass on build.sh's. And per probe, not over
-        // the whole script: setup-signing.sh unlocks the keychain a second
-        // time where it creates it, so a file-wide search answers yes with the
-        // probe's own unlock deleted — and then the first signing build after
-        // a reboot is back on the SecurityAgent dialog this branch removes.
-        for (script, lines, probeName, verdict) in
-            [("build.sh", buildScriptLines, "legacy_identity_installed",
-              "LEGACY_IDENTITY_USABLE=yes"),
-             ("Tools/setup-signing.sh", signingSetupLines, "identity_can_sign", "signed=0")] {
-            // Once, not at least once: a second definition later in the file is
-            // the one the shell runs, and everything below here reads the first.
-            let definitions = lines.filter {
-                $0.trimmingCharacters(in: .whitespaces).hasPrefix("\(probeName)() {")
-            }
-            expect(definitions.count == 1,
-                   "\(script) defines \(probeName)() exactly once, found \(definitions.count)")
-            let probe = probeBody(lines, probeName)
-            expect(!probe.isEmpty, "\(script) still defines \(probeName)()")
-            let probeCode = probe.joined(separator: "\n")
-            let namedQueries = lines
-                .filter { $0.contains("find-identity") }
-                .filter { $0.contains("$LEGACY_IDENTITY") || $0.contains("$IDENTITY") }
-            let identityQueries = probe
-                .filter { $0.contains("find-identity") }
-                .filter { $0.contains("$LEGACY_IDENTITY") || $0.contains("$IDENTITY") }
-            expect(!identityQueries.isEmpty,
-                   "\(script)'s \(probeName) still looks the stable identity up by name")
-            // Presence is not the whole guarantee. The defect this branch fixes
-            // was call sites deciding off the raw listing, copy-pasted five
-            // times; a sixth added beside the probe leaves the probe intact and
-            // brings the bug straight back. The listing may be asked for this
-            // identity only where the answer is then handed to codesign.
-            expect(namedQueries.count == identityQueries.count,
-                   "\(script) asks find-identity for the stable identity only inside "
-                    + "\(probeName), found \(namedQueries.count - identityQueries.count) "
-                    + "such lookup(s) outside it")
-            // This one stays file-wide on purpose: it forbids a spelling
-            // rather than requiring a line, and -v against this identity is
-            // wrong wherever it is written.
-            let trustQueries = namedQueries.filter { $0.contains("-v") }
-            expect(trustQueries.isEmpty,
-                   "\(script) looks the self-signed identity up without asking find-identity "
-                    + "for valid identities only, found \(trustQueries.count) that do")
-            expect(probeCode.contains("unlock-keychain -p"),
-                   "\(script)'s \(probeName) unlocks the dedicated signing keychain itself")
-            // Requiring the codesign call is not enough by itself: a line
-            // setting the verdict unconditionally leaves the call in place and
-            // answers yes without it. Exactly one call, exactly one verdict,
-            // and the verdict no earlier than the call it is meant to read.
-            let signingProbes = probe.indices.filter {
-                probe[$0].contains("codesign --force --sign")
-            }
-            let verdicts = probe.indices.filter { probe[$0].contains(verdict) }
-            expect(signingProbes.count == 1 && verdicts.count == 1
-                    && verdicts[0] >= signingProbes[0],
-                   "\(script)'s \(probeName) reaches `\(verdict)` only through asking codesign "
-                    + "whether the identity can sign, found \(signingProbes.count) call(s) and "
-                    + "\(verdicts.count) verdict line(s)")
+        // The set the -v ban reads, and the reason it cannot pass vacuously.
+        // It is a union across the two scripts on purpose: this is the input
+        // for a negative, not a claim that each script still asks.
+        let identityQueries = (buildScriptLines + signingSetupLines)
+            .filter { $0.contains("find-identity") }
+            .filter { $0.contains("$LEGACY_IDENTITY") || $0.contains("$IDENTITY") }
+        expect(!identityQueries.isEmpty,
+               "the stable identity is still looked up by name in these two scripts")
+        let trustQueries = identityQueries.filter { $0.contains("-v") }
+        expect(trustQueries.isEmpty,
+               "no lookup of the self-signed identity asks find-identity for valid "
+                + "identities only, found \(trustQueries.count) that do")
+        // build.sh's only unlock is the probe's own, so deleting it fails here.
+        // Tools/setup-signing.sh unlocks a second time where it creates the
+        // keychain, which answers a file-wide read on its own — so the probe's
+        // unlock is left unasserted there rather than asserted vacuously.
+        expect(buildScriptLines.joined(separator: "\n").contains("unlock-keychain -p"),
+               "build.sh unlocks the dedicated signing keychain itself")
+        for (script, lines) in [("build.sh", buildScriptLines),
+                                ("Tools/setup-signing.sh", signingSetupLines)] {
+            let code = lines.joined(separator: "\n")
+            expect(code.contains("codesign --force --sign"),
+                   "\(script) asks codesign whether the identity can sign before relying on it")
             // zsh keeps `status` as a second name for $?, and it is read-only:
             // `local status=1` aborts the script on the first call to the
             // function that declares it, so the probe never runs at all.
@@ -21398,53 +21350,19 @@ struct MetricsTests {
                     + "the script, found \(readOnlyLocals.count)")
         }
 
-        // Each unlock names the keychain and its password with a literal of
-        // its own. Password drift fails the unlock and the build signs ad-hoc
-        // in silence; path drift is worse, because `[[ ! -f "$LEGACY_KEYCHAIN" ]]`
-        // then goes true and the unlock is skipped without a word, leaving
-        // codesign to meet a locked keychain and raise the SecurityAgent
-        // dialog. Pin both values against each other, not just the call.
-        // Every assignment, not the first: reading one and comparing it would
-        // pass a second assignment added below it, and the shell obeys the last
-        // one to run. So the value has to be written exactly once per script.
-        let shellLiterals: (String, [String]) -> [String] = { name, lines in
-            lines.compactMap { line -> String? in
-                let trimmed = line.trimmingCharacters(in: .whitespaces)
-                guard trimmed.hasPrefix("\(name)=\"") else { return nil }
-                return String(trimmed.dropFirst(name.count + 2).prefix { $0 != "\"" })
-            }
-        }
-        for (what, inBuildScript, inSetupScript) in
-            [("password", "LEGACY_KEYCHAIN_PASSWORD", "KCPASS"),
-             ("path", "LEGACY_KEYCHAIN", "KC")] {
-            let fromBuild = shellLiterals(inBuildScript, buildScriptLines)
-            let fromSetup = shellLiterals(inSetupScript, signingSetupLines)
-            expect(fromBuild.count == 1 && fromBuild.first?.isEmpty == false
-                    && fromBuild == fromSetup,
-                   "build.sh's \(inBuildScript) and Tools/setup-signing.sh's \(inSetupScript) "
-                    + "are each assigned once and name the same signing keychain \(what), "
-                    + "found \(fromBuild) and \(fromSetup)")
-        }
-
         // The signing probe is asked once and cached. Running the repair is the
         // only thing that changes its answer, so the cache has to be dropped
         // there: otherwise --dev creates a working identity and then signs the
         // build ad-hoc off the "no" recorded a moment earlier.
-        // Every invocation, located the same way runsSigningSetup locates one:
-        // a bare substring also matches the ad-hoc fallback's advice string,
-        // which names the script and repairs nothing. And a second repair site
-        // added later is the same bug again, so each one carries its own reset.
-        let repairs = buildScriptLines.indices.filter { invokesSigningSetup(buildScriptLines[$0]) }
-        expect(!repairs.isEmpty,
-               "build.sh still runs Tools/setup-signing.sh when no identity is usable")
-        for repair in repairs {
+        if let repair = buildScriptLines.firstIndex(where: { $0.contains("Tools/setup-signing.sh") }) {
             let afterRepair = Array(buildScriptLines[(repair + 1)...])
             let nextRead = afterRepair.firstIndex { $0.contains("legacy_identity_installed") }
                 ?? afterRepair.count
             expect(afterRepair[..<nextRead].contains { $0.contains("LEGACY_IDENTITY_USABLE=\"\"") },
-                   "build.sh clears the cached identity verdict after running the repair at "
-                    + "`\(buildScriptLines[repair].trimmingCharacters(in: .whitespaces))`, "
+                   "build.sh clears the cached identity verdict after running the repair, "
                     + "before anything reads it again")
+        } else {
+            expect(false, "build.sh still runs Tools/setup-signing.sh when no identity is usable")
         }
 
         // The setup script must run against the stock /usr/bin/openssl, which

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21294,30 +21294,39 @@ struct MetricsTests {
             .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#") }
         let signingSetupCode = signingSetupLines.joined(separator: "\n")
 
-        // MARK: Signing identity checks only ever count identities that can sign
-        // `security find-identity` without -v lists certificates that cannot
-        // sign, an expired self-signed one included. Matching one of those made
-        // build.sh prefer an unusable identity over the ad-hoc fallback, and
-        // codesign then failed the whole build with errSecInternalComponent --
-        // on a machine whose only fault was a stale certificate left in the
-        // keychain. setup-signing.sh asks the same question twice and both
-        // answers matter: the front-door check decides whether the repair runs
-        // at all, and the post-import read-back decides whether the new
-        // identity counts as installed. Either one reading a dead certificate
-        // as usable puts the build back on the failing path. The flag is the
-        // contract here, so it is what is pinned, in both scripts.
-        let buildScriptQueries = buildScript.components(separatedBy: "\n")
+        // MARK: The stable identity is judged by whether codesign can sign with it
+        // Neither spelling of `find-identity` answers that. Without -v the
+        // listing includes certificates that cannot sign, an expired one
+        // included, which failed a build with errSecInternalComponent after a
+        // clean compile. With -v it answers whether the certificate is trusted,
+        // and a self-signed one never is: on a machine where codesign signs
+        // with that identity happily, -v reports zero valid identities. Pinning
+        // that flag would send every build to the ad-hoc fallback this identity
+        // exists to prevent -- releases included, since CI imports the same
+        // self-signed certificate -- and would have setup-signing.sh delete and
+        // recreate a working identity on every run. So both scripts ask
+        // codesign, and unlock the dedicated keychain before they do: it is not
+        // the login keychain, so it is locked again after every login, and a
+        // locked one turns the probe, and then the build, into a GUI prompt for
+        // a password only setup-signing.sh knows.
+        let buildScriptLines = buildScript.components(separatedBy: "\n")
             .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#") }
+        let identityQueries = (buildScriptLines + signingSetupLines)
             .filter { $0.contains("find-identity") }
-        let setupScriptQueries = signingSetupLines.filter { $0.contains("find-identity") }
-        expect(!buildScriptQueries.isEmpty, "build.sh still asks for a signing identity")
-        expect(!setupScriptQueries.isEmpty,
-               "setup-signing.sh still asks for a signing identity")
-        let identityQueries = buildScriptQueries + setupScriptQueries
-        let unvalidatedQueries = identityQueries.filter { !$0.contains("-v") }
-        expect(unvalidatedQueries.isEmpty,
-               "every find-identity in build.sh and Tools/setup-signing.sh asks for "
-                + "valid identities only, found \(unvalidatedQueries.count) without -v")
+            .filter { $0.contains("$LEGACY_IDENTITY") || $0.contains("$IDENTITY") }
+        expect(!identityQueries.isEmpty,
+               "both scripts still look the stable identity up by name")
+        let trustQueries = identityQueries.filter { $0.contains("-v") }
+        expect(trustQueries.isEmpty,
+               "no lookup of the self-signed identity asks find-identity for valid "
+                + "identities only, found \(trustQueries.count) that do")
+        for (script, code) in [("build.sh", buildScriptLines.joined(separator: "\n")),
+                               ("Tools/setup-signing.sh", signingSetupCode)] {
+            expect(code.contains("unlock-keychain -p"),
+                   "\(script) unlocks the dedicated signing keychain itself")
+            expect(code.contains("codesign --force --sign"),
+                   "\(script) asks codesign whether the identity can sign before relying on it")
+        }
 
         // The setup script must run against the stock /usr/bin/openssl, which
         // is LibreSSL: it rejects OpenSSL 3's -legacy flag outright, and the

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21301,27 +21301,33 @@ struct MetricsTests {
         // clean compile. With -v it answers whether the certificate is trusted,
         // and a self-signed one never is: on a machine where codesign signs
         // with that identity happily, -v reports zero valid identities. Pinning
-        // that flag would send every build to the ad-hoc fallback this identity
-        // exists to prevent -- releases included, since CI imports the same
-        // self-signed certificate -- and would have setup-signing.sh delete and
-        // recreate a working identity on every run. So both scripts ask
-        // codesign, and unlock the dedicated keychain before they do: it is not
-        // the login keychain, so it is locked again after every login, and a
-        // locked one turns the probe, and then the build, into a GUI prompt for
-        // a password only setup-signing.sh knows.
+        // that flag would send every local build to the ad-hoc fallback this
+        // identity exists to prevent, and would have setup-signing.sh delete
+        // and recreate a working identity on every run. Releases are not
+        // affected: ci-setup-signing.sh imports a Developer ID certificate from
+        // a repository secret, and release.yml re-verifies the signature
+        // against that team's OU. So both scripts ask codesign, and unlock the
+        // dedicated keychain before they do: it is not the login keychain, so
+        // it is locked again after every login, and a locked one turns the
+        // probe, and then the build, into a GUI prompt for a password only
+        // setup-signing.sh knows.
         let buildScriptLines = buildScript.components(separatedBy: "\n")
             .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#") }
-        let identityQueries = (buildScriptLines + signingSetupLines)
-            .filter { $0.contains("find-identity") }
-            .filter { $0.contains("$LEGACY_IDENTITY") || $0.contains("$IDENTITY") }
-        expect(!identityQueries.isEmpty,
-               "both scripts still look the stable identity up by name")
-        let trustQueries = identityQueries.filter { $0.contains("-v") }
-        expect(trustQueries.isEmpty,
-               "no lookup of the self-signed identity asks find-identity for valid "
-                + "identities only, found \(trustQueries.count) that do")
-        for (script, code) in [("build.sh", buildScriptLines.joined(separator: "\n")),
-                               ("Tools/setup-signing.sh", signingSetupCode)] {
+        // Asserted per script, not over the pair: a union is satisfied by one
+        // surviving line in either file, so deleting the lookup out of
+        // setup-signing.sh would pass on build.sh's.
+        for (script, lines) in [("build.sh", buildScriptLines),
+                                ("Tools/setup-signing.sh", signingSetupLines)] {
+            let code = lines.joined(separator: "\n")
+            let identityQueries = lines
+                .filter { $0.contains("find-identity") }
+                .filter { $0.contains("$LEGACY_IDENTITY") || $0.contains("$IDENTITY") }
+            expect(!identityQueries.isEmpty,
+                   "\(script) still looks the stable identity up by name")
+            let trustQueries = identityQueries.filter { $0.contains("-v") }
+            expect(trustQueries.isEmpty,
+                   "\(script) looks the self-signed identity up without asking find-identity "
+                    + "for valid identities only, found \(trustQueries.count) that do")
             expect(code.contains("unlock-keychain -p"),
                    "\(script) unlocks the dedicated signing keychain itself")
             expect(code.contains("codesign --force --sign"),
@@ -21329,7 +21335,7 @@ struct MetricsTests {
             // zsh keeps `status` as a second name for $?, and it is read-only:
             // `local status=1` aborts the script on the first call to the
             // function that declares it, so the probe never runs at all.
-            let readOnlyLocals = (script == "build.sh" ? buildScriptLines : signingSetupLines)
+            let readOnlyLocals = lines
                 .filter { line in
                     line.contains("local ")
                         && line.split(whereSeparator: { $0 == " " || $0 == "\t" })
@@ -21339,6 +21345,26 @@ struct MetricsTests {
                    "\(script) declares zsh's read-only `status` as a local, which aborts "
                     + "the script, found \(readOnlyLocals.count)")
         }
+
+        // Both unlocks pass a password literal of their own. If they drift the
+        // probe either fails its unlock and the build signs ad-hoc in silence,
+        // or reaches codesign against a locked keychain and raises the
+        // SecurityAgent dialog these unlocks exist to avoid. Pin the values
+        // against each other, not just the presence of the call.
+        let keychainPassword: (String, [String]) -> String? = { name, lines in
+            lines.compactMap { line -> String? in
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                guard trimmed.hasPrefix("\(name)=\"") else { return nil }
+                return String(trimmed.dropFirst(name.count + 2).prefix { $0 != "\"" })
+            }.first
+        }
+        let buildKeychainPassword = keychainPassword("LEGACY_KEYCHAIN_PASSWORD", buildScriptLines)
+        let setupKeychainPassword = keychainPassword("KCPASS", signingSetupLines)
+        expect(buildKeychainPassword?.isEmpty == false
+                && buildKeychainPassword == setupKeychainPassword,
+               "build.sh and Tools/setup-signing.sh unlock the signing keychain with the same "
+                + "password, found \(buildKeychainPassword ?? "none") "
+                + "and \(setupKeychainPassword ?? "none")")
 
         // The signing probe is asked once and cached. Running the repair is the
         // only thing that changes its answer, so the cache has to be dropped

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21333,9 +21333,23 @@ struct MetricsTests {
                "build.sh unlocks the dedicated signing keychain itself")
         for (script, lines) in [("build.sh", buildScriptLines),
                                 ("Tools/setup-signing.sh", signingSetupLines)] {
-            let code = lines.joined(separator: "\n")
-            expect(code.contains("codesign --force --sign"),
+            let tokens = { (line: String) in
+                line.split(whereSeparator: { $0 == " " || $0 == "\t" })
+            }
+            let signingCalls = lines.filter { line in
+                let words = tokens(line)
+                return line.contains("codesign")
+                    && words.contains("--force") && words.contains("--sign")
+            }
+            expect(!signingCalls.isEmpty,
                    "\(script) asks codesign whether the identity can sign before relying on it")
+            // build.sh's header: copies pick up xattrs (com.apple.provenance etc.)
+            // that invalidate codesign. A probe that fails on one reads as "no
+            // usable identity", and that is a silent ad-hoc build.
+            let unstripped = signingCalls.filter { !tokens($0).contains("--strip-disallowed-xattrs") }
+            expect(unstripped.isEmpty,
+                   "\(script) passes --strip-disallowed-xattrs to every codesign --force --sign "
+                    + "call, found \(unstripped.count) without it")
             // zsh keeps `status` as a second name for $?, and it is read-only:
             // `local status=1` aborts the script on the first call to the
             // function that declares it, so the probe never runs at all.

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21326,6 +21326,33 @@ struct MetricsTests {
                    "\(script) unlocks the dedicated signing keychain itself")
             expect(code.contains("codesign --force --sign"),
                    "\(script) asks codesign whether the identity can sign before relying on it")
+            // zsh keeps `status` as a second name for $?, and it is read-only:
+            // `local status=1` aborts the script on the first call to the
+            // function that declares it, so the probe never runs at all.
+            let readOnlyLocals = (script == "build.sh" ? buildScriptLines : signingSetupLines)
+                .filter { line in
+                    line.contains("local ")
+                        && line.split(whereSeparator: { $0 == " " || $0 == "\t" })
+                            .contains { $0 == "status" || $0.hasPrefix("status=") }
+                }
+            expect(readOnlyLocals.isEmpty,
+                   "\(script) declares zsh's read-only `status` as a local, which aborts "
+                    + "the script, found \(readOnlyLocals.count)")
+        }
+
+        // The signing probe is asked once and cached. Running the repair is the
+        // only thing that changes its answer, so the cache has to be dropped
+        // there: otherwise --dev creates a working identity and then signs the
+        // build ad-hoc off the "no" recorded a moment earlier.
+        if let repair = buildScriptLines.firstIndex(where: { $0.contains("Tools/setup-signing.sh") }) {
+            let afterRepair = Array(buildScriptLines[(repair + 1)...])
+            let nextRead = afterRepair.firstIndex { $0.contains("legacy_identity_installed") }
+                ?? afterRepair.count
+            expect(afterRepair[..<nextRead].contains { $0.contains("LEGACY_IDENTITY_USABLE=\"\"") },
+                   "build.sh clears the cached identity verdict after running the repair, "
+                    + "before anything reads it again")
+        } else {
+            expect(false, "build.sh still runs Tools/setup-signing.sh when no identity is usable")
         }
 
         // The setup script must run against the stock /usr/bin/openssl, which

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21287,31 +21287,42 @@ struct MetricsTests {
         expect(runsSigningSetup,
                "an identity-less Developer build invokes Tools/setup-signing.sh itself")
 
+        let signingSetup = (try? String(contentsOfFile: "Tools/setup-signing.sh",
+                                         encoding: .utf8)) ?? ""
+        expect(!signingSetup.isEmpty, "the signing setup script reads back for its shape check")
+        let signingSetupLines = signingSetup.components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#") }
+        let signingSetupCode = signingSetupLines.joined(separator: "\n")
+
         // MARK: Signing identity checks only ever count identities that can sign
         // `security find-identity` without -v lists certificates that cannot
         // sign, an expired self-signed one included. Matching one of those made
-        // the script prefer an unusable identity over the ad-hoc fallback, and
+        // build.sh prefer an unusable identity over the ad-hoc fallback, and
         // codesign then failed the whole build with errSecInternalComponent --
         // on a machine whose only fault was a stale certificate left in the
-        // keychain. The flag is the contract here, so it is what is pinned.
-        let identityQueries = buildScript.components(separatedBy: "\n")
+        // keychain. setup-signing.sh asks the same question twice and both
+        // answers matter: the front-door check decides whether the repair runs
+        // at all, and the post-import read-back decides whether the new
+        // identity counts as installed. Either one reading a dead certificate
+        // as usable puts the build back on the failing path. The flag is the
+        // contract here, so it is what is pinned, in both scripts.
+        let buildScriptQueries = buildScript.components(separatedBy: "\n")
             .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#") }
             .filter { $0.contains("find-identity") }
-        expect(!identityQueries.isEmpty, "build.sh still asks for a signing identity")
+        let setupScriptQueries = signingSetupLines.filter { $0.contains("find-identity") }
+        expect(!buildScriptQueries.isEmpty, "build.sh still asks for a signing identity")
+        expect(!setupScriptQueries.isEmpty,
+               "setup-signing.sh still asks for a signing identity")
+        let identityQueries = buildScriptQueries + setupScriptQueries
         let unvalidatedQueries = identityQueries.filter { !$0.contains("-v") }
         expect(unvalidatedQueries.isEmpty,
-               "every find-identity in build.sh asks for valid identities only, "
-                + "found \(unvalidatedQueries.count) without -v")
+               "every find-identity in build.sh and Tools/setup-signing.sh asks for "
+                + "valid identities only, found \(unvalidatedQueries.count) without -v")
+
         // The setup script must run against the stock /usr/bin/openssl, which
         // is LibreSSL: it rejects OpenSSL 3's -legacy flag outright, and the
         // script once died on exactly that with its stderr discarded. The
         // portable spelling names the PBE algorithms instead of the flag.
-        let signingSetup = (try? String(contentsOfFile: "Tools/setup-signing.sh",
-                                         encoding: .utf8)) ?? ""
-        expect(!signingSetup.isEmpty, "the signing setup script reads back for its shape check")
-        let signingSetupCode = signingSetup.components(separatedBy: "\n")
-            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#") }
-            .joined(separator: "\n")
         expect(!signingSetupCode.contains("-legacy"),
                "setup-signing.sh avoids the -legacy flag the stock LibreSSL openssl rejects")
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21313,25 +21313,48 @@ struct MetricsTests {
         // setup-signing.sh knows.
         let buildScriptLines = buildScript.components(separatedBy: "\n")
             .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#") }
+        // The lines of a top-level shell function, closing brace at column 0.
+        let probeBody: ([String], String) -> [String] = { lines, name in
+            guard let start = lines.firstIndex(where: {
+                $0.trimmingCharacters(in: .whitespaces).hasPrefix("\(name)() {")
+            }) else { return [] }
+            let rest = lines[(start + 1)...]
+            guard let end = rest.firstIndex(of: "}") else { return [] }
+            return Array(rest[..<end])
+        }
         // Asserted per script, not over the pair: a union is satisfied by one
         // surviving line in either file, so deleting the lookup out of
-        // setup-signing.sh would pass on build.sh's.
-        for (script, lines) in [("build.sh", buildScriptLines),
-                                ("Tools/setup-signing.sh", signingSetupLines)] {
-            let code = lines.joined(separator: "\n")
-            let identityQueries = lines
+        // setup-signing.sh would pass on build.sh's. And per probe, not over
+        // the whole script: setup-signing.sh unlocks the keychain a second
+        // time where it creates it, so a file-wide search answers yes with the
+        // probe's own unlock deleted — and then the first signing build after
+        // a reboot is back on the SecurityAgent dialog this branch removes.
+        for (script, lines, probeName) in
+            [("build.sh", buildScriptLines, "legacy_identity_installed"),
+             ("Tools/setup-signing.sh", signingSetupLines, "identity_can_sign")] {
+            let probe = probeBody(lines, probeName)
+            expect(!probe.isEmpty, "\(script) still defines \(probeName)()")
+            let probeCode = probe.joined(separator: "\n")
+            let identityQueries = probe
                 .filter { $0.contains("find-identity") }
                 .filter { $0.contains("$LEGACY_IDENTITY") || $0.contains("$IDENTITY") }
             expect(!identityQueries.isEmpty,
-                   "\(script) still looks the stable identity up by name")
-            let trustQueries = identityQueries.filter { $0.contains("-v") }
+                   "\(script)'s \(probeName) still looks the stable identity up by name")
+            // This one stays file-wide on purpose: it forbids a spelling
+            // rather than requiring a line, and -v against this identity is
+            // wrong wherever it is written.
+            let trustQueries = lines
+                .filter { $0.contains("find-identity") }
+                .filter { $0.contains("$LEGACY_IDENTITY") || $0.contains("$IDENTITY") }
+                .filter { $0.contains("-v") }
             expect(trustQueries.isEmpty,
                    "\(script) looks the self-signed identity up without asking find-identity "
                     + "for valid identities only, found \(trustQueries.count) that do")
-            expect(code.contains("unlock-keychain -p"),
-                   "\(script) unlocks the dedicated signing keychain itself")
-            expect(code.contains("codesign --force --sign"),
-                   "\(script) asks codesign whether the identity can sign before relying on it")
+            expect(probeCode.contains("unlock-keychain -p"),
+                   "\(script)'s \(probeName) unlocks the dedicated signing keychain itself")
+            expect(probeCode.contains("codesign --force --sign"),
+                   "\(script)'s \(probeName) asks codesign whether the identity can sign "
+                    + "before relying on it")
             // zsh keeps `status` as a second name for $?, and it is read-only:
             // `local status=1` aborts the script on the first call to the
             // function that declares it, so the probe never runs at all.
@@ -21346,25 +21369,29 @@ struct MetricsTests {
                     + "the script, found \(readOnlyLocals.count)")
         }
 
-        // Both unlocks pass a password literal of their own. If they drift the
-        // probe either fails its unlock and the build signs ad-hoc in silence,
-        // or reaches codesign against a locked keychain and raises the
-        // SecurityAgent dialog these unlocks exist to avoid. Pin the values
-        // against each other, not just the presence of the call.
-        let keychainPassword: (String, [String]) -> String? = { name, lines in
+        // Each unlock names the keychain and its password with a literal of
+        // its own. Password drift fails the unlock and the build signs ad-hoc
+        // in silence; path drift is worse, because `[[ ! -f "$LEGACY_KEYCHAIN" ]]`
+        // then goes true and the unlock is skipped without a word, leaving
+        // codesign to meet a locked keychain and raise the SecurityAgent
+        // dialog. Pin both values against each other, not just the call.
+        let shellLiteral: (String, [String]) -> String? = { name, lines in
             lines.compactMap { line -> String? in
                 let trimmed = line.trimmingCharacters(in: .whitespaces)
                 guard trimmed.hasPrefix("\(name)=\"") else { return nil }
                 return String(trimmed.dropFirst(name.count + 2).prefix { $0 != "\"" })
             }.first
         }
-        let buildKeychainPassword = keychainPassword("LEGACY_KEYCHAIN_PASSWORD", buildScriptLines)
-        let setupKeychainPassword = keychainPassword("KCPASS", signingSetupLines)
-        expect(buildKeychainPassword?.isEmpty == false
-                && buildKeychainPassword == setupKeychainPassword,
-               "build.sh and Tools/setup-signing.sh unlock the signing keychain with the same "
-                + "password, found \(buildKeychainPassword ?? "none") "
-                + "and \(setupKeychainPassword ?? "none")")
+        for (what, inBuildScript, inSetupScript) in
+            [("password", "LEGACY_KEYCHAIN_PASSWORD", "KCPASS"),
+             ("path", "LEGACY_KEYCHAIN", "KC")] {
+            let fromBuild = shellLiteral(inBuildScript, buildScriptLines)
+            let fromSetup = shellLiteral(inSetupScript, signingSetupLines)
+            expect(fromBuild?.isEmpty == false && fromBuild == fromSetup,
+                   "build.sh's \(inBuildScript) and Tools/setup-signing.sh's \(inSetupScript) "
+                    + "are the same signing keychain \(what), found \(fromBuild ?? "none") "
+                    + "and \(fromSetup ?? "none")")
+        }
 
         // The signing probe is asked once and cached. Running the repair is the
         // only thing that changes its answer, so the cache has to be dropped

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21286,6 +21286,22 @@ struct MetricsTests {
         }
         expect(runsSigningSetup,
                "an identity-less Developer build invokes Tools/setup-signing.sh itself")
+
+        // MARK: Signing identity checks only ever count identities that can sign
+        // `security find-identity` without -v lists certificates that cannot
+        // sign, an expired self-signed one included. Matching one of those made
+        // the script prefer an unusable identity over the ad-hoc fallback, and
+        // codesign then failed the whole build with errSecInternalComponent --
+        // on a machine whose only fault was a stale certificate left in the
+        // keychain. The flag is the contract here, so it is what is pinned.
+        let identityQueries = buildScript.components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#") }
+            .filter { $0.contains("find-identity") }
+        expect(!identityQueries.isEmpty, "build.sh still asks for a signing identity")
+        let unvalidatedQueries = identityQueries.filter { !$0.contains("-v") }
+        expect(unvalidatedQueries.isEmpty,
+               "every find-identity in build.sh asks for valid identities only, "
+                + "found \(unvalidatedQueries.count) without -v")
         // The setup script must run against the stock /usr/bin/openssl, which
         // is LibreSSL: it rejects OpenSSL 3's -legacy flag outright, and the
         // script once died on exactly that with its stderr discarded. The

--- a/Tools/setup-signing.sh
+++ b/Tools/setup-signing.sh
@@ -44,7 +44,7 @@ identity_can_sign() {
     local probe signed=1
     probe="$(mktemp -d)"
     cp /bin/echo "$probe/probe"
-    codesign --force --sign "$IDENTITY" "$probe/probe" >/dev/null 2>&1 && signed=0
+    codesign --force --strip-disallowed-xattrs --sign "$IDENTITY" "$probe/probe" >/dev/null 2>&1 && signed=0
     rm -rf "$probe"
     return $signed
 }

--- a/Tools/setup-signing.sh
+++ b/Tools/setup-signing.sh
@@ -25,11 +25,29 @@ IDENTITY="Vorssaint Utils Signing"
 KC="$HOME/Library/Keychains/vorssaint-signing.keychain-db"
 KCPASS="vorssaint-signing"
 
-# -v is what makes this idempotent rather than merely quiet: without it the
-# search also lists certificates that cannot sign, so a stale one left in the
-# keychain reports "already installed" and the repair build.sh just asked for
-# never happens — the build then signs ad-hoc and loses its grants anyway.
-if security find-identity -v -p codesigning 2>/dev/null | grep -q "$IDENTITY"; then
+# What makes this idempotent rather than merely quiet: whether codesign can sign
+# with the identity, not whether one is listed. The unvalidated listing includes
+# certificates that cannot sign, so a stale one reports "already installed" and
+# the repair build.sh just asked for never happens. `find-identity -v` is not
+# the fix — it asks whether the certificate is trusted, which a self-signed one
+# never is, so it would delete and recreate a perfectly good identity on every
+# single build. codesign is the only thing that answers the real question.
+identity_can_sign() {
+    security find-identity -p codesigning 2>/dev/null | grep -q "$IDENTITY" || return 1
+    # Unlock first: the keychain is locked again after every login, and a locked
+    # one makes codesign raise a GUI password prompt instead of answering.
+    if [[ -f "$KC" ]] && ! security unlock-keychain -p "$KCPASS" "$KC" 2>/dev/null; then
+        return 1
+    fi
+    local probe status=1
+    probe="$(mktemp -d)"
+    cp /bin/echo "$probe/probe"
+    codesign --force --sign "$IDENTITY" "$probe/probe" >/dev/null 2>&1 && status=0
+    rm -rf "$probe"
+    return $status
+}
+
+if identity_can_sign; then
     echo "✓ Signing identity already installed."
     exit 0
 fi
@@ -65,8 +83,8 @@ security list-keychains -d user -s "$KC" ${=EXISTING}
 # Import succeeding is not evidence codesign can see it: read it back the same
 # way build.sh looks it up, so a broken search list fails here and not as a
 # silent ad-hoc fallback three builds later.
-security find-identity -v -p codesigning 2>/dev/null | grep -q "$IDENTITY" || {
-    echo "✗ Identity imported but codesign cannot find it; keychain search list may be off." >&2
+identity_can_sign || {
+    echo "✗ Identity imported but codesign cannot sign with it; keychain search list may be off." >&2
     exit 1
 }
 echo "✓ Created signing identity '$IDENTITY'. Future ./build.sh runs use it automatically."

--- a/Tools/setup-signing.sh
+++ b/Tools/setup-signing.sh
@@ -39,12 +39,14 @@ identity_can_sign() {
     if [[ -f "$KC" ]] && ! security unlock-keychain -p "$KCPASS" "$KC" 2>/dev/null; then
         return 1
     fi
-    local probe status=1
+    # Not `status`: zsh keeps that as a second name for $?, and it is read-only,
+    # so declaring it local aborts the script on the first call.
+    local probe signed=1
     probe="$(mktemp -d)"
     cp /bin/echo "$probe/probe"
-    codesign --force --sign "$IDENTITY" "$probe/probe" >/dev/null 2>&1 && status=0
+    codesign --force --sign "$IDENTITY" "$probe/probe" >/dev/null 2>&1 && signed=0
     rm -rf "$probe"
-    return $status
+    return $signed
 }
 
 if identity_can_sign; then

--- a/Tools/setup-signing.sh
+++ b/Tools/setup-signing.sh
@@ -13,7 +13,7 @@
 # requirement and drop every user's granted permissions. The name lives only in
 # the keychain and codesign output, never in anything the app shows.
 #
-# Free, offline, and idempotent (re-running is a no-op once the identity exists).
+# Free, offline, and idempotent (re-running is a no-op once a usable identity exists).
 # It does NOT replace Apple notarization: downloaded builds still show Gatekeeper's
 # "unverified developer" prompt on first launch. It only stabilizes the identity.
 #
@@ -25,7 +25,11 @@ IDENTITY="Vorssaint Utils Signing"
 KC="$HOME/Library/Keychains/vorssaint-signing.keychain-db"
 KCPASS="vorssaint-signing"
 
-if security find-identity -p codesigning 2>/dev/null | grep -q "$IDENTITY"; then
+# -v is what makes this idempotent rather than merely quiet: without it the
+# search also lists certificates that cannot sign, so a stale one left in the
+# keychain reports "already installed" and the repair build.sh just asked for
+# never happens — the build then signs ad-hoc and loses its grants anyway.
+if security find-identity -v -p codesigning 2>/dev/null | grep -q "$IDENTITY"; then
     echo "✓ Signing identity already installed."
     exit 0
 fi
@@ -61,7 +65,7 @@ security list-keychains -d user -s "$KC" ${=EXISTING}
 # Import succeeding is not evidence codesign can see it: read it back the same
 # way build.sh looks it up, so a broken search list fails here and not as a
 # silent ad-hoc fallback three builds later.
-security find-identity -p codesigning 2>/dev/null | grep -q "$IDENTITY" || {
+security find-identity -v -p codesigning 2>/dev/null | grep -q "$IDENTITY" || {
     echo "✗ Identity imported but codesign cannot find it; keychain search list may be off." >&2
     exit 1
 }

--- a/build.sh
+++ b/build.sh
@@ -10,14 +10,16 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-# The icon catalog and the bundle are staged in temp dirs; sweep both however
-# the script ends.
+# The icon catalog, the bundle and the signing probe are staged in temp dirs;
+# sweep all three however the script ends.
 ICON_TMP=""
 STAGE_TMP=""
+PROBE_TMP=""
 
 cleanup() {
     [[ -n "$ICON_TMP" ]] && rm -rf "$ICON_TMP"
     [[ -n "$STAGE_TMP" ]] && rm -rf "$STAGE_TMP"
+    [[ -n "$PROBE_TMP" ]] && rm -rf "$PROBE_TMP"
     return 0
 }
 trap cleanup EXIT
@@ -58,6 +60,10 @@ FAN_HELPER_ID="$APP_BUNDLE_ID.fan-control"
 TARGET="arm64-apple-macosx14.0"
 ENTITLEMENTS="Resources/Vorssaint.entitlements"
 LEGACY_IDENTITY="Vorssaint Utils Signing"
+# Tools/setup-signing.sh keeps that identity in a keychain of its own, with a
+# password that lives in that script and nowhere else.
+LEGACY_KEYCHAIN="$HOME/Library/Keychains/vorssaint-signing.keychain-db"
+LEGACY_KEYCHAIN_PASSWORD="vorssaint-signing"
 
 developer_id_identity() {
     security find-identity -v -p codesigning 2>/dev/null \
@@ -66,12 +72,41 @@ developer_id_identity() {
         | sed -E 's/.*"(.*)".*/\1/' || true
 }
 
-# `find-identity` without -v lists identities that cannot sign: a self-signed
-# certificate that has expired still appears. Matching one of those picked an
-# unusable identity over the ad-hoc fallback, and codesign then failed the
-# build outright with errSecInternalComponent. Only a valid identity counts.
+# Whether codesign can sign with the stable self-signed identity, asked once
+# and reused. Neither spelling of `find-identity` answers that question: without
+# -v the listing includes certificates that cannot sign, which is how an expired
+# one failed a build with errSecInternalComponent; with -v it answers "is this
+# certificate trusted", and a self-signed one never is, so it reports zero valid
+# identities on a machine where codesign signs with that identity happily.
+# Deciding by either would send builds to the ad-hoc fallback this identity
+# exists to avoid — releases included, since CI imports the same self-signed
+# certificate. Ask codesign itself instead.
+#
+# The keychain is unlocked first: it is not the login keychain, so it is locked
+# again after every login and nothing else opens it. That is what made the first
+# signing build after a reboot stop on a GUI prompt for a keychain password only
+# setup-signing.sh knows. A keychain that will not open counts as no identity,
+# rather than letting the probe raise that same dialog — for --dev that runs
+# setup-signing.sh, which rebuilds the keychain from scratch.
+LEGACY_IDENTITY_USABLE=""
 legacy_identity_installed() {
-    security find-identity -v -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"
+    if [[ -z "$LEGACY_IDENTITY_USABLE" ]]; then
+        LEGACY_IDENTITY_USABLE=no
+        if security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY" \
+            && { [[ ! -f "$LEGACY_KEYCHAIN" ]] \
+                || security unlock-keychain -p "$LEGACY_KEYCHAIN_PASSWORD" \
+                    "$LEGACY_KEYCHAIN" 2>/dev/null; }; then
+            PROBE_TMP="$(mktemp -d)"
+            cp /bin/echo "$PROBE_TMP/probe"
+            if /usr/bin/codesign --force --sign "$LEGACY_IDENTITY" \
+                "$PROBE_TMP/probe" >/dev/null 2>&1; then
+                LEGACY_IDENTITY_USABLE=yes
+            fi
+            rm -rf "$PROBE_TMP"
+            PROBE_TMP=""
+        fi
+    fi
+    [[ "$LEGACY_IDENTITY_USABLE" == yes ]]
 }
 
 # The Developer build exists for iterative local work, where an ad-hoc

--- a/build.sh
+++ b/build.sh
@@ -78,9 +78,10 @@ developer_id_identity() {
 # one failed a build with errSecInternalComponent; with -v it answers "is this
 # certificate trusted", and a self-signed one never is, so it reports zero valid
 # identities on a machine where codesign signs with that identity happily.
-# Deciding by either would send builds to the ad-hoc fallback this identity
-# exists to avoid — releases included, since CI imports the same self-signed
-# certificate. Ask codesign itself instead.
+# Deciding by either would send local builds to the ad-hoc fallback this
+# identity exists to avoid. Releases are not affected: Tools/ci-setup-signing.sh
+# imports a Developer ID certificate from a repository secret, and release.yml
+# re-verifies the signature against that team's OU. Ask codesign itself instead.
 #
 # The keychain is unlocked first: it is not the login keychain, so it is locked
 # again after every login and nothing else opens it. That is what made the first

--- a/build.sh
+++ b/build.sh
@@ -99,7 +99,7 @@ legacy_identity_installed() {
                     "$LEGACY_KEYCHAIN" 2>/dev/null; }; then
             PROBE_TMP="$(mktemp -d)"
             cp /bin/echo "$PROBE_TMP/probe"
-            if /usr/bin/codesign --force --sign "$LEGACY_IDENTITY" \
+            if /usr/bin/codesign --force --strip-disallowed-xattrs --sign "$LEGACY_IDENTITY" \
                 "$PROBE_TMP/probe" >/dev/null 2>&1; then
                 LEGACY_IDENTITY_USABLE=yes
             fi

--- a/build.sh
+++ b/build.sh
@@ -125,6 +125,10 @@ if (( DEV )) && [[ -z "$(developer_id_identity)" ]] \
         echo "    After fixing the identity, clear the stale grant once with:" >&2
         echo "      tccutil reset Accessibility $APP_BUNDLE_ID" >&2
     fi
+    # The guard above cached "no". The repair is the one thing in this script
+    # that changes that answer, so forget it here or every later call site reads
+    # the stale verdict and signs the build ad-hoc anyway.
+    LEGACY_IDENTITY_USABLE=""
 fi
 
 codesign_with_timestamp_retry() {

--- a/build.sh
+++ b/build.sh
@@ -66,6 +66,14 @@ developer_id_identity() {
         | sed -E 's/.*"(.*)".*/\1/' || true
 }
 
+# `find-identity` without -v lists identities that cannot sign: a self-signed
+# certificate that has expired still appears. Matching one of those picked an
+# unusable identity over the ad-hoc fallback, and codesign then failed the
+# build outright with errSecInternalComponent. Only a valid identity counts.
+legacy_identity_installed() {
+    security find-identity -v -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"
+}
+
 # The Developer build exists for iterative local work, where an ad-hoc
 # signature is a trap: macOS ties Accessibility and Screen Recording grants to
 # the exact binary hash, so every rebuild orphans them while System Settings
@@ -73,7 +81,7 @@ developer_id_identity() {
 # identity is installed, create the stable local one up front instead of
 # falling through to ad-hoc — setup-signing.sh is free, offline and idempotent.
 if (( DEV )) && [[ -z "$(developer_id_identity)" ]] \
-    && ! security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"; then
+    && ! legacy_identity_installed; then
     echo "▸ No signing identity installed; creating the stable local one…"
     if ! ./Tools/setup-signing.sh; then
         echo "  ⚠ Tools/setup-signing.sh failed; signing ad-hoc instead." >&2
@@ -135,7 +143,7 @@ finalize_installed_bundle_after_child() {
             --options runtime --timestamp --identifier "$FAN_HELPER_ID" --sign "$devid" "$helper"
         codesign_with_timestamp_retry --force --strip-disallowed-xattrs --options runtime --timestamp \
             --entitlements "$ENTITLEMENTS" --sign "$devid" "$bundle"
-    elif security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"; then
+    elif legacy_identity_installed; then
         [[ -f "$helper" ]] && /usr/bin/codesign --force --strip-disallowed-xattrs \
             --identifier "$FAN_HELPER_ID" --sign "$LEGACY_IDENTITY" "$helper"
         /usr/bin/codesign --force --strip-disallowed-xattrs --sign "$LEGACY_IDENTITY" "$bundle"
@@ -520,7 +528,7 @@ codesign_app() {
     if [[ -n "$DEVID" ]]; then
         codesign_with_timestamp_retry --force --strip-disallowed-xattrs --options runtime --timestamp \
             --entitlements "$ENTITLEMENTS" --sign "$DEVID" "$target"
-    elif security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"; then
+    elif legacy_identity_installed; then
         codesign --force --strip-disallowed-xattrs --sign "$LEGACY_IDENTITY" "$target"
     else
         codesign --force --strip-disallowed-xattrs --sign - "$target"
@@ -532,7 +540,7 @@ codesign_fan_helper() {
     if [[ -n "$DEVID" ]]; then
         codesign_with_timestamp_retry --force --strip-disallowed-xattrs --options runtime --timestamp \
             --identifier "$FAN_HELPER_ID" --sign "$DEVID" "$target"
-    elif security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"; then
+    elif legacy_identity_installed; then
         codesign --force --strip-disallowed-xattrs --identifier "$FAN_HELPER_ID" \
             --sign "$LEGACY_IDENTITY" "$target"
     else
@@ -547,7 +555,7 @@ sign_bundle() {
 
     if [[ -n "$DEVID" ]]; then
         echo "  signing with Developer ID (hardened runtime): $DEVID"
-    elif security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"; then
+    elif legacy_identity_installed; then
         echo "  signing with legacy self-signed identity: $LEGACY_IDENTITY"
     else
         echo "  signing ad-hoc (no identity installed — run Tools/setup-signing.sh)"


### PR DESCRIPTION
## Summary

`build.sh` and `Tools/setup-signing.sh` both decided whether the stable
self-signed identity `Vorssaint Utils Signing` was usable by reading a
`security find-identity` listing. A listing is not that answer, in either
spelling:

- **Without `-v`** it includes certificates that cannot sign. A stale one is
  handed to `codesign`, which answers `errSecInternalComponent`, and the
  script exits 1 at "Assembling and signing bundle" after a clean release
  compile. The ad-hoc fallback that exists for this case sits in the `else`
  arm and is never reached. On `--dev` the same misreading makes the guard
  skip `Tools/setup-signing.sh`, and the script's own front door then prints
  `✓ Signing identity already installed.` over the dead certificate.
- **With `-v`** it answers "is this certificate trusted", which a self-signed
  one never is — nothing signs it but itself. On a machine where `codesign`
  signs with the identity happily, `find-identity -v -p codesigning` reports
  zero valid identities. Deciding by that flag would send every local build to
  the ad-hoc fallback the identity exists to prevent, and have
  `setup-signing.sh` delete and reissue a perfectly good certificate on every
  run, changing the designated requirement each time.

So neither flag is the fix. Both scripts now ask `codesign` itself: sign a
throwaway copy of `/bin/echo` with the identity and believe the result. The
probe passes `--strip-disallowed-xattrs` like every other signing call in
`build.sh`: a copy into `$TMPDIR` carries `com.apple.provenance`, the xattr
the header names as invalidating codesign, and a probe that failed on it
would read as "no usable identity" and sign the build ad-hoc.
`build.sh` asks once through `legacy_identity_installed` and reuses the
answer; `setup-signing.sh` asks through `identity_can_sign` at its front door
and again as the post-import read-back, so an import `codesign` cannot see
fails there instead of surfacing as a silent ad-hoc build later.

The probe unlocks the dedicated keychain first. That keychain is not the login
keychain, so it is locked again after every login and nothing in the repo ever
reopens it — `setup-signing.sh` unlocks once at creation and exits early
forever after. The first signing build after a reboot therefore stopped on a
GUI prompt for a keychain password that is a literal string inside
`setup-signing.sh`, which no contributor can be expected to know. A keychain
that will not open now counts as no identity, rather than letting the probe
raise that dialog; `--dev` then rebuilds it through `setup-signing.sh`.

Two defects in that arrangement were fixed in a later round:

- **The cached verdict outlived the repair.** `--dev` asks the guard first,
  records "no", and only then runs `setup-signing.sh`. Nothing cleared
  `LEGACY_IDENTITY_USABLE`, so every later call site read the stale "no": the
  build that had just created a working identity signed itself ad-hoc and
  printed `run Tools/setup-signing.sh`. That is #1123's failure on the one
  path this branch adds the repair for. The cache is cleared where the repair
  ends, before anything reads it again.
- **`setup-signing.sh` could not have repaired anything either.** Its probe
  declared `local probe status=1`. zsh keeps `status` as a second name for
  `$?` and holds it read-only, so the declaration aborts the script at the
  first call to `identity_can_sign`, before it decides anything: the script
  exits 1 with `read-only variable: status` and `build.sh` prints its ad-hoc
  warning. The counter is named `signed`.

`git grep find-identity` reaches `build.sh` (2 — the Developer ID lookup,
which correctly keeps `-v`, and the helper), `Tools/setup-signing.sh` (2, both
through `identity_can_sign`) and the test. `.github/` has none;
`Tools/ci-setup-signing.sh` imports a certificate and never enumerates. No
other `local status` exists in any script in the tree, and
`LEGACY_IDENTITY_USABLE` is the only cached signing verdict.

Releases are not affected by any of this: the release job signs with the
Developer ID from the repository secret and `Verify release signature` pins
`certificate leaf[subject.OU] = "3D485NHW29"`, so a release cannot silently
ship ad-hoc. The damage was to everyone building locally.

### The shape check, and what was removed from it

Four rounds after the behaviour fix went in, the script shape check kept
growing. Each of those rounds reported `Impact: none today`: they changed the
test and two comments, and no behaviour changed. Those additions are removed
in `9755ed9f`, because what they bought was drift that might happen later and
what they cost was a mechanism that has to be maintained and can fail in
silence — two closures parsing zsh by string matching (`probeBody`, slicing a
function between `name() {` and a `}` at column 0; `shellLiterals`, reading
`NAME="` prefixes), and a set of index-order assertions built on top of them.
A rename, a continuation line or an indented closing brace makes either
closure return nothing, and then every assertion above it passes vacuously,
which is the failure mode those rounds kept finding in the assertions they
replaced.

Removed: the probe extracted by function name and required to be defined
exactly once; `find-identity` counted file-wide and required to equal the
count inside the probe; one `codesign` call and one verdict line with an
index ordering between them; `LEGACY_KEYCHAIN`/`KC` and
`LEGACY_KEYCHAIN_PASSWORD`/`KCPASS` pinned across the two files and each
required to be assigned exactly once; and the cache-reset check widened from
the repair invocation to every invocation.

Two more went with them because they could not be made to fail. The unlock
read over `Tools/setup-signing.sh` is answered by the creation-time unlock
next to `security create-keychain`, so deleting the probe's own unlock left it
green — it is dropped rather than left asserting nothing, with a comment
saying why. The identity lookup is kept, but as what it is: the input set the
`-v` ban reads, so that ban cannot pass vacuously, rather than a claim that
each script still asks.

What remains is the part with a behaviour fix behind it, each one re-checked
by reverting its own shell fix and watching it go red:

| Assertion | Drift that turns it red |
| --- | --- |
| no `-v` on this identity | restoring `-v` in `legacy_identity_installed` |
| `codesign --force --sign` in both scripts | stubbing the `setup-signing.sh` probe out; in `build.sh` the bundle and helper signing calls answer the same read, so the probe stub stays green there |
| `--strip-disallowed-xattrs` on every such call | dropping it from either probe |
| `build.sh` unlocks the keychain itself | deleting the unlock from the probe |
| no zsh `local status` | restoring `local probe status=1` |
| the cache is cleared after the repair | deleting `LEGACY_IDENTITY_USABLE=""` |
| the repair is invoked at all | removing the `./Tools/setup-signing.sh` call |

### Trade-offs

- The probe costs one `codesign` call per build, not per call site, because
  the answer is cached. That cache is the reason the repair has to invalidate
  it, and the shape check pins that it does.
- The guard matches on `find-identity`, `unlock-keychain`,
  `codesign --force --sign` and `--strip-disallowed-xattrs`, which are the
  `security` and `codesign` CLIs' own contract, not on helper names. The
  `codesign` read splits each line into tokens, so flag order does not matter
  to it. It reads each script as a whole rather than
  the probe body: a rename or a reindent then cannot make it read nothing, at
  the price of a second call site being able to answer for the probe. That is
  the trade the removal above takes on purpose.
- Nothing changes for a machine with a valid Developer ID: that lookup is a
  different question and still uses `-v`. What changes is that a machine with
  only an unusable self-signed certificate signs ad-hoc and builds instead of
  failing, and on `--dev` gets a working identity created for it first.
- `setup-signing.sh` is idempotent against a *usable* identity rather than any
  certificate of that name. Re-running it where the certificate has gone stale
  deletes and recreates the `vorssaint-signing` keychain, which is what the
  repair is for; where one works it is still a no-op.

## Verification

macOS 26.x, Apple silicon.

- `./build.sh --test`: 9479 of 9481 pass. The two failures are
  `nil layout falls back to ANSI semicolon` and
  `App Switcher icon-row hints describe default app and window shortcuts`;
  both read this machine's live input source, which is a Chinese IME. They
  fail identically on this branch's base, `16216d56`, run in a separate
  worktree in an earlier round: 9467 of 9469 there, same two names.
- Red-first on every assertion that is left, one drift at a time, each
  reverted back to green afterwards:
  - restoring `-v` in `legacy_identity_installed` fails "no lookup of the
    self-signed identity asks find-identity for valid identities only, found
    1 that do";
  - `local probe status=1` back in `identity_can_sign` fails
    "Tools/setup-signing.sh declares zsh's read-only `status` as a local";
  - deleting `LEGACY_IDENTITY_USABLE=""` fails "build.sh clears the cached
    identity verdict after running the repair";
  - deleting the unlock out of `legacy_identity_installed` fails "build.sh
    unlocks the dedicated signing keychain itself";
  - replacing the `codesign --force --sign` call in `identity_can_sign` with
    a stub fails "Tools/setup-signing.sh asks codesign whether the identity
    can sign before relying on it";
  - dropping `--strip-disallowed-xattrs` from either probe fails that
    script's "passes --strip-disallowed-xattrs to every codesign --force
    --sign call, found 1 without it", one script at a time;
  - removing the `./Tools/setup-signing.sh` invocation fails "an
    identity-less Developer build invokes Tools/setup-signing.sh itself".
- Two drifts stay green, measured rather than assumed. Deleting the unlock
  out of `identity_can_sign` in `Tools/setup-signing.sh` leaves the suite at
  2 of 9481, the two input-source failures and nothing else, because the
  creation-time unlock answers a file-wide read. That is why the assertion
  for that file is gone rather than kept. Stubbing the probe's `codesign` out
  of `legacy_identity_installed` in `build.sh` also stays at 2 of 9481: once
  the probe passes the same flags as the bundle and helper signing calls,
  those calls answer the file-wide read for it. Before the flag was added
  the probe was the only `codesign --force --sign` literal in `build.sh`, so
  that assertion was probe-specific by accident of flag order, not by design.
- `cp /bin/echo` into `$TMPDIR`, and into a `mktemp -d` directory under it,
  was measured with `xattr -l`: `/bin/echo` itself has no xattrs, the copy
  has `com.apple.provenance`. Whether that xattr alone makes `codesign` fail
  was not measured, for the reason below.
- `zsh -n build.sh` and `zsh -n Tools/setup-signing.sh`: both parse.
- The release claim in the comments was checked against the two files it
  names, not from memory: `Tools/ci-setup-signing.sh` lines 12-31 import
  `SIGNING_CERT_P12` and never create a certificate, and
  `.github/workflows/release.yml` runs it with `REQUIRE_SIGNING: "1"` and then
  verifies against `anchor apple generic and certificate
  leaf[subject.OU] = "3D485NHW29"` at four call sites.
- Evidence from earlier rounds still stands: the `status` defect was
  reproduced by extracting the real `identity_can_sign` body and running it
  under `zsh` with `security` and `codesign` stubbed — `local probe status=1`
  aborts at that line with `read-only variable: status`, exit 1, before the
  probe runs; with `signed` the same body returns usable for a stub that signs
  and unusable for one that fails.

**What this branch changes has never been run against real `security` or
`codesign`.** The new criterion is "`codesign` can sign with the identity
**and** the dedicated keychain can be unlocked". Neither half has been
exercised on any machine:

- No `security` command, no `Tools/setup-signing.sh`, no `--dev`, and no full
  `./build.sh` has been run here since the criterion changed. The signing
  keychain on this machine is locked, and each of those reaches `codesign` or
  `security` against it and blocks on a SecurityAgent password dialog that
  never returns. All evidence for the new criterion is stubs plus `zsh -n`.
  The `-v` measurements that motivated dropping that flag are in the PR
  discussion, from an earlier round on an unlocked keychain — they are
  evidence against `-v`, not evidence for the unlock-and-sign probe. The
  `--strip-disallowed-xattrs` on the probe has likewise never been run: the
  xattr on the copy is measured, the probe signing with and without the flag
  is not.
- No machine with a valid Developer ID identity. That branch was not taken.

The consequence is worth naming, because it is #1123's failure mode. In
`build.sh`:

```sh
if security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY" \
    && { [[ ! -f "$LEGACY_KEYCHAIN" ]] \
        || security unlock-keychain -p "$LEGACY_KEYCHAIN_PASSWORD" \
            "$LEGACY_KEYCHAIN" 2>/dev/null; }; then
```

A failed unlock is read as "no usable identity". On a non-`--dev` build there
is no repair path, so the build signs ad-hoc and the developer's
Accessibility and Screen Recording grants stop surviving rebuilds — the exact
#1123 symptom, now reachable through a keychain whose password drifted, whose
path moved, or which the user relocated. Whether that is a real risk or a
theoretical one is exactly what has not been measured. The check that would
settle it is one run of `./build.sh --dev` on a Mac whose signing keychain is
locked, followed by `codesign -dv --verbose=4 build/Vorssaint.app` to see
which identity it actually used.

## Anything else

Refs #1123

