### PR TITLE
fix(update): bound the What's New showcase video download

### DIFF
--- a/Sources/Vorssaint/Services/Update/UpdateService.swift
+++ b/Sources/Vorssaint/Services/Update/UpdateService.swift
@@ -474,7 +474,10 @@ final class UpdateService: ObservableObject {
     }
 }
 
-private final class BoundedUpdateDownloadDelegate: NSObject, URLSessionDataDelegate {
+/// Writes a response to a scratch file and abandons it once it passes
+/// `byteLimit`, so a body that never ends cannot fill the disk. Shared by the
+/// app update download and the What's New showcase video.
+final class BoundedUpdateDownloadDelegate: NSObject, URLSessionDataDelegate {
     private let byteLimit: Int64
     private let progress: (Int64, Int64?) -> Void
     private let completion: (URL?, URLResponse?, Error?) -> Void

--- a/Sources/Vorssaint/Services/Update/UpdateShowcaseMedia.swift
+++ b/Sources/Vorssaint/Services/Update/UpdateShowcaseMedia.swift
@@ -69,7 +69,7 @@ final class UpdateShowcaseMediaLoader: ObservableObject {
     }
 
     @Published private(set) var state: State = .idle
-    private var task: URLSessionDownloadTask?
+    private var session: URLSession?
 
     func load() {
         if case .ready = state { return }
@@ -88,38 +88,55 @@ final class UpdateShowcaseMediaLoader: ObservableObject {
         try? FileManager.default.removeItem(at: cached)
 
         state = .loading
-        let request = URLRequest(url: UpdateShowcaseInfo.remoteMediaURL,
-                                 cachePolicy: .reloadIgnoringLocalCacheData,
-                                 timeoutInterval: 12)
-        task = URLSession.shared.downloadTask(with: request) { [weak self] tempURL, response, error in
-            guard let self else { return }
-            let ok = (response as? HTTPURLResponse).map { (200..<300).contains($0.statusCode) } ?? true
-            guard let tempURL, error == nil, ok else {
-                DispatchQueue.main.async { self.state = .failed }
-                return
-            }
-            guard UpdateShowcaseInfo.mediaIsTrusted(at: tempURL) else {
-                DispatchQueue.main.async { self.state = .failed }
-                return
-            }
-
-            do {
-                try FileManager.default.createDirectory(at: UpdateShowcaseInfo.cacheDirectory,
-                                                        withIntermediateDirectories: true)
-                let target = UpdateShowcaseInfo.cachedMediaURL
-                try? FileManager.default.removeItem(at: target)
-                try FileManager.default.moveItem(at: tempURL, to: target)
-                DispatchQueue.main.async { self.state = .ready(target) }
-            } catch {
-                DispatchQueue.main.async { self.state = .failed }
-            }
+        // The checksum is verified after the download, so it cannot stop a
+        // response from filling the disk on the way there; the byte ceiling
+        // and the resource timeout are what bound this. A request timeout
+        // alone only limits the gap between packets, which a slow trickle
+        // never exceeds.
+        let delegate: BoundedUpdateDownloadDelegate
+        do {
+            delegate = try BoundedUpdateDownloadDelegate(
+                byteLimit: UpdateInstallerSupport.downloadCeilingBytes,
+                progress: { _, _ in },
+                completion: { [weak self] tempURL, response, error in
+                    guard let self else { return }
+                    self.session?.finishTasksAndInvalidate()
+                    DispatchQueue.main.async { self.session = nil }
+                    let ok = (response as? HTTPURLResponse)
+                        .map { (200..<300).contains($0.statusCode) } ?? true
+                    guard let tempURL, error == nil, ok,
+                          UpdateShowcaseInfo.mediaIsTrusted(at: tempURL) else {
+                        DispatchQueue.main.async { self.state = .failed }
+                        return
+                    }
+                    do {
+                        try FileManager.default.createDirectory(
+                            at: UpdateShowcaseInfo.cacheDirectory,
+                            withIntermediateDirectories: true)
+                        let target = UpdateShowcaseInfo.cachedMediaURL
+                        try? FileManager.default.removeItem(at: target)
+                        try FileManager.default.moveItem(at: tempURL, to: target)
+                        DispatchQueue.main.async { self.state = .ready(target) }
+                    } catch {
+                        DispatchQueue.main.async { self.state = .failed }
+                    }
+                })
+        } catch {
+            state = .failed
+            return
         }
-        task?.resume()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.timeoutIntervalForRequest = 12
+        configuration.timeoutIntervalForResource = 120
+        let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+        self.session = session
+        session.dataTask(with: UpdateShowcaseInfo.remoteMediaURL).resume()
     }
 
     func cancel() {
-        task?.cancel()
-        task = nil
+        session?.invalidateAndCancel()
+        session = nil
     }
 
     func cleanupCache() {

--- a/Sources/Vorssaint/Services/Update/UpdateShowcaseMedia.swift
+++ b/Sources/Vorssaint/Services/Update/UpdateShowcaseMedia.swift
@@ -139,6 +139,19 @@ final class UpdateShowcaseMediaLoader: ObservableObject {
         session = nil
     }
 
+    /// `.onDisappear` is the only caller of `cancel()`, and SwiftUI can drop the
+    /// `@StateObject` without it ever running. A session that is never
+    /// invalidated holds its delegate for the life of the process, and the
+    /// delegate's own `deinit` is what closes the scratch file and deletes it —
+    /// so every exit path that leaves a scratch file behind ends here.
+    /// `invalidateAndCancel()`, not `finishTasksAndInvalidate()`, which would let
+    /// an abandoned download run to completion first. The completion closure
+    /// captures `self` weakly and that reference is already nil by now, so the
+    /// teardown cannot resurrect the loader.
+    deinit {
+        session?.invalidateAndCancel()
+    }
+
     func cleanupCache() {
         UpdateShowcaseInfo.cleanupCache()
     }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -8331,6 +8331,20 @@ struct MetricsTests {
                                                        expectedBytes: nil),
                "a plausible body with no advertised size is accepted")
 
+        // The showcase loader is a @StateObject, so it can be released without
+        // `.onDisappear` running. Its session holds the download delegate, and
+        // that delegate's deinit is what deletes the scratch file, so the
+        // release path has to invalidate the session too.
+        let showcaseSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Update/UpdateShowcaseMedia.swift",
+            encoding: .utf8)) ?? ""
+        let showcaseDeinitBody = (showcaseSource.components(separatedBy: "\n    deinit {")
+            .dropFirst().first ?? "").components(separatedBy: "\n    }").first ?? ""
+        expect(showcaseDeinitBody.contains("session?.invalidateAndCancel()"),
+               "a released showcase loader invalidates its session, freeing the delegate and its scratch file")
+        expect(!showcaseDeinitBody.contains("finishTasksAndInvalidate"),
+               "a released showcase loader cancels its download instead of letting it finish")
+
         expect(SettingsSearchSupport.matches(query: "", title: "Monitor"),
                "a blank settings search matches everything")
         expect(SettingsSearchSupport.matches(query: "moni", title: "Monitor"),


### PR DESCRIPTION
## Summary

The What's New showcase video was downloaded with a bare
`URLSession.shared.downloadTask`, with nothing bounding how much it could
write.

`timeoutInterval: 12` on the request is the idle timeout — the gap allowed
between two arrivals of data — so a response that trickles a byte at a time
never trips it. `downloadTask` writes the body straight to disk, whatever its
size. The SHA-256 check happens *after* the download completes, so it decides
whether the file is used, not how much of it lands.

The fix is the answer this directory already has.
`UpdateService` solved the identical problem with
`BoundedUpdateDownloadDelegate`, which writes to a scratch file and abandons
the task once it passes a limit, and with `downloadCeilingBytes`, whose
comment says it exists "only to stop a response that never ends". Rather than
write a second delegate for the same job, that one is now shared (`private`
dropped, doc comment added) and the loader runs its download through it on a
session that sets `timeoutIntervalForResource`, which does bound the whole
transfer.

Teardown then has to cover both ways the loader can go away. `cancel()`
invalidates the session rather than just cancelling the task, but its only
caller is `.onDisappear` in `UpdateShowcaseIntroView`, and the loader is a
`@StateObject` that SwiftUI can drop without `.onDisappear` ever running. On
that path the delegate completion returns at `guard let self else { return }`
before `finishTasksAndInvalidate()`, so the session is never invalidated — and
a live session holds its delegate for the life of the process, while it is the
delegate's own `deinit` that closes and deletes the scratch file. A `deinit` on
the loader invalidates the session on the release path too. It cancels rather
than finishes, because `finishTasksAndInvalidate()` would let an abandoned
download run to completion first; the completion closure holds `self` weakly
and that reference is already nil by then, so the teardown cannot resurrect the
loader.

That `deinit` is also the last exit path that could strand a scratch file.
Every other path either moves the file to the cache or ends in the delegate's
`complete()`, which deletes it — including the untrusted-checksum and
failed-move paths, where the file survives `complete()` and is deleted by the
delegate's `deinit` once the session releases it.

Severity is low: the URL is a hardcoded HTTPS
GitHub release address, so reaching this needs the TLS channel or the CDN
behind it to be under someone else's control. This is a missing bound on an
untrusted-length response, not a vulnerability. The leak it now closes is not
user-visible either — one session, one delegate and one temporary file per
abandoned download, until the app quits.

Trade-offs:

- **The 200 MB ceiling is reused rather than given a tighter, video-specific
  value.** A demo mp4 is far smaller and a dedicated constant could say so,
  but that would be a second answer to the question `downloadCeilingBytes`
  already answers, and the next reader would have to work out why the two
  differ. The bound exists to end an endless response, and any finite number
  does that.
- **`BoundedUpdateDownloadDelegate` was shared in place, not moved to its own
  file.** Moving it would be a larger diff in `UpdateService.swift` for no
  behavioural difference; it stays beside its first caller in the same
  directory.
- **No Content-Length pre-check was added.** The delegate stores
  `expectedContentLength` but does not refuse on it, and adding that would
  change `UpdateService`'s behaviour too. The byte counter already stops the
  write, which is the bound that matters.
- 120 s resource timeout: generous for a file of this size, chosen above the
  neighbouring services' 20 s because those fetch JSON and this fetches video.

## Verification

```sh
./build.sh --test     # 9489 checks, 0 failures
```

Two assertions were added beside the existing update-download checks. They
read `UpdateShowcaseMedia.swift` and assert that the loader's `deinit` calls
`session?.invalidateAndCancel()` and does not call
`finishTasksAndInvalidate()`. That is a source-shape check, the idiom this
suite already uses for code it cannot link; a `deinit` on a `@StateObject` is
not reachable from a standalone test binary. Both were confirmed red first:
against the previous revision of the file the first fails, and against a
variant whose `deinit` finishes instead of cancelling, both fail.

`UpdateShowcaseMedia.swift` is not in the `--test` whitelist, so it is not
compiled here; CI covers it on both runners. The full `./build.sh` was not run
— with the signing keychain locked it blocks on an unlock dialog.

**Not tested:** no download was performed. The showcase asset is fetched only
when the running version equals `UpdateShowcaseInfo.releaseVersion` (3.1.4)
and What's New opens, which this build does not satisfy. The bounded path, the
cancel path, the new release path and the resource timeout were read, not
observed; the delegate they share is exercised in production by
`UpdateService`'s own download.

## Anything else

The same shape was checked everywhere else it could occur. `UpdateService` and
`SpeedTest` own delegate-backed sessions but are process-lifetime singletons,
so neither can be released with a session running. The favicon downloader in
`RadialMenuSupport` is its own session's delegate, so the session keeps it
alive to the end of the transfer, and it holds no scratch file. Every other
`URLSession` in the app is delegate-less or `URLSession.shared`. This loader
was the only one that could be dropped mid-transfer.

`UpdateService.check()` pulling the releases JSON through `URLSession.shared`
with no resource timeout and no ceiling is a real observation, but it is a
different file and a different failure, and adding it here would widen a PR
that is already about the showcase download. It is left for a separate change.
