### PR TITLE
fix(window-layout): hand the window taps back across a fast user switch

### DIFF
--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
@@ -310,11 +310,7 @@ final class WindowLayoutService: ObservableObject {
         guard let onScreenWindowIDs = onScreenWindowIDs() else { return nil }
         for pid in pids {
             let isFocusedOwnApp = pid == ownPID && hasFocusedResizableOwnWindow
-            // One lookup by pid, not a fresh bridge of every running app on
-            // each turn of a list that can hold dozens of them. The edge-snap
-            // drag already resolves its app this way.
-            guard let app = NSRunningApplication(processIdentifier: pid),
-                  !app.isTerminated,
+            guard let app = NSWorkspace.shared.runningApplications.first(where: { $0.processIdentifier == pid }),
                   isFocusedOwnApp
                     || (app.activationPolicy == .regular && !app.isHidden
                         && app.bundleIdentifier != ownBundleID)
@@ -759,16 +755,9 @@ final class WindowLayoutService: ObservableObject {
                                                       action: nil,
                                                       manualOverride: nil)
         showDirectionalIndicator(at: NSEvent.mouseLocation, action: nil)
-        // The gesture's own tap takes leftMouseDown and rightMouseDown, so a
-        // held mouse button puts the main run loop in event tracking and a
-        // default-mode timer stops firing: the indicator and the preview would
-        // freeze on the frame before the press. Common modes keep the 60 Hz
-        // feedback running for as long as the hotkey is held.
-        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) {
+        directionalTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) {
             [weak self] _ in self?.updateDirectionalGesture()
         }
-        directionalTimer = timer
-        RunLoop.main.add(timer, forMode: .common)
         startDirectionalTap()
     }
 

--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
@@ -107,7 +107,7 @@ final class WindowLayoutService: ObservableObject {
         let wantsDirectional = SessionActivitySupport.tapShouldRun(
             featureWanted: available
                 && UserDefaults.standard.bool(forKey: DefaultsKey.windowDirectionalEnabled),
-            accessibilityGranted: trusted,
+            accessibilityGranted: AXIsProcessTrusted(),
             sessionIsActive: sessionIsActive
         )
         wantsDirectional ? registerDirectionalHotkey() : unregisterDirectionalHotkey()
@@ -115,7 +115,7 @@ final class WindowLayoutService: ObservableObject {
         let wantsGesture = SessionActivitySupport.tapShouldRun(
             featureWanted: available
                 && UserDefaults.standard.bool(forKey: DefaultsKey.windowGestureEnabled),
-            accessibilityGranted: trusted,
+            accessibilityGranted: AXIsProcessTrusted(),
             sessionIsActive: sessionIsActive
         )
         wantsGesture ? startGestureTap() : stopGestureTap()
@@ -124,7 +124,7 @@ final class WindowLayoutService: ObservableObject {
             featureWanted: available
                 && UserDefaults.standard.bool(forKey: DefaultsKey.windowEdgeSnapEnabled)
                 && !WindowEdgeSnapSupport.isSystemTilingEnabled,
-            accessibilityGranted: trusted,
+            accessibilityGranted: AXIsProcessTrusted(),
             sessionIsActive: sessionIsActive
         )
         wantsEdgeSnap ? startEdgeSnapTap() : stopEdgeSnapTap()

--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
@@ -310,7 +310,11 @@ final class WindowLayoutService: ObservableObject {
         guard let onScreenWindowIDs = onScreenWindowIDs() else { return nil }
         for pid in pids {
             let isFocusedOwnApp = pid == ownPID && hasFocusedResizableOwnWindow
-            guard let app = NSWorkspace.shared.runningApplications.first(where: { $0.processIdentifier == pid }),
+            // One lookup by pid, not a fresh bridge of every running app on
+            // each turn of a list that can hold dozens of them. The edge-snap
+            // drag already resolves its app this way.
+            guard let app = NSRunningApplication(processIdentifier: pid),
+                  !app.isTerminated,
                   isFocusedOwnApp
                     || (app.activationPolicy == .regular && !app.isHidden
                         && app.bundleIdentifier != ownBundleID)
@@ -755,9 +759,16 @@ final class WindowLayoutService: ObservableObject {
                                                       action: nil,
                                                       manualOverride: nil)
         showDirectionalIndicator(at: NSEvent.mouseLocation, action: nil)
-        directionalTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) {
+        // The gesture's own tap takes leftMouseDown and rightMouseDown, so a
+        // held mouse button puts the main run loop in event tracking and a
+        // default-mode timer stops firing: the indicator and the preview would
+        // freeze on the frame before the press. Common modes keep the 60 Hz
+        // feedback running for as long as the hotkey is held.
+        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) {
             [weak self] _ in self?.updateDirectionalGesture()
         }
+        directionalTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
         startDirectionalTap()
     }
 

--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
@@ -80,30 +80,53 @@ final class WindowLayoutService: ObservableObject {
     private let resizeGestureUpdateInterval: TimeInterval = 1.0 / 60.0
     private let edgeSnapSampleInterval: TimeInterval = 1.0 / 30.0
 
-    private init() {}
+    private init() {
+        // A filter tap owned by a switched-away login session keeps its place
+        // in the chain and stalls input for the account on screen. Hand every
+        // tap back on resign and build them again from the preferences on the
+        // way back in.
+        SessionActivity.shared.onChange { [weak self] _ in
+            self?.syncWithPreferences()
+        }
+    }
 
     func syncWithPreferences() {
         let available = AppFeature.windowLayout.isAvailable
         let trusted = AXIsProcessTrusted()
+        let sessionIsActive = SessionActivity.shared.isActive
+        // Carbon hotkeys are registered per session, so the plain layout
+        // shortcuts need no session gate: they own no tap.
         let wantsShortcuts = available
             && UserDefaults.standard.bool(forKey: DefaultsKey.windowLayoutShortcutsEnabled)
             && trusted
         wantsShortcuts ? registerHotkeys() : unregisterHotkeys()
 
-        let wantsDirectional = available
-            && UserDefaults.standard.bool(forKey: DefaultsKey.windowDirectionalEnabled)
-            && trusted
+        // The directional hotkey is gated all the same, because holding it is
+        // what creates the third tap. Dropping the hotkey is how that tap stays
+        // out of a session it cannot serve.
+        let wantsDirectional = SessionActivitySupport.tapShouldRun(
+            featureWanted: available
+                && UserDefaults.standard.bool(forKey: DefaultsKey.windowDirectionalEnabled),
+            accessibilityGranted: trusted,
+            sessionIsActive: sessionIsActive
+        )
         wantsDirectional ? registerDirectionalHotkey() : unregisterDirectionalHotkey()
 
-        let wantsGesture = available
-            && UserDefaults.standard.bool(forKey: DefaultsKey.windowGestureEnabled)
-            && trusted
+        let wantsGesture = SessionActivitySupport.tapShouldRun(
+            featureWanted: available
+                && UserDefaults.standard.bool(forKey: DefaultsKey.windowGestureEnabled),
+            accessibilityGranted: trusted,
+            sessionIsActive: sessionIsActive
+        )
         wantsGesture ? startGestureTap() : stopGestureTap()
 
-        let wantsEdgeSnap = available
-            && UserDefaults.standard.bool(forKey: DefaultsKey.windowEdgeSnapEnabled)
-            && !WindowEdgeSnapSupport.isSystemTilingEnabled
-            && trusted
+        let wantsEdgeSnap = SessionActivitySupport.tapShouldRun(
+            featureWanted: available
+                && UserDefaults.standard.bool(forKey: DefaultsKey.windowEdgeSnapEnabled)
+                && !WindowEdgeSnapSupport.isSystemTilingEnabled,
+            accessibilityGranted: trusted,
+            sessionIsActive: sessionIsActive
+        )
         wantsEdgeSnap ? startEdgeSnapTap() : stopEdgeSnapTap()
     }
 
@@ -765,6 +788,30 @@ final class WindowLayoutService: ObservableObject {
     }
 
     private func observeDirectionalEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            let wanted = directionalSession != nil
+                && AppFeature.windowLayout.isAvailable
+                && UserDefaults.standard.bool(forKey: DefaultsKey.windowDirectionalEnabled)
+            let shouldRearm = SessionActivitySupport.tapShouldRun(
+                featureWanted: wanted,
+                accessibilityGranted: AXIsProcessTrusted(),
+                sessionIsActive: SessionActivity.shared.isActive
+            )
+            if shouldRearm, let directionalTap {
+                CGEvent.tapEnable(tap: directionalTap, enable: true)
+            } else {
+                // Invalidating the port from its own callback stack is unsafe;
+                // finish this callback fail-open, then drop the gesture and its
+                // tap. The sync also takes the hotkey away while the session is
+                // off screen, so no press can build the tap again.
+                DispatchQueue.main.async { [weak self] in
+                    self?.cancelDirectionalGesture()
+                    self?.syncWithPreferences()
+                }
+            }
+            return Unmanaged.passUnretained(event)
+        }
+
         guard var session = directionalSession else { return Unmanaged.passUnretained(event) }
 
         if type == .scrollWheel {
@@ -823,7 +870,10 @@ final class WindowLayoutService: ObservableObject {
                 hideEdgeSnapPreview(immediately: true)
                 return nil
             } else if keyCode == 53 { // Escape
-                cancelDirectionalGesture()
+                // Cancelling invalidates this very port, which is unsafe from
+                // the port's own callback stack. The edge-snap tap leaves its
+                // callback the same way.
+                DispatchQueue.main.async { [weak self] in self?.cancelDirectionalGesture() }
                 return nil
             }
         }
@@ -1016,8 +1066,24 @@ final class WindowLayoutService: ObservableObject {
     private func observeEdgeSnapEvent(type: CGEventType,
                                       event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let edgeSnapTap { CGEvent.tapEnable(tap: edgeSnapTap, enable: true) }
-            DispatchQueue.main.async { [weak self] in self?.cancelEdgeSnapTracking() }
+            let wanted = AppFeature.windowLayout.isAvailable
+                && UserDefaults.standard.bool(forKey: DefaultsKey.windowEdgeSnapEnabled)
+            let shouldRearm = SessionActivitySupport.tapShouldRun(
+                featureWanted: wanted,
+                accessibilityGranted: AXIsProcessTrusted(),
+                sessionIsActive: SessionActivity.shared.isActive
+            )
+            if shouldRearm, let edgeSnapTap {
+                CGEvent.tapEnable(tap: edgeSnapTap, enable: true)
+                DispatchQueue.main.async { [weak self] in self?.cancelEdgeSnapTracking() }
+            } else {
+                // Invalidating the port from its own callback stack is unsafe;
+                // finish this callback fail-open, then release the tap.
+                DispatchQueue.main.async { [weak self] in
+                    self?.stopEdgeSnapTap()
+                    self?.syncWithPreferences()
+                }
+            }
             return Unmanaged.passUnretained(event)
         }
         guard event.getIntegerValueField(.eventSourceUserData) != Self.syntheticEventMarker,
@@ -1461,8 +1527,25 @@ final class WindowLayoutService: ObservableObject {
         }
 
         let tapDisabled = type == .tapDisabledByTimeout || type == .tapDisabledByUserInput
-        if tapDisabled, let gestureTap {
-            CGEvent.tapEnable(tap: gestureTap, enable: true)
+        if tapDisabled {
+            let wanted = AppFeature.windowLayout.isAvailable
+                && UserDefaults.standard.bool(forKey: DefaultsKey.windowGestureEnabled)
+            let shouldRearm = SessionActivitySupport.tapShouldRun(
+                featureWanted: wanted,
+                accessibilityGranted: AXIsProcessTrusted(),
+                sessionIsActive: SessionActivity.shared.isActive
+            )
+            if shouldRearm, let gestureTap {
+                CGEvent.tapEnable(tap: gestureTap, enable: true)
+            } else {
+                // The decision below still hands a held press back to the app.
+                // Only after this callback returns is the port released, since
+                // invalidating it from its own callback stack is unsafe.
+                DispatchQueue.main.async { [weak self] in
+                    self?.stopGestureTap()
+                    self?.syncWithPreferences()
+                }
+            }
         }
 
         var chord: (button: WindowPointerGesture.Button, wantsResize: Bool)?

--- a/Sources/Vorssaint/Services/WindowMaximizer.swift
+++ b/Sources/Vorssaint/Services/WindowMaximizer.swift
@@ -8,7 +8,8 @@ import CoreGraphics
 
 /// Makes the green traffic-light button maximize in the current Space instead
 /// of entering macOS fullscreen. The event tap is installed only while the user
-/// has opted in and Accessibility is granted.
+/// has opted in, Accessibility is granted, and this login session is the one on
+/// screen.
 final class WindowMaximizer: ObservableObject {
     static let shared = WindowMaximizer()
 
@@ -25,12 +26,23 @@ final class WindowMaximizer: ObservableObject {
     private let frameTolerance: CGFloat = 4
     private let zoomAnimationDuration: TimeInterval = 0.22
 
-    private init() {}
+    private init() {
+        // A filter tap owned by a switched-away login session keeps its place
+        // in the chain and stalls input for the account on screen. Hand the tap
+        // back on resign and build it again from the preferences on the way in.
+        SessionActivity.shared.onChange { [weak self] _ in
+            self?.syncWithPreferences()
+        }
+    }
 
     func syncWithPreferences() {
         let wanted = AppFeature.windowMaximizer.isAvailable
             && UserDefaults.standard.bool(forKey: DefaultsKey.windowMaximizeEnabled)
-        if wanted, Permissions.shared.accessibility {
+        if SessionActivitySupport.tapShouldRun(
+            featureWanted: wanted,
+            accessibilityGranted: Permissions.shared.accessibility,
+            sessionIsActive: SessionActivity.shared.isActive
+        ) {
             start()
         } else {
             stop()
@@ -88,7 +100,23 @@ final class WindowMaximizer: ObservableObject {
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
+            let wanted = AppFeature.windowMaximizer.isAvailable
+                && UserDefaults.standard.bool(forKey: DefaultsKey.windowMaximizeEnabled)
+            let shouldRearm = SessionActivitySupport.tapShouldRun(
+                featureWanted: wanted,
+                accessibilityGranted: AXIsProcessTrusted(),
+                sessionIsActive: SessionActivity.shared.isActive
+            )
+            if shouldRearm, let tap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            } else {
+                // Invalidating the port from its own callback stack is unsafe;
+                // finish this callback fail-open, then release the tap.
+                DispatchQueue.main.async { [weak self] in
+                    self?.stop()
+                    self?.syncWithPreferences()
+                }
+            }
             return Unmanaged.passUnretained(event)
         }
 

--- a/Sources/Vorssaint/Services/WindowMaximizer.swift
+++ b/Sources/Vorssaint/Services/WindowMaximizer.swift
@@ -38,9 +38,13 @@ final class WindowMaximizer: ObservableObject {
     func syncWithPreferences() {
         let wanted = AppFeature.windowMaximizer.isAvailable
             && UserDefaults.standard.bool(forKey: DefaultsKey.windowMaximizeEnabled)
+        // `Permissions.shared.accessibility` is polled on a timer and lags a
+        // revoked grant. A timeout that refused to re-arm on
+        // `AXIsProcessTrusted()` then calls this, so reading the mirror here
+        // would start the tap straight back on the stale value.
         if SessionActivitySupport.tapShouldRun(
             featureWanted: wanted,
-            accessibilityGranted: Permissions.shared.accessibility,
+            accessibilityGranted: AXIsProcessTrusted(),
             sessionIsActive: SessionActivity.shared.isActive
         ) {
             start()

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21763,8 +21763,11 @@ struct MetricsTests {
                        "\(tapOwner) does not keep a modifying tap alive after Accessibility is lost")
                 // `Permissions.shared.accessibility` is polled on a timer, so a
                 // re-arm that refused on the live answer must not be undone by
-                // a sync that trusts the stale one.
-                expect(!code.contains("accessibilityGranted: Permissions.shared.accessibility"),
+                // a sync that trusts the stale one. The symbol is rejected
+                // outright rather than one call-site spelling of it, so a
+                // different argument label or a local reading it is caught too;
+                // none of the files behind this gate reads the mirror at all.
+                expect(!code.contains("Permissions.shared.accessibility"),
                        "\(tapOwner) asks Accessibility directly everywhere it decides to run a tap")
             }
             // Switching a tap off leaves the process owning it, which is what

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21761,14 +21761,24 @@ struct MetricsTests {
                 || tapOwner.contains("Window") {
                 expect(code.contains("AXIsProcessTrusted()"),
                        "\(tapOwner) does not keep a modifying tap alive after Accessibility is lost")
-                // `Permissions.shared.accessibility` is polled on a timer, so a
-                // re-arm that refused on the live answer must not be undone by
-                // a sync that trusts the stale one. The symbol is rejected
-                // outright rather than one call-site spelling of it, so a
-                // different argument label or a local reading it is caught too;
-                // none of the files behind this gate reads the mirror at all.
-                expect(!code.contains("Permissions.shared.accessibility"),
-                       "\(tapOwner) asks Accessibility directly everywhere it decides to run a tap")
+            }
+            // `Permissions.shared.accessibility` is polled on a timer and lags
+            // a revoked grant by up to `PermissionPollingSupport.interval`. A
+            // re-arm that refused on the live answer hands the tap to the sync
+            // to be stopped, so a gate reading the mirror would start it
+            // straight back on the stale value. Asked of the files that refuse
+            // on the live answer, which is where the two can disagree, rather
+            // than off a second hand-kept name list. Read off the gate's own
+            // argument and not the whole file, because the same mirror is
+            // deliberately cached on the per-event paths that must not pay a
+            // TCC round-trip per keystroke.
+            if code.contains("AXIsProcessTrusted()") {
+                let gateArguments = code
+                    .components(separatedBy: "SessionActivitySupport.tapShouldRun(")
+                    .dropFirst()
+                    .map { $0.components(separatedBy: "sessionIsActive:").first ?? "" }
+                expect(gateArguments.allSatisfy { !$0.contains("Permissions.shared.accessibility") },
+                       "\(tapOwner) asks Accessibility directly wherever it decides to run a tap")
             }
             // Switching a tap off leaves the process owning it, which is what
             // the window server waits on; teardown must invalidate the port.

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21737,7 +21737,9 @@ struct MetricsTests {
                          "Sources/Vorssaint/Services/MouseNavigation/MouseNavigationService.swift",
                          "Sources/Vorssaint/Services/MouseButtons/MouseButtonShortcutService.swift",
                          "Sources/Vorssaint/Services/MiddleClick/MiddleClickService.swift",
-                         "Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift"] {
+                         "Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift",
+                         "Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift",
+                         "Sources/Vorssaint/Services/WindowMaximizer.swift"] {
             let source = (try? String(contentsOfFile: tapOwner, encoding: .utf8)) ?? ""
             expect(!source.isEmpty, "\(tapOwner) reads back for its session-switch check")
             let code = source.components(separatedBy: "\n")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21777,8 +21777,8 @@ struct MetricsTests {
                     .components(separatedBy: "SessionActivitySupport.tapShouldRun(")
                     .dropFirst()
                     .map { $0.components(separatedBy: "sessionIsActive:").first ?? "" }
-                expect(gateArguments.allSatisfy { !$0.contains("Permissions.shared.accessibility") },
-                       "\(tapOwner) asks Accessibility directly wherever it decides to run a tap")
+                expect(gateArguments.allSatisfy { $0.contains("AXIsProcessTrusted()") },
+                       "\(tapOwner) asks Accessibility live wherever it decides to run a tap")
             }
             // Switching a tap off leaves the process owning it, which is what
             // the window server waits on; teardown must invalidate the port.

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21747,16 +21747,25 @@ struct MetricsTests {
                 .joined(separator: "\n")
             expect(code.contains("SessionActivity.shared.onChange"),
                    "\(tapOwner) rebuilds its tap when the session comes back")
-            let rearm = code.components(separatedBy: "tapDisabledByTimeout")
-                .dropFirst().first?.components(separatedBy: "return").first ?? ""
-            expect(rearm.contains("SessionActivity.shared.isActive"),
-                   "\(tapOwner) does not re-arm a disabled tap into a switched-away session")
+            // A file can own several taps, so every re-arm is checked, not the
+            // first one the split happens to land on.
+            let rearms = code.components(separatedBy: "tapDisabledByTimeout").dropFirst()
+                .map { $0.components(separatedBy: "return").first ?? "" }
+            expect(!rearms.isEmpty
+                    && rearms.allSatisfy { $0.contains("SessionActivity.shared.isActive") },
+                   "\(tapOwner) does not re-arm any disabled tap into a switched-away session")
             if tapOwner.contains("MouseNavigation")
                 || tapOwner.contains("MouseButtonShortcut")
                 || tapOwner.contains("MiddleClick")
-                || tapOwner.contains("QuitProtection") {
+                || tapOwner.contains("QuitProtection")
+                || tapOwner.contains("Window") {
                 expect(code.contains("AXIsProcessTrusted()"),
                        "\(tapOwner) does not keep a modifying tap alive after Accessibility is lost")
+                // `Permissions.shared.accessibility` is polled on a timer, so a
+                // re-arm that refused on the live answer must not be undone by
+                // a sync that trusts the stale one.
+                expect(!code.contains("accessibilityGranted: Permissions.shared.accessibility"),
+                       "\(tapOwner) asks Accessibility directly everywhere it decides to run a tap")
             }
             // Switching a tap off leaves the process owning it, which is what
             // the window server waits on; teardown must invalidate the port.


### PR DESCRIPTION
## Summary

Window Layout owns three `.defaultTap` event taps and the green-button
maximizer owns a fourth. None of them followed the login session:

| tap | mask | created |
| --- | --- | --- |
| move/resize gesture | left+right down/dragged/up | while the feature is on |
| edge snap | left down/dragged/up | while the feature is on |
| directional gesture | scroll, left/right down, keyDown | only while the hotkey is held |
| maximizer | left down/up | while the feature is on |

All four run on the main run loop, so the re-arm reads
`SessionActivity.shared.isActive` in place, the way
`MouseNavigation/MouseNavigationService.swift` does. The taps that run a
thread of their own — Finder, keyboard, Super Key, snippets, switcher — hop to
the main queue for the same answer, because that is where the flag is written.

After a fast user switch this process keeps running in the session that left
the screen, and a filter tap created there keeps its place in the chain. The
window server still routes every matching event through a process that cannot
answer and waits out the tap timeout on each one, so the account actually in
use pays it (#1153). Each of the four now asks
`SessionActivitySupport.tapShouldRun` in both places that can put a tap into
the chain — the preference sync and the timeout re-arm — and subscribes to
`SessionActivity.shared.onChange` so the taps come back with the session.

The maximizer's two permission sources disagreed inside one path. `handle`
refuses to re-arm on `AXIsProcessTrusted() == false` and then, from the same
async block, calls `syncWithPreferences()` — which asked the timer-polled
`Permissions.shared.accessibility` and could `start()` the tap straight back
on a value that had not caught up with the revoke. `syncWithPreferences()` now
asks `AXIsProcessTrusted()` directly, the way
`WindowLayoutService.syncWithPreferences` already does. Nothing else changes:
the only other caller path is the `Permissions.shared.$accessibility` sink in
`AppDelegate`, which fires after the grant, so the direct read is the fresh
one there too.

Two smaller fixes in the same code:

- The directional gesture cancelled itself on Escape from inside its own tap
  callback, removing the run loop source and invalidating the port on that
  stack. The repository states three times that this is unsafe
  (`MouseButtonShortcutService.swift`, `CleaningModeManager.swift`,
  `MiddleClickService.swift`), and the edge-snap tap in this same file already
  defers to the main queue. Escape now does the same, as do the three new
  teardown paths, so this change does not reintroduce the shape it removes.
- The directional tap had no `tapDisabledByTimeout` handling at all. A tap the
  window server disabled stayed disabled and the gesture went quiet until the
  hotkey was released.

Trade-offs:

- The directional *hotkey* is gated too, not just its tap. Gating only the tap
  would leave `beginDirectionalGesture()` free to create one while the session
  is off screen; taking the hotkey away removes the only path to it, in one
  line, at the same place the other three gates live.
- The re-arm branches call `syncWithPreferences()` after teardown, following
  `MouseNavigationService`, so a tap released by a timeout that raced the
  resign notification is rebuilt if the session was in fact still on screen.
- No new guard file was written. `MetricsTests.swift` already carries the
  session-switch guard as a loop over tap owners; both files were added to it
  and two of its assertions were changed, because as written they did not
  reach the code this pull request adds:
  - the re-arm slice split on the *first* `tapDisabledByTimeout` in the file,
    which in `WindowLayoutService.swift` is `observeDirectionalEvent`, so the
    edge-snap and gesture re-arms went unchecked. It now checks every slice.
  - the `AXIsProcessTrusted()` assertion sat behind an `if tapOwner.contains(…)`
    naming four other services, so it skipped both new files. The gate now
    admits them, and a second check rejects the polled mirror at the gate.

    That second check reads the gate's own argument — everything between
    `SessionActivitySupport.tapShouldRun(` and its `sessionIsActive:` label,
    for every call in the file — rather than banning
    `Permissions.shared.accessibility` across the source. A whole-file ban
    holds for the eight files behind this gate today and breaks on the taps
    that come next: `FinderCutPaste` and `AppSwitcher` both cache that mirror
    on purpose on their per-keystroke path, each with a comment saying a live
    TCC round-trip per key is what the cache exists to avoid. The gate's
    argument is where a stale answer actually does harm, and it is the only
    place the check now looks.

    It is asked of the files whose re-arm refuses on `AXIsProcessTrusted()`,
    which is where the two answers can disagree, rather than off a second
    hand-kept name list. `ScrollInverter.swift` re-arms on the session alone
    and never consults Accessibility, so there is no pair of sources to
    disagree there; it passes `accessibilityGranted:
    Permissions.shared.accessibility` legitimately and stays exempt.

  PR #1230 replaces the owner list with a sweep of every file containing
  `CGEvent.tapCreate`; this change is what lets both files drop out of its
  `knownUngatedTaps` table.

Two riders that were in this branch are now on their own:

- the directional gesture's 60 Hz feedback timer moving to common run loop
  modes — an independent UI defect, visible without any second account, that
  none of the assertions here reach — is #1267.
- `focusedTarget(for:)` looking its app up by pid instead of re-bridging
  `NSWorkspace.runningApplications` — a performance change with no measurement
  behind it and one behaviour difference on a terminated pid — is #1268.

A third finding from the same audit was left out entirely: caching
`WindowEdgeSnapSupport.isSystemTilingEnabled`, which rebuilds a `UserDefaults`
suite and reads three keys on every left mouse down. PR #1208 is rewriting that
exact computed property (and makes it read a second suite), so the cache should
be rebased onto it rather than conflict with it.

## Verification

MacBook Pro, macOS 26. Rebased onto `main` at `a952b829`.

```
./build.sh --test      TESTS OK (9550 checks)
swiftc -typecheck      exit 0, whole module
```

`--test` compiles a whitelist that does not include either changed source
file — that list is almost entirely `*Support.swift` and `*Strings.swift` — so
the whole of `Sources/Vorssaint/**` was type-checked separately with the same
target and SDK `build.sh` uses. The full `./build.sh` was not run: with the
signing keychain locked, `codesign` blocks on an unlock dialog that never
returns.

The two input-source failures reported on the earlier revision
(`nil layout falls back to ANSI semicolon` and `App Switcher icon-row hints`)
did not appear this round; the machine's input source is ANSI now rather than
a Chinese IME. They read the current input source and are unrelated to this
diff either way.

The changed assertions were checked by breaking the code they are meant to
hold, not by argument. Each break was applied alone and reverted:

- `sessionIsActive: SessionActivity.shared.isActive` replaced with `true` in
  the **edge-snap** re-arm — the second of the three, the one the old
  first-slice split could not see. Fails `WindowLayoutService.swift does not
  re-arm any disabled tap into a switched-away session`.
- the maximizer's `syncWithPreferences()` put back on the polled mirror. Fails
  `WindowMaximizer.swift asks Accessibility directly wherever it decides to run
  a tap`. Restored: green.
- the gate-argument form was also checked against the case that made the
  whole-file ban wrong: `ScrollInverter.swift` reads the mirror in its gate
  today and is caught by this check when it is not exempt, and the
  per-keystroke caches in `FinderCutPaste` and `AppSwitcher` are not caught by
  it at all.

**What was not tested.**

- **The behaviour itself.** There is no second login session on this machine,
  so the fast user switch this change is about was never performed. What is
  verified is that the wiring matches the services that already carry it.
- The revoke race is not reproduced either. Reaching it needs the window server
  to disable the maximizer's tap inside the polling interval that follows a
  revoked Accessibility grant; the fix is the read the sibling service already
  makes at the same point.
- The bundle assembly and signing step of `./build.sh`, for the reason above.
- The Escape teardown is a divergence from a rule this repository states three
  times, not an observed crash. Nothing was seen to fail before the change.
- The directional tap's new timeout handling was not exercised: reaching it
  needs the window server to disable a tap that only exists while a hotkey is
  physically held.

## Anything else

Refs #1153
