### PR TITLE
fix(recorder): lock the typing samples and run the sampler monitors on the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project are documented here. The format follows
 ## [Unreleased]
 
 ### Summary
-Vorssaint adds quit and close protections, expands screen text recognition, capture magnifier, clipboard, Super key, Dock Preview, App Switcher, Window Layout, mouse controls and snippet controls, broadens app update and safe cleanup discovery, and hardens shortcut capture and key caps, permission guide recovery, input session switching, Accessibility timeouts, Volume Mixer audio rendering, helper process attribution and teardown, Super key shutdown, process termination, update and uninstallation teardown, window handling and shared on-screen parsing, pasteboard restoration, sensor selection, Cleaning Mode unlock, favicon downloads and the What's New showcase video download. It also improves mouse scrolling feel, disk space and system monitor metrics, Command Bar responsiveness, Settings, Scratchpad, Screenshot Editor, floating panels and several menu bar behaviors.
+Vorssaint adds quit and close protections, expands screen text recognition, capture magnifier, clipboard, Super key, Dock Preview, App Switcher, Window Layout, mouse controls and snippet controls, broadens app update and safe cleanup discovery, and hardens shortcut capture and key caps, permission guide recovery, input session switching, Accessibility timeouts, Volume Mixer audio rendering, helper process attribution and teardown, Super key shutdown, process termination, update and uninstallation teardown, window handling and shared on-screen parsing, pasteboard restoration, sensor selection, Cleaning Mode unlock, favicon downloads, the What's New showcase video download and stopping a recording. It also improves mouse scrolling feel, disk space and system monitor metrics, Command Bar responsiveness, Settings, Scratchpad, Screenshot Editor, floating panels and several menu bar behaviors.
 
 ### Added
 - Settings now includes optional protections for Command-Q and Command-W with customizable hold duration, double press, extra modifier requirements and per-app scopes. Thanks to @RuanMD.
@@ -105,6 +105,7 @@ Vorssaint adds quit and close protections, expands screen text recognition, capt
 - The battery icon in the menu bar now preserves its rectangular aspect ratio when split into its own item instead of rendering as a square. Thanks to @Yahddyyp.
 - Cleaning Mode now uses a forgiving 6-second press window for the Escape unlock gesture and resets the count when modifier keys are pressed while wiping. Thanks to @iltonandrew.
 - Dock previews now move to the vacated screen edge when an auto-hiding Dock slides away instead of floating detached. Thanks to @iltonandrew.
+- Stopping a recording while you are still typing no longer risks a crash or a recording whose typing moments land in the wrong place. Thanks to @PathGao.
 
 ## [3.3.3-beta.3] - 2026-08-26
 

--- a/Sources/Vorssaint/Services/Recorder/RecorderPointerSampler.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderPointerSampler.swift
@@ -10,8 +10,7 @@ import QuartzCore
 /// three reasons: it needs no permission at all, it costs about a hundred
 /// nanoseconds per sample, and a filter that runs offline wants its input on
 /// an even grid anyway. The presses come from a mouse-only global monitor,
-/// which is ungated unlike key events, and which stamps every press with the
-/// moment it happened rather than the moment it was handed over.
+/// which is exact and, unlike key events, ungated.
 ///
 /// Nothing here exists between recordings: the thread, the monitor and the
 /// buffer are all created in `start()` and gone after `stop()`.
@@ -68,10 +67,8 @@ final class RecorderPointerSampler {
             return self.generation
         }
 
-        // Mouse-only monitors need no Accessibility grant. The press carries
-        // its own moment, which is what gets recorded: the callback can be
-        // handed over late behind the main thread's own work, and a click
-        // ring that lands after the click is visible.
+        // Mouse-only monitors need no Accessibility grant, and a press is
+        // never coalesced the way a move is, so these timestamps are exact.
         clickMonitor = NSEvent.addGlobalMonitorForEvents(
             matching: [.leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp]
         ) { [weak self] event in
@@ -165,7 +162,7 @@ final class RecorderPointerSampler {
     private func record(_ event: NSEvent, generation: Int) {
         lock.withLock {
             guard running, self.generation == generation else { return }
-            guard let time = pauseClock.eventTime(event.timestamp, since: startedAt)
+            guard let time = pauseClock.eventTime(CACurrentMediaTime(), since: startedAt)
             else { return }
             let isDown = event.type == .leftMouseDown || event.type == .rightMouseDown
             let click = RecorderMotion.Click(time: time, isDown: isDown)

--- a/Sources/Vorssaint/Services/Recorder/RecorderPointerSampler.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderPointerSampler.swift
@@ -10,7 +10,8 @@ import QuartzCore
 /// three reasons: it needs no permission at all, it costs about a hundred
 /// nanoseconds per sample, and a filter that runs offline wants its input on
 /// an even grid anyway. The presses come from a mouse-only global monitor,
-/// which is exact and, unlike key events, ungated.
+/// which is ungated unlike key events, and which stamps every press with the
+/// moment it happened rather than the moment it was handed over.
 ///
 /// Nothing here exists between recordings: the thread, the monitor and the
 /// buffer are all created in `start()` and gone after `stop()`.
@@ -67,8 +68,10 @@ final class RecorderPointerSampler {
             return self.generation
         }
 
-        // Mouse-only monitors need no Accessibility grant, and a press is
-        // never coalesced the way a move is, so these timestamps are exact.
+        // Mouse-only monitors need no Accessibility grant. The press carries
+        // its own moment, which is what gets recorded: the callback can be
+        // handed over late behind the main thread's own work, and a click
+        // ring that lands after the click is visible.
         clickMonitor = NSEvent.addGlobalMonitorForEvents(
             matching: [.leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp]
         ) { [weak self] event in
@@ -162,7 +165,7 @@ final class RecorderPointerSampler {
     private func record(_ event: NSEvent, generation: Int) {
         lock.withLock {
             guard running, self.generation == generation else { return }
-            guard let time = pauseClock.eventTime(CACurrentMediaTime(), since: startedAt)
+            guard let time = pauseClock.eventTime(event.timestamp, since: startedAt)
             else { return }
             let isDown = event.type == .leftMouseDown || event.type == .rightMouseDown
             let click = RecorderMotion.Click(time: time, isDown: isDown)

--- a/Sources/Vorssaint/Services/Recorder/RecorderTypingTrack.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderTypingTrack.swift
@@ -22,6 +22,8 @@ struct RecorderTypingTrack: Codable, Equatable {
 /// The monitor exists only while recording and remembers timing, never keys.
 final class RecorderTypingSampler {
     private let pauseClock: RecorderPauseClock
+    /// Written by `start()` and read by the monitor callback, so it lives
+    /// under the same lock as the buffer it times events against.
     private var startedAt: CFTimeInterval = 0
     private var globalMonitor: Any?
     private var localMonitor: Any?
@@ -34,7 +36,7 @@ final class RecorderTypingSampler {
 
     func start() {
         guard globalMonitor == nil, localMonitor == nil else { return }
-        startedAt = CACurrentMediaTime()
+        lock.withLock { startedAt = CACurrentMediaTime() }
         globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
             self?.record(event)
         }
@@ -61,8 +63,10 @@ final class RecorderTypingSampler {
         // The key's own moment, not the moment the callback was scheduled:
         // the main thread is busy redrawing the indicator while recording,
         // and this timestamp starts an auto zoom in the finished video.
-        guard let time = pauseClock.eventTime(event.timestamp, since: startedAt) else { return }
-        lock.withLock { times.append(time) }
+        lock.withLock {
+            guard let time = pauseClock.eventTime(event.timestamp, since: startedAt) else { return }
+            times.append(time)
+        }
     }
 
     deinit {

--- a/Sources/Vorssaint/Services/Recorder/RecorderTypingTrack.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderTypingTrack.swift
@@ -60,11 +60,9 @@ final class RecorderTypingSampler {
 
     private func record(_ event: NSEvent) {
         guard !event.isARepeat else { return }
-        // The key's own moment, not the moment the callback was scheduled:
-        // the main thread is busy redrawing the indicator while recording,
-        // and this timestamp starts an auto zoom in the finished video.
+        let now = CACurrentMediaTime()
         lock.withLock {
-            guard let time = pauseClock.eventTime(event.timestamp, since: startedAt) else { return }
+            guard let time = pauseClock.eventTime(now, since: startedAt) else { return }
             times.append(time)
         }
     }

--- a/Sources/Vorssaint/Services/Recorder/RecorderTypingTrack.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderTypingTrack.swift
@@ -25,6 +25,7 @@ final class RecorderTypingSampler {
     private var startedAt: CFTimeInterval = 0
     private var globalMonitor: Any?
     private var localMonitor: Any?
+    private let lock = NSLock()
     private var times: [Double] = []
 
     init(pauseClock: RecorderPauseClock) {
@@ -48,14 +49,20 @@ final class RecorderTypingSampler {
         if let localMonitor { NSEvent.removeMonitor(localMonitor) }
         globalMonitor = nil
         localMonitor = nil
-        return RecorderTypingTrack(times: times)
+        return lock.withLock {
+            let track = RecorderTypingTrack(times: times)
+            times.removeAll()
+            return track
+        }
     }
 
     private func record(_ event: NSEvent) {
         guard !event.isARepeat else { return }
-        let now = CACurrentMediaTime()
-        guard let time = pauseClock.eventTime(now, since: startedAt) else { return }
-        times.append(time)
+        // The key's own moment, not the moment the callback was scheduled:
+        // the main thread is busy redrawing the indicator while recording,
+        // and this timestamp starts an auto zoom in the finished video.
+        guard let time = pauseClock.eventTime(event.timestamp, since: startedAt) else { return }
+        lock.withLock { times.append(time) }
     }
 
     deinit {

--- a/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
+++ b/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
@@ -104,8 +104,14 @@ private final class RecorderSession: NSObject, RecorderCaptureEngineDelegate {
             await engine.stop()
             return .streamFailed
         }
-        pointer.start()
-        typing.start()
+        // This method is nonisolated and async, so its body runs on the
+        // cooperative pool however main-actor the caller was (SE-0338). The
+        // two samplers install AppKit event monitors, which belong to the
+        // main thread's dispatch, so they are started and stopped there.
+        await MainActor.run {
+            pointer.start()
+            typing.start()
+        }
         return nil
     }
 
@@ -136,8 +142,7 @@ private final class RecorderSession: NSObject, RecorderCaptureEngineDelegate {
         } else {
             await engine.stop()
         }
-        let track = pointer.stop()
-        let typingTrack = typing.stop()
+        let (track, typingTrack) = await MainActor.run { (pointer.stop(), typing.stop()) }
         let end = CMClockGetTime(CMClockGetHostTimeClock())
         writerQueue.sync {}
         let written = await writer.finish(at: end)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -20382,6 +20382,35 @@ struct MetricsTests {
         expect(RecorderMotion.ringProgress(at: 2.0, clicks: clicks) == nil,
                "the ring is gone well before the next second")
 
+        // Both recorder samplers fill an array from an NSEvent monitor
+        // callback while the stop path reads it, so every append has to be
+        // under the lock: an unsynchronised one races the copy-on-write
+        // buffer. And both stamp an event by NSEvent's own `timestamp`, not
+        // by the moment the callback was handed over, which on a busy main
+        // thread lands the click ring after the click.
+        for samplerPath in ["Sources/Vorssaint/Services/Recorder/RecorderTypingTrack.swift",
+                            "Sources/Vorssaint/Services/Recorder/RecorderPointerSampler.swift"] {
+            let samplerSource = (try? String(contentsOfFile: samplerPath, encoding: .utf8)) ?? ""
+            expect(!samplerSource.isEmpty, "\(samplerPath) reads back for the sampler checks")
+            var blockIsLocked: [Bool] = []
+            var samplerLine = ""
+            var lockedAppends = 0
+            var looseAppends = 0
+            for character in samplerSource {
+                if character == "\n" { samplerLine = ""; continue }
+                samplerLine.append(character)
+                if character == "{" { blockIsLocked.append(samplerLine.contains("withLock")) }
+                if character == "}", !blockIsLocked.isEmpty { blockIsLocked.removeLast() }
+                if samplerLine.hasSuffix(".append(") {
+                    if blockIsLocked.contains(true) { lockedAppends += 1 } else { looseAppends += 1 }
+                }
+            }
+            expect(samplerSource.contains("NSLock()") && lockedAppends > 0 && looseAppends == 0,
+                   "\(samplerPath) appends to its sampler buffer only under the lock")
+            expect(samplerSource.contains("event.timestamp"),
+                   "\(samplerPath) times an event by when it happened, not when it was delivered")
+        }
+
         let uniform = RecorderMotion.resampled(
             [RecorderMotion.Sample(time: 0, point: CGPoint(x: 0, y: 0)),
              RecorderMotion.Sample(time: 1, point: CGPoint(x: 1, y: 1))],

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -20385,9 +20385,8 @@ struct MetricsTests {
         // Both recorder samplers fill an array from an NSEvent monitor
         // callback while the stop path reads it, so every append has to be
         // under the lock: an unsynchronised one races the copy-on-write
-        // buffer. And both stamp an event by NSEvent's own `timestamp`, not
-        // by the moment the callback was handed over, which on a busy main
-        // thread lands the click ring after the click.
+        // buffer. The recording's start time is written from `start()` and
+        // read from that same callback, so it belongs under the lock too.
         for samplerPath in ["Sources/Vorssaint/Services/Recorder/RecorderTypingTrack.swift",
                             "Sources/Vorssaint/Services/Recorder/RecorderPointerSampler.swift"] {
             let samplerSource = (try? String(contentsOfFile: samplerPath, encoding: .utf8)) ?? ""
@@ -20406,24 +20405,16 @@ struct MetricsTests {
                 if samplerLine.hasSuffix(".append(") {
                     if blockIsLocked.contains(true) { lockedAppends += 1 } else { looseAppends += 1 }
                 }
-                // The stored `startedAt`: assigned in `start()`, and read in
-                // the monitor callback to turn `event.timestamp` into a time
-                // on the recording. A local or a parameter of the same name
-                // is not it, hence the two exclusions.
-                let storesOrigin = samplerLine.hasSuffix("startedAt =")
-                    && !samplerLine.contains("let startedAt")
-                let readsOrigin = samplerLine.hasSuffix("since: startedAt")
-                    && samplerLine.contains("event.timestamp")
-                if storesOrigin || readsOrigin {
+                // The stored `startedAt`, assigned in `start()`. A local of
+                // the same name is not it, hence the exclusion.
+                if samplerLine.hasSuffix("startedAt =") && !samplerLine.contains("let startedAt") {
                     if blockIsLocked.contains(true) { lockedOrigin += 1 } else { looseOrigin += 1 }
                 }
             }
             expect(samplerSource.contains("NSLock()") && lockedAppends > 0 && looseAppends == 0,
                    "\(samplerPath) appends to its sampler buffer only under the lock")
-            expect(lockedOrigin == 2 && looseOrigin == 0,
-                   "\(samplerPath) writes and reads the recording's start time under the lock")
-            expect(samplerSource.contains("event.timestamp"),
-                   "\(samplerPath) times an event by when it happened, not when it was delivered")
+            expect(lockedOrigin == 1 && looseOrigin == 0,
+                   "\(samplerPath) writes the recording's start time under the lock")
         }
 
         let uniform = RecorderMotion.resampled(

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -20410,6 +20410,12 @@ struct MetricsTests {
                 if blockIsLocked.contains(true) { lockedOrigin += 1 } else { looseOrigin += 1 }
             }
         }
+        // The walk above is a brace counter, and it counts every `{`, including
+        // one inside a comment or a string. A single unbalanced push shifts the
+        // stack, so a `withLock` entry outlives its block and reports a loose
+        // append as a locked one - the check would go on passing while the thing
+        // it watches was gone.
+        expect(blockIsLocked.isEmpty, "\(samplerPath) parses to balanced braces")
         expect(samplerSource.contains("NSLock()") && lockedAppends > 0 && looseAppends == 0,
                "\(samplerPath) appends to its sampler buffer only under the lock")
         expect(lockedOrigin == 1 && looseOrigin == 0,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -20396,6 +20396,8 @@ struct MetricsTests {
             var samplerLine = ""
             var lockedAppends = 0
             var looseAppends = 0
+            var lockedOrigin = 0
+            var looseOrigin = 0
             for character in samplerSource {
                 if character == "\n" { samplerLine = ""; continue }
                 samplerLine.append(character)
@@ -20404,9 +20406,22 @@ struct MetricsTests {
                 if samplerLine.hasSuffix(".append(") {
                     if blockIsLocked.contains(true) { lockedAppends += 1 } else { looseAppends += 1 }
                 }
+                // The stored `startedAt`: assigned in `start()`, and read in
+                // the monitor callback to turn `event.timestamp` into a time
+                // on the recording. A local or a parameter of the same name
+                // is not it, hence the two exclusions.
+                let storesOrigin = samplerLine.hasSuffix("startedAt =")
+                    && !samplerLine.contains("let startedAt")
+                let readsOrigin = samplerLine.hasSuffix("since: startedAt")
+                    && samplerLine.contains("event.timestamp")
+                if storesOrigin || readsOrigin {
+                    if blockIsLocked.contains(true) { lockedOrigin += 1 } else { looseOrigin += 1 }
+                }
             }
             expect(samplerSource.contains("NSLock()") && lockedAppends > 0 && looseAppends == 0,
                    "\(samplerPath) appends to its sampler buffer only under the lock")
+            expect(lockedOrigin == 2 && looseOrigin == 0,
+                   "\(samplerPath) writes and reads the recording's start time under the lock")
             expect(samplerSource.contains("event.timestamp"),
                    "\(samplerPath) times an event by when it happened, not when it was delivered")
         }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -20618,43 +20618,38 @@ struct MetricsTests {
                "the ring is gone well before the next second")
 
         // The typing sampler fills an array from an NSEvent monitor callback
-        // while the stop path reads it, so every append has to be under the
+        // while the stop path reads it, so the append has to be under the
         // lock: an unsynchronised one races the copy-on-write buffer. The
-        // recording's start time is written from `start()` and read from that
+        // recording's start time is written by `start()` and read from that
         // same callback, so it belongs under the lock too.
-        let samplerPath = "Sources/Vorssaint/Services/Recorder/RecorderTypingTrack.swift"
-        let samplerSource = (try? String(contentsOfFile: samplerPath, encoding: .utf8)) ?? ""
-        expect(!samplerSource.isEmpty, "\(samplerPath) reads back for the sampler checks")
-        var blockIsLocked: [Bool] = []
-        var samplerLine = ""
-        var lockedAppends = 0
-        var looseAppends = 0
-        var lockedOrigin = 0
-        var looseOrigin = 0
-        for character in samplerSource {
-            if character == "\n" { samplerLine = ""; continue }
-            samplerLine.append(character)
-            if character == "{" { blockIsLocked.append(samplerLine.contains("withLock")) }
-            if character == "}", !blockIsLocked.isEmpty { blockIsLocked.removeLast() }
-            if samplerLine.hasSuffix(".append(") {
-                if blockIsLocked.contains(true) { lockedAppends += 1 } else { looseAppends += 1 }
-            }
-            // The stored `startedAt`, assigned in `start()`. A local of the
-            // same name is not it, hence the exclusion.
-            if samplerLine.hasSuffix("startedAt =") && !samplerLine.contains("let startedAt") {
-                if blockIsLocked.contains(true) { lockedOrigin += 1 } else { looseOrigin += 1 }
-            }
-        }
-        // The walk above is a brace counter, and it counts every `{`, including
-        // one inside a comment or a string. A single unbalanced push shifts the
-        // stack, so a `withLock` entry outlives its block and reports a loose
-        // append as a locked one - the check would go on passing while the thing
-        // it watches was gone.
-        expect(blockIsLocked.isEmpty, "\(samplerPath) parses to balanced braces")
-        expect(samplerSource.contains("NSLock()") && lockedAppends > 0 && looseAppends == 0,
-               "\(samplerPath) appends to its sampler buffer only under the lock")
-        expect(lockedOrigin == 1 && looseOrigin == 0,
-               "\(samplerPath) writes the recording's start time under the lock")
+        let typingSampler = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Recorder/RecorderTypingTrack.swift",
+            encoding: .utf8)) ?? "")
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }.joined(separator: " ")
+        expect(typingSampler.contains("let lock = NSLock()"),
+               "the typing sampler guards its buffer the way the pointer sampler does")
+        expect(typingSampler.contains("lock.withLock { startedAt = CACurrentMediaTime() }"),
+               "the typing sampler writes the recording's start time under the lock")
+        expect(typingSampler.contains(
+            "lock.withLock { guard let time = pauseClock.eventTime(now, since: startedAt) "
+            + "else { return } times.append(time) }"
+        ), "the typing sampler appends a keystroke time only under the lock")
+        // `RecorderSession.stop()` is nonisolated and async, so its body runs
+        // off the main thread however main-actor the caller was (SE-0338).
+        // Both samplers install and remove AppKit event monitors, so they are
+        // started and stopped back on the main thread.
+        let recorderSessionShape = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift",
+            encoding: .utf8)) ?? "")
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }.joined(separator: " ")
+        expect(recorderSessionShape.contains(
+            "await MainActor.run { pointer.start() typing.start() }"
+        ), "the recorder installs its event monitors on the main thread")
+        expect(recorderSessionShape.contains(
+            "await MainActor.run { (pointer.stop(), typing.stop()) }"
+        ), "the recorder removes its event monitors on the main thread")
 
         let uniform = RecorderMotion.resampled(
             [RecorderMotion.Sample(time: 0, point: CGPoint(x: 0, y: 0)),

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -20382,40 +20382,38 @@ struct MetricsTests {
         expect(RecorderMotion.ringProgress(at: 2.0, clicks: clicks) == nil,
                "the ring is gone well before the next second")
 
-        // Both recorder samplers fill an array from an NSEvent monitor
-        // callback while the stop path reads it, so every append has to be
-        // under the lock: an unsynchronised one races the copy-on-write
-        // buffer. The recording's start time is written from `start()` and
-        // read from that same callback, so it belongs under the lock too.
-        for samplerPath in ["Sources/Vorssaint/Services/Recorder/RecorderTypingTrack.swift",
-                            "Sources/Vorssaint/Services/Recorder/RecorderPointerSampler.swift"] {
-            let samplerSource = (try? String(contentsOfFile: samplerPath, encoding: .utf8)) ?? ""
-            expect(!samplerSource.isEmpty, "\(samplerPath) reads back for the sampler checks")
-            var blockIsLocked: [Bool] = []
-            var samplerLine = ""
-            var lockedAppends = 0
-            var looseAppends = 0
-            var lockedOrigin = 0
-            var looseOrigin = 0
-            for character in samplerSource {
-                if character == "\n" { samplerLine = ""; continue }
-                samplerLine.append(character)
-                if character == "{" { blockIsLocked.append(samplerLine.contains("withLock")) }
-                if character == "}", !blockIsLocked.isEmpty { blockIsLocked.removeLast() }
-                if samplerLine.hasSuffix(".append(") {
-                    if blockIsLocked.contains(true) { lockedAppends += 1 } else { looseAppends += 1 }
-                }
-                // The stored `startedAt`, assigned in `start()`. A local of
-                // the same name is not it, hence the exclusion.
-                if samplerLine.hasSuffix("startedAt =") && !samplerLine.contains("let startedAt") {
-                    if blockIsLocked.contains(true) { lockedOrigin += 1 } else { looseOrigin += 1 }
-                }
+        // The typing sampler fills an array from an NSEvent monitor callback
+        // while the stop path reads it, so every append has to be under the
+        // lock: an unsynchronised one races the copy-on-write buffer. The
+        // recording's start time is written from `start()` and read from that
+        // same callback, so it belongs under the lock too.
+        let samplerPath = "Sources/Vorssaint/Services/Recorder/RecorderTypingTrack.swift"
+        let samplerSource = (try? String(contentsOfFile: samplerPath, encoding: .utf8)) ?? ""
+        expect(!samplerSource.isEmpty, "\(samplerPath) reads back for the sampler checks")
+        var blockIsLocked: [Bool] = []
+        var samplerLine = ""
+        var lockedAppends = 0
+        var looseAppends = 0
+        var lockedOrigin = 0
+        var looseOrigin = 0
+        for character in samplerSource {
+            if character == "\n" { samplerLine = ""; continue }
+            samplerLine.append(character)
+            if character == "{" { blockIsLocked.append(samplerLine.contains("withLock")) }
+            if character == "}", !blockIsLocked.isEmpty { blockIsLocked.removeLast() }
+            if samplerLine.hasSuffix(".append(") {
+                if blockIsLocked.contains(true) { lockedAppends += 1 } else { looseAppends += 1 }
             }
-            expect(samplerSource.contains("NSLock()") && lockedAppends > 0 && looseAppends == 0,
-                   "\(samplerPath) appends to its sampler buffer only under the lock")
-            expect(lockedOrigin == 1 && looseOrigin == 0,
-                   "\(samplerPath) writes the recording's start time under the lock")
+            // The stored `startedAt`, assigned in `start()`. A local of the
+            // same name is not it, hence the exclusion.
+            if samplerLine.hasSuffix("startedAt =") && !samplerLine.contains("let startedAt") {
+                if blockIsLocked.contains(true) { lockedOrigin += 1 } else { looseOrigin += 1 }
+            }
         }
+        expect(samplerSource.contains("NSLock()") && lockedAppends > 0 && looseAppends == 0,
+               "\(samplerPath) appends to its sampler buffer only under the lock")
+        expect(lockedOrigin == 1 && looseOrigin == 0,
+               "\(samplerPath) writes the recording's start time under the lock")
 
         let uniform = RecorderMotion.resampled(
             [RecorderMotion.Sample(time: 0, point: CGPoint(x: 0, y: 0)),


### PR DESCRIPTION
## Summary

`RecorderTypingSampler` appends to a plain `[Double]` from its key monitor while `stop()` reads
that same array to build the track, with nothing between them. The stop order is
`engine.stop()` → `pointer.stop()` → `typing.stop()`, and the monitor is only removed inside
that last call, so every keystroke in that window is a concurrent append into a copy-on-write
buffer being copied — a crash or a corrupt track, not a stale value. Its twin
`RecorderPointerSampler` already guards the same shape with an `NSLock`; this gives the typing
sampler the same lock.

The lock covers `startedAt` as well as the buffer. `start()` was writing it and the monitor
callback was reading it with nothing between them, so only the buffer append had actually moved
inside the lock — half of what the pointer sampler does, which writes `startedAt` in `start()`
and reads it in `record()` both under its lock. `startedAt` is the origin every recorded time is
measured from, so a torn or stale read of it shifts the whole typing track, not one sample.
`record()` now takes the lock once and does the `pauseClock.eventTime` conversion and the append
inside it, which is the pointer sampler's shape line for line.

`RecorderSession.start`/`stop` are `nonisolated async`, so awaiting them from
`Task { @MainActor }` runs their bodies on the cooperative pool (SE-0338), which put
`NSEvent.addGlobalMonitorForEvents` and `removeMonitor` on a background thread. Verified with a
standalone reproduction on this toolchain: the caller is on the main thread, the awaited body
is not. The two sampler calls now hop back with `MainActor.run`.

Trade-offs. The lock is `NSLock` rather than a serial queue or an actor because that is what
the pointer sampler next to it already uses for the identical shape, and the append is a few
nanoseconds. Calling `pauseClock.eventTime` while the sampler's lock is held nests two locks,
which the pointer sampler already does; `RecorderPauseClock` never calls back into a sampler, so
there is no cycle. For the threading, marking `RecorderSession.start`/`stop` `@MainActor` was the
smaller edit but would have moved every `await` in them — and the `writerQueue.sync {}` in
`stop()` — onto the main thread, so the hop is scoped to the two calls that need AppKit.
Clearing the typing buffer in `stop()` mirrors what the pointer sampler does and stops a second
`start()` from inheriting the first recording's keystrokes.

The only other `startedAt` on this shape is `ScreenRecorderService`'s, and it is not the same
one: it is written in `recordingDidStart()` and read from `tickElapsed()` and `togglePause()`,
all on the main thread, with no monitor callback touching it. It is left alone.

Dropped from the branch: stamping an event by `NSEvent.timestamp` instead of
`CACurrentMediaTime()`. Earlier commits here changed only the event side, while `startedAt` and
the `now` that `togglePause()` hands to `RecorderPauseClock.pause(at:)`/`resume(at:)` both stay
on `CACurrentMediaTime()`, which leaves three subtractions across two clocks. That
`NSEvent.timestamp` shares a time base with `CACurrentMediaTime()` has no Apple documentation
behind it and was never checked against a real recording, and `RecorderSupport.elapsed(since:at:)`
opens with `guard time > origin else { return 0 }`, so a mismatched base is clamped to zero
silently. Separately, the synthetic `.leftMouseDown` that `DockClickService.handleDragged` posts
carries no timestamp of its own, and what a zero-timestamp event should do here was never
settled. Earning it back means moving `startedAt` and the pause clock to the same source,
deciding the zero-timestamp case, and measuring the delivery delay on one real recording; with
none of the three done the whole half comes out. `RecorderPointerSampler.swift` is unchanged by
this branch as a result, and the source-shape check that walked both samplers now walks only the
typing track: it was added here for a change that no longer exists on that file. The pointer
sampler's own lock discipline is therefore pinned by nothing, which is left to whoever changes
that file next.

That narrowed check is a brace counter, and it counts every `{` in the file, a comment's or a
string literal's included. One unbalanced push shifts the stack, so a `withLock` entry outlives
its own block and the next append is read as a locked one: the check goes on passing while the
lock it watches is gone. It desyncs green, which is the one direction a source-shape check must
not fail in, so the walk now also asserts the file parses to balanced braces.

## Verification

`./build.sh --test` on this branch: `TESTS OK (9491 checks)`, no failures. Both files this
change touches — `RecorderTypingTrack.swift` and `Tests/MetricsTests.swift` — are in the
`--test` whitelist, so both were compiled here.

`ScreenRecorderService.swift` is outside that whitelist and was not compiled here; CI covers it
on both runners. The full `./build.sh` was not run: with the signing keychain locked, `codesign`
blocks on an unlock dialog that never returns.

The assertions were confirmed red before they were trusted. They are source-shape checks over
`RecorderTypingTrack.swift` alone: reverting the typing sampler to an unlocked append turns the
buffer check red, and reverting the `startedAt` write out of the lock turns the start-time check
red, both naming the file. Re-adding an assertion on `event.timestamp` after the drop above turns
red as well, which is why it is gone rather than kept.

The brace-balance assertion was confirmed the same way, and it was written because the failure it
covers was reproduced rather than assumed. A `{` inside a comment in the locked block, with the
only `times.append(` moved outside the lock, left both lock assertions green - a real unguarded
append, reported as locked. With the assertion in place that same file is
`TESTS FAILED (1 of 9491)` naming the parse, and the untouched file is `TESTS OK (9491 checks)`.

Not tested: no actual recording was made. The data race needs typing during the stop window to
reproduce, which is timing-dependent by nature. Single display, no second login session, no
external mouse.

## Anything else

No open or closed issue reports this. The recorder issues on the tracker are about window
capture, editor handles, shortcuts and webcam overlay, and none of them describes a corrupt or
shifted typing track, and the three long-lived index issues do not carry it either. Nothing is
referenced rather than referencing something adjacent, since the fix-status bot would then track
the wrong report.

One review note is outside this change and stays open on purpose. `RecorderTypingSampler`
`deinit` calling `stop()` runs `NSEvent.removeMonitor` on whatever thread releases the sampler,
which is the same off-main AppKit call the `MainActor.run` hop fixed on the normal path; the
pointer sampler has no `deinit` to compare against, so making the two agree is its own change.


