### PR TITLE
fix(homebrew): bound the streaming command's wait, output and log

### DIFF
--- a/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
@@ -778,11 +778,13 @@ final class HomebrewManager: ObservableObject {
                     DispatchQueue.main.async { onOutput(chunk) }
                 }
             }
-            // Watched through the termination handler, never `waitUntilExit()`:
-            // that parks a worker of the shared 64-thread pool for the whole
-            // command, and one hung `brew install` used to hold this serial
-            // queue for good, with every later refresh, search and ownership
-            // lookup stuck behind it (see BoundedProcessRunner, issue #971).
+            // The bound is the fix. This wait blocks the serial queue's thread
+            // exactly as `waitUntilExit()` did — one at a time, never
+            // abandoned, so it cannot fill the shared pool the way #971's
+            // waits do. Unbounded it starved this one queue instead: a `brew
+            // install` that never returned left every later refresh, search
+            // and ownership lookup behind it for good. The semaphore is only
+            // how a timeout is put on a wait `waitUntilExit()` will not take.
             let finished = DispatchSemaphore(value: 0)
             process.terminationHandler = { _ in finished.signal() }
             do {

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
@@ -668,6 +668,19 @@ final class HomebrewManager: ObservableObject {
     private static let brewReadTimeout: TimeInterval = 30
     private static let processTerminationGrace: TimeInterval = 2
 
+    /// Timeout for an operation the person started (install, upgrade,
+    /// uninstall). Deliberately far beyond any real command: a large cask on
+    /// a slow line legitimately runs for many minutes, and cutting one of
+    /// those off is worse than the stall this exists to end. It only has to
+    /// be finite, because the wait holds the serial queue and everything
+    /// behind it.
+    private static let brewOperationTimeout: TimeInterval = 30 * 60
+
+    /// How much of an operation's output is kept for the completion handler,
+    /// which reads the last few lines of it. The download phase is a curl
+    /// progress bar that can run to megabytes.
+    private static let brewOperationOutputLimit = 4 * 1024 * 1024
+
     /// SIGTERM is cooperative. Escalate only when a command ignores it so a
     /// cancelled or timed-out operation cannot keep the serial queue forever.
     private static func stop(_ process: Process, finished: DispatchSemaphore? = nil) {
@@ -752,12 +765,26 @@ final class HomebrewManager: ObservableObject {
                     return
                 }
                 lock.lock()
+                // Keep draining once the retained tail is full, so the child
+                // can never block on a full pipe or turn its output into
+                // memory use. The tail is kept and not the head because the
+                // error this is read for is the last thing brew prints.
                 output.append(data)
+                if output.count > Self.brewOperationOutputLimit * 2 {
+                    output.removeFirst(output.count - Self.brewOperationOutputLimit)
+                }
                 lock.unlock()
                 if let chunk = String(data: data, encoding: .utf8) {
                     DispatchQueue.main.async { onOutput(chunk) }
                 }
             }
+            // Watched through the termination handler, never `waitUntilExit()`:
+            // that parks a worker of the shared 64-thread pool for the whole
+            // command, and one hung `brew install` used to hold this serial
+            // queue for good, with every later refresh, search and ownership
+            // lookup stuck behind it (see BoundedProcessRunner, issue #971).
+            let finished = DispatchSemaphore(value: 0)
+            process.terminationHandler = { _ in finished.signal() }
             do {
                 try process.run()
             } catch {
@@ -770,19 +797,24 @@ final class HomebrewManager: ObservableObject {
                 self.activeProcess = process
                 if self.cancelRequested { Self.stop(process) }
             }
-            process.waitUntilExit()
+            if finished.wait(timeout: .now() + Self.brewOperationTimeout) == .timedOut {
+                Self.stop(process, finished: finished)
+            }
             _ = drained.wait(timeout: .now() + 1)
             pipe.fileHandleForReading.readabilityHandler = nil
             try? pipe.fileHandleForReading.close()
             lock.lock()
-            let finalOutput = String(data: output, encoding: .utf8) ?? ""
+            // Decoded leniently: a dropped head can cut a multi-byte
+            // character in half, and losing the whole output over that would
+            // take the error message with it.
+            let finalOutput = String(decoding: output, as: UTF8.self)
             lock.unlock()
-            completion(process.terminationStatus, finalOutput)
+            completion(process.isRunning ? -1 : process.terminationStatus, finalOutput)
         }
     }
 
     private func appendLog(_ text: String) {
-        log.append(text)
+        log = HomebrewProgressParser.appendingToLog(log, text)
     }
 
     private func appleScriptString(_ value: String) -> String {

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
@@ -517,7 +517,11 @@ enum HomebrewProgressParser {
                                limit: Int = logLimit) -> String {
         var log = existing
         log.append(text)
-        guard log.utf8.count > limit * 2 else { return log }
+        // Counted in Characters, the same unit `suffix(limit)` trims in. A
+        // byte count here would fire on multi-byte text while `suffix` was
+        // already the whole string, dropping a leading line per call instead
+        // of capping anything.
+        guard log.count > limit * 2 else { return log }
         let tail = log.suffix(limit)
         let wholeLines = tail.drop { !$0.isNewline }.dropFirst()
         return "…\n" + (wholeLines.isEmpty ? tail : wholeLines)

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
@@ -517,11 +517,14 @@ enum HomebrewProgressParser {
                                limit: Int = logLimit) -> String {
         var log = existing
         log.append(text)
-        // Counted in Characters, the same unit `suffix(limit)` trims in. A
-        // byte count here would fire on multi-byte text while `suffix` was
-        // already the whole string, dropping a leading line per call instead
-        // of capping anything.
-        guard log.count > limit * 2 else { return log }
+        // The cut is decided in Characters, the same unit `suffix(limit)`
+        // trims in: a byte count deciding it would fire on multi-byte text
+        // while `suffix` was already the whole string, dropping a leading
+        // line per call instead of capping anything. The byte count leads
+        // because it is O(1) and never below the Character count, so it
+        // turns away the chunks that would otherwise pay for an O(n) walk
+        // on the main thread. Order matters; keep the cheap test first.
+        guard log.utf8.count > limit * 2, log.count > limit * 2 else { return log }
         let tail = log.suffix(limit)
         let wholeLines = tail.drop { !$0.isNewline }.dropFirst()
         return "…\n" + (wholeLines.isEmpty ? tail : wholeLines)

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
@@ -496,10 +496,36 @@ enum HomebrewAnalytics {
 }
 
 enum HomebrewProgressParser {
+    /// Compiled once. Every one of these runs on the main thread for every
+    /// chunk a running operation emits, and brew's download phase is a curl
+    /// progress bar that refreshes many times a second.
+    private static let percentRegex = try? NSRegularExpression(
+        pattern: #"([0-9]{1,3}(?:\.[0-9]+)?)%"#)
+    private static let ansiRegex = try? NSRegularExpression(
+        pattern: #"\u001B\[[0-9;?]*[ -/]*[@-~]"#)
+
+    /// How much of a running operation's log is kept. `brew upgrade --cask
+    /// --greedy` across several packages emits megabytes of progress bars,
+    /// and every append republishes the whole string for the view to lay out
+    /// again.
+    static let logLimit = 64 * 1024
+
+    /// The log with `text` appended, cut back to its last `limit` characters
+    /// once it grows past twice that. The tail is what says where the
+    /// operation is, so the head is what goes.
+    static func appendingToLog(_ existing: String, _ text: String,
+                               limit: Int = logLimit) -> String {
+        var log = existing
+        log.append(text)
+        guard log.utf8.count > limit * 2 else { return log }
+        let tail = log.suffix(limit)
+        let wholeLines = tail.drop { !$0.isNewline }.dropFirst()
+        return "…\n" + (wholeLines.isEmpty ? tail : wholeLines)
+    }
+
     static func progressFraction(in output: String) -> Double? {
         var latest: Double?
-        let pattern = #"([0-9]{1,3}(?:\.[0-9]+)?)%"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        guard let regex = percentRegex else { return nil }
         let range = NSRange(output.startIndex..<output.endIndex, in: output)
         regex.enumerateMatches(in: output, range: range) { match, _, _ in
             guard let match,
@@ -601,9 +627,7 @@ enum HomebrewProgressParser {
     }
 
     private static func stripANSI(_ value: String) -> String {
-        guard let regex = try? NSRegularExpression(pattern: #"\u001B\[[0-9;?]*[ -/]*[@-~]"#) else {
-            return value
-        }
+        guard let regex = ansiRegex else { return value }
         let range = NSRange(value.startIndex..<value.endIndex, in: value)
         return regex.stringByReplacingMatches(in: value, range: range, withTemplate: "")
     }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11514,18 +11514,6 @@ struct MetricsTests {
         expect(HomebrewProgressParser.appendingToLog(String(repeating: "日本語テキスト\n", count: 2),
                                                      "日本語テキスト\n", limit: 32) == multibyteLog,
                "Homebrew operation log measures its limit in the unit it trims in")
-        // Both counts answer the same question, but `log.count` walks
-        // graphemes on the main thread for every chunk a running operation
-        // emits. Nothing observable separates the two orders, so the order
-        // is pinned here instead.
-        let homebrewSupportSource = (try? String(
-            contentsOfFile: "Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift",
-            encoding: .utf8)) ?? ""
-        let logCapGuard = homebrewSupportSource.components(separatedBy: "\n").first {
-            $0.trimmingCharacters(in: .whitespaces).hasPrefix("guard log.")
-        } ?? ""
-        expect(logCapGuard.contains("log.utf8.count > limit * 2, log.count > limit * 2"),
-               "Homebrew operation log screens on the O(1) byte count before walking Characters")
 
         let homebrewJSON = """
         {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11501,6 +11501,14 @@ struct MetricsTests {
                == "Error: Cask failed",
                "Homebrew progress parser hides command lines from visible errors")
 
+        expect(HomebrewProgressParser.appendingToLog("head\n", "tail\n", limit: 64) == "head\ntail\n",
+               "Homebrew operation log is left alone while it fits")
+        let cappedLog = HomebrewProgressParser.appendingToLog(
+            String(repeating: "old\n", count: 200), "last line\n", limit: 32)
+        expect(cappedLog.hasSuffix("last line\n") && cappedLog.utf8.count <= 96
+                && !cappedLog.hasPrefix("old"),
+               "Homebrew operation log keeps its tail instead of growing without bound")
+
         let homebrewJSON = """
         {
           "formulae": [

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11514,6 +11514,18 @@ struct MetricsTests {
         expect(HomebrewProgressParser.appendingToLog(String(repeating: "日本語テキスト\n", count: 2),
                                                      "日本語テキスト\n", limit: 32) == multibyteLog,
                "Homebrew operation log measures its limit in the unit it trims in")
+        // Both counts answer the same question, but `log.count` walks
+        // graphemes on the main thread for every chunk a running operation
+        // emits. Nothing observable separates the two orders, so the order
+        // is pinned here instead.
+        let homebrewSupportSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift",
+            encoding: .utf8)) ?? ""
+        let logCapGuard = homebrewSupportSource.components(separatedBy: "\n").first {
+            $0.trimmingCharacters(in: .whitespaces).hasPrefix("guard log.")
+        } ?? ""
+        expect(logCapGuard.contains("log.utf8.count > limit * 2, log.count > limit * 2"),
+               "Homebrew operation log screens on the O(1) byte count before walking Characters")
 
         let homebrewJSON = """
         {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11508,6 +11508,12 @@ struct MetricsTests {
         expect(cappedLog.hasSuffix("last line\n") && cappedLog.utf8.count <= 96
                 && !cappedLog.hasPrefix("old"),
                "Homebrew operation log keeps its tail instead of growing without bound")
+        // 24 Characters, 66 UTF-8 bytes: under a limit counted in Characters,
+        // over one counted in bytes.
+        let multibyteLog = String(repeating: "日本語テキスト\n", count: 3)
+        expect(HomebrewProgressParser.appendingToLog(String(repeating: "日本語テキスト\n", count: 2),
+                                                     "日本語テキスト\n", limit: 32) == multibyteLog,
+               "Homebrew operation log measures its limit in the unit it trims in")
 
         let homebrewJSON = """
         {


### PR DESCRIPTION
## Summary

A Homebrew operation that never finishes used to take the whole Homebrew pane
with it, and a long one grew without bound in three places.

**The process was waited on with `waitUntilExit()`, which takes no timeout.**
That wait ran on `HomebrewManager`'s *serial* `workQueue`, so one stuck `brew
install` parked every later `refreshInstalled`, `search`, `refreshOutdated`,
`select` and `packageManagingApplication` behind it, permanently.
`runStreaming` now waits on a semaphore its `terminationHandler` signals — the
same shape as `run` a few lines above — bounded at 30 minutes, and escalates
through the existing `stop(_:finished:)` when the bound expires. The bound is
the whole fix: that semaphore blocks the same thread `waitUntilExit()` blocked,
it is just finite.

**The retained output was unbounded.** `runStreaming` accumulated every byte
for the completion handler, which reads the last few lines of it. It now keeps
a 4 MB tail. The tail and not the head, because the error this output is read
for is the last thing brew prints. Decoding moved to `String(decoding:as:)` so
a dropped head cutting a multi-byte character in half cannot take the whole
output — and the error message with it — down with it.

**The published log was unbounded and republished whole.** `appendLog` did
`log.append(text)` on an `@Published` string for every stdout chunk. brew's
download phase is a curl progress bar refreshing on `\r` many times a second,
and `brew upgrade --cask --greedy` across several packages runs to megabytes;
every append pushed the entire string to `HomebrewOperationStatusView`, which
laid all of it out again. The log is now cut back to its last 64 KB.

**Three regular expressions were compiled per output chunk on the main
thread.** `updateOperationStatus` calls `phase` + `progressFraction` +
`activity` for every chunk, and both `progressFraction` and `stripANSI` built
a fresh `NSRegularExpression` on each call. They are `static let` now.

### What each bound does when it trips

The three bounds do not behave alike, and only one of them ends the operation.

- **The 30-minute wait aborts the operation.** `stop(_:finished:)` sends
  SIGTERM, waits 2 s, then SIGKILL, then waits 2 s more. The completion
  handler is reached with a non-zero status and `cancelRequested` false, so
  `perform` takes its last branch: the operation card goes to **Failed** and
  `errorMessage` is whatever `visibleError` finds in the retained tail. It is
  not reported as cancelled, because the person did not cancel it. brew is
  killed mid-command, so the package can be left half-installed exactly as it
  would be after a crash or a cancel — rerunning the action is the fix, and
  that is unchanged from the existing cancel path.
- **The 4 MB output cap truncates silently and the operation keeps running.**
  The head is dropped, no marker is inserted, and the read handler keeps
  draining so the child can never block on a full pipe. Nothing downstream
  loses a signal to it: `visibleError`, `needsTerminalFallback` and
  `untrustedTapName` all look for things brew prints as it stops, which are in
  the tail by construction.
- **The 64 KB log cap truncates visibly and the operation keeps running.** The
  head is dropped back to a whole-line boundary and a leading `…` is left in
  its place, so the pane and "copy log" both show that something was cut.

**No child is left orphaned by a tripped bound.** SIGKILL cannot be ignored,
`activeProcess` is cleared in the completion handler, and the drain that
follows is itself capped at one second before the read handle is closed — so
even a child wedged in an uninterruptible wait releases the serial queue
instead of holding it. What survives a kill is what already survived a cancel:
brew's own grandchildren (`curl`, `git`) are not in a process group this
signals, and that shape is untouched here.

### Scope against #971

The previous round of this section was wrong, in the direction of claiming
more than the diff does. Corrected:

**#971 names two sites, and this PR touches neither.**

- `BoundedProcessRunner.run` — a `waitUntilExit()` parked on
  `DispatchQueue.global` and then *abandoned*, because `run` returned on
  timeout without ever collecting it. That is the one that accumulates: seven
  call sites reach it on this head, several of them periodic samplers, so
  stranded waiters piled up on their own until the 64-thread pool had nothing
  left.
- `WindowEnumerator.listWindows` — `waitUntilAllOperationsAreFinished()` with
  no timeout, on the main thread, which is what turns a full pool into a dead
  app rather than a slow one.

Both are already bounded on current `main`, which is why the issue carries
`fixed (pending release)`.

**What this PR fixes is a third occurrence of the shape, at a site #971 never
mentions, and one that could not have produced the reported freeze.** The
reporter's own notes say Homebrew is uninstalled on his machine, so this call
site was dead for him. More to the point, this wait runs on Homebrew's private
*serial* `workQueue` and is never abandoned — it holds one thread at a time and
cannot count towards the 64. Unbounded it starved that one queue, which is the
defect in the Summary above, not the pool exhaustion #971 reports.

**The same is true of the two `waitUntilExit()` calls still on `main`**, so the
previous round's "the pool can still fill from those two" was wrong on both:

- `DiskImageInstallerService.run` (`DiskImageInstallerService.swift:303`) —
  `readDataToEndOfFile()` then `waitUntilExit()`, no timeout, on that service's
  own serial `workQueue`. A stalled `spctl -a` parks that queue for good, one
  thread, no accumulation.
- `JunkCleaner.bootoutUserAgent` (`JunkCleaner.swift:284`) — called from a
  sequential `for` loop inside a single `DispatchQueue.global` block, once per
  login-item plist. A hung `launchctl bootout` parks that one clean run.

So the precise claim: **this PR fixes neither defect #971 reports, and #971
should not take `half` on account of it.** The `Refs #971` line has therefore
been removed: on merge that line is what puts a report on the fix track and
tells its reporter which release carries the fix, and neither is true here.
The shape and the diagnosis still come from #971, which is why it is named
throughout this section — as a reference, not as a claim to have fixed it.

Trade-offs:

- **Timeout value: 30 minutes, deliberately loose.** A large cask on a slow
  line legitimately runs for many minutes, and cutting off a real install is
  worse than the stall this exists to end. The value only has to be finite,
  because what it protects is the serial queue behind it. A tight bound
  modelled on `brewReadTimeout` (30s) was rejected for that reason.
- **The log keeps its tail, so a very long install loses its beginning**, and
  "copy log" then hands over the last 64 KB with a leading `…`. The
  alternative — a ring of chunks, or spilling to a file — is a data structure
  and a lifetime for a string that is already erased 8 seconds after the
  operation ends.
- The output cap and the log cap stayed separate limits because they answer
  to different readers: 4 MB feeds the error parser, 64 KB feeds a `Text`
  view.
- `appendingToLog` decides its cut in `Characters`, the unit `suffix(limit)`
  trims in. An earlier round decided it on `utf8.count` alone, which mixed
  units: on multi-byte text the guard fired while `suffix(limit)` was already
  the whole string, so each call dropped one leading line and prepended `…`
  instead of capping anything. brew's output is ASCII so it never bit that
  path, but a localised tool's error line would have reached it.
- **The Character walk is now screened, so this change does not undo its own
  regex hoist.** `log.count` is O(n) per chunk on the main thread, in a
  change that hoisted three regexes off that same path for exactly that
  reason. The guard is now `guard log.utf8.count > limit * 2, log.count >
  limit * 2`: `utf8.count` is O(1) on a native string and a string never has
  more Characters than UTF-8 bytes, so the cheap test can only turn away a
  chunk no trim was due for, and `log.count` runs only for the few that get
  past it. The decision stays in Characters. Nothing observable separates
  the two orders, so nothing pins the screen: the comment above the guard
  is what records it. A source-shape assertion that pinned the guard's
  spelling was added and then dropped, because it went red on an equivalent
  spelling and stayed green on the same O(n) walk anywhere else.
- **The per-chunk `String(data:encoding:.utf8)` in the read handler is
  untouched, and it is a real defect.** It returns nil when a read boundary
  splits a multi-byte character, and the entire chunk is then dropped — from
  the log and from the progress parser both. That line predates this PR, and
  the fix is not the lenient decode used for the final output: decoding
  leniently per chunk trades a lost line for a `U+FFFD` in the middle of one.
  Doing it correctly means carrying the trailing partial bytes over to the
  next chunk, which is state this change has no other reason to introduce.
  Flagged rather than fixed; either version can be had here or in a follow-up.

## Verification

```sh
./build.sh --test     # 9490 checks, 0 failures
```

Run on this head. `./build.sh --test` compiles a whitelist that contains
`HomebrewSupport.swift` but **not** `HomebrewManager.swift`, so that file is
not compiled here at all and CI covers it on both runners.

The only change to `HomebrewManager.swift` across the review rounds was the block comment above the
`terminationHandler` (later rounds touched `HomebrewSupport.swift` and the tests only) — it stated the defect wrongly
(pool exhaustion rather than starvation of this one serial queue, and the
mechanism rather than the bound as the fix), and it is what the two remaining
sites would be copied from.

Every new assertion was verified red-first when it was added — broken, seen to
fail, restored, seen green:

- `Homebrew operation log measures its limit in the unit it trims in` —
  dropping `log.count` so `utf8.count` becomes the decision rather than the
  screen fails it.
- `Homebrew operation log keeps its tail instead of growing without bound` —
  neutering the length check in `appendingToLog` fails it.
- `Homebrew progress parser cleans activity lines` (existing) — breaking the
  hoisted ANSI pattern fails it.

**Not tested:** none of it against a real slow or hung `brew`. The timeout
path, the SIGTERM/SIGKILL escalation and the 4 MB output cap were reasoned
from the code and from the matching paths in `run` and
`BoundedProcessRunner`, not exercised — including the Failed-not-Cancelled
routing described above, which was traced through `perform` rather than
observed. No multi-package `brew upgrade --cask --greedy` was run to watch the
log actually reach the 64 KB cap in the UI. No GUI testing was done at all.
The claims about `DiskImageInstallerService` and `JunkCleaner` in *Scope
against #971* are read from the code on `main`, not run.

## Anything else

The two `waitUntilExit()` calls outside this PR's files are left untouched on
purpose. Each starves its own queue and neither can fill the pool, as set out
in *Scope against #971* above, so neither is a #971 site and neither is urgent
on that account — they are still unbounded waits and still worth bounding.
Reaching them means `DiskImageInstallerService` and `JunkCleaner`, neither of
which this change otherwise goes near, and a separate change is what the
review called that.


No `Refs`. #566 asks for the Homebrew log of the last action to be kept instead of wiped,
and this does not do that: `scheduleCompletedOperationCleanup` still sets `log = ""` after
a success, a cancel and a failure, and nothing here goes near it. The 64 KB cap is a
constraint on #566 rather than a piece of it — if the log is ever kept, the cap is what
decides what "kept" means — so it belongs in a comment there, where `Refs` semantics cannot
put the report on the fix track for a build in which the log still vanishes.

