### PR TITLE
fix(system-monitor): stop leaking an IOKit service on every GPU sample

### DIFF
--- a/Sources/Vorssaint/Services/Display/ExtraBrightnessService.swift
+++ b/Sources/Vorssaint/Services/Display/ExtraBrightnessService.swift
@@ -112,6 +112,18 @@ final class ExtraBrightnessService: ObservableObject {
         }
     }
 
+    /// The screen the overlay was built for. Which panel qualifies moves only
+    /// with the display topology, and `didChangeScreenParametersNotification`
+    /// already tracks that into `overlayDisplayID`, so the poll looks the
+    /// display up instead of asking `builtInXDRScreen()` four times a second:
+    /// that walks every screen reading `localizedName` and the potential EDR
+    /// value, all of it on the main thread, to re-derive an answer that has
+    /// not changed.
+    private var overlayScreen: NSScreen? {
+        guard let overlayDisplayID else { return nil }
+        return NSScreen.screens.first { Self.displayID(of: $0) == overlayDisplayID }
+    }
+
     private func refreshSupported() {
         let now = Self.builtInXDRScreen() != nil
         if supported != now { supported = now }
@@ -400,7 +412,7 @@ final class ExtraBrightnessService: ObservableObject {
     /// snaps straight to the target.
     private func renderIfNeeded(immediate: Bool = false) {
         guard !screensAsleep else { return }
-        guard let screen = Self.builtInXDRScreen(), overlayLayer != nil else { return }
+        guard let screen = overlayScreen, overlayLayer != nil else { return }
         presentTrigger()
         let level = Double(UserDefaults.standard.integer(forKey: DefaultsKey.extraBrightnessLevel)) / 100.0
         let headroom = Double(screen.maximumExtendedDynamicRangeColorComponentValue)

--- a/Sources/Vorssaint/Services/Display/ExtraBrightnessService.swift
+++ b/Sources/Vorssaint/Services/Display/ExtraBrightnessService.swift
@@ -115,10 +115,13 @@ final class ExtraBrightnessService: ObservableObject {
     /// The screen the overlay was built for. Which panel qualifies moves only
     /// with the display topology, and `didChangeScreenParametersNotification`
     /// already tracks that into `overlayDisplayID`, so the poll looks the
-    /// display up instead of asking `builtInXDRScreen()` four times a second:
-    /// that walks every screen reading `localizedName` and the potential EDR
-    /// value, all of it on the main thread, to re-derive an answer that has
-    /// not changed.
+    /// display up instead of re-deriving it with `builtInXDRScreen()` four
+    /// times a second. Both walk `NSScreen.screens` reading
+    /// `deviceDescription`; what this drops is the per-screen
+    /// `CGDisplayIsBuiltin` call and, on the built-in panel, `localizedName`
+    /// and `maximumPotentialExtendedDynamicRangeColorComponentValue` through
+    /// `isSupportedPanel` — a small saving on the main thread, and an answer
+    /// that could not have changed since the last screen-change notification.
     private var overlayScreen: NSScreen? {
         guard let overlayDisplayID else { return nil }
         return NSScreen.screens.first { Self.displayID(of: $0) == overlayDisplayID }

--- a/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
@@ -1015,25 +1015,23 @@ final class SystemMonitor: ObservableObject {
                                            &iterator) == kIOReturnSuccess else { return nil }
         defer { IOObjectRelease(iterator) }
 
-        // Released by hand rather than in a `defer`, because the defer would
-        // also have to advance the iterator: on the way out it would take a
-        // reference on the next service that nothing then releases. Machines
-        // with a second IOAccelerator (Intel dual graphics, an eGPU) leaked
-        // one io_object_t per sampling tick that way.
-        var entry = IOIteratorNext(iterator)
-        while entry != 0 {
+        // The advance lives in the `while` condition so the `defer` only
+        // releases. With the advance inside the defer, returning from the loop
+        // ran it: it released the entry it was done with and then took a
+        // reference on the next service that nothing released. Machines with a
+        // second IOAccelerator (Intel dual graphics, an eGPU) leaked one
+        // io_object_t per sampling tick that way.
+        while case let entry = IOIteratorNext(iterator), entry != 0 {
+            defer { IOObjectRelease(entry) }
             // Fetch ONLY PerformanceStatistics, not the whole (large) property
             // tree. Copying every property each tick is what made continuous GPU
             // sampling for the menu bar expensive.
-            if let ref = IORegistryEntryCreateCFProperty(entry, "PerformanceStatistics" as CFString,
-                                                         kCFAllocatorDefault, 0),
-               let stats = ref.takeRetainedValue() as? [String: Any],
-               let utilization = stats["Device Utilization %"] as? Int {
-                IOObjectRelease(entry)
-                return Double(utilization) / 100.0
-            }
-            IOObjectRelease(entry)
-            entry = IOIteratorNext(iterator)
+            guard let ref = IORegistryEntryCreateCFProperty(entry, "PerformanceStatistics" as CFString,
+                                                            kCFAllocatorDefault, 0),
+                  let stats = ref.takeRetainedValue() as? [String: Any],
+                  let utilization = stats["Device Utilization %"] as? Int
+            else { continue }
+            return Double(utilization) / 100.0
         }
         return nil
     }

--- a/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
@@ -1015,21 +1015,25 @@ final class SystemMonitor: ObservableObject {
                                            &iterator) == kIOReturnSuccess else { return nil }
         defer { IOObjectRelease(iterator) }
 
+        // Released by hand rather than in a `defer`, because the defer would
+        // also have to advance the iterator: on the way out it would take a
+        // reference on the next service that nothing then releases. Machines
+        // with a second IOAccelerator (Intel dual graphics, an eGPU) leaked
+        // one io_object_t per sampling tick that way.
         var entry = IOIteratorNext(iterator)
         while entry != 0 {
-            defer {
-                IOObjectRelease(entry)
-                entry = IOIteratorNext(iterator)
-            }
             // Fetch ONLY PerformanceStatistics, not the whole (large) property
             // tree. Copying every property each tick is what made continuous GPU
             // sampling for the menu bar expensive.
-            guard let ref = IORegistryEntryCreateCFProperty(entry, "PerformanceStatistics" as CFString,
-                                                            kCFAllocatorDefault, 0),
-                  let stats = ref.takeRetainedValue() as? [String: Any],
-                  let utilization = stats["Device Utilization %"] as? Int
-            else { continue }
-            return Double(utilization) / 100.0
+            if let ref = IORegistryEntryCreateCFProperty(entry, "PerformanceStatistics" as CFString,
+                                                         kCFAllocatorDefault, 0),
+               let stats = ref.takeRetainedValue() as? [String: Any],
+               let utilization = stats["Device Utilization %"] as? Int {
+                IOObjectRelease(entry)
+                return Double(utilization) / 100.0
+            }
+            IOObjectRelease(entry)
+            entry = IOIteratorNext(iterator)
         }
         return nil
     }


### PR DESCRIPTION
## Summary

Two unrelated per-tick costs in the sampling loops.

**`SystemMonitor.readGPUUsage()` leaked one `io_object_t` per sample on a Mac
with more than one `IOAccelerator`.** The loop released the current entry and
advanced the iterator in the same `defer`, then returned from inside the loop.
`return` runs the `defer`: it released the entry it was done with, then called
`IOIteratorNext` — which returns a service with a +1 reference — and the
function returned holding it. `IOObjectRelease(iterator)` only releases the
iterator, not that service. On a single-GPU Mac `IOIteratorNext` returns 0 and
nothing leaks, so this is confined to machines that match two or more
accelerators: Intel dual graphics, an eGPU, some virtualised setups.

The fix moves the advance into the `while` condition
(`while case let entry = IOIteratorNext(iterator), entry != 0`), which leaves
the `defer` with nothing but the release. No exit path can then skip it and
the early return needs no special case, so the loop body keeps its original
`guard`/`continue`. That shape is already in the repo twice:
`BrightnessService.externalServices` and both hotplug drains in
`MiddleClickService.installHotplugObserver`.

**Census of the idiom, corrected.** An earlier version of this description
said the defer-and-advance shape appears four more times in `Sources/`. It
does not. It appears twice more, both in `ProcessUsageService.gpuTimePerPid`
(the accelerator loop and the user-client loop nested in it), and both are
correct: neither returns from inside a loop, so the advance is always followed
by another iteration. `DiskSampler` (three loops) and
`PeripheralBatterySampler` release by hand at the bottom of the loop and
advance on the next line — they are not instances of the idiom, they are the
precedent for releasing without a `defer`.

Every other IOKit acquisition in the tree was checked against its exit paths:
`DiskSampler.wholeDiskBSDName` releases the child on the recursive early
return as well as the fall-through; `PowerSampler` caches `batteryService` and
releases it in `deinit`, and zeroes it after releasing on the property-read
failure; `PowerSampler.hasInternalBattery`, `BluetoothSleepService.isSupported`,
`SMCClient.init`, `SuperKeyService.withHIDSystem` each take a single service
and release it on every return. `readGPUUsage` was the only leak.

**`ExtraBrightnessService.renderIfNeeded` re-derived which panel is XDR four
times a second on the main thread.** It called `builtInXDRScreen()`, whose
predicate reads `deviceDescription` and `CGDisplayIsBuiltin` for each screen
and then, for the built-in one, runs `isSupportedPanel` over `localizedName`
and `maximumPotentialExtendedDynamicRangeColorComponentValue`. That answer
moves only with the display topology, which
`didChangeScreenParametersNotification` already tracks —
`handleScreenChange` stores the result in `overlayDisplayID`. The only thing
the tick genuinely has to read fresh is the live
`maximumExtendedDynamicRangeColorComponentValue`. The poll now looks the
display up by the stored ID; the four event-driven callers of
`builtInXDRScreen()` are unchanged.

The saving here is smaller than the first version of this description and of
the code comment claimed. Looking the display up by ID still walks
`NSScreen.screens` reading `deviceDescription` for every screen. What is
dropped is the per-screen `CGDisplayIsBuiltin` call and, on the built-in panel
only, `isSupportedPanel` — `localizedName` was never reached for any other
screen. The comment in the source has been corrected to say that.

Trade-offs:

- `renderIfNeeded` now bails when the overlay's own display is gone, instead
  of when no display qualifies. Those differ only while the overlay exists on
  a display that no longer qualifies, which `handleScreenChange` tears down on
  the same notification that would have changed the old answer.
- `ExtraBrightnessSupport.isSupportedPanel` is untouched, including the
  `localizedName` path its comment marks as a deliberate extra acceptance
  route kept after issue 191.

## Verification

```sh
./build.sh --test     # 9487 checks, 0 failures
swiftc -parse         # on both changed files
```

Neither changed file is in the `--test` whitelist (it is almost entirely
`*Support.swift`), so they are not compiled here — CI covers them on both
runners. That run proves no regression elsewhere.

No assertion was added: both changes are resource and scheduling discipline
with no new pure logic, and the only propositions available ("nothing leaks",
"the predicate is not recomputed") are reachable from a test only through the
private symbols in these two service files, which is the marker a source-shape
test must not use.

**Not tested:** the leak itself. Written on a Mac17,3 (M5) running macOS 26,
where `ioreg -c IOAccelerator` reports exactly one accelerator — the
configuration in which the bug provably does not occur, because
`IOIteratorNext` returns 0 and the defer's advance is harmless. Nothing here
reproduces it.

Extra Brightness could not be exercised either: this machine's built-in panel
is a Liquid Retina, not an XDR, and Mac17,3 is not in `xdrModelIdentifiers`,
so `builtInXDRScreen()` returns nil and the poll never starts. The external
display attached is irrelevant to it. Both changes were read against the code,
not measured on hardware that runs them.

## Anything else

No open or closed issue matches either defect. Searches over the tracker for
`IOAccelerator`, `io_object_t`, GPU sampling, memory leaks, and Extra
Brightness CPU cost turned up nothing that describes what is fixed here, and
neither #836 nor #838 names the symptom. Nothing is referenced rather than
attaching this to a report it does not answer.
