### PR TITLE
fix: hand the switcher, snippet, volume and Dock taps back across a user switch

### DIFF
--- a/Sources/Vorssaint/Services/Audio/PreciseVolumeRollerService.swift
+++ b/Sources/Vorssaint/Services/Audio/PreciseVolumeRollerService.swift
@@ -2,10 +2,12 @@
 // Copyright (C) 2026 Vorssaint
 
 import AppKit
+import ApplicationServices
 import Combine
 
 /// Turns coarse hardware volume wheel bursts into macOS' fine volume step.
-/// Active only while enabled and Accessibility is granted.
+/// Active only while enabled, Accessibility is granted and this login session
+/// is the one on screen.
 final class PreciseVolumeRollerService: ObservableObject {
     static let shared = PreciseVolumeRollerService()
 
@@ -15,12 +17,28 @@ final class PreciseVolumeRollerService: ObservableObject {
     private var source: CFRunLoopSource?
     private var gate = PreciseVolumeRollerGate()
 
-    private init() {}
+    private init() {
+        // A filter tap owned by a switched-away login session keeps its place
+        // in the chain, so the account on screen waits out the tap timeout on
+        // every volume key it presses (issue #1075). Hand the tap back on
+        // resign and build it again from preferences on the way in.
+        SessionActivity.shared.onChange { [weak self] _ in
+            self?.syncWithPreferences()
+        }
+    }
 
     func syncWithPreferences() {
         let wanted = AppFeature.mixer.isAvailable
             && UserDefaults.standard.bool(forKey: DefaultsKey.preciseVolumeRollerEnabled)
-        wanted ? start() : stop()
+        if SessionActivitySupport.tapShouldRun(
+            featureWanted: wanted,
+            accessibilityGranted: AXIsProcessTrusted(),
+            sessionIsActive: SessionActivity.shared.isActive
+        ) {
+            start()
+        } else {
+            stop()
+        }
     }
 
     func suspend() {
@@ -44,11 +62,6 @@ final class PreciseVolumeRollerService: ObservableObject {
     }
 
     private func start() {
-        guard AXIsProcessTrusted() else {
-            removeTap()
-            tapFailed = false
-            return
-        }
         if let tap, !CGEvent.tapIsEnabled(tap: tap) {
             CGEvent.tapEnable(tap: tap, enable: true)
         }
@@ -85,8 +98,12 @@ final class PreciseVolumeRollerService: ObservableObject {
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if AXIsProcessTrusted(), let tap {
+            if AXIsProcessTrusted(), SessionActivity.shared.isActive, let tap {
                 CGEvent.tapEnable(tap: tap, enable: true)
+            } else {
+                // Invalidating the port from its own callback stack is unsafe;
+                // finish this callback fail-open, then release the tap.
+                DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
             }
             return Unmanaged.passUnretained(event)
         }

--- a/Sources/Vorssaint/Services/DockClick/DockClickService.swift
+++ b/Sources/Vorssaint/Services/DockClick/DockClickService.swift
@@ -139,7 +139,7 @@ final class DockClickService {
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if SessionActivity.shared.isActive, let tap {
+            if AXIsProcessTrusted(), SessionActivity.shared.isActive, let tap {
                 CGEvent.tapEnable(tap: tap, enable: true)
             } else {
                 // Invalidating the port from its own callback stack is unsafe;

--- a/Sources/Vorssaint/Services/DockClick/DockClickService.swift
+++ b/Sources/Vorssaint/Services/DockClick/DockClickService.swift
@@ -8,7 +8,8 @@ import CoreGraphics
 
 /// Adds optional actions when the active app's Dock icon is clicked: minimize
 /// its windows, hide the app, or cycle its windows. The Dock's native behavior
-/// remains untouched for every other click. Requires Accessibility.
+/// remains untouched for every other click. Requires Accessibility, and the
+/// tap only exists while this login session is the one on screen.
 final class DockClickService {
     static let shared = DockClickService()
 
@@ -60,15 +61,26 @@ final class DockClickService {
     private static let syntheticEventMarker: Int64 = 0x564F5253
     private var pendingSweeps: [pid_t: DispatchWorkItem] = [:]
 
-    private init() {}
+    private init() {
+        // A filter tap owned by a switched-away login session keeps its place
+        // in the chain, so every click the account on screen makes waits out
+        // this tap's timeout (issue #1075). Hand the tap back on resign and
+        // build it again from preferences on the way in.
+        SessionActivity.shared.onChange { [weak self] _ in
+            self?.syncWithPreferences()
+        }
+    }
 
     func syncWithPreferences() {
         let minimizeEnabled = UserDefaults.standard.bool(forKey: DefaultsKey.dockClickMinimize)
         let hideEnabled = UserDefaults.standard.bool(forKey: DefaultsKey.dockClickHide)
         let cycleEnabled = UserDefaults.standard.bool(forKey: DefaultsKey.dockClickCycleWindows)
-        if AppFeature.dockClick.isAvailable,
-           (minimizeEnabled || hideEnabled || cycleEnabled),
-           Permissions.shared.accessibility {
+        if SessionActivitySupport.tapShouldRun(
+            featureWanted: AppFeature.dockClick.isAvailable
+                && (minimizeEnabled || hideEnabled || cycleEnabled),
+            accessibilityGranted: Permissions.shared.accessibility,
+            sessionIsActive: SessionActivity.shared.isActive
+        ) {
             start()
         } else {
             stop()
@@ -123,7 +135,13 @@ final class DockClickService {
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
+            if SessionActivity.shared.isActive, let tap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            } else {
+                // Invalidating the port from its own callback stack is unsafe;
+                // finish this callback fail-open, then release the tap.
+                DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
+            }
             return Unmanaged.passUnretained(event)
         }
         // The replayed down of a press that became a drag: the Dock must

--- a/Sources/Vorssaint/Services/DockClick/DockClickService.swift
+++ b/Sources/Vorssaint/Services/DockClick/DockClickService.swift
@@ -75,10 +75,14 @@ final class DockClickService {
         let minimizeEnabled = UserDefaults.standard.bool(forKey: DefaultsKey.dockClickMinimize)
         let hideEnabled = UserDefaults.standard.bool(forKey: DefaultsKey.dockClickHide)
         let cycleEnabled = UserDefaults.standard.bool(forKey: DefaultsKey.dockClickCycleWindows)
+        // Accessibility is asked of the system and not of `Permissions.shared`,
+        // whose answer is a poll up to `PermissionPollingSupport.interval` old.
+        // The re-arm hands a tap it declines to put back to this sync to be
+        // stopped, and a stale grant here would install it straight back.
         if SessionActivitySupport.tapShouldRun(
             featureWanted: AppFeature.dockClick.isAvailable
                 && (minimizeEnabled || hideEnabled || cycleEnabled),
-            accessibilityGranted: Permissions.shared.accessibility,
+            accessibilityGranted: AXIsProcessTrusted(),
             sessionIsActive: SessionActivity.shared.isActive
         ) {
             start()

--- a/Sources/Vorssaint/Services/Snippets/TextSnippetService.swift
+++ b/Sources/Vorssaint/Services/Snippets/TextSnippetService.swift
@@ -8,7 +8,8 @@ import CoreGraphics
 /// Text snippets: typing a trigger replaces it with its expansion, with
 /// {{date}}, {{time}}, {{datetime}} and {{clipboard}} filled in. The key tap,
 /// the observers and the snippet cache only exist while the feature is on;
-/// off means nothing lives. Requires Accessibility (the tap).
+/// off means nothing lives. Requires Accessibility (the tap), and the tap is
+/// handed back while this login session is not the one on screen.
 final class TextSnippetService {
     static let shared = TextSnippetService()
 
@@ -33,7 +34,15 @@ final class TextSnippetService {
     private var immediateSnippets: [TextSnippet] = []
     private var delimiterSnippets: [TextSnippet] = []
 
-    private init() {}
+    private init() {
+        // A filter tap owned by a switched-away login session keeps its place
+        // in the chain, so every keystroke the account on screen types waits
+        // out this tap's timeout (issue #1075). Hand the tap back on resign
+        // and build it again from preferences on the way in.
+        SessionActivity.shared.onChange { [weak self] _ in
+            self?.syncWithPreferences()
+        }
+    }
 
     var isRunning: Bool { tapLifecycleLock.withLock { tap != nil } }
 
@@ -44,7 +53,11 @@ final class TextSnippetService {
         let hasWork = inputLock.withLock {
             !(immediateSnippets.isEmpty && delimiterSnippets.isEmpty)
         }
-        if enabled, hasWork, Permissions.shared.accessibility {
+        if SessionActivitySupport.tapShouldRun(
+            featureWanted: enabled && hasWork,
+            accessibilityGranted: Permissions.shared.accessibility,
+            sessionIsActive: SessionActivity.shared.isActive
+        ) {
             let libraryIsVisible = SnippetLibraryService.shared.isVisible
             let commandBarIsVisible = AppFeature.commandBar.isAvailable
                 && CommandBarService.shared.isVisible
@@ -224,6 +237,13 @@ final class TextSnippetService {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             let currentTap = tapLifecycleLock.withLock { shouldStopTapThread ? nil : tap }
             if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
+            // The session flag is written on the main thread, so this callback
+            // must not read it: the re-arm above is provisional and the answer
+            // is asked where it is written. A tap put back into a session that
+            // is no longer on screen stalls the account that is (issue #1075).
+            DispatchQueue.main.async { [weak self] in
+                if !SessionActivity.shared.isActive { self?.syncWithPreferences() }
+            }
             return Unmanaged.passUnretained(event)
         }
         // Clicks move the caret somewhere unknown; the half-typed trigger is

--- a/Sources/Vorssaint/Services/Snippets/TextSnippetService.swift
+++ b/Sources/Vorssaint/Services/Snippets/TextSnippetService.swift
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Vorssaint
 
 import AppKit
+import ApplicationServices
 import Carbon.HIToolbox
 import CoreGraphics
 
@@ -53,9 +54,13 @@ final class TextSnippetService {
         let hasWork = inputLock.withLock {
             !(immediateSnippets.isEmpty && delimiterSnippets.isEmpty)
         }
+        // Accessibility is asked of the system and not of `Permissions.shared`,
+        // whose answer is a poll up to `PermissionPollingSupport.interval` old.
+        // The re-arm hands a tap it declines to put back to this sync to be
+        // stopped, and a stale grant here would install it straight back.
         if SessionActivitySupport.tapShouldRun(
             featureWanted: enabled && hasWork,
-            accessibilityGranted: Permissions.shared.accessibility,
+            accessibilityGranted: AXIsProcessTrusted(),
             sessionIsActive: SessionActivity.shared.isActive
         ) {
             let libraryIsVisible = SnippetLibraryService.shared.isVisible
@@ -200,6 +205,13 @@ final class TextSnippetService {
         }
     }
 
+    /// Puts the tap back after the window server disabled it, unless a stop is
+    /// already on its way and the port is about to go. Main thread.
+    private func rearmDisabledTap() {
+        let currentTap = tapLifecycleLock.withLock { shouldStopTapThread ? nil : tap }
+        if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
+    }
+
     /// Runs on the tap thread once its run loop has stopped. A restart that
     /// `start` left pending goes back through `syncWithPreferences` instead of
     /// straight to `start`: the session flag is written on the main thread, and
@@ -240,14 +252,20 @@ final class TextSnippetService {
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            let currentTap = tapLifecycleLock.withLock { shouldStopTapThread ? nil : tap }
-            if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
-            // The session flag is written on the main thread, so this callback
-            // must not read it: the re-arm above is provisional and the answer
-            // is asked where it is written. A tap put back into a session that
-            // is no longer on screen stalls the account that is (issue #1075).
+            // A tap put straight back is a tap put back into whatever session
+            // is on screen now (issue #1075). The flag that answers that is
+            // written on the main thread and this callback runs on the tap's
+            // own thread, so the question is asked where the answer lives
+            // rather than read across the two, and the tap stays out of the
+            // chain until it is. Accessibility is asked in the same place and
+            // for the same reason as the sync: this tap modifies events, so a
+            // revoked grant has to end it rather than put it back.
             DispatchQueue.main.async { [weak self] in
-                if !SessionActivity.shared.isActive { self?.syncWithPreferences() }
+                if SessionActivity.shared.isActive, AXIsProcessTrusted() {
+                    self?.rearmDisabledTap()
+                } else {
+                    self?.syncWithPreferences()
+                }
             }
             return Unmanaged.passUnretained(event)
         }

--- a/Sources/Vorssaint/Services/Snippets/TextSnippetService.swift
+++ b/Sources/Vorssaint/Services/Snippets/TextSnippetService.swift
@@ -145,7 +145,7 @@ final class TextSnippetService {
             let runLoop = CFRunLoopGetCurrent()
             tapLifecycleLock.withLock { tapRunLoop = runLoop }
             guard !tapLifecycleLock.withLock({ shouldStopTapThread }) else {
-                if clearEventTapThread() { startOnMain() }
+                if clearEventTapThread() { restartTapOnMain() }
                 return
             }
 
@@ -184,7 +184,7 @@ final class TextSnippetService {
             CGEvent.tapEnable(tap: tap, enable: false)
             CFRunLoopRemoveSource(runLoop, source, .commonModes)
             CFMachPortInvalidate(tap)
-            if clearEventTapThread() { startOnMain() }
+            if clearEventTapThread() { restartTapOnMain() }
         }
     }
 
@@ -200,8 +200,13 @@ final class TextSnippetService {
         }
     }
 
-    private func startOnMain() {
-        DispatchQueue.main.async { [weak self] in self?.start() }
+    /// Runs on the tap thread once its run loop has stopped. A restart that
+    /// `start` left pending goes back through `syncWithPreferences` instead of
+    /// straight to `start`: the session flag is written on the main thread, and
+    /// a tap rebuilt into a session that is no longer on screen stalls the
+    /// account that is (issue #1075).
+    private func restartTapOnMain() {
+        DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
     }
 
     private func tapDidStart(_ startedTap: CFMachPort) {

--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -432,6 +432,14 @@ final class AppSwitcher: ObservableObject {
         }
     }
 
+    /// Puts the tap back after the window server disabled it, unless a stop is
+    /// already on its way and the port is about to go. Main thread.
+    private func rearmDisabledTap() {
+        // Never resurrect a tap that removeTap is already tearing down.
+        let currentTap = lifecycleLock.withLock { shouldStopTapThread ? nil : tap }
+        if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
+    }
+
     /// Runs on the tap thread once its run loop has stopped. A restart that
     /// `installTap` left pending goes back through `syncWithPreferences`
     /// instead of straight to `installTap`: the session flag is written on the
@@ -488,19 +496,22 @@ final class AppSwitcher: ObservableObject {
     /// then the handful of keys typed while the panel is up.
     private func route(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            // Never resurrect a tap that removeTap is already tearing down.
-            let currentTap = lifecycleLock.withLock { shouldStopTapThread ? nil : tap }
-            if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
             routeLock.withLock { routePendingSessionStart = nil }
+            // A tap put straight back is a tap put back into whatever session
+            // is on screen now (issue #1075). The flag that answers that is
+            // written on the main thread and this callback runs on the tap's
+            // own thread, so the question is asked where the answer lives
+            // rather than read across the two, and the tap stays out of the
+            // chain until it is. Accessibility is asked in the same place and
+            // for the same reason as the sync: this tap modifies events, so a
+            // revoked grant has to end it rather than put it back.
             DispatchQueue.main.async { [weak self] in
-                // The session flag is written on the main thread, so this tap
-                // thread must not read it: the re-arm above is provisional and
-                // the answer is asked where it is written. A tap put back into
-                // a session that is no longer on screen stalls the account
-                // that is (issue #1075).
-                if !SessionActivity.shared.isActive { self?.syncWithPreferences() }
-                guard let self, self.sessionActive else { return }
-                self.cancelSession()
+                if self?.sessionActive == true { self?.cancelSession() }
+                if SessionActivity.shared.isActive, AXIsProcessTrusted() {
+                    self?.rearmDisabledTap()
+                } else {
+                    self?.syncWithPreferences()
+                }
             }
             return Unmanaged.passUnretained(event)
         }

--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -157,13 +157,41 @@ final class AppSwitcher: ObservableObject {
         static let upArrow: Int64 = 126
     }
 
-    private init() {}
+    private init() {
+        // A filter tap owned by a switched-away login session keeps its place
+        // in the chain, so every keystroke the account on screen types waits
+        // out this tap's timeout (issue #1075). Hand the tap back on resign
+        // and build it again from preferences on the way in.
+        SessionActivity.shared.onChange { [weak self] _ in
+            self?.syncWithPreferences()
+        }
+    }
 
     private var isTapLive: Bool {
         lifecycleLock.withLock {
             guard let tap else { return false }
             return CFMachPortIsValid(tap) && CGEvent.tapIsEnabled(tap: tap)
         }
+    }
+
+    /// The single answer to "should the tap be in the event chain": the
+    /// feature is on, Accessibility is granted, and this login session is the
+    /// one on screen. Both the preference sync and the post-wake recheck ask
+    /// it, so neither can put the tap back on its own terms. Named apart from
+    /// `SessionActivitySupport.tapShouldRun`, which it calls.
+    ///
+    /// Accessibility is asked of the system and not of `Permissions.shared`,
+    /// whose answer is a poll up to `PermissionPollingSupport.interval` old.
+    /// The re-arm hands a tap it declines to put back to the sync to be
+    /// stopped, and a stale grant here would install it straight back. The
+    /// mirror stays on the per-key path in `handle`, where the comment explains
+    /// it is cached to keep a live TCC round-trip off every keystroke.
+    private var tapIsWanted: Bool {
+        SessionActivitySupport.tapShouldRun(
+            featureWanted: AppFeature.switcher.isAvailable
+                && UserDefaults.standard.bool(forKey: DefaultsKey.switcherEnabled),
+            accessibilityGranted: AXIsProcessTrusted(),
+            sessionIsActive: SessionActivity.shared.isActive)
     }
 
     /// Applies the persisted preference; safe to call repeatedly.
@@ -176,9 +204,7 @@ final class AppSwitcher: ObservableObject {
             routeShortcut = shortcut
             routeWindowShortcut = windowShortcut
         }
-        let enabled = AppFeature.switcher.isAvailable
-            && UserDefaults.standard.bool(forKey: DefaultsKey.switcherEnabled)
-        let canStartSession = enabled && Permissions.shared.accessibility
+        let canStartSession = tapIsWanted
         routeLock.withLock { routeCanStartSession = canStartSession }
         if canStartSession {
             startObservingKeyboardLayout()
@@ -283,9 +309,9 @@ final class AppSwitcher: ObservableObject {
     }
 
     private func reconcileTakeover() {
-        guard AppFeature.switcher.isAvailable,
-              UserDefaults.standard.bool(forKey: DefaultsKey.switcherEnabled),
-              Permissions.shared.accessibility else {
+        // The post-wake recheck asks the same gate as the sync, so a wake in a
+        // switched-away session cannot put the tap back on its own terms.
+        guard tapIsWanted else {
             restoreNativeHotkeys()
             return
         }
@@ -458,6 +484,12 @@ final class AppSwitcher: ObservableObject {
             if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
             routeLock.withLock { routePendingSessionStart = nil }
             DispatchQueue.main.async { [weak self] in
+                // The session flag is written on the main thread, so this tap
+                // thread must not read it: the re-arm above is provisional and
+                // the answer is asked where it is written. A tap put back into
+                // a session that is no longer on screen stalls the account
+                // that is (issue #1075).
+                if !SessionActivity.shared.isActive { self?.syncWithPreferences() }
                 guard let self, self.sessionActive else { return }
                 self.cancelSession()
             }

--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -378,7 +378,7 @@ final class AppSwitcher: ObservableObject {
 
             let shouldStopBeforeCreatingTap = lifecycleLock.withLock { shouldStopTapThread }
             guard !shouldStopBeforeCreatingTap else {
-                if clearEventTapThread() { installTap() }
+                if clearEventTapThread() { restartTapOnMain() }
                 return
             }
 
@@ -428,8 +428,17 @@ final class AppSwitcher: ObservableObject {
             CGEvent.tapEnable(tap: tap, enable: false)
             CFRunLoopRemoveSource(runLoop, source, .commonModes)
             CFMachPortInvalidate(tap)
-            if clearEventTapThread() { installTap() }
+            if clearEventTapThread() { restartTapOnMain() }
         }
+    }
+
+    /// Runs on the tap thread once its run loop has stopped. A restart that
+    /// `installTap` left pending goes back through `syncWithPreferences`
+    /// instead of straight to `installTap`: the session flag is written on the
+    /// main thread, and a tap rebuilt into a session that is no longer on
+    /// screen stalls the account that is (issue #1075).
+    private func restartTapOnMain() {
+        DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
     }
 
     /// Dock's ⌘Tab handler is a symbolic hotkey, not an event the session tap

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21737,7 +21737,11 @@ struct MetricsTests {
                          "Sources/Vorssaint/Services/MouseNavigation/MouseNavigationService.swift",
                          "Sources/Vorssaint/Services/MouseButtons/MouseButtonShortcutService.swift",
                          "Sources/Vorssaint/Services/MiddleClick/MiddleClickService.swift",
-                         "Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift"] {
+                         "Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift",
+                         "Sources/Vorssaint/Services/Switcher/AppSwitcher.swift",
+                         "Sources/Vorssaint/Services/Snippets/TextSnippetService.swift",
+                         "Sources/Vorssaint/Services/Audio/PreciseVolumeRollerService.swift",
+                         "Sources/Vorssaint/Services/DockClick/DockClickService.swift"] {
             let source = (try? String(contentsOfFile: tapOwner, encoding: .utf8)) ?? ""
             expect(!source.isEmpty, "\(tapOwner) reads back for its session-switch check")
             let code = source.components(separatedBy: "\n")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21768,8 +21768,14 @@ struct MetricsTests {
             // thread's tail when a stop and a start crossed. That restart must
             // not put the tap back on the tap thread's terms: the session
             // answer is written on the main thread, so the tail hops there and
-            // asks the same gate the preference sync asks.
-            if code.contains("clearEventTapThread") {
+            // asks the same gate the preference sync asks. Asked of the files
+            // that adopted the hop, because the half-fix is the hazard — one
+            // tail still calling installTap() directly rebuilds the tap into a
+            // switched-away session while the other tail is careful about it.
+            // Four more own-thread taps still restart the old way and are not
+            // this change's to fix: FinderCutPaste, FinderRenameService,
+            // SuperKeyService and KeyboardDebounceService.
+            if code.contains("restartTapOnMain") {
                 expect(!code.contains("clearEventTapThread() { installTap() }")
                         && !code.contains("clearEventTapThread() { startOnMain() }"),
                        "\(tapOwner) has no tap-thread restart that goes around the session gate")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21764,6 +21764,21 @@ struct MetricsTests {
             // the window server waits on; teardown must invalidate the port.
             expect(code.contains("CFMachPortInvalidate"),
                    "\(tapOwner) hands its tap back rather than only disabling it")
+            // Owners that run the tap on their own thread restart it from the
+            // thread's tail when a stop and a start crossed. That restart must
+            // not put the tap back on the tap thread's terms: the session
+            // answer is written on the main thread, so the tail hops there and
+            // asks the same gate the preference sync asks.
+            if code.contains("clearEventTapThread") {
+                expect(!code.contains("clearEventTapThread() { installTap() }")
+                        && !code.contains("clearEventTapThread() { startOnMain() }"),
+                       "\(tapOwner) has no tap-thread restart that goes around the session gate")
+                let restart = code.components(separatedBy: "private func restartTapOnMain")
+                    .dropFirst().first?.components(separatedBy: "\n    }").first ?? ""
+                expect(restart.contains("DispatchQueue.main.async")
+                        && restart.contains("syncWithPreferences"),
+                       "\(tapOwner) restarts its tap thread through the gate on the main thread")
+            }
         }
 
         // Disabling a tap and dropping the last Swift reference does not hand

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21768,14 +21768,10 @@ struct MetricsTests {
             // thread's tail when a stop and a start crossed. That restart must
             // not put the tap back on the tap thread's terms: the session
             // answer is written on the main thread, so the tail hops there and
-            // asks the same gate the preference sync asks. Asked of the files
-            // that adopted the hop, because the half-fix is the hazard — one
-            // tail still calling installTap() directly rebuilds the tap into a
-            // switched-away session while the other tail is careful about it.
-            // Four more own-thread taps still restart the old way and are not
-            // this change's to fix: FinderCutPaste, FinderRenameService,
-            // SuperKeyService and KeyboardDebounceService.
-            if code.contains("restartTapOnMain") {
+            // asks the same gate the preference sync asks. Asked of every owner
+            // in this roster that runs a tap thread, so a restart added to
+            // another gated owner has to answer the same question.
+            if code.contains("clearEventTapThread") {
                 expect(!code.contains("clearEventTapThread() { installTap() }")
                         && !code.contains("clearEventTapThread() { startOnMain() }"),
                        "\(tapOwner) has no tap-thread restart that goes around the session gate")


### PR DESCRIPTION
## Summary

Four `.defaultTap` event taps stayed in the event chain after a fast user
switch. A filter tap owned by a switched-away login session keeps its place in
the chain, so the window server still routes the front account's events through
a process that cannot answer and waits out the ~4s tap timeout on each one
(#1075). `AppSwitcher`, `TextSnippetService`, `PreciseVolumeRollerService` and
`DockClickService` never subscribed to `SessionActivity`.

Each service now does what `MouseNavigationService` does: subscribe to
`SessionActivity.shared.onChange` in `init`, route its preference sync through
`SessionActivitySupport.tapShouldRun`, and ask the same question before a tap
the window server disabled goes back into the chain. The
`CFMachPortInvalidate` calls this branch carried are on `main` through #1225
and are gone from the diff.

**Where the session is asked.** Two of the four run their tap on their own
thread (`AppSwitcher`, `TextSnippetService`) because a `keyDown` tap on the main
run loop turns any main-thread stall into system-wide keyboard lag (#275).
`SessionActivity.isActive` is written on the main thread, so those two must not
read it from the tap callback. An earlier revision re-armed provisionally under
the lifecycle lock and then corrected on the main thread; that is the one shape
that cannot hold, because putting the tap back first is putting it back into
whatever session is on screen now — the stall this branch exists to end — for as
long as the main queue takes to correct it. Both now leave the tap out of the
chain, hop to the main queue, and either re-arm there or hand the tap to the
sync to be stopped. That is what the keyboard, Super Key and Finder taps do in
the same position. `PreciseVolumeRollerService` and `DockClickService` run on
the main run loop, so their callback is already on the thread that writes the
flag and they read it in place.

Sampling the answer into a lock-protected field, the way #1234 did, was the
other option and is not taken anywhere now: that precedent was
`BrightnessService`'s flag, which has since been withdrawn from #1231, and the
sample is a second copy of state the process already has.

**Which Accessibility.** All four gates ask `AXIsProcessTrusted()`. It was mixed
before — `PreciseVolumeRollerService` asked the system while `AppSwitcher`,
`DockClickService` and `TextSnippetService` read `Permissions.shared`, whose
answer is a poll up to `PermissionPollingSupport.interval` old. The re-arm hands
a tap it declines to put back to the sync to be stopped, so a stale grant there
installs it straight back. The cached mirror stays on the per-key paths in
`AppSwitcher.handle` and `beginPendingSession`, where the comments explain that
a live TCC round-trip per keystroke is what they avoid.
`PreciseVolumeRollerService.start()` loses its own `AXIsProcessTrusted()` guard:
the gate asks that now, and the not-granted path lands on the same `stop()` the
guard was calling by hand.

**The tap-thread restart.** Those same two services restart their tap thread
from the thread's own tail. When a stop and a start cross,
`clearEventTapThread()` reports the pending start and the tail used to rebuild
the tap on the spot — `installTap()` in the switcher, `start()` in the snippet
service — without going through the gate. If the session hands over while that
restart is in flight, the resign handler's teardown finds the thread already
gone and no-ops, and the tail then installs a fresh filter tap into a session
that is no longer on screen. Both tails now hop to the main thread and call
`syncWithPreferences()`, which is the shape
`MouseClickDebounceService.finishEventTapThread` uses. The third
`clearEventTapThread()` call in each file, on the `tapCreate` failure path,
deliberately drops the pending restart and is unchanged — none of these services
retries a failed creation.

**`AppSwitcher` after #882.** That branch replaced `recoverTapIfNeeded` with
`reconcileTakeover`, and the post-wake recheck is still the second place that
can install the tap, so it asks the same gate. Both readers now go through one
private property rather than each spelling the condition out. It is named
`tapIsWanted`, not `tapShouldRun`: it *calls*
`SessionActivitySupport.tapShouldRun`, and #1234 used that same name for a
stored sample, so one name meant three things across three open branches.

`Tests/MetricsTests.swift` gains the four paths in the existing session-switch
roster, which pins the four-part wiring as source shape, plus a restart-tail
check. That check asks every owner in the roster that runs a tap thread, so a
restart added to another gated owner has to answer the same question. The four
other own-thread taps that restarted the old way have since been fixed on the
branches that own them — `FinderCutPaste` and `FinderRenameService` in #1234,
`SuperKeyService` and `KeyboardDebounceService` in #1235 — so whichever of the
three lands first, the roster only ever holds files that already answer it.
`MouseClickDebounceService` is already gated and its tail already hops.

PR #1230 replaces that hand-written roster with a sweep of every file containing
`CGEvent.tapCreate`; these four files are in its `knownUngatedTaps` exemption
table and those entries should be dropped when the two land together.

## Verification

MacBook Pro (Apple silicon), macOS 26. Rebased onto `main` at `a952b829`.

```
./build.sh --test      TESTS OK (9553 checks)
swiftc -typecheck      exit 0, whole module
```

None of the four service files is in the `--test` compile whitelist, so a green
`--test` never compiled them. The whole of `Sources/Vorssaint/**` was
type-checked separately with the build's own target and SDK
(`arm64-apple-macosx14.0`, `MacOSX26.sdk`, plus the two `-I` compat paths) and
is clean. The full `./build.sh` was not run this round: with the signing
keychain locked, `codesign` blocks on an unlock dialog. On an earlier revision
it compiled the app and the fan helper with zero warnings and then failed at the
signing step with `errSecInternalComponent`, so the compile is verified and the
bundle step is not.

The two input-source failures reported on earlier revisions (`nil layout falls
back to ANSI semicolon`, `App Switcher icon-row hints`) did not appear this
round; the machine's input source is ANSI now rather than a Chinese IME.

Both guardrails were checked by breaking them. For the wiring: removing the
session read from `AppSwitcher`'s timeout branch and the `onChange`
subscription from `DockClickService` turned the run red with those named
failures, and green again on restore. For the restart tails: putting
`installTap()` back in `AppSwitcher`'s two tails turned the run red with
`AppSwitcher.swift has no tap-thread restart that goes around the session gate`,
and green again on restore.

**Not tested:** the behaviour itself. There is no second login session on this
machine, so nothing here was observed under a real fast user switch — the
mechanism is inherited from #1075 and #1145, not measured. In particular the
restart-tail race is a read of the lifecycle code, not a reproduction: it needs a
stop and a start to cross at the moment of a session handover. Snippet expansion,
Dock click actions, the volume roller and the switcher were not exercised
interactively either; the tap lifecycle is what changed, so the ordinary paths
should be unaffected, but that is an argument, not a run. The revoke race is
not reproduced either: reaching it needs the window server to disable one of
these taps inside the polling interval that follows a revoked grant.

## Anything else

Refs #1153
Refs #1075

`Sources/Vorssaint/Services/DockClick/DockClickService.swift` was also touched by
#1219 and `Sources/Vorssaint/Services/Switcher/AppSwitcher.swift` by #882; both
have landed and this branch is rebased on them.
