### PR TITLE
fix(quick-tools): honour excluded volume UUIDs everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Vorssaint adds quit and close protections, expands screen text recognition, capt
 - Cleaning Mode now offers an option in Settings to keep the screen visible with a discreet corner indicator instead of blacking out the screen.
 - Mouse button shortcuts can now switch Spaces or open Mission Control and App Exposé by holding an extra button and dragging. Thanks to @iltonandrew.
 - Window Layout now offers configurable window and screen gaps, so snapped windows can keep a preset distance from each other and from the screen edge. Thanks to @marcelharinck.
-- Eject all disks can now exclude specific drives in Settings, keeping backup drives and permanent storage mounted when ejecting other external disks.
+- Eject all disks can now exclude specific drives in Settings, keeping backup drives and permanent storage mounted when ejecting other external disks. Thanks to @PathGao.
 - Dock Preview now includes an option in Settings to quit an app from a thumbnail's × button instead of closing only that window, and closes the preview as soon as the quit request is accepted. Thanks to @arefshal.
 - Copy Text from Screen now includes an option in Settings to remove line breaks and join recognized lines as a single paragraph with script-aware spacing. Thanks to @ywu73.
 - Clipboard history now offers retention limit options for 10,000 items and unlimited storage.

--- a/Sources/Vorssaint/Services/Metrics/DiskProtectionService.swift
+++ b/Sources/Vorssaint/Services/Metrics/DiskProtectionService.swift
@@ -51,6 +51,7 @@ final class DiskProtectionService: ObservableObject {
         guard !excludedVolumes.isEmpty else { return false }
         let set = Set(excludedVolumes.map { $0.lowercased() })
         return QuickTogglesSupport.isExcluded(volumeName: disk.name,
+                                              volumeUUID: disk.volumeUUID,
                                               mountPath: disk.mountPath,
                                               excludedVolumes: set)
     }

--- a/Sources/Vorssaint/Services/Metrics/DiskSampler.swift
+++ b/Sources/Vorssaint/Services/Metrics/DiskSampler.swift
@@ -53,6 +53,7 @@ final class DiskSampler {
             return DiskDeviceReading(id: volume.mountPath,
                                      name: volume.name,
                                      mountPath: volume.mountPath,
+                                     volumeUUID: volume.volumeUUID,
                                      bsdName: metadata.bsdName,
                                      wholeDisk: wholeDisk,
                                      ioCounterID: counter?.id,
@@ -164,6 +165,7 @@ final class DiskSampler {
     private struct MountedVolume {
         var name: String
         var mountPath: String
+        var volumeUUID: String?
         var totalBytes: UInt64
         var freeBytes: UInt64
         var rawFreeBytes: UInt64?
@@ -187,6 +189,7 @@ final class DiskSampler {
             .volumeIsRemovableKey,
             .volumeIsEjectableKey,
             .volumeIsLocalKey,
+            .volumeUUIDStringKey,
         ]
         guard let urls = FileManager.default.mountedVolumeURLs(includingResourceValuesForKeys: Array(keys),
                                                                options: [.skipHiddenVolumes]) else {
@@ -214,6 +217,7 @@ final class DiskSampler {
             let identity = statfsIdentity(for: url.path)
             return MountedVolume(name: name.isEmpty ? url.path : name,
                                  mountPath: url.path,
+                                 volumeUUID: values.volumeUUIDString,
                                  totalBytes: total,
                                  freeBytes: min(free, total),
                                  rawFreeBytes: rawFree,

--- a/Sources/Vorssaint/Services/Metrics/DiskSupport.swift
+++ b/Sources/Vorssaint/Services/Metrics/DiskSupport.swift
@@ -26,6 +26,9 @@ struct DiskDeviceReading: Identifiable, Equatable {
     var id: String
     var name: String
     var mountPath: String
+    /// Stable across renames and remounts, so the eject exclusion list matches
+    /// on it as well as on the name and the mount path.
+    var volumeUUID: String?
     var bsdName: String?
     var wholeDisk: String?
     var ioCounterID: String?

--- a/Sources/Vorssaint/Services/QuickTools/QuickTogglesSupport.swift
+++ b/Sources/Vorssaint/Services/QuickTools/QuickTogglesSupport.swift
@@ -71,9 +71,12 @@ enum QuickTogglesSupport {
 
     /// Whether a volume matches any entry in the user's exclusion list by
     /// name (case-insensitive), volume UUID, full mount path or mount directory name.
+    /// None of the four forms is optional to pass: an entry the user typed is
+    /// honoured or ignored depending on which identifiers the caller happened
+    /// to hand over, so a caller that has none says so with an explicit nil.
     static func isExcluded(volumeName: String?,
-                           volumeUUID: String? = nil,
-                           mountPath: String? = nil,
+                           volumeUUID: String?,
+                           mountPath: String?,
                            excludedVolumes: Set<String>) -> Bool {
         guard !excludedVolumes.isEmpty else { return false }
         if let name = volumeName?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotShareService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotShareService.swift
@@ -35,6 +35,15 @@ final class ScreenshotShareService: ObservableObject {
         configuration.timeoutIntervalForResource = 90
         configuration.waitsForConnectivity = false
         session = URLSession(configuration: configuration)
+        // An expiry that came due during sleep never triggers its timer: the
+        // deadline below is armed on a clock that stops with the Mac, so a link
+        // that ran out overnight stays listed as live for as long as the Mac
+        // slept. Waking up recomputes and catches the miss.
+        NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification,
+            object: nil, queue: .main) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.refresh() }
+        }
         refresh()
     }
 

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotShareService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotShareService.swift
@@ -35,15 +35,6 @@ final class ScreenshotShareService: ObservableObject {
         configuration.timeoutIntervalForResource = 90
         configuration.waitsForConnectivity = false
         session = URLSession(configuration: configuration)
-        // An expiry that came due during sleep never triggers its timer: the
-        // deadline below is armed on a clock that stops with the Mac, so a link
-        // that ran out overnight stays listed as live for as long as the Mac
-        // slept. Waking up recomputes and catches the miss.
-        NSWorkspace.shared.notificationCenter.addObserver(
-            forName: NSWorkspace.didWakeNotification,
-            object: nil, queue: .main) { [weak self] _ in
-            Task { @MainActor [weak self] in self?.refresh() }
-        }
         refresh()
     }
 

--- a/Sources/Vorssaint/UI/Settings/DiskExclusionsList.swift
+++ b/Sources/Vorssaint/UI/Settings/DiskExclusionsList.swift
@@ -116,6 +116,7 @@ struct DiskExclusionsList: View {
             .volumeIsRootFileSystemKey,
             .volumeNameKey,
             .volumeLocalizedNameKey,
+            .volumeUUIDStringKey,
         ]
         guard let urls = FileManager.default.mountedVolumeURLs(
             includingResourceValuesForKeys: Array(keys),
@@ -134,7 +135,15 @@ struct DiskExclusionsList: View {
             guard isOfferable else { continue }
             let name = values.volumeLocalizedName ?? values.volumeName ?? url.lastPathComponent
             let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty, !currentExcluded.contains(trimmed.lowercased()), !results.contains(trimmed) {
+            // The same exclusion test the eject paths use: an entry the user
+            // typed as a volume UUID or a mount path excludes the drive just as
+            // much as its name, so the picker must not offer it again.
+            let alreadyExcluded = QuickTogglesSupport.isExcluded(
+                volumeName: trimmed,
+                volumeUUID: values.volumeUUIDString,
+                mountPath: url.path,
+                excludedVolumes: currentExcluded)
+            if !trimmed.isEmpty, !alreadyExcluded, !results.contains(trimmed) {
                 results.append(trimmed)
             }
         }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21725,6 +21725,24 @@ struct MetricsTests {
                          "\(language.rawValue) quit protection modifier HUD format")
         }
 
+        // MARK: A sleeping clock and a dropped identifier
+        let screenshotShareCode = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/QuickTools/ScreenshotShareService.swift",
+            encoding: .utf8)) ?? "").components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(screenshotShareCode.contains("NSWorkspace.didWakeNotification"),
+               "share links recompute their expiry on wake, which their sleeping clock missed")
+        expect(QuickTogglesSupport.isExcluded(volumeName: "SD Card",
+                                              volumeUUID: "1234-5678-ABCD",
+                                              mountPath: "/Volumes/SD Card",
+                                              excludedVolumes: ["1234-5678-abcd"])
+                && !QuickTogglesSupport.isExcluded(volumeName: "SD Card",
+                                                   volumeUUID: nil,
+                                                   mountPath: "/Volumes/SD Card",
+                                                   excludedVolumes: ["1234-5678-abcd"]),
+               "an excluded volume UUID is honoured only when the caller hands the UUID over")
+
         if failures.isEmpty {
             print("TESTS OK (\(checks) checks)")
             exit(0)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21742,6 +21742,14 @@ struct MetricsTests {
                                                    mountPath: "/Volumes/SD Card",
                                                    excludedVolumes: ["1234-5678-abcd"]),
                "an excluded volume UUID is honoured only when the caller hands the UUID over")
+        let diskExclusionsListCode = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/UI/Settings/DiskExclusionsList.swift",
+            encoding: .utf8)) ?? "").components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(diskExclusionsListCode.contains(".volumeUUIDStringKey")
+                && diskExclusionsListCode.contains("QuickTogglesSupport.isExcluded("),
+               "the exclusions picker asks the shared exclusion test, UUID included, not a name-only one")
 
         if failures.isEmpty {
             print("TESTS OK (\(checks) checks)")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21725,14 +21725,7 @@ struct MetricsTests {
                          "\(language.rawValue) quit protection modifier HUD format")
         }
 
-        // MARK: A sleeping clock and a dropped identifier
-        let screenshotShareCode = ((try? String(
-            contentsOfFile: "Sources/Vorssaint/Services/QuickTools/ScreenshotShareService.swift",
-            encoding: .utf8)) ?? "").components(separatedBy: "\n")
-            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
-            .joined(separator: "\n")
-        expect(screenshotShareCode.contains("NSWorkspace.didWakeNotification"),
-               "share links recompute their expiry on wake, which their sleeping clock missed")
+        // MARK: A dropped identifier
         expect(QuickTogglesSupport.isExcluded(volumeName: "SD Card",
                                               volumeUUID: "1234-5678-ABCD",
                                               mountPath: "/Volumes/SD Card",


### PR DESCRIPTION
## Summary

**A volume UUID in the eject exclusion list was honoured in some places and
ignored in others.** `Defaults` documents that key as "volume names/UUIDs
excluded from Eject all disks" and `QuickTogglesSupport.isExcluded` matches
four forms: name, UUID, full mount path and mount directory name. Three
places ask the question, and two of them asked it weakly.

`volumeUUID` and `mountPath` were declared with a default of `nil`, so a
caller could omit them and get a quietly weaker match with nothing to flag it.
`QuickTogglesService` passed all four. `DiskProtectionService` — the panel's
disk section, which is where the eject buttons live — passed only name and
mount path. Someone who typed a volume UUID into the exclusion list got it
respected by "Eject all disks" and ignored by the panel. Rather than fix that
one call site, the two defaults are gone, so the omission no longer compiles.
That is what pointed at `DiskProtectionService`, and carrying the UUID over to
it meant `DiskDeviceReading` had to have one: `DiskSampler` already builds
every reading from `FileManager.mountedVolumeURLs`, so it is one more resource
key (`.volumeUUIDStringKey`) and one more field passed through. `MountedVolume`
and `DiskDeviceReading` are unchanged for every other caller — the optional
field keeps them omittable in the memberwise initializer, so the synthetic
preview disk in `MenuBarRenderer` needed no edit.

The third place the compiler could not reach.
`DiskExclusionsList.mountedCandidateDrives`, the picker in Settings that offers
connected drives to add, did not call `isExcluded` at all: it compared the
volume's name against the list and nothing else. A drive excluded by UUID —
or by mount path — kept being offered as a candidate, as if it were not
excluded. It now reads `.volumeUUIDStringKey` like the other two enumerations
and asks `isExcluded` with name, UUID and mount path, so all three sites give
the same answer for the same drive. Those are every site: a grep for the
exclusion set finds `QuickTogglesService`, `DiskProtectionService` and this
picker; `addExcludedVolume` and `removeExcludedVolume` also compare strings,
but they deduplicate the user's own list entries rather than test a drive.

Considered and not taken: giving `DiskProtectionService` an explicit
`volumeUUID: nil` with a comment saying why it cannot pass one. That is a
smaller diff, but it leaves the user-visible inconsistency in place and turns
a bug into a documented bug. Also not taken: removing the defaults from
`shouldOfferEject` as well. Its four exclusion arguments are one coherent
all-or-nothing group, and `DiskExclusionsList` deliberately calls it with none
of them because it only wants the "is this drive ejectable at all" half — the
exclusion half is now the separate `isExcluded` call right below it.

## Verification

- `./build.sh --test` on this branch: `TESTS OK (9489 checks)`, no failures.
  That count is one lower than the previous push of this branch, which is the
  wake assertion that left with its fix. The branch's base is `ed882cd3`; I did
  not re-run `--test` there in this round, so I am not quoting a baseline count.
- Of the files this branch changes, only `QuickTogglesSupport.swift`,
  `DiskSupport.swift` and the tests are in the whitelist `--test` compiles.
  `DiskSampler.swift`, `DiskProtectionService.swift` and
  `DiskExclusionsList.swift` are not compiled here; CI covers them on both
  runners.
- The removed defaults were confirmed to be the guard they are meant to be: a
  reduced two-function case compiles silently when `volumeUUID` has a default
  and errors with `missing argument for parameter 'volumeUUID' in call` when
  it does not.
- The picker assertion is a source-shape check, because the file is outside
  the `--test` whitelist. Rather than spend a second build on it, its predicate
  was evaluated directly against the pre-fix content of the file
  (`git show HEAD~1:…/DiskExclusionsList.swift`, comment lines stripped the
  same way the assertion strips them): zero matches before the change, both
  matches after. The assertion is red on the old file and green on the new one.

**Not tested.** I did not run the app. I have no second volume with a UUID
mounted here, so neither the panel nor the picker honouring a UUID exclusion
was confirmed on hardware — only that the value now reaches `isExcluded` in
all three places. `./build.sh` was not run here: with the signing keychain
locked, codesign blocks on an unlock dialog and never exits, so the release
build and the zero-warning check are left to CI.

## Anything else

This branch opened with two unrelated small fixes on it. The share-link expiry
one — nine lines observing `NSWorkspace.didWakeNotification` in
`ScreenshotShareService`, plus its assertion — has been taken off and sent as
#1266, so a question about the shared signature here does not hold it behind.
Nothing that stays touches that file, and the two share no code.

No issue in the tracker describes this defect. The closest, #396
("Eject all disks doesn't seem to work"), is closed and was a different
cause — the removable/ejectable flags hiding every fixed external drive —
so I have not referenced it.
