### PR TITLE
fix(keyboard): hand the keyboard, Super Key and recording taps back across a user switch

### DIFF
--- a/Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift
+++ b/Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift
@@ -27,12 +27,27 @@ final class KeyboardDebounceService: ObservableObject {
                                                 globalWindowMs: Defaults.defaultKeyboardDebounceWindowMs,
                                                 keyWindows: [:])
 
-    private init() {}
+    private init() {
+        // This tap sits at the HID stage, ahead of the split into login
+        // sessions, so a session that is switched away still sees the keys of
+        // the account on screen — and this one answers them from state that was
+        // built out of another account's typing, swallowing what it reads as a
+        // bounce. Hand the tap back on resign and build it again from the
+        // preferences on the way in (issue #1075).
+        SessionActivity.shared.onChange { [weak self] _ in
+            self?.syncWithPreferences()
+        }
+    }
 
     func syncWithPreferences() {
-        let nextConfig = KeyboardDebounceConfig(
-            enabled: AppFeature.keyboardDebounce.isAvailable
+        let shouldRun = SessionActivitySupport.tapShouldRun(
+            featureWanted: AppFeature.keyboardDebounce.isAvailable
                 && UserDefaults.standard.bool(forKey: DefaultsKey.keyboardDebounceEnabled),
+            accessibilityGranted: Permissions.shared.accessibility,
+            sessionIsActive: SessionActivity.shared.isActive
+        )
+        let nextConfig = KeyboardDebounceConfig(
+            enabled: shouldRun,
             globalWindowMs: Defaults.sanitizedKeyboardDebounceWindow(
                 UserDefaults.standard.integer(forKey: DefaultsKey.keyboardDebounceWindowMs)
             ),
@@ -44,7 +59,7 @@ final class KeyboardDebounceService: ObservableObject {
             config = nextConfig
         }
 
-        if nextConfig.enabled, Permissions.shared.accessibility {
+        if shouldRun {
             start()
         } else {
             stop()
@@ -109,6 +124,10 @@ final class KeyboardDebounceService: ObservableObject {
 
         if let tap = snapshot.tap {
             CGEvent.tapEnable(tap: tap, enable: false)
+            // Switching a tap off leaves this process owning the port, and the
+            // port is what the window server waits on. Handing the tap back
+            // means leaving the chain, not going quiet in it.
+            CFMachPortInvalidate(tap)
         }
         if let runLoop = snapshot.runLoop {
             CFRunLoopPerformBlock(runLoop, CFRunLoopMode.commonModes.rawValue) {
@@ -212,6 +231,15 @@ final class KeyboardDebounceService: ObservableObject {
         }
     }
 
+    /// Puts the tap back after the window server disabled it, unless a stop is
+    /// already on its way and the port is about to go. Main thread.
+    private func rearmDisabledTap() {
+        let currentTap = lifecycleLock.withLock {
+            shouldStopTapThread ? nil : tap
+        }
+        if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
+    }
+
     private func publishRunning(_ running: Bool, generation: UInt) {
         let update = { [weak self] in
             guard let self else { return }
@@ -231,10 +259,24 @@ final class KeyboardDebounceService: ObservableObject {
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            let currentTap = lifecycleLock.withLock {
-                tap
+            // Keys flowed untapped while the tap was out of the chain, so the
+            // gap must not be read as a quiet stretch and the next press as a
+            // bounce.
+            eventLock.withLock {
+                state.reset()
             }
-            if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
+            // A tap put straight back is a tap put back into whatever session
+            // is on screen now (issue #1075). The flag that answers that is
+            // written on the main thread, and this callback runs on the tap's
+            // own thread, so the question is asked where the answer lives
+            // rather than read across the two.
+            DispatchQueue.main.async { [weak self] in
+                if SessionActivity.shared.isActive {
+                    self?.rearmDisabledTap()
+                } else {
+                    self?.syncWithPreferences()
+                }
+            }
             return Unmanaged.passUnretained(event)
         }
 

--- a/Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift
+++ b/Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Vorssaint
 
+import ApplicationServices
 import Combine
 import CoreGraphics
 import Foundation
@@ -270,8 +271,11 @@ final class KeyboardDebounceService: ObservableObject {
             // written on the main thread, and this callback runs on the tap's
             // own thread, so the question is asked where the answer lives
             // rather than read across the two.
+            // Accessibility is asked here for the same reason the mouse twin
+            // asks it: this tap modifies events, so a revoked permission has to
+            // end it rather than put it back. The sync then stops it for good.
             DispatchQueue.main.async { [weak self] in
-                if SessionActivity.shared.isActive {
+                if SessionActivity.shared.isActive, AXIsProcessTrusted() {
                     self?.rearmDisabledTap()
                 } else {
                     self?.syncWithPreferences()

--- a/Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift
+++ b/Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift
@@ -163,11 +163,8 @@ final class KeyboardDebounceService: ObservableObject {
             }
             guard !shouldStopBeforeCreatingTap else {
                 let shouldRestart = clearEventTapThread()
-                if shouldRestart {
-                    start()
-                } else {
-                    publishRunning(false, generation: generation)
-                }
+                publishRunning(false, generation: generation)
+                if shouldRestart { restartTapOnMain() }
                 return
             }
 
@@ -218,11 +215,8 @@ final class KeyboardDebounceService: ObservableObject {
                 state.reset()
             }
             let shouldRestart = clearEventTapThread()
-            if shouldRestart {
-                start()
-            } else {
-                publishRunning(false, generation: generation)
-            }
+            publishRunning(false, generation: generation)
+            if shouldRestart { restartTapOnMain() }
         }
     }
 
@@ -237,6 +231,18 @@ final class KeyboardDebounceService: ObservableObject {
             pendingStartAfterStop = false
             return shouldRestart
         }
+    }
+
+    /// Runs on the tap thread once its run loop has stopped. A restart that
+    /// `start` left pending goes back through `syncWithPreferences` instead of
+    /// straight to `start`: the session flag is written on the main thread, and
+    /// a tap rebuilt into a session that is no longer on screen stalls the
+    /// account that is (issue #1075). `isRunning` is published false first, so
+    /// the gap between the two is not a green tick over a tap that is down;
+    /// the sync publishes it true again if it starts one. Its twin
+    /// `MouseClickDebounceService.finishEventTapThread` hops the same way.
+    private func restartTapOnMain() {
+        DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
     }
 
     /// Puts the tap back after the window server disabled it, unless a stop is

--- a/Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift
+++ b/Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift
@@ -44,7 +44,14 @@ final class KeyboardDebounceService: ObservableObject {
         let shouldRun = SessionActivitySupport.tapShouldRun(
             featureWanted: AppFeature.keyboardDebounce.isAvailable
                 && UserDefaults.standard.bool(forKey: DefaultsKey.keyboardDebounceEnabled),
-            accessibilityGranted: Permissions.shared.accessibility,
+            // Asked of the system and not of `Permissions.shared`, whose
+            // answer is a poll up to `PermissionPollingSupport.interval` old.
+            // The re-arm hands a revoked tap to this sync to be stopped, and a
+            // stale grant here would leave `shouldRun` true, so `start()` would
+            // see the thread still up, publish running and return — a tap that
+            // is neither back in the chain nor stopped. The mouse twin asks the
+            // same way.
+            accessibilityGranted: AXIsProcessTrusted(),
             sessionIsActive: SessionActivity.shared.isActive
         )
         let nextConfig = KeyboardDebounceConfig(

--- a/Sources/Vorssaint/Services/ShortcutRecordingTap.swift
+++ b/Sources/Vorssaint/Services/ShortcutRecordingTap.swift
@@ -14,7 +14,9 @@ import Foundation
 ///
 /// The tap lives only while a field records, plus the tail of a key still
 /// held when recording ends, so its release and autorepeats cannot reach the
-/// app as a fresh press of the recorded combination. Only one field ever
+/// app as a fresh press of the recorded combination. A fast user switch ends it
+/// too: a tap left behind by a session that is no longer on screen swallows the
+/// keys of the account that is. Only one field ever
 /// records at a time (the ShortcutCapture invariant), so one static tap is
 /// enough. Main thread only. Without Accessibility, begin fails and the
 /// field falls back to plain view events, which is how it always worked.
@@ -33,6 +35,14 @@ enum ShortcutRecordingTap {
     /// super key does lets a field record the combination the way it will be
     /// pressed later, instead of asking for the chosen modifiers by hand.
     private static var superState = SuperKeySupport.State()
+    /// Registered on the first recording and kept for the process. A recorder
+    /// that is still open when this login session stops being the one on screen
+    /// would otherwise keep a tap that swallows every key in the chain the
+    /// account switched in is typing into, and the timeout re-arm below would
+    /// put it back there (issue #1075). Only the command bar's capture card
+    /// reaches that state — the shortcut fields in Settings already stop on
+    /// `didResignActive` — but the tap is shared, so the guard is here.
+    private static var observingSession = false
 
     /// Starts swallowing key events and delivering each fresh press to the
     /// handler. Returns false when the tap cannot exist (no Accessibility),
@@ -50,6 +60,13 @@ enum ShortcutRecordingTap {
         }
         if tap == nil {
             guard AXIsProcessTrusted() else { return false }
+            if !observingSession {
+                observingSession = true
+                SessionActivity.shared.onChange { isActive in
+                    guard !isActive else { return }
+                    tearDown()
+                }
+            }
             let mask = (CGEventMask(1) << CGEventType.keyDown.rawValue)
                 | (CGEventMask(1) << CGEventType.keyUp.rawValue)
             guard let created = CGEvent.tapCreate(
@@ -116,7 +133,13 @@ enum ShortcutRecordingTap {
 
     private static func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
+            if SessionActivity.shared.isActive, let tap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            } else {
+                // Invalidating the port from its own callback stack is unsafe;
+                // finish this callback fail-open, then release the tap.
+                DispatchQueue.main.async { tearDown() }
+            }
             return Unmanaged.passUnretained(event)
         }
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)

--- a/Sources/Vorssaint/Services/ShortcutRecordingTap.swift
+++ b/Sources/Vorssaint/Services/ShortcutRecordingTap.swift
@@ -58,15 +58,21 @@ enum ShortcutRecordingTap {
         if let tap, !CGEvent.tapIsEnabled(tap: tap) {
             tearDown()
         }
+        // Registered on the way in, before the tap is asked for: the exit this
+        // installs is the recording's, not the tap's. Without Accessibility
+        // the lines below give up and the caller records through its own
+        // monitor, but `ShortcutCapture.begin()` has already switched the app's
+        // global shortcuts off, so a resign with no handler registered leaves
+        // them off with nothing left to turn them back on.
+        if !observingSession {
+            observingSession = true
+            SessionActivity.shared.onChange { isActive in
+                guard !isActive else { return }
+                endForSessionSwitch()
+            }
+        }
         if tap == nil {
             guard AXIsProcessTrusted() else { return false }
-            if !observingSession {
-                observingSession = true
-                SessionActivity.shared.onChange { isActive in
-                    guard !isActive else { return }
-                    endForSessionSwitch()
-                }
-            }
             let mask = (CGEventMask(1) << CGEventType.keyDown.rawValue)
                 | (CGEventMask(1) << CGEventType.keyUp.rawValue)
             guard let created = CGEvent.tapCreate(

--- a/Sources/Vorssaint/Services/ShortcutRecordingTap.swift
+++ b/Sources/Vorssaint/Services/ShortcutRecordingTap.swift
@@ -64,7 +64,7 @@ enum ShortcutRecordingTap {
                 observingSession = true
                 SessionActivity.shared.onChange { isActive in
                     guard !isActive else { return }
-                    tearDown()
+                    endForSessionSwitch()
                 }
             }
             let mask = (CGEventMask(1) << CGEventType.keyDown.rawValue)
@@ -113,6 +113,20 @@ enum ShortcutRecordingTap {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: watchdog)
     }
 
+    /// The session leaving ends the recording, not only the tap, and the two
+    /// are not the same teardown: whoever called `begin` also called
+    /// `ShortcutCapture.begin()`, which left `HotkeyManager`, Shelf, clipboard,
+    /// sound-output and window-layout shortcuts switched off. Dropping the tap
+    /// alone comes back with the capture card still up and every global
+    /// shortcut in the app dead. Nothing here reopens the card; giving the keys
+    /// back early is the safe direction, and `ShortcutCapture.end()` is
+    /// idempotent, so the caller's own exit still runs unchanged.
+    /// Main thread, like `ShortcutCapture`.
+    private static func endForSessionSwitch() {
+        tearDown()
+        ShortcutCapture.end()
+    }
+
     private static func tearDown() {
         drainWatchdog?.cancel()
         drainWatchdog = nil
@@ -138,7 +152,7 @@ enum ShortcutRecordingTap {
             } else {
                 // Invalidating the port from its own callback stack is unsafe;
                 // finish this callback fail-open, then release the tap.
-                DispatchQueue.main.async { tearDown() }
+                DispatchQueue.main.async { endForSessionSwitch() }
             }
             return Unmanaged.passUnretained(event)
         }

--- a/Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift
+++ b/Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift
@@ -235,7 +235,7 @@ final class SuperKeyService: ObservableObject {
             let runLoop = CFRunLoopGetCurrent()
             lifecycleLock.withLock { tapRunLoop = runLoop }
             guard !lifecycleLock.withLock({ shouldStopTapThread }) else {
-                if clearEventTapThread() { startOnMain() }
+                if clearEventTapThread() { restartTapOnMain() }
                 return
             }
 
@@ -329,7 +329,7 @@ final class SuperKeyService: ObservableObject {
                 if let mouseSource { CFRunLoopRemoveSource(runLoop, mouseSource, .commonModes) }
                 CFMachPortInvalidate(mouseTap)
             }
-            if clearEventTapThread() { startOnMain() }
+            if clearEventTapThread() { restartTapOnMain() }
         }
     }
 
@@ -349,8 +349,14 @@ final class SuperKeyService: ObservableObject {
         }
     }
 
-    private func startOnMain() {
-        DispatchQueue.main.async { [weak self] in self?.start() }
+    /// Runs on the tap thread once its run loop has stopped. A restart that
+    /// `start` left pending goes back through `syncWithPreferences` instead of
+    /// straight to `start`: the hop to the main thread was already here, but
+    /// `start` asks only `AXIsProcessTrusted()`, so a restart that crossed a
+    /// session handover rebuilt both taps into a session that is no longer on
+    /// screen (issue #1075). The sync is the only place the session gate lives.
+    private func restartTapOnMain() {
+        DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
     }
 
     private func tapDidStart(_ startedTap: CFMachPort) {

--- a/Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift
+++ b/Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift
@@ -15,7 +15,8 @@ import IOKit.hidsystem
 /// F18; the event tap then keeps that key to itself and adds the user's
 /// chosen modifiers to whatever is pressed while it is down. Nothing is
 /// installed while the feature is off, and the mapping is always taken back
-/// out when the feature goes off or the app quits. Requires Accessibility:
+/// out when the feature goes off, when this login session stops being the one
+/// on screen, or when the app quits. Requires Accessibility:
 /// without it the tap cannot modify events, and the mapping is not applied
 /// either, so the source is never left as a key that does nothing.
 final class SuperKeyService: ObservableObject {
@@ -109,7 +110,16 @@ final class SuperKeyService: ObservableObject {
         return min(30, max(3, firstRepeat * 2))
     }
 
-    private init() {}
+    private init() {
+        // Both halves have to go when this login session stops being the one
+        // on screen. The taps keep their place in the chain and the account
+        // switched in pays their timeout on every event (issue #1075), and the
+        // mapping is written with hidutil for the whole Mac, so leaving it
+        // behind hands that account a source key that does nothing.
+        SessionActivity.shared.onChange { [weak self] _ in
+            self?.syncWithPreferences()
+        }
+    }
 
     func syncWithPreferences() {
         let defaults = UserDefaults.standard
@@ -132,6 +142,7 @@ final class SuperKeyService: ObservableObject {
         self.source = source
         let enabled = AppFeature.superKey.isAvailable
             && defaults.bool(forKey: DefaultsKey.superKeyEnabled)
+            && SessionActivity.shared.isActive
         guard enabled else {
             stop()
             return
@@ -588,14 +599,31 @@ final class SuperKeyService: ObservableObject {
 
     // MARK: - The tap
 
+    /// Puts both taps back after the window server disabled them, unless a stop
+    /// is already on its way and the ports are about to go. Main thread.
+    private func rearmDisabledTaps() {
+        let currentTaps = lifecycleLock.withLock { () -> (CFMachPort?, CFMachPort?) in
+            shouldStopTapThread ? (nil, nil) : (tap, mouseTap)
+        }
+        if let currentTap = currentTaps.0 { CGEvent.tapEnable(tap: currentTap, enable: true) }
+        if let currentMouseTap = currentTaps.1 { CGEvent.tapEnable(tap: currentMouseTap, enable: true) }
+    }
+
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            let currentTaps = lifecycleLock.withLock {
-                shouldStopTapThread ? (nil, nil) : (tap, mouseTap)
-            }
-            if let currentTap = currentTaps.0 { CGEvent.tapEnable(tap: currentTap, enable: true) }
-            if let currentMouseTap = currentTaps.1 { CGEvent.tapEnable(tap: currentMouseTap, enable: true) }
             forgetHeldKey()
+            // Putting a tap straight back puts it into whatever session is on
+            // screen now, and the account switched in then pays its timeout on
+            // every event (issue #1075). The flag that answers that is written
+            // on the main thread while this callback runs on the tap's own
+            // thread, so the question is asked where the answer lives.
+            DispatchQueue.main.async { [weak self] in
+                if SessionActivity.shared.isActive {
+                    self?.rearmDisabledTaps()
+                } else {
+                    self?.syncWithPreferences()
+                }
+            }
             return Unmanaged.passUnretained(event)
         }
         let source = stateLock.withLock { eventSource }

--- a/Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift
+++ b/Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift
@@ -617,8 +617,14 @@ final class SuperKeyService: ObservableObject {
             // every event (issue #1075). The flag that answers that is written
             // on the main thread while this callback runs on the tap's own
             // thread, so the question is asked where the answer lives.
+            // Accessibility is asked for the same reason: these are modifying
+            // taps, so a revoked grant has to end them rather than put them
+            // back. The re-arm never reaches `start()` and its own guard, so
+            // without this the taps stay disabled while `isRunning` still
+            // publishes true. The sync's dead-tap check then rebuilds, and
+            // `start()` clears the mapping and publishes not-running.
             DispatchQueue.main.async { [weak self] in
-                if SessionActivity.shared.isActive {
+                if SessionActivity.shared.isActive, AXIsProcessTrusted() {
                     self?.rearmDisabledTaps()
                 } else {
                     self?.syncWithPreferences()

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21737,7 +21737,16 @@ struct MetricsTests {
                          "Sources/Vorssaint/Services/MouseNavigation/MouseNavigationService.swift",
                          "Sources/Vorssaint/Services/MouseButtons/MouseButtonShortcutService.swift",
                          "Sources/Vorssaint/Services/MiddleClick/MiddleClickService.swift",
-                         "Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift"] {
+                         "Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift",
+                         // Keyboard taps join the list for the same reason. The
+                         // debounce one is worse than a stall: it is created at
+                         // the HID stage with .defaultTap, so a switched-away
+                         // session answers the keys of the account on screen
+                         // out of state built from another account's typing,
+                         // and a nil answer is a swallowed keystroke.
+                         "Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift",
+                         "Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift",
+                         "Sources/Vorssaint/Services/ShortcutRecordingTap.swift"] {
             let source = (try? String(contentsOfFile: tapOwner, encoding: .utf8)) ?? ""
             expect(!source.isEmpty, "\(tapOwner) reads back for its session-switch check")
             let code = source.components(separatedBy: "\n")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21837,6 +21837,31 @@ struct MetricsTests {
             .components(separatedBy: "let nextConfig").first ?? ""
         expect(keyboardDebounceGate.contains("accessibilityGranted: AXIsProcessTrusted()"),
                "the keyboard debounce gate asks the system for Accessibility, not the poll cache")
+        // The session half of the same gate. The re-arm declining is only half a
+        // fix: what actually takes the tap out of the chain on a resign is this
+        // sync answering the onChange, and it only reaches stop() while the gate
+        // still asks the session.
+        expect(keyboardDebounceGate.contains("sessionIsActive: SessionActivity.shared.isActive"),
+               "the keyboard debounce gate stops the tap when the session leaves")
+        // Super Key answers the resign in its own sync gate rather than through
+        // tapShouldRun, and the session conjunct there is the whole of that
+        // answer: without it `enabled` stays true on a resign, no tap reads
+        // dead, start() returns on tapExists, and both taps keep their place in
+        // the chain while the hidutil mapping stays written for the whole Mac.
+        // Sliced to the gate so the same call anywhere else in the file — the
+        // re-arm included — cannot answer for it.
+        let superKeyCode = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift",
+            encoding: .utf8)) ?? "")
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.hasPrefix("//") }
+            .joined(separator: "\n")
+        let superKeyGate = superKeyCode
+            .components(separatedBy: "let enabled = AppFeature.superKey.isAvailable").last?
+            .components(separatedBy: "guard enabled else").first ?? ""
+        expect(superKeyGate.contains("&& SessionActivity.shared.isActive"),
+               "the Super Key sync gate stops both taps when the session leaves")
         // The recording tap is the one whose teardown is not the whole exit.
         // Whoever calls begin also calls ShortcutCapture.begin(), which switches
         // off HotkeyManager, Shelf, clipboard, sound output and the window

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21765,10 +21765,13 @@ struct MetricsTests {
                 expect(code.contains("AXIsProcessTrusted()"),
                        "\(tapOwner) does not keep a modifying tap alive after Accessibility is lost")
             }
-            if tapOwner.contains("KeyboardDebounce") {
+            if tapOwner.contains("KeyboardDebounce") || tapOwner.contains("SuperKey") {
                 // Its twin MouseClickDebounceService asks the same question in
                 // the same place: a modifying tap the window server disabled
-                // after Accessibility went away must end, not go back in.
+                // after Accessibility went away must end, not go back in. The
+                // Super Key taps modify too, and their re-arm never reaches
+                // start() and the guard it keeps, so asking there is the only
+                // place that catches a grant revoked mid-session.
                 expect(rearm.contains("AXIsProcessTrusted()"),
                        "\(tapOwner) does not put a modifying tap back after Accessibility is lost")
             }
@@ -21814,6 +21817,26 @@ struct MetricsTests {
                "every event tap owner invalidates its port on teardown, across "
                + "\(tapOwners) scanned owners: \(tapOwnersWithoutInvalidate)")
 
+        // The debounce re-arm hands a tap it declines to put back to the sync
+        // to be stopped, so the sync has to ask Accessibility the same way it
+        // does. `Permissions.shared.accessibility` is a poll up to
+        // PermissionPollingSupport.interval old; inside that window shouldRun
+        // stays true, start() finds the thread still up, publishes running and
+        // returns, and the tap is neither back in the chain nor stopped while
+        // isRunning says it is live. Lines are trimmed so the check is on the
+        // gate and not on indentation.
+        let keyboardDebounceCode = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift",
+            encoding: .utf8)) ?? "")
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.hasPrefix("//") }
+            .joined(separator: "\n")
+        let keyboardDebounceGate = keyboardDebounceCode
+            .components(separatedBy: "func syncWithPreferences() {").last?
+            .components(separatedBy: "let nextConfig").first ?? ""
+        expect(keyboardDebounceGate.contains("accessibilityGranted: AXIsProcessTrusted()"),
+               "the keyboard debounce gate asks the system for Accessibility, not the poll cache")
         // The recording tap is the one whose teardown is not the whole exit.
         // Whoever calls begin also calls ShortcutCapture.begin(), which switches
         // off HotkeyManager, Shelf, clipboard, sound output and the window

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21779,6 +21779,23 @@ struct MetricsTests {
             // the window server waits on; teardown must invalidate the port.
             expect(code.contains("CFMachPortInvalidate"),
                    "\(tapOwner) hands its tap back rather than only disabling it")
+            // Owners that run the tap on their own thread restart it from the
+            // thread's tail when a stop and a start crossed. That restart must
+            // not put the tap back on the tap thread's terms: the session
+            // answer is written on the main thread, so the tail hops there and
+            // asks the same gate the preference sync asks. Asked of every owner
+            // in this roster that runs a tap thread, so a restart added to
+            // another gated owner has to answer the same question.
+            if code.contains("clearEventTapThread") {
+                expect(!code.contains("clearEventTapThread() { installTap() }")
+                        && !code.contains("clearEventTapThread() { startOnMain() }"),
+                       "\(tapOwner) has no tap-thread restart that goes around the session gate")
+                let restart = code.components(separatedBy: "private func restartTapOnMain")
+                    .dropFirst().first?.components(separatedBy: "\n    }").first ?? ""
+                expect(restart.contains("DispatchQueue.main.async")
+                        && restart.contains("syncWithPreferences"),
+                       "\(tapOwner) restarts its tap thread through the gate on the main thread")
+            }
         }
 
         // Disabling a tap and dropping the last Swift reference does not hand

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21889,6 +21889,18 @@ struct MetricsTests {
                "resigning the session ends the recording rather than only the tap")
         expect(recordingTapCode.contains("DispatchQueue.main.async { endForSessionSwitch() }"),
                "a tap timeout in a switched-away session ends the recording too")
+        // That exit has to be registered before the tap is asked for. On a Mac
+        // without Accessibility begin() returns at the guard, the caller records
+        // through its own monitor, and ShortcutCapture.begin() has already
+        // switched the app's shortcuts off — so a registration behind the guard
+        // never happens and a resign leaves them off for good. Sliced to the
+        // part of begin above the guard, so the tap-creation path cannot answer
+        // for it.
+        let recordingTapBeginPreamble = recordingTapCode
+            .components(separatedBy: "static func begin(").last?
+            .components(separatedBy: "guard AXIsProcessTrusted()").first ?? ""
+        expect(recordingTapBeginPreamble.contains("SessionActivity.shared.onChange"),
+               "the recording tap watches the session even when Accessibility denies it a tap")
         let mouseTapAppDelegateSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/App/AppDelegate.swift",
             encoding: .utf8)) ?? ""

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21765,6 +21765,13 @@ struct MetricsTests {
                 expect(code.contains("AXIsProcessTrusted()"),
                        "\(tapOwner) does not keep a modifying tap alive after Accessibility is lost")
             }
+            if tapOwner.contains("KeyboardDebounce") {
+                // Its twin MouseClickDebounceService asks the same question in
+                // the same place: a modifying tap the window server disabled
+                // after Accessibility went away must end, not go back in.
+                expect(rearm.contains("AXIsProcessTrusted()"),
+                       "\(tapOwner) does not put a modifying tap back after Accessibility is lost")
+            }
             // Switching a tap off leaves the process owning it, which is what
             // the window server waits on; teardown must invalidate the port.
             expect(code.contains("CFMachPortInvalidate"),
@@ -21807,6 +21814,33 @@ struct MetricsTests {
                "every event tap owner invalidates its port on teardown, across "
                + "\(tapOwners) scanned owners: \(tapOwnersWithoutInvalidate)")
 
+        // The recording tap is the one whose teardown is not the whole exit.
+        // Whoever calls begin also calls ShortcutCapture.begin(), which switches
+        // off HotkeyManager, Shelf, clipboard, sound output and the window
+        // layout shortcuts. A session-driven teardown that drops the tap alone
+        // comes back with the capture card still up and every global shortcut
+        // in the app dead, so both session paths go through one exit that ends
+        // the capture as well. Lines are trimmed so the pairing is pinned
+        // without pinning indentation.
+        let recordingTapCode = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/ShortcutRecordingTap.swift",
+            encoding: .utf8)) ?? "")
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.hasPrefix("//") }
+            .joined(separator: "\n")
+        let sessionExitParts = recordingTapCode
+            .components(separatedBy: "private static func endForSessionSwitch() {")
+        expect(sessionExitParts.count > 1,
+               "the recording tap has one exit for the session going away")
+        let sessionExit = (sessionExitParts.last ?? "").components(separatedBy: "\n}").first ?? ""
+        expect(sessionExit.contains("tearDown()")
+                && sessionExit.contains("ShortcutCapture.end()"),
+               "a session switch gives the app's own shortcuts back, not only the tap")
+        expect(recordingTapCode.contains("guard !isActive else { return }\nendForSessionSwitch()"),
+               "resigning the session ends the recording rather than only the tap")
+        expect(recordingTapCode.contains("DispatchQueue.main.async { endForSessionSwitch() }"),
+               "a tap timeout in a switched-away session ends the recording too")
         let mouseTapAppDelegateSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/App/AppDelegate.swift",
             encoding: .utf8)) ?? ""


### PR DESCRIPTION
## Summary

Three keyboard event taps stayed in the chain across a fast user switch. They
now follow the session the way the mouse taps already do: handed back on
resign, rebuilt from the preferences on the way in, and the timeout re-arm asks
whether this session is still the one on screen before putting a tap back.

**`KeyboardDebounceService`** is the one that mattered most. It creates its tap
at the HID stage with `.defaultTap`, which is ahead of the split into login
sessions, and `KeyboardDebounceState` keys its bounce windows on the key code
alone — nothing in it knows which account is typing. A session left running
behind a switch therefore does not merely stall the account on screen; it
answers that account's keystrokes out of timing state built from someone else's
typing, and its answer can be `nil`, which is a keystroke that never arrives.
Its teardown also only disabled the tap and never called `CFMachPortInvalidate`.
#1225 has since landed the call after the run loop returns; what is left here
is the second one, in `stop()`, so a teardown that reaches the port before the
thread does hands it back too. That is the pair its twin
`MouseClickDebounceService` has. The re-arm asks that twin's full question:
`AXIsProcessTrusted()` as well as the session, because a modifying tap whose
permission went away while it was disabled has to end rather than go back in.

The branch that question falls through to has to be able to end it, and it
could not. `syncWithPreferences` read Accessibility off
`Permissions.shared.accessibility`, a value polled at
`PermissionPollingSupport.interval` (60s); the twin passes `AXIsProcessTrusted()`.
Inside that window the gate still computed true, so the sync called `start()`,
which saw the tap thread still up, published running and returned. The tap was
neither back in the chain nor stopped, and `isRunning` went on saying it was
live. The gate now asks the system directly, so the sync reaches `stop()` and
publishes not-running.

**`SuperKeyService`** owns two taps (session-level for keys, HID for mouse
buttons) plus a `hidutil` keyboard mapping. The mapping is the part that is
easy to miss: `hidutil` writes it for the whole Mac, so a session that keeps it
across a switch hands the account switched in a source key that does nothing.
`stop()` already clears the mapping, so gating the sync covers both halves at
once. Both taps are re-armed through one guarded path.

That path asked the session only. `start()` carries the Accessibility guard, but
a re-arm never reaches `start()`, so a grant revoked mid-session left both taps
disabled — same modifying `.defaultTap`, same failure as the debounce one — with
`isRunning` still true behind them. It now asks `AXIsProcessTrusted()` too. The
sync it falls through to sees the disabled tap as dead through its existing
`CGEvent.tapIsEnabled` check, tears down and rebuilds, and `start()`'s guard
clears the leftover mapping and publishes not-running.

**`ShortcutRecordingTap`** swallows every key while a field is listening, so a
recorder still open across a switch is the worst-behaved of the three for as
long as it lasts. #1153 left this one open with "it only exists while someone
is recording a shortcut in Settings … unless it stays armed after the sheet
closes, which I didn't check". Checked: the Settings fields do stop themselves
(`ShortcutRecorderButton.observeExits` subscribes to `didResignActive`), but the
command bar's shortcut-capture card is a second caller, and nothing hides that
panel on resign or deactivation. The tap is shared, so the guard is in the tap.

Dropping the tap is not the whole exit, though, and the first version of this
branch did only that. Everything that calls `ShortcutRecordingTap.begin` also
called `ShortcutCapture.begin()`, which switches off `HotkeyManager`, Shelf,
clipboard, sound output and the window-layout shortcuts; only
`ShortcutCapture.end()` gives them back. Switching away with the command bar's
capture card open therefore came back with the card still up, the tap gone and
every global shortcut in the app dead. Both session-driven teardowns — the
`onChange` handler and the timeout branch that declines to re-arm — now go
through one exit that ends the capture too. The five ordinary exits (the command
bar's `endCapturingShortcut`, `ShortcutRecorderButton.stopRecording` and its
`deinit`) already paired the two and are untouched; `ShortcutCapture.end()` is
idempotent, so whichever of them runs after a session switch is a no-op.
Nothing here hides or re-opens the capture card: giving the keys back early is
the direction `ShortcutCapture` documents as the safe one, and the card's own
local-monitor fallback still records.

That exit also has to be installed before the tap is asked for, and it was not.
The `onChange` registration sat inside `if tap == nil`, below
`guard AXIsProcessTrusted()`, so on a Mac without the grant `begin` returned at
the guard and nothing was ever listening for the switch — while
`ShortcutCapture.begin()` had already switched the app's shortcuts off. The
capture card still records through its caller's own key monitor, the documented
fallback, so nothing looks wrong until the session resigns and every global
shortcut stays dead with no exit left to give them back: round one's symptom
reached through the other door. The registration is now above the guard. It is
`observingSession`-guarded and kept for the process, so on a Mac that does have
the grant the first tap-creating recording installed it anyway; the gap was the
stretch before that, not a permanent state. Both halves of
`endForSessionSwitch()` are safe with no tap — `tearDown()` touches nil state
and `ShortcutCapture.end()` guards on `isCapturing`.

### The tap thread's own restart

Both threaded services build the tap in two places, and neither second place asked
the gate. When a stop and a start cross, the pending start is recorded and the tap
thread's tail rebuilds on a decision taken before the session handed over. `stop()`
clears that flag under the lock, so the window is the gap between
`clearEventTapThread()` reading `true` and the restart running: a resign landing there
finds the thread already gone, resets `shouldStopTapThread`, and the tail builds a
fresh tap into the session that has just left the screen.

The two were missing different amounts of it.

`KeyboardDebounceService` called `start()` straight from the tap thread, so both halves
were wrong — the thread and the question. It now hops and syncs. `isRunning` is published
false before the hop rather than only on the no-restart branch, so the gap between the two
is not a green "Active now" tick over a tap that is down; the sync publishes it true again
if it starts one. `publishRunning` already drops a stale generation and the two main-queue
blocks run in order, so nothing else is needed to keep that honest.

`SuperKeyService` already hopped: `startOnMain()` was a `DispatchQueue.main.async` onto
`start()`. What it did not do is ask. `start()` guards on `AXIsProcessTrusted()` alone and
the session conjunct lives in `syncWithPreferences`, which the restart skipped — so a
restart that crossed a handover rebuilt both taps in a switched-away session with the
grant still in place, which is the common case. It calls the sync now, and is renamed
`restartTapOnMain` to say so: "on main" was never the part that was missing.

The third `clearEventTapThread()` call in each file, on the `tapCreate` failure path,
deliberately drops the pending restart and is unchanged: neither service retries a failed
creation. `AppSwitcher` and `TextSnippetService` have the same window and the same fix in
#1236, and `FinderCutPaste` and `FinderRenameService` in #1234.

**One of the two is not pinned.** The restart check in `MetricsTests` asks this of every
owner in the roster that runs a tap thread, and it catches `SuperKeyService` — pointing
its helper back at `start()` turns it red. It does not reach
`KeyboardDebounceService`'s tail, which branches on a local
(`let shouldRestart = clearEventTapThread()` … `if shouldRestart { … }`) rather than
spelling the call inline the way the other five do. Reverting both of its tails to
`start()` leaves the suite green, which I checked rather than assumed. Pinning it would
mean matching a variable name and its indentation, or reshaping the tail to suit the
check; neither is worth it, so it is named here instead.

### Trade-offs

The re-arm in the first two runs on the tap's own thread, not the main run
loop. `SessionActivity.isActive` is written on the main thread, so reading it
from there would be a cross-thread read of main-thread state — the reason
`BrightnessService` samples the answer under `keyThreadLock` instead. Two ways
out were available and a third was rejected:

- **Sample the gate under the existing lock** (the `BrightnessService` shape).
  Decides instantly, but the tap thread then acts on an answer from the last
  preference sync.
- **Ask on the main thread** (chosen). The callback hands the event back
  fail-open, then hops to main, where the flag is written, and either re-arms or
  re-syncs. The answer cannot be stale relative to the `onChange` handler,
  because both run on the same thread in order. The cost is one main-queue hop
  before the tap comes back; the tap had already been out of the chain for its
  full timeout by then, and `KeyboardDebounceService` now resets its debounce
  state over that gap so the untapped stretch is not read as silence and the
  next press as a bounce.
- **Read `SessionActivity.shared.isActive` straight from the tap thread**, which
  is what `MouseClickDebounceService` does today. Rejected: it satisfies the
  wording of the guard without being correct on the thread it runs on.

The chosen option is now the answer across the four branches that gate a tap on
the session. #1234 sampled the gate instead and has moved to this shape;
`FinderCutPaste`, `FinderRenameService`, `AppSwitcher` and `TextSnippetService`
all hop to the main thread in the same position now, and the taps that live on
the main run loop — `WindowLayoutService`, `WindowMaximizer`,
`ShortcutRecordingTap`, `PreciseVolumeRollerService`, `DockClickService` — read
the flag in place because their callback is already there. One rule: the re-arm
decision is made on the thread that writes the answer.

Both Accessibility gates route through the existing stop paths rather than just
declining to re-arm, because `isRunning` has live readers: `@ObservedObject`
bindings in `KeyboardDebounceSettings`, `SuperKeySettings` and
`ShortcutsSettings`. A stale `true` is a green "Active now" tick over a dead tap
and a Super Key alternative offered in the shortcut rows for a tap that is not
running. Closing a gate without reporting the state is what the previous
revision did. No new write of `isRunning` was added — the existing `stop()` and
`start()` paths publish it at the right moment once the gates are honest.

`ShortcutRecordingTap` runs on the main run loop, so it reads the flag directly,
and defers only the teardown — invalidating a port from inside its own callback
stack is unsafe. Deferring it also puts `ShortcutCapture.end()` on the main
thread, which is where it belongs.

Nothing here adds a retry on `tapCreate` failure. None of the three retried
before: the debounce and Super Key services publish "not running" and stop,
and the recording tap returns `false` so the field falls back to plain view
events. The bounded retry `f25d1aa8` gave the scroll taps exists because those
retried without a bound; adding one where none existed would be a separate
change.

The three files are added to the existing session-switch guard in
`Tests/MetricsTests.swift`, which pins all four halves of the wiring as text.
Four more assertions pin the capture pairing: that one exit exists, that it
calls both halves, and that each of the two session paths reaches it. The
debounce re-arm's `AXIsProcessTrusted()` is asserted on the re-arm slice
itself rather than on the file, so a mention elsewhere cannot answer for it.
That re-arm-slice assertion now covers `SuperKeyService` alongside it, and one
more pins the debounce gate to `AXIsProcessTrusted()` on the
`syncWithPreferences` slice, so the polled cache cannot come back. Two further
assertions pin the session half of the same two gates, on those same slices:
`sessionIsActive: SessionActivity.shared.isActive` in the debounce gate, and the
`&& SessionActivity.shared.isActive` conjunct in Super Key's `enabled`. The
re-arm declining is only half of each fix — the sync answering `onChange` is
what actually reaches `stop()` on a resign, and for Super Key that conjunct is
the whole of it. `ShortcutRecordingTap` needs no gate assertion of that kind: it has no
sync, and both of its session paths are already pinned. It gains one of its own
instead, on the slice of `begin` above the Accessibility guard, so the
tap-creation path cannot answer for where the session handler is registered.

## Verification

MacBook Pro (Apple silicon), macOS 26. Rebased onto `main` at `a952b829`.

```
./build.sh --test      TESTS OK (9559 checks)
swiftc -typecheck      exit 0, whole module
```

None of `KeyboardDebounceService.swift`, `SuperKeyService.swift` or
`ShortcutRecordingTap.swift` is in the `--test` compile list, so a green
`--test` did not compile them. The whole of `Sources/Vorssaint/**` was
type-checked separately with the build's own target and SDK
(`arm64-apple-macosx14.0`, `MacOSX26.sdk`, plus the two `-I` compat paths) and
is clean. The full `./build.sh` was not run for this revision: with the signing
keychain locked, `codesign` blocks on an unlock dialog. (It was run and
reported on the earlier head `0f5e2de8` in the thread.)

The two input-source failures reported on earlier revisions (`nil layout falls
back to ANSI semicolon`, `App Switcher icon-row hints`) did not appear this
round; the machine's input source is ANSI now rather than a Chinese IME. They
read the current input source and are unrelated to this diff either way.

Every assertion added on this branch was checked red first, and each one on its
own, by removing the real conjunct from the source rather than by misspelling
it: deleting `&& SessionActivity.shared.isActive` from
`SuperKeyService.syncWithPreferences` turns only "the Super Key sync gate stops
both taps when the session leaves" red — every earlier assertion, including the
re-arm-slice ones, stays green under that break, which is the hole it was added
for; passing `sessionIsActive: true` in the debounce gate turns only "the
keyboard debounce gate stops the tap when the session leaves" red; putting
`accessibilityGranted: Permissions.shared.accessibility` back turns "the
keyboard debounce gate asks the system for Accessibility, not the poll cache"
red on its own; dropping `AXIsProcessTrusted()` from the Super Key re-arm turns
"SuperKeyService.swift does not put a modifying tap back after Accessibility is
lost" red on its own; restoring the previous `ShortcutRecordingTap.swift` turns
the four capture assertions red together; and "the recording tap watches the
session even when Accessibility denies it a tap" is red with the registration
back below the guard and green with it above. For the restart tails: pointing
`SuperKeyService`'s helper back at `start()` turns "SuperKeyService.swift restarts
its tap thread through the gate on the main thread" red on its own; reverting
`KeyboardDebounceService`'s two tails leaves the suite green, which is the gap
described above.

**Not tested:** there is no second login session on this machine, and
Accessibility was not revoked by hand — the app was never launched. Every claim
about what the account switched in experiences, and about what happens after a
revoked grant, is read off `KeyboardDebounceState`, the `hidutil` call,
`ShortcutCapture`'s callers, the two services' `start()`/`stop()` paths and
HID-versus-session tap placement. None of it was reproduced. Whether the window
server lets a tap re-enable at all once Accessibility is gone is not something I
checked either; the change makes the app stop asking, which is correct in both
cases. The same caveat stands on #1075 and #1153 themselves.

## Anything else

The capture card itself is left alone. Nothing hides the command bar panel on
session resign, so the card is still on screen for the account that comes back —
it just no longer holds the keyboard or the app's shortcuts. Hiding the panel
belongs to whoever owns the command bar's session behaviour, not to a tap.

`ScrollInverter` is the one remaining `SessionActivitySupport.tapShouldRun`
caller still passing `Permissions.shared.accessibility`, and its re-arm gates on
the session without asking Accessibility. Every other caller
(`SmoothScrollService`, `MouseNavigationService`, `MouseButtonShortcutService`,
`MiddleClickService`, `QuitProtectionService`, `MouseClickDebounceService`) asks
the system. That shape landed with its own review in #1145 and is not in this
branch's diff, so it is left alone here rather than widening this PR into a
third feature.

Refs #1075
Refs #1153




