### PR TITLE
fix(finder): hand the Finder taps back across a user switch

### DIFF
--- a/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
@@ -12,12 +12,9 @@ import SwiftUI
 /// shortcuts only while Finder is frontmost and no text field is being edited,
 /// so renaming and text editing keep working untouched.
 ///
-/// A keystroke is answered on the tap thread where a wrong answer would cost
-/// nothing: which app is in front is kept there, and ⌘C outside Finder — which
-/// this service never swallows anyway — is handed straight back. ⌘X and ⌘V
-/// cross to the main thread, where the marks, the pasteboard change count and a
-/// fast Accessibility role check decide; the slow parts (reading the Finder
-/// selection, moving files) run off both threads.
+/// The decision to swallow a keystroke is made synchronously (in-memory marks +
+/// the pasteboard change count + a fast Accessibility role check); the slow
+/// parts (reading the Finder selection, moving files) run off the tap thread.
 /// Requires Accessibility, and Automation consent for Finder on first use.
 final class FinderCutPaste: ObservableObject {
     static let shared = FinderCutPaste()
@@ -86,13 +83,6 @@ final class FinderCutPaste: ObservableObject {
     private var imagePasteInProgress = false
     private var appObserver: NSObjectProtocol?
 
-    /// Which app is in front, written by the activation observer on the main
-    /// thread and read by the tap callback on its own. Nil whenever the
-    /// observer is not installed, so a cached answer can never outlive the
-    /// thing that maintains it.
-    private let routeLock = NSLock()
-    private var frontmostBundleID: String?
-
     private static let finderBundleID = "com.apple.finder"
     private static let syntheticPasteMarker: Int64 = 0x564F5249
     private static let maxRawImageBytes = 64 * 1024 * 1024
@@ -128,21 +118,6 @@ final class FinderCutPaste: ObservableObject {
         showHUD = UserDefaults.standard.object(forKey: DefaultsKey.finderCutPasteShowHUD) as? Bool ?? true
         pasteImageAsFileEnabled = available
             && UserDefaults.standard.bool(forKey: DefaultsKey.finderPasteImageAsFile)
-        // The observer is what keeps the front app the tap thread reads
-        // current, so it follows either shortcut path rather than cut and paste
-        // alone, and it goes up before the tap: a live tap with nothing
-        // maintaining that answer behind it hands ⌘C back everywhere.
-        if cutPasteEnabled || pasteImageAsFileEnabled {
-            installAppObserver()
-        } else {
-            removeAppObserver()
-        }
-        // The marks belong to cut and paste, so they go on that switch alone.
-        // Sharing the observer's condition would leave a staged cut live when
-        // cut and paste is turned off while image paste keeps the observer up:
-        // the HUD stays on screen, the change count still matches, and the next
-        // ⌘V moves the files the user thought they had un-staged.
-        if !cutPasteEnabled { clearMarks() }
         let wanted = SessionActivitySupport.tapShouldRun(
             featureWanted: cutPasteEnabled || pasteImageAsFileEnabled,
             accessibilityGranted: Permissions.shared.accessibility,
@@ -152,6 +127,12 @@ final class FinderCutPaste: ObservableObject {
             installTap()
         } else {
             removeTap()
+        }
+        if cutPasteEnabled {
+            installAppObserver()
+        } else {
+            removeAppObserver()
+            clearMarks()
         }
         refreshPanel()
     }
@@ -167,8 +148,6 @@ final class FinderCutPaste: ObservableObject {
 
     private func installAppObserver() {
         guard appObserver == nil else { return }
-        // The app already in front sends no activation of its own.
-        cacheFrontmostApplication()
         appObserver = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didActivateApplicationNotification,
             object: nil,
@@ -183,18 +162,11 @@ final class FinderCutPaste: ObservableObject {
             NSWorkspace.shared.notificationCenter.removeObserver(observer)
             appObserver = nil
         }
-        routeLock.withLock { frontmostBundleID = nil }
     }
 
     private func handleApplicationActivation() {
-        cacheFrontmostApplication()
         guard cutPasteEnabled else { return }
         refreshPanel()
-    }
-
-    private func cacheFrontmostApplication() {
-        let bundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
-        routeLock.withLock { frontmostBundleID = bundleID }
     }
 
     // MARK: - Event tap
@@ -293,10 +265,9 @@ final class FinderCutPaste: ObservableObject {
         }
     }
 
-    /// Runs on the tap thread. Every key except a plain Command-X/C/V returns
-    /// after reading only the event, and Command-C outside Finder after one
-    /// cached string as well; the rare candidate is handed to the main thread
-    /// where the service's UI and pasteboard state live.
+    /// Runs on the tap thread. Every key except plain Command-X/C/V returns
+    /// after reading only the event itself; the rare candidate is handed to
+    /// the main thread where the service's UI and pasteboard state live.
     private func route(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             // The gate the preference sync applied, asked again: a tap re-armed
@@ -320,25 +291,6 @@ final class FinderCutPaste: ObservableObject {
               !flags.contains(.maskControl), !flags.contains(.maskAlternate),
               keyCode == Key.x || keyCode == Key.c || keyCode == Key.v
         else { return Unmanaged.passUnretained(event) }
-
-        // ⌘C is one of the two most-pressed combinations on the machine, and
-        // outside Finder the answer is always no. Learning that on the main
-        // thread would make every copy anywhere wait for whatever this app is
-        // drawing, so the activation observer keeps the answer over here.
-        //
-        // Only ⌘C. The observer refreshes this on the main queue, which is the
-        // thread this reject exists because it is busy, so through that stall
-        // the cache still names the app the user just left. A stale reject is
-        // free here — the main thread passes ⌘C through in every branch, and
-        // the pending-cut marks it would have dropped are dropped again by the
-        // change-count check on the next ⌘V. It is not free for the other two:
-        // ⌘X swallows the key and cuts, ⌘V moves the marked files or writes the
-        // pasteboard image out as a file, and Finder has no native answer for
-        // either, so a stale reject makes them silently do nothing.
-        if keyCode == Key.c,
-           routeLock.withLock({ frontmostBundleID }) != Self.finderBundleID {
-            return Unmanaged.passUnretained(event)
-        }
 
         var verdict: Unmanaged<CGEvent>?
         DispatchQueue.main.sync {

--- a/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
@@ -12,12 +12,12 @@ import SwiftUI
 /// shortcuts only while Finder is frontmost and no text field is being edited,
 /// so renaming and text editing keep working untouched.
 ///
-/// A keystroke is answered on the tap thread wherever it can be: which app is
-/// in front is kept there, so ⌘C and ⌘V outside Finder are handed straight
-/// back. Only those combinations inside Finder cross to the main thread, where
-/// the marks, the pasteboard change count and a fast Accessibility role check
-/// decide; the slow parts (reading the Finder selection, moving files) run off
-/// both threads.
+/// A keystroke is answered on the tap thread where a wrong answer would cost
+/// nothing: which app is in front is kept there, and ⌘C outside Finder — which
+/// this service never swallows anyway — is handed straight back. ⌘X and ⌘V
+/// cross to the main thread, where the marks, the pasteboard change count and a
+/// fast Accessibility role check decide; the slow parts (reading the Finder
+/// selection, moving files) run off both threads.
 /// Requires Accessibility, and Automation consent for Finder on first use.
 final class FinderCutPaste: ObservableObject {
     static let shared = FinderCutPaste()
@@ -131,7 +131,7 @@ final class FinderCutPaste: ObservableObject {
         // The observer is what keeps the front app the tap thread reads
         // current, so it follows either shortcut path rather than cut and paste
         // alone, and it goes up before the tap: a live tap with nothing
-        // maintaining that answer behind it hands every shortcut back.
+        // maintaining that answer behind it hands ⌘C back everywhere.
         if cutPasteEnabled || pasteImageAsFileEnabled {
             installAppObserver()
         } else {
@@ -288,10 +288,10 @@ final class FinderCutPaste: ObservableObject {
         }
     }
 
-    /// Runs on the tap thread. Every key except a plain Command-X/C/V pressed
-    /// in Finder returns after reading only the event and one cached string;
-    /// the rare candidate is handed to the main thread where the service's UI
-    /// and pasteboard state live.
+    /// Runs on the tap thread. Every key except a plain Command-X/C/V returns
+    /// after reading only the event, and Command-C outside Finder after one
+    /// cached string as well; the rare candidate is handed to the main thread
+    /// where the service's UI and pasteboard state live.
     private func route(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             // The gate the preference sync applied, asked again: a tap re-armed
@@ -316,13 +316,24 @@ final class FinderCutPaste: ObservableObject {
               keyCode == Key.x || keyCode == Key.c || keyCode == Key.v
         else { return Unmanaged.passUnretained(event) }
 
-        // ⌘C and ⌘V are the two most-pressed combinations on the machine, and
+        // ⌘C is one of the two most-pressed combinations on the machine, and
         // outside Finder the answer is always no. Learning that on the main
         // thread would make every copy anywhere wait for whatever this app is
-        // drawing, so the activation observer keeps the answer over here. The
-        // main thread reads the live value again before acting on it.
-        guard routeLock.withLock({ frontmostBundleID }) == Self.finderBundleID
-        else { return Unmanaged.passUnretained(event) }
+        // drawing, so the activation observer keeps the answer over here.
+        //
+        // Only ⌘C. The observer refreshes this on the main queue, which is the
+        // thread this reject exists because it is busy, so through that stall
+        // the cache still names the app the user just left. A stale reject is
+        // free here — the main thread passes ⌘C through in every branch, and
+        // the pending-cut marks it would have dropped are dropped again by the
+        // change-count check on the next ⌘V. It is not free for the other two:
+        // ⌘X swallows the key and cuts, ⌘V moves the marked files or writes the
+        // pasteboard image out as a file, and Finder has no native answer for
+        // either, so a stale reject makes them silently do nothing.
+        if keyCode == Key.c,
+           routeLock.withLock({ frontmostBundleID }) != Self.finderBundleID {
+            return Unmanaged.passUnretained(event)
+        }
 
         var verdict: Unmanaged<CGEvent>?
         DispatchQueue.main.sync {

--- a/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
@@ -213,7 +213,7 @@ final class FinderCutPaste: ObservableObject {
             let runLoop = CFRunLoopGetCurrent()
             tapLifecycleLock.withLock { tapRunLoop = runLoop }
             guard !tapLifecycleLock.withLock({ shouldStopTapThread }) else {
-                if clearEventTapThread() { installTap() }
+                if clearEventTapThread() { restartTapOnMain() }
                 return
             }
 
@@ -248,7 +248,7 @@ final class FinderCutPaste: ObservableObject {
             CGEvent.tapEnable(tap: tap, enable: false)
             CFRunLoopRemoveSource(runLoop, source, .commonModes)
             CFMachPortInvalidate(tap)
-            if clearEventTapThread() { installTap() }
+            if clearEventTapThread() { restartTapOnMain() }
         }
     }
 
@@ -262,6 +262,15 @@ final class FinderCutPaste: ObservableObject {
             pendingTapRestart = false
             return shouldRestart
         }
+    }
+
+    /// Runs on the tap thread once its run loop has stopped. A restart that
+    /// `installTap` left pending goes back through `syncWithPreferences`
+    /// instead of straight to `installTap`: the session flag is written on the
+    /// main thread, and a tap rebuilt into a session that is no longer on
+    /// screen stalls the account that is (issue #1075).
+    private func restartTapOnMain() {
+        DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
     }
 
     /// Puts the tap back after the window server disabled it, unless a stop is

--- a/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
@@ -12,9 +12,12 @@ import SwiftUI
 /// shortcuts only while Finder is frontmost and no text field is being edited,
 /// so renaming and text editing keep working untouched.
 ///
-/// The decision to swallow a keystroke is made synchronously (in-memory marks +
-/// the pasteboard change count + a fast Accessibility role check); the slow
-/// parts (reading the Finder selection, moving files) run off the tap thread.
+/// A keystroke is answered on the tap thread wherever it can be: which app is
+/// in front is kept there, so ⌘C and ⌘V outside Finder are handed straight
+/// back. Only those combinations inside Finder cross to the main thread, where
+/// the marks, the pasteboard change count and a fast Accessibility role check
+/// decide; the slow parts (reading the Finder selection, moving files) run off
+/// both threads.
 /// Requires Accessibility, and Automation consent for Finder on first use.
 final class FinderCutPaste: ObservableObject {
     static let shared = FinderCutPaste()
@@ -68,6 +71,11 @@ final class FinderCutPaste: ObservableObject {
     private var tapThread: Thread?
     private var shouldStopTapThread = false
     private var pendingTapRestart = false
+    /// `SessionActivitySupport.tapShouldRun`'s answer, sampled by the
+    /// preference sync. The timeout re-arm runs on the tap thread and the
+    /// session flag is written on the main one, so the re-arm reads the sample
+    /// instead of reaching across for the flag itself.
+    private var tapShouldRun = false
     private var panel: NSPanel?
     private var resultDismiss: DispatchWorkItem?
     private var operationGeneration = 0
@@ -77,6 +85,13 @@ final class FinderCutPaste: ObservableObject {
     private var pasteImageAsFileEnabled = false
     private var imagePasteInProgress = false
     private var appObserver: NSObjectProtocol?
+
+    /// Which app is in front, written by the activation observer on the main
+    /// thread and read by the tap callback on its own. Nil whenever the
+    /// observer is not installed, so a cached answer can never outlive the
+    /// thing that maintains it.
+    private let routeLock = NSLock()
+    private var frontmostBundleID: String?
 
     private static let finderBundleID = "com.apple.finder"
     private static let syntheticPasteMarker: Int64 = 0x564F5249
@@ -89,7 +104,15 @@ final class FinderCutPaste: ObservableObject {
         static let v: Int64 = 9
     }
 
-    private init() {}
+    private init() {
+        // A filter tap owned by a switched-away login session keeps its place
+        // in the chain, so the window server waits out the tap timeout on every
+        // key the account on screen presses (issue #1075). Hand the tap back on
+        // resign and build it from the preferences again on the way in.
+        SessionActivity.shared.onChange { [weak self] _ in
+            self?.syncWithPreferences()
+        }
+    }
 
     var isRunning: Bool { tapLifecycleLock.withLock { tap != nil } }
 
@@ -105,16 +128,25 @@ final class FinderCutPaste: ObservableObject {
         showHUD = UserDefaults.standard.object(forKey: DefaultsKey.finderCutPasteShowHUD) as? Bool ?? true
         pasteImageAsFileEnabled = available
             && UserDefaults.standard.bool(forKey: DefaultsKey.finderPasteImageAsFile)
-        if (cutPasteEnabled || pasteImageAsFileEnabled), Permissions.shared.accessibility {
-            installTap()
-        } else {
-            removeTap()
-        }
-        if cutPasteEnabled {
+        // The observer is what keeps the front app the tap thread reads
+        // current, so it follows either shortcut path rather than cut and paste
+        // alone, and it goes up before the tap: a live tap with nothing
+        // maintaining that answer behind it hands every shortcut back.
+        if cutPasteEnabled || pasteImageAsFileEnabled {
             installAppObserver()
         } else {
             removeAppObserver()
             clearMarks()
+        }
+        let wanted = SessionActivitySupport.tapShouldRun(
+            featureWanted: cutPasteEnabled || pasteImageAsFileEnabled,
+            accessibilityGranted: Permissions.shared.accessibility,
+            sessionIsActive: SessionActivity.shared.isActive)
+        tapLifecycleLock.withLock { tapShouldRun = wanted }
+        if wanted {
+            installTap()
+        } else {
+            removeTap()
         }
         refreshPanel()
     }
@@ -130,6 +162,8 @@ final class FinderCutPaste: ObservableObject {
 
     private func installAppObserver() {
         guard appObserver == nil else { return }
+        // The app already in front sends no activation of its own.
+        cacheFrontmostApplication()
         appObserver = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didActivateApplicationNotification,
             object: nil,
@@ -144,11 +178,18 @@ final class FinderCutPaste: ObservableObject {
             NSWorkspace.shared.notificationCenter.removeObserver(observer)
             appObserver = nil
         }
+        routeLock.withLock { frontmostBundleID = nil }
     }
 
     private func handleApplicationActivation() {
+        cacheFrontmostApplication()
         guard cutPasteEnabled else { return }
         refreshPanel()
+    }
+
+    private func cacheFrontmostApplication() {
+        let bundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        routeLock.withLock { frontmostBundleID = bundleID }
     }
 
     // MARK: - Event tap
@@ -247,12 +288,20 @@ final class FinderCutPaste: ObservableObject {
         }
     }
 
-    /// Runs on the tap thread. Every key except plain Command-X/C/V returns
-    /// after reading only the event itself; the rare candidate is handed to
-    /// the main thread where the service's UI and pasteboard state live.
+    /// Runs on the tap thread. Every key except a plain Command-X/C/V pressed
+    /// in Finder returns after reading only the event and one cached string;
+    /// the rare candidate is handed to the main thread where the service's UI
+    /// and pasteboard state live.
     private func route(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            let currentTap = tapLifecycleLock.withLock { shouldStopTapThread ? nil : tap }
+            // The gate the preference sync applied, asked again: a tap re-armed
+            // into a session that is no longer on screen puts the stall it was
+            // handed back to avoid straight back on the account that is
+            // (issue #1075). Its answer was sampled with the tap, so nothing
+            // here reaches for main-thread state.
+            let currentTap = tapLifecycleLock.withLock {
+                tapShouldRun && !shouldStopTapThread ? tap : nil
+            }
             if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
             return Unmanaged.passUnretained(event)
         }
@@ -265,6 +314,14 @@ final class FinderCutPaste: ObservableObject {
         guard flags.contains(.maskCommand),
               !flags.contains(.maskControl), !flags.contains(.maskAlternate),
               keyCode == Key.x || keyCode == Key.c || keyCode == Key.v
+        else { return Unmanaged.passUnretained(event) }
+
+        // ⌘C and ⌘V are the two most-pressed combinations on the machine, and
+        // outside Finder the answer is always no. Learning that on the main
+        // thread would make every copy anywhere wait for whatever this app is
+        // drawing, so the activation observer keeps the answer over here. The
+        // main thread reads the live value again before acting on it.
+        guard routeLock.withLock({ frontmostBundleID }) == Self.finderBundleID
         else { return Unmanaged.passUnretained(event) }
 
         var verdict: Unmanaged<CGEvent>?

--- a/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
@@ -136,8 +136,13 @@ final class FinderCutPaste: ObservableObject {
             installAppObserver()
         } else {
             removeAppObserver()
-            clearMarks()
         }
+        // The marks belong to cut and paste, so they go on that switch alone.
+        // Sharing the observer's condition would leave a staged cut live when
+        // cut and paste is turned off while image paste keeps the observer up:
+        // the HUD stays on screen, the change count still matches, and the next
+        // ⌘V moves the files the user thought they had un-staged.
+        if !cutPasteEnabled { clearMarks() }
         let wanted = SessionActivitySupport.tapShouldRun(
             featureWanted: cutPasteEnabled || pasteImageAsFileEnabled,
             accessibilityGranted: Permissions.shared.accessibility,

--- a/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
@@ -68,11 +68,6 @@ final class FinderCutPaste: ObservableObject {
     private var tapThread: Thread?
     private var shouldStopTapThread = false
     private var pendingTapRestart = false
-    /// `SessionActivitySupport.tapShouldRun`'s answer, sampled by the
-    /// preference sync. The timeout re-arm runs on the tap thread and the
-    /// session flag is written on the main one, so the re-arm reads the sample
-    /// instead of reaching across for the flag itself.
-    private var tapShouldRun = false
     private var panel: NSPanel?
     private var resultDismiss: DispatchWorkItem?
     private var operationGeneration = 0
@@ -118,12 +113,16 @@ final class FinderCutPaste: ObservableObject {
         showHUD = UserDefaults.standard.object(forKey: DefaultsKey.finderCutPasteShowHUD) as? Bool ?? true
         pasteImageAsFileEnabled = available
             && UserDefaults.standard.bool(forKey: DefaultsKey.finderPasteImageAsFile)
-        let wanted = SessionActivitySupport.tapShouldRun(
+        // Accessibility is asked of the system and not of `Permissions.shared`,
+        // whose answer is a poll up to `PermissionPollingSupport.interval` old.
+        // The re-arm hands a revoked tap to this sync to be stopped, and a
+        // stale grant here would install it straight back. The cached mirror
+        // still stands on the per-keystroke path below, where a live round-trip
+        // per key is what it exists to avoid.
+        if SessionActivitySupport.tapShouldRun(
             featureWanted: cutPasteEnabled || pasteImageAsFileEnabled,
-            accessibilityGranted: Permissions.shared.accessibility,
-            sessionIsActive: SessionActivity.shared.isActive)
-        tapLifecycleLock.withLock { tapShouldRun = wanted }
-        if wanted {
+            accessibilityGranted: AXIsProcessTrusted(),
+            sessionIsActive: SessionActivity.shared.isActive) {
             installTap()
         } else {
             removeTap()
@@ -265,20 +264,34 @@ final class FinderCutPaste: ObservableObject {
         }
     }
 
+    /// Puts the tap back after the window server disabled it, unless a stop is
+    /// already on its way and the port is about to go. Main thread.
+    private func rearmDisabledTap() {
+        let currentTap = tapLifecycleLock.withLock { shouldStopTapThread ? nil : tap }
+        if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
+    }
+
     /// Runs on the tap thread. Every key except plain Command-X/C/V returns
     /// after reading only the event itself; the rare candidate is handed to
     /// the main thread where the service's UI and pasteboard state live.
     private func route(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            // The gate the preference sync applied, asked again: a tap re-armed
-            // into a session that is no longer on screen puts the stall it was
-            // handed back to avoid straight back on the account that is
-            // (issue #1075). Its answer was sampled with the tap, so nothing
-            // here reaches for main-thread state.
-            let currentTap = tapLifecycleLock.withLock {
-                tapShouldRun && !shouldStopTapThread ? tap : nil
+            // A tap put straight back is a tap put back into whatever session
+            // is on screen now (issue #1075). The flag that answers that is
+            // written on the main thread and this callback runs on the tap's
+            // own thread, so the question is asked where the answer lives
+            // rather than read across the two. Accessibility is asked in the
+            // same place and for the same reason as the sync: this tap modifies
+            // events, so a revoked grant has to end it rather than put it back.
+            // Leaving the tap disabled until then is the safe direction — keys
+            // reach Finder untapped, which is how the feature is off.
+            DispatchQueue.main.async { [weak self] in
+                if SessionActivity.shared.isActive, AXIsProcessTrusted() {
+                    self?.rearmDisabledTap()
+                } else {
+                    self?.syncWithPreferences()
+                }
             }
-            if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
             return Unmanaged.passUnretained(event)
         }
         guard type == .keyDown,

--- a/Sources/Vorssaint/Services/Finder/FinderRenameService.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderRenameService.swift
@@ -107,7 +107,7 @@ final class FinderRenameService {
 
             let shouldStop = lifecycleLock.withLock { shouldStopTapThread }
             guard !shouldStop else {
-                if clearEventTapThread() { installTap() }
+                if clearEventTapThread() { restartTapOnMain() }
                 return
             }
 
@@ -144,7 +144,7 @@ final class FinderRenameService {
             CGEvent.tapEnable(tap: tap, enable: false)
             CFRunLoopRemoveSource(runLoop, source, .commonModes)
             CFMachPortInvalidate(tap)
-            if clearEventTapThread() { installTap() }
+            if clearEventTapThread() { restartTapOnMain() }
         }
     }
 
@@ -158,6 +158,15 @@ final class FinderRenameService {
             pendingStartAfterStop = false
             return shouldRestart
         }
+    }
+
+    /// Runs on the tap thread once its run loop has stopped. A restart that
+    /// `installTap` left pending goes back through `syncWithPreferences`
+    /// instead of straight to `installTap`: the session flag is written on the
+    /// main thread, and a tap rebuilt into a session that is no longer on
+    /// screen stalls the account that is (issue #1075).
+    private func restartTapOnMain() {
+        DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
     }
 
     /// Puts the tap back after the window server disabled it, unless a stop is

--- a/Sources/Vorssaint/Services/Finder/FinderRenameService.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderRenameService.swift
@@ -9,7 +9,8 @@ import Foundation
 
 /// Turns one chosen key combination into Finder's native Rename command.
 /// Unrelated keys stay on the tap thread's fast path, and the tap only lives
-/// while the feature is on and Accessibility is available.
+/// while the feature is on, Accessibility is available and this login session
+/// is the one on screen.
 final class FinderRenameService {
     static let shared = FinderRenameService()
 
@@ -20,13 +21,25 @@ final class FinderRenameService {
 
     private let lifecycleLock = NSLock()
     private var tap: CFMachPort?
-    private var runLoopSource: CFRunLoopSource?
     private var tapRunLoop: CFRunLoop?
     private var tapThread: Thread?
     private var shouldStopTapThread = false
     private var pendingStartAfterStop = false
+    /// `SessionActivitySupport.tapShouldRun`'s answer, sampled by the
+    /// preference sync. The timeout re-arm runs on the tap thread and the
+    /// session flag is written on the main one, so the re-arm reads the sample
+    /// instead of reaching across for the flag itself.
+    private var tapShouldRun = false
 
-    private init() {}
+    private init() {
+        // A filter tap owned by a switched-away login session keeps its place
+        // in the chain, so the window server waits out the tap timeout on every
+        // key the account on screen presses (issue #1075). Hand the tap back on
+        // resign and build it from the preferences again on the way in.
+        SessionActivity.shared.onChange { [weak self] _ in
+            self?.syncWithPreferences()
+        }
+    }
 
     func syncWithPreferences() {
         let shortcut = GlobalShortcut.saved(for: DefaultsKey.finderRenameShortcut,
@@ -34,7 +47,12 @@ final class FinderRenameService {
         routeLock.withLock { routeShortcut = shortcut }
         let enabled = AppFeature.finderRename.isAvailable
             && UserDefaults.standard.bool(forKey: DefaultsKey.finderRenameEnabled)
-        if enabled, Permissions.shared.accessibility {
+        let wanted = SessionActivitySupport.tapShouldRun(
+            featureWanted: enabled,
+            accessibilityGranted: Permissions.shared.accessibility,
+            sessionIsActive: SessionActivity.shared.isActive)
+        lifecycleLock.withLock { tapShouldRun = wanted }
+        if wanted {
             installTap()
         } else {
             removeTap()
@@ -116,10 +134,7 @@ final class FinderRenameService {
             }
 
             let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
-            lifecycleLock.withLock {
-                self.tap = tap
-                runLoopSource = source
-            }
+            lifecycleLock.withLock { self.tap = tap }
             CFRunLoopAddSource(runLoop, source, .commonModes)
             CGEvent.tapEnable(tap: tap, enable: true)
 
@@ -140,7 +155,6 @@ final class FinderRenameService {
         lifecycleLock.withLock {
             let shouldRestart = pendingStartAfterStop
             tap = nil
-            runLoopSource = nil
             tapRunLoop = nil
             tapThread = nil
             shouldStopTapThread = false
@@ -154,7 +168,14 @@ final class FinderRenameService {
     /// combination.
     private func route(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            let currentTap = lifecycleLock.withLock { shouldStopTapThread ? nil : tap }
+            // The gate the preference sync applied, asked again: a tap re-armed
+            // into a session that is no longer on screen puts the stall it was
+            // handed back to avoid straight back on the account that is
+            // (issue #1075). Its answer was sampled with the tap, so nothing
+            // here reaches for main-thread state.
+            let currentTap = lifecycleLock.withLock {
+                tapShouldRun && !shouldStopTapThread ? tap : nil
+            }
             if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
             return Unmanaged.passUnretained(event)
         }

--- a/Sources/Vorssaint/Services/Finder/FinderRenameService.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderRenameService.swift
@@ -25,11 +25,6 @@ final class FinderRenameService {
     private var tapThread: Thread?
     private var shouldStopTapThread = false
     private var pendingStartAfterStop = false
-    /// `SessionActivitySupport.tapShouldRun`'s answer, sampled by the
-    /// preference sync. The timeout re-arm runs on the tap thread and the
-    /// session flag is written on the main one, so the re-arm reads the sample
-    /// instead of reaching across for the flag itself.
-    private var tapShouldRun = false
 
     private init() {
         // A filter tap owned by a switched-away login session keeps its place
@@ -47,12 +42,14 @@ final class FinderRenameService {
         routeLock.withLock { routeShortcut = shortcut }
         let enabled = AppFeature.finderRename.isAvailable
             && UserDefaults.standard.bool(forKey: DefaultsKey.finderRenameEnabled)
-        let wanted = SessionActivitySupport.tapShouldRun(
+        // Accessibility is asked of the system and not of `Permissions.shared`,
+        // whose answer is a poll up to `PermissionPollingSupport.interval` old.
+        // The re-arm hands a revoked tap to this sync to be stopped, and a
+        // stale grant here would install it straight back.
+        if SessionActivitySupport.tapShouldRun(
             featureWanted: enabled,
-            accessibilityGranted: Permissions.shared.accessibility,
-            sessionIsActive: SessionActivity.shared.isActive)
-        lifecycleLock.withLock { tapShouldRun = wanted }
-        if wanted {
+            accessibilityGranted: AXIsProcessTrusted(),
+            sessionIsActive: SessionActivity.shared.isActive) {
             installTap()
         } else {
             removeTap()
@@ -163,20 +160,35 @@ final class FinderRenameService {
         }
     }
 
+    /// Puts the tap back after the window server disabled it, unless a stop is
+    /// already on its way and the port is about to go. Main thread.
+    private func rearmDisabledTap() {
+        let currentTap = lifecycleLock.withLock { shouldStopTapThread ? nil : tap }
+        if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
+    }
+
     /// Runs on the tap thread. Every unrelated key returns after an in-memory
     /// comparison; Finder and Accessibility are consulted only for the chosen
     /// combination.
     private func route(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            // The gate the preference sync applied, asked again: a tap re-armed
-            // into a session that is no longer on screen puts the stall it was
-            // handed back to avoid straight back on the account that is
-            // (issue #1075). Its answer was sampled with the tap, so nothing
-            // here reaches for main-thread state.
-            let currentTap = lifecycleLock.withLock {
-                tapShouldRun && !shouldStopTapThread ? tap : nil
+            // A tap put straight back is a tap put back into whatever session
+            // is on screen now (issue #1075). The flag that answers that is
+            // written on the main thread and this callback runs on the tap's
+            // own thread, so the question is asked where the answer lives
+            // rather than read across the two. Accessibility is asked in the
+            // same place and for the same reason as the sync: this tap modifies
+            // events, so a revoked grant has to end it rather than put it back.
+            // Leaving the tap disabled until then is the safe direction — the
+            // combination reaches Finder untapped, which is how the feature is
+            // off.
+            DispatchQueue.main.async { [weak self] in
+                if SessionActivity.shared.isActive, AXIsProcessTrusted() {
+                    self?.rearmDisabledTap()
+                } else {
+                    self?.syncWithPreferences()
+                }
             }
-            if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
             return Unmanaged.passUnretained(event)
         }
         guard type == .keyDown else { return Unmanaged.passUnretained(event) }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21910,6 +21910,19 @@ struct MetricsTests {
                 && cachedReject.contains("Key.c")
                 && !cachedReject.contains("Key.x") && !cachedReject.contains("Key.v"),
                "only ⌘C is turned down from the cached front app; ⌘X and ⌘V ask the main thread")
+        // Which features need the activation observer and which feature owns
+        // the marks are two different questions. Cut and paste owns the marks,
+        // so turning it off drops a staged cut whatever image paste is set to —
+        // otherwise the HUD survives a feature that is off and the change count
+        // still matches, so a later ⌘V moves files the user un-staged.
+        let clearGuard = cutPasteCode
+            .components(separatedBy: "func syncWithPreferences").dropFirst().first?
+            .components(separatedBy: "clearMarks()").first?
+            .components(separatedBy: "if ").last ?? ""
+        expect(!clearGuard.isEmpty
+                && clearGuard.contains("cutPasteEnabled")
+                && !clearGuard.contains("pasteImageAsFileEnabled"),
+               "turning Finder cut & paste off clears the staged cut on its own switch alone")
 
         // MARK: Uninstallation paths stay aligned across SelfUninstall and Tools/uninstall.sh
         let selfUninstallSource = (try? String(contentsOfFile: "Sources/Vorssaint/Services/SelfUninstall.swift",

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21859,6 +21859,44 @@ struct MetricsTests {
                 && cleaningModeSource.contains("AXIsProcessTrusted()")
                 && cleaningModeSource.contains("CFMachPortInvalidate"),
                "Cleaning Mode ends and releases its filter tap when the login session leaves the screen")
+        // The two Finder taps run their callback on a thread of their own, so
+        // their timeout re-arm cannot read the session flag the main thread
+        // writes. They take the gate's answer from the preference sync and keep
+        // it under the lock that holds the tap, which is why the re-arm here is
+        // spelled as a sampled field rather than as SessionActivity.shared.
+        // Comments are stripped so prose naming the API cannot answer for it.
+        for finderTapOwner in ["Sources/Vorssaint/Services/Finder/FinderCutPaste.swift",
+                               "Sources/Vorssaint/Services/Finder/FinderRenameService.swift"] {
+            let code = ((try? String(contentsOfFile: finderTapOwner, encoding: .utf8)) ?? "")
+                .components(separatedBy: "\n")
+                .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+                .joined(separator: "\n")
+            expect(code.contains("SessionActivity.shared.onChange")
+                    && code.contains("SessionActivitySupport.tapShouldRun(")
+                    && code.contains("CFMachPortInvalidate"),
+                   "\(finderTapOwner) joins the session gate and releases its port on teardown")
+            let rearm = code.components(separatedBy: "tapDisabledByTimeout")
+                .dropFirst().first?.components(separatedBy: "return").first ?? ""
+            expect(!rearm.isEmpty && !rearm.contains("SessionActivity.shared."),
+                   "\(finderTapOwner) re-arms off the sampled answer, never off main-thread state")
+        }
+        // ⌘C and ⌘V are pressed everywhere, and outside Finder the answer is
+        // always no. Asking the main thread for it would put the app's drawing
+        // in front of every copy on the machine, so the tap thread decides from
+        // an answer the activation observer leaves for it.
+        let cutPasteCode = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Finder/FinderCutPaste.swift",
+            encoding: .utf8)) ?? "")
+            .components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(cutPasteCode.contains("didActivateApplicationNotification"),
+               "an activation observer keeps the front app the cut-paste tap reads current")
+        let beforeMainThread = cutPasteCode
+            .components(separatedBy: "eventSourceUserData").dropFirst().first?
+            .components(separatedBy: "DispatchQueue.main.sync").first ?? ""
+        expect(!beforeMainThread.isEmpty && !beforeMainThread.contains("NSWorkspace"),
+               "the cut-paste tap thread turns a shortcut down without waiting for the main thread")
 
         // MARK: Uninstallation paths stay aligned across SelfUninstall and Tools/uninstall.sh
         let selfUninstallSource = (try? String(contentsOfFile: "Sources/Vorssaint/Services/SelfUninstall.swift",

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21775,6 +21775,23 @@ struct MetricsTests {
             // the window server waits on; teardown must invalidate the port.
             expect(code.contains("CFMachPortInvalidate"),
                    "\(tapOwner) hands its tap back rather than only disabling it")
+            // Owners that run the tap on their own thread restart it from the
+            // thread's tail when a stop and a start crossed. That restart must
+            // not put the tap back on the tap thread's terms: the session
+            // answer is written on the main thread, so the tail hops there and
+            // asks the same gate the preference sync asks. Asked of every owner
+            // in this roster that runs a tap thread, so a restart added to
+            // another gated owner has to answer the same question.
+            if code.contains("clearEventTapThread") {
+                expect(!code.contains("clearEventTapThread() { installTap() }")
+                        && !code.contains("clearEventTapThread() { startOnMain() }"),
+                       "\(tapOwner) has no tap-thread restart that goes around the session gate")
+                let restart = code.components(separatedBy: "private func restartTapOnMain")
+                    .dropFirst().first?.components(separatedBy: "\n    }").first ?? ""
+                expect(restart.contains("DispatchQueue.main.async")
+                        && restart.contains("syncWithPreferences"),
+                       "\(tapOwner) restarts its tap thread through the gate on the main thread")
+            }
         }
 
         // Disabling a tap and dropping the last Swift reference does not hand

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21880,49 +21880,6 @@ struct MetricsTests {
             expect(!rearm.isEmpty && !rearm.contains("SessionActivity.shared."),
                    "\(finderTapOwner) re-arms off the sampled answer, never off main-thread state")
         }
-        // ⌘C is pressed everywhere, and outside Finder the answer is always no.
-        // Asking the main thread for it would put the app's drawing in front of
-        // every copy on the machine, so the tap thread decides from an answer
-        // the activation observer leaves for it.
-        let cutPasteCode = ((try? String(
-            contentsOfFile: "Sources/Vorssaint/Services/Finder/FinderCutPaste.swift",
-            encoding: .utf8)) ?? "")
-            .components(separatedBy: "\n")
-            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
-            .joined(separator: "\n")
-        expect(cutPasteCode.contains("didActivateApplicationNotification"),
-               "an activation observer keeps the front app the cut-paste tap reads current")
-        let beforeMainThread = cutPasteCode
-            .components(separatedBy: "eventSourceUserData").dropFirst().first?
-            .components(separatedBy: "DispatchQueue.main.sync").first ?? ""
-        expect(!beforeMainThread.isEmpty && !beforeMainThread.contains("NSWorkspace"),
-               "the cut-paste tap thread turns a shortcut down without waiting for the main thread")
-        // That cached answer is refreshed on the main queue, so through the very
-        // stall it exists to skip it still names the app the user just left.
-        // Only ⌘C may be turned down on it: the main thread passes ⌘C through in
-        // every branch. ⌘X swallows the key and cuts, ⌘V moves the marked files
-        // or writes the pasteboard image out as a file, and Finder answers for
-        // neither, so a stale reject would make those two silently no-op.
-        let cachedReject = beforeMainThread
-            .components(separatedBy: "frontmostBundleID").first?
-            .components(separatedBy: "if ").last ?? ""
-        expect(beforeMainThread.contains("frontmostBundleID")
-                && cachedReject.contains("Key.c")
-                && !cachedReject.contains("Key.x") && !cachedReject.contains("Key.v"),
-               "only ⌘C is turned down from the cached front app; ⌘X and ⌘V ask the main thread")
-        // Which features need the activation observer and which feature owns
-        // the marks are two different questions. Cut and paste owns the marks,
-        // so turning it off drops a staged cut whatever image paste is set to —
-        // otherwise the HUD survives a feature that is off and the change count
-        // still matches, so a later ⌘V moves files the user un-staged.
-        let clearGuard = cutPasteCode
-            .components(separatedBy: "func syncWithPreferences").dropFirst().first?
-            .components(separatedBy: "clearMarks()").first?
-            .components(separatedBy: "if ").last ?? ""
-        expect(!clearGuard.isEmpty
-                && clearGuard.contains("cutPasteEnabled")
-                && !clearGuard.contains("pasteImageAsFileEnabled"),
-               "turning Finder cut & paste off clears the staged cut on its own switch alone")
 
         // MARK: Uninstallation paths stay aligned across SelfUninstall and Tools/uninstall.sh
         let selfUninstallSource = (try? String(contentsOfFile: "Sources/Vorssaint/Services/SelfUninstall.swift",

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21880,10 +21880,10 @@ struct MetricsTests {
             expect(!rearm.isEmpty && !rearm.contains("SessionActivity.shared."),
                    "\(finderTapOwner) re-arms off the sampled answer, never off main-thread state")
         }
-        // ⌘C and ⌘V are pressed everywhere, and outside Finder the answer is
-        // always no. Asking the main thread for it would put the app's drawing
-        // in front of every copy on the machine, so the tap thread decides from
-        // an answer the activation observer leaves for it.
+        // ⌘C is pressed everywhere, and outside Finder the answer is always no.
+        // Asking the main thread for it would put the app's drawing in front of
+        // every copy on the machine, so the tap thread decides from an answer
+        // the activation observer leaves for it.
         let cutPasteCode = ((try? String(
             contentsOfFile: "Sources/Vorssaint/Services/Finder/FinderCutPaste.swift",
             encoding: .utf8)) ?? "")
@@ -21897,6 +21897,19 @@ struct MetricsTests {
             .components(separatedBy: "DispatchQueue.main.sync").first ?? ""
         expect(!beforeMainThread.isEmpty && !beforeMainThread.contains("NSWorkspace"),
                "the cut-paste tap thread turns a shortcut down without waiting for the main thread")
+        // That cached answer is refreshed on the main queue, so through the very
+        // stall it exists to skip it still names the app the user just left.
+        // Only ⌘C may be turned down on it: the main thread passes ⌘C through in
+        // every branch. ⌘X swallows the key and cuts, ⌘V moves the marked files
+        // or writes the pasteboard image out as a file, and Finder answers for
+        // neither, so a stale reject would make those two silently no-op.
+        let cachedReject = beforeMainThread
+            .components(separatedBy: "frontmostBundleID").first?
+            .components(separatedBy: "if ").last ?? ""
+        expect(beforeMainThread.contains("frontmostBundleID")
+                && cachedReject.contains("Key.c")
+                && !cachedReject.contains("Key.x") && !cachedReject.contains("Key.v"),
+               "only ⌘C is turned down from the cached front app; ⌘X and ⌘V ask the main thread")
 
         // MARK: Uninstallation paths stay aligned across SelfUninstall and Tools/uninstall.sh
         let selfUninstallSource = (try? String(contentsOfFile: "Sources/Vorssaint/Services/SelfUninstall.swift",

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21737,7 +21737,9 @@ struct MetricsTests {
                          "Sources/Vorssaint/Services/MouseNavigation/MouseNavigationService.swift",
                          "Sources/Vorssaint/Services/MouseButtons/MouseButtonShortcutService.swift",
                          "Sources/Vorssaint/Services/MiddleClick/MiddleClickService.swift",
-                         "Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift"] {
+                         "Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift",
+                         "Sources/Vorssaint/Services/Finder/FinderCutPaste.swift",
+                         "Sources/Vorssaint/Services/Finder/FinderRenameService.swift"] {
             let source = (try? String(contentsOfFile: tapOwner, encoding: .utf8)) ?? ""
             expect(!source.isEmpty, "\(tapOwner) reads back for its session-switch check")
             let code = source.components(separatedBy: "\n")
@@ -21752,9 +21754,22 @@ struct MetricsTests {
             if tapOwner.contains("MouseNavigation")
                 || tapOwner.contains("MouseButtonShortcut")
                 || tapOwner.contains("MiddleClick")
-                || tapOwner.contains("QuitProtection") {
+                || tapOwner.contains("QuitProtection")
+                || tapOwner.contains("Finder") {
                 expect(code.contains("AXIsProcessTrusted()"),
                        "\(tapOwner) does not keep a modifying tap alive after Accessibility is lost")
+                // `Permissions.shared.accessibility` is polled on a timer, so a
+                // re-arm that refused on the live answer must not be undone by
+                // a sync that trusts the stale one. Read off the gate's own
+                // argument rather than the whole file: FinderCutPaste caches
+                // the mirror on purpose on its per-keystroke path, where a live
+                // TCC round-trip per key is what the cache exists to avoid.
+                let gateArguments = code
+                    .components(separatedBy: "SessionActivitySupport.tapShouldRun(")
+                    .dropFirst()
+                    .map { $0.components(separatedBy: "sessionIsActive:").first ?? "" }
+                expect(gateArguments.allSatisfy { !$0.contains("Permissions.shared.accessibility") },
+                       "\(tapOwner) asks Accessibility directly wherever it decides to run a tap")
             }
             // Switching a tap off leaves the process owning it, which is what
             // the window server waits on; teardown must invalidate the port.
@@ -21859,28 +21874,6 @@ struct MetricsTests {
                 && cleaningModeSource.contains("AXIsProcessTrusted()")
                 && cleaningModeSource.contains("CFMachPortInvalidate"),
                "Cleaning Mode ends and releases its filter tap when the login session leaves the screen")
-        // The two Finder taps run their callback on a thread of their own, so
-        // their timeout re-arm cannot read the session flag the main thread
-        // writes. They take the gate's answer from the preference sync and keep
-        // it under the lock that holds the tap, which is why the re-arm here is
-        // spelled as a sampled field rather than as SessionActivity.shared.
-        // Comments are stripped so prose naming the API cannot answer for it.
-        for finderTapOwner in ["Sources/Vorssaint/Services/Finder/FinderCutPaste.swift",
-                               "Sources/Vorssaint/Services/Finder/FinderRenameService.swift"] {
-            let code = ((try? String(contentsOfFile: finderTapOwner, encoding: .utf8)) ?? "")
-                .components(separatedBy: "\n")
-                .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
-                .joined(separator: "\n")
-            expect(code.contains("SessionActivity.shared.onChange")
-                    && code.contains("SessionActivitySupport.tapShouldRun(")
-                    && code.contains("CFMachPortInvalidate"),
-                   "\(finderTapOwner) joins the session gate and releases its port on teardown")
-            let rearm = code.components(separatedBy: "tapDisabledByTimeout")
-                .dropFirst().first?.components(separatedBy: "return").first ?? ""
-            expect(!rearm.isEmpty && !rearm.contains("SessionActivity.shared."),
-                   "\(finderTapOwner) re-arms off the sampled answer, never off main-thread state")
-        }
-
         // MARK: Uninstallation paths stay aligned across SelfUninstall and Tools/uninstall.sh
         let selfUninstallSource = (try? String(contentsOfFile: "Sources/Vorssaint/Services/SelfUninstall.swift",
                                               encoding: .utf8)) ?? ""


### PR DESCRIPTION
# Hand both Finder taps back on a user switch

## Summary

`FinderCutPaste` and `FinderRenameService` are near-identical twins: same threaded
`runEventTap()`, same `CFRunLoopRun()` shape, both long-lived `.defaultTap` keyboard
taps. Two things were wrong across the pair.

**Neither observed fast user switching.** Both gated only on the feature switch and
Accessibility, so an instance left running in a switched-away session kept its place in
the event chain: the window server still routes the front account's keystrokes through a
process that cannot answer and waits out the tap timeout on each one (#1153). Both now
subscribe to `SessionActivity` in `init`, ask `SessionActivitySupport.tapShouldRun` in
the preference sync, and re-arm after a timeout only through that answer.

Both callbacks run on a thread of their own, and `SessionActivity.shared.isActive` is
written on the main thread, so the re-arm cannot read it where it runs. The callback
finishes fail-open and hops to the main queue, and the main thread either puts the tap
back or hands it to the sync to be stopped. That is what the keyboard, Super Key,
snippet and switcher taps do in the same position; the taps that live on the main run
loop read the flag in place because their callback is already there. This file already
hands its candidate keys to the main thread with `DispatchQueue.main.sync`, so the hop
is not a new relationship between the two threads.

Accessibility is asked of the system in that gate, not of `Permissions.shared`, whose
answer is a poll up to `PermissionPollingSupport.interval` old: the re-arm hands a
revoked tap to the sync to be stopped, and a stale grant there would install it straight
back. The mirror stays on `FinderCutPaste`'s per-keystroke path in `handle`, where the
comment explains it is cached to keep a live TCC round-trip off every key.

**The tap thread's own restart went around that gate.** Both files build the tap in
two places. When a stop and a start cross, `installTap()` records the pending start and
the tap thread's tail rebuilds on the spot — from the tap thread, on a decision taken
before the session handed over. `removeTap()` clears that flag under the lock, so the
window is the gap between `clearEventTapThread()` reading `true` and `installTap()`
running: a resign landing there finds `tapThread` already nil, takes the `!threadExists`
branch and resets `shouldStopTapThread`, and the tail then builds a fresh filter tap into
the session that has just left the screen. That is the stall this pull request exists to
end, reached through the one door it had left open, in the same file.

Both tails now hop to the main thread and call `syncWithPreferences()` — the same rule
the re-arm follows, and the shape `MouseClickDebounceService.finishEventTapThread` uses.
The third `clearEventTapThread()` call in each file, on the `tapCreate` failure path,
deliberately drops the pending restart and is unchanged: neither service retries a failed
creation. `AppSwitcher` and `TextSnippetService` have the same window and the same fix in
#1236, and the restart check in `MetricsTests` now asks it of every owner in the roster
that runs a tap thread.

**`FinderRenameService` disabled its port on teardown without invalidating it.** That
line is now on `main` through #1225, so what is left of it here is the removal of its
write-only `runLoopSource` field, which its twin never had.

### Trade-offs

- **Asking on the main thread vs. sampling the gate.** An earlier revision sampled
  `tapShouldRun`'s answer into a field under the tap lock, following
  `BrightnessService`. That precedent no longer exists — the sampled flag was withdrawn
  from #1231 for carrying no information its sync did not already have — and the sample
  is a second copy of the session state in the process. The cost of asking instead is
  one main-queue hop before the tap comes back, in a branch that only runs after the tap
  has already been out of the chain for its full timeout. Over that hop the keys reach
  Finder untapped, which is how the feature is off.
- **Reading `SessionActivity.shared.isActive` straight from the tap thread**, which is
  what `MouseClickDebounceService` does today. Not followed: it satisfies the wording of
  the guard without being correct on the thread it runs on.
- **Tying the observer's lifetime to the tap's.** Rejected: on a session switch the tap
  goes down and the staged cut is deliberately kept, and dropping the observer with the
  tap would leave the HUD without its background auto-hide.
- **Collapsing the two files onto a shared tap helper.** Not done. The remaining
  differences are deliberate (`.headInsertEventTap` vs `.tailAppendEventTap`, one filters
  its own synthetic pastes, one rewrites the event), so a shared helper would arrive
  carrying flags for each of them.

Both files join the shared tap-owner sweep in `MetricsTests.swift` rather than carrying
their own checks, so the re-arm rule is stated once for every owner in it. The earlier
revision's own block said the opposite of what the sweep says — it required the re-arm
*not* to name `SessionActivity.shared.` — and is gone with the sample it was written for.
The gate check added alongside reads the argument between
`SessionActivitySupport.tapShouldRun(` and its `sessionIsActive:` label rather than
banning `Permissions.shared.accessibility` across the file, because `FinderCutPaste`'s
per-keystroke cache is the same symbol used on purpose.

### Dropped from this branch: the cached front app

An earlier revision kept the frontmost bundle id on the tap thread so ⌘X, ⌘C and ⌘V
outside Finder could be turned down without waiting on `DispatchQueue.main.sync`. The
cache is refreshed by the activation observer **on the main queue** — the very thread the
reject exists to skip — so through a stall it names the app the user just left.

Stale is free for ⌘C and only ⌘C. It is not free for the other two: ⌘X swallows the key
and cuts, ⌘V moves the marked files or writes a pasteboard image out as a file, and
Finder has no native answer for either, so a stale reject makes them silently do nothing.
Narrowing the cache to ⌘C alone was the fix, and it took the win with it — the case this
started from named ⌘C and ⌘V as the two most-pressed combinations on a Mac.

What was left is smaller than it reads. `handle()` guards on
`NSWorkspace.shared.frontmostApplication?.bundleIdentifier == finderBundleID` before it
switches on the key code, so under a stale reject the main thread was letting ⌘C through
anyway. That remainder has never been measured, and it was bought with an `NSLock`, a
cache field refreshed on the thread it exists because it stalls, and an observer
condition widened to `cutPasteEnabled || pasteImageAsFileEnabled` — which left a staged
cut live behind a switched-off Cut & Paste and needed a follow-up of its own. Both the
widened condition and the `clearMarks()` split it forced are back to what `main` has.

If it is worth having, it is worth its own pull request: a measurement of the `main.sync`
on the ⌘C path, and an account of why refreshing the cache on the main thread is
acceptable when a stalled main thread is the premise.

## Verification

MacBook Pro, macOS 26. Rebased onto `main` at `a952b829`.

```
./build.sh --test      TESTS OK (9553 checks)
swiftc -typecheck      exit 0, whole module
```

`FinderCutPaste.swift` and `FinderRenameService.swift` are both outside the `--test`
compile whitelist, so `--test` is no evidence that they compile. The whole of
`Sources/Vorssaint/**` was type-checked separately against the same target and SDK the
app build uses:

```sh
swiftc -typecheck -target arm64-apple-macosx14.0 \
    -sdk /Library/Developer/CommandLineTools/SDKs/MacOSX26.sdk \
    -Xfrontend -interface-compiler-version -Xfrontend 6.3.2 \
    -I Sources/VMStatisticsCompat -I Sources/HIDEventSystem \
    Sources/Vorssaint/**/*.swift
```

Clean. The full `./build.sh` was **not** run: with the signing keychain locked,
`codesign` blocks on an unlock dialog and never exits.

The two input-source failures reported on the earlier revision (`nil layout falls back to
ANSI semicolon`, `App Switcher icon-row hints`) did not appear this round; the machine's
input source is ANSI now rather than a Chinese IME. They read the current input source
and are unrelated to this diff either way.

Verified both ways, each break applied alone and reverted: replacing the main-thread hop
in `FinderCutPaste` with a direct re-arm turns `FinderCutPaste.swift does not re-arm a
disabled tap into a switched-away session` red on its own; putting `installTap()` back on
`FinderRenameService`'s tail turns `FinderRenameService.swift has no tap-thread restart
that goes around the session gate` red on its own.

**Not tested.** I have no second logged-in account, so the session-switch behaviour is
inferred from the mechanism in #1153, not measured — the same caveat that issue carries.
The revoke race is not reproduced either: reaching it needs the window server to disable
one of these taps inside the polling interval that follows a revoked grant. The
restart-tail window is a read of the lifecycle code, not a reproduction — it needs a stop
and a start to cross at the moment of a handover, and the resign to land inside the gap
between two lock acquisitions. macOS 26,
Apple silicon, `--test` and `-typecheck` only.

## Anything else

Refs #1153
