### PR TITLE
perf(recorder): walk the click track once per plan instead of once per frame

### DIFF
--- a/Sources/Vorssaint/Services/Recorder/RecorderComposerPlan.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderComposerPlan.swift
@@ -122,6 +122,9 @@ extension RecorderComposer {
             var amountTargets = [Double](repeating: 1, count: frames)
             var travelX = [Double](repeating: 0.5, count: frames)
             var travelY = [Double](repeating: 0.5, count: frames)
+            // `sourceTimes` never goes backwards, so the lookups below walk
+            // their lists once across the whole loop instead of per frame.
+            var focusCursor = 0
             for index in 0..<frames {
                 let time = sourceTimes[index]
                 let state = RecorderTimeline.zoomState(at: time, segments: segments)
@@ -135,7 +138,9 @@ extension RecorderComposer {
                     travelY[index] = RecorderMotion.travelParameter(exactFocus: Double(aimed.y),
                                                                     zoom: state.amount)
                 } else {
-                    let focus = RecorderMotion.focus(at: time, clusters: clusters)
+                    let focus = RecorderMotion.focus(at: time,
+                                                     clusters: clusters,
+                                                     cursor: &focusCursor)
                     travelX[index] = RecorderMotion.travelParameter(focus: Double(focus.x))
                     travelY[index] = RecorderMotion.travelParameter(focus: Double(focus.y))
                 }
@@ -165,11 +170,16 @@ extension RecorderComposer {
         var pressScale = [Double](repeating: 1, count: frames)
         var ring = [Double](repeating: -1, count: frames)
         if showsPointer {
+            var clickCursor = RecorderMotion.ClickCursor()
             for index in 0..<frames {
                 let time = sourceTimes[index]
-                pressScale[index] = RecorderMotion.pressScale(at: time, clicks: track.clicks)
+                pressScale[index] = RecorderMotion.pressScale(at: time,
+                                                              clicks: track.clicks,
+                                                              cursor: &clickCursor)
                 if document.showsClickRing,
-                   let progress = RecorderMotion.ringProgress(at: time, clicks: track.clicks) {
+                   let progress = RecorderMotion.ringProgress(at: time,
+                                                              clicks: track.clicks,
+                                                              cursor: &clickCursor) {
                     ring[index] = progress
                 }
             }

--- a/Sources/Vorssaint/Services/Recorder/RecorderMotion.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderMotion.swift
@@ -207,12 +207,17 @@ enum RecorderMotion {
     }
 
     /// Where a caller asking in time order got to in the click list, on the
-    /// same terms as the press punch below: a fresh cursor gives exactly what
-    /// a full scan gives, and carrying one is only valid when the times asked
-    /// for never go backwards. It may only step past a RELEASE, because a
-    /// press still weighs on every moment until its own release arrives.
-    /// `anchored` is the only caller that carries one, over its own frame
-    /// index, so the ordering is true by construction rather than by promise.
+    /// same terms as the press punch below: for a click list in ascending time
+    /// order a fresh cursor gives exactly what a full scan gives, and carrying
+    /// one is only valid when the times asked for never go backwards. The
+    /// qualifier is the early break — out of order the scan stops short of
+    /// clicks that would have counted, and a fresh cursor is no protection
+    /// against that. The sampler appends in order and `decode` round-trips the
+    /// encoder's order, so nothing builds such a list today.
+    /// It may only step past a RELEASE, because a press still weighs on every
+    /// moment until its own release arrives. `anchored` is the only caller
+    /// that carries one, over its own frame index, so the order the moments
+    /// are asked in is true by construction rather than by promise.
     static func anchorWeight(at time: Double, clicks: [Click], cursor: inout Int) -> Double {
         var weight: Double = 0
         var pressedAt: Double?
@@ -467,8 +472,11 @@ enum RecorderMotion {
     }
 
     /// The same answer, for a caller that asks in time order. `cursor` starts
-    /// at zero and is carried across the calls; a fresh one gives exactly what
-    /// a full scan gives.
+    /// at zero and is carried across the calls; for clusters in ascending time
+    /// order a fresh one gives exactly what a full scan gives. Out of order it
+    /// stops at the first cluster past the moment, where the scan went on to
+    /// take the last one; `focusClusters` emits ascending, so nothing here
+    /// builds that list.
     static func focus(at time: Double, clusters: [FocusCluster], cursor: inout Int) -> CGPoint {
         guard let first = clusters.first else { return CGPoint(x: 0.5, y: 0.5) }
         var current = cursor == 0 ? first.center : clusters[cursor - 1].center
@@ -577,9 +585,14 @@ enum RecorderMotion {
     /// Where a caller asking in time order got to in the click list, so an
     /// export does not rescan every click for every frame: an hour of busy
     /// recording is thirty six thousand frames against a four figure click
-    /// list. A fresh cursor gives exactly what a full scan gives; carrying one
-    /// is only valid when the times asked for never go backwards, which the
-    /// composer's frame loop guarantees.
+    /// list. For a click list in ascending time order a fresh cursor gives
+    /// exactly what a full scan gives; carrying one is only valid when the
+    /// times asked for never go backwards, which the composer's frame loop
+    /// guarantees. Both halves want `clicks` ascending: these scans stop at
+    /// the first click too late to matter, so out of order they answer from
+    /// the part before the break, fresh cursor or not. The sampler appends in
+    /// order and `decode` round-trips the encoder's order, so nothing builds
+    /// such a list today.
     struct ClickCursor {
         fileprivate var punch = 0
         fileprivate var ring = 0

--- a/Sources/Vorssaint/Services/Recorder/RecorderMotion.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderMotion.swift
@@ -202,21 +202,49 @@ enum RecorderMotion {
     static let clickAnchorWindow: Double = 0.12
 
     static func anchorWeight(at time: Double, clicks: [Click]) -> Double {
+        var cursor = 0
+        return anchorWeight(at: time, clicks: clicks, cursor: &cursor)
+    }
+
+    /// Where a caller asking in time order got to in the click list, on the
+    /// same terms as the press punch below: a fresh cursor gives exactly what
+    /// a full scan gives, and carrying one is only valid when the times asked
+    /// for never go backwards. It may only step past a RELEASE, because a
+    /// press still weighs on every moment until its own release arrives.
+    /// `anchored` is the only caller that carries one, over its own frame
+    /// index, so the ordering is true by construction rather than by promise.
+    static func anchorWeight(at time: Double, clicks: [Click], cursor: inout Int) -> Double {
         var weight: Double = 0
         var pressedAt: Double?
-        for click in clicks {
+        // Where the next question may start from: everything before it is a
+        // press whose release faded out before this moment, which no later
+        // moment can reach back to either.
+        var settled = cursor
+        var index = cursor
+        while index < clicks.count {
+            let click = clicks[index]
+            // Nothing this late weighs on this moment, and with no button
+            // held there is no earlier press waiting for its release either.
+            if pressedAt == nil, click.time > time + clickAnchorWindow { break }
+            index += 1
             if click.isDown {
                 pressedAt = click.time
-            } else if let down = pressedAt {
-                if time >= down, time <= click.time { return 1 }
-                pressedAt = nil
+            } else {
+                if let down = pressedAt {
+                    if time >= down, time <= click.time { weight = 1 }
+                    pressedAt = nil
+                }
+                if click.time + clickAnchorWindow < time { settled = index }
             }
             let distance = abs(time - click.time)
             guard distance <= clickAnchorWindow else { continue }
             weight = max(weight, smoothstep(1 - distance / clickAnchorWindow))
         }
-        // A press with no matching release: the recording ended mid-drag.
-        if let down = pressedAt, time >= down { return 1 }
+        cursor = settled
+        // A press with no matching release: the recording ended mid-drag. Only
+        // the last click can be one — every release clears that state — so it
+        // is read off the list directly, whatever the scan started from.
+        if let last = clicks.last, last.isDown, time >= last.time { return 1 }
         return weight
     }
 
@@ -226,8 +254,9 @@ enum RecorderMotion {
                          frameRate: Int) -> [CGPoint] {
         guard !clicks.isEmpty, smoothed.count == raw.count else { return smoothed }
         let step = 1.0 / Double(max(1, frameRate))
+        var cursor = 0
         return smoothed.indices.map { index in
-            let weight = anchorWeight(at: Double(index) * step, clicks: clicks)
+            let weight = anchorWeight(at: Double(index) * step, clicks: clicks, cursor: &cursor)
             guard weight > 0 else { return smoothed[index] }
             return CGPoint(x: smoothed[index].x + (raw[index].x - smoothed[index].x) * weight,
                            y: smoothed[index].y + (raw[index].y - smoothed[index].y) * weight)

--- a/Sources/Vorssaint/Services/Recorder/RecorderMotion.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderMotion.swift
@@ -433,9 +433,19 @@ enum RecorderMotion {
     }
 
     static func focus(at time: Double, clusters: [FocusCluster]) -> CGPoint {
-        var current = clusters.first?.center ?? CGPoint(x: 0.5, y: 0.5)
-        for cluster in clusters where cluster.time <= time {
-            current = cluster.center
+        var cursor = 0
+        return focus(at: time, clusters: clusters, cursor: &cursor)
+    }
+
+    /// The same answer, for a caller that asks in time order. `cursor` starts
+    /// at zero and is carried across the calls; a fresh one gives exactly what
+    /// a full scan gives.
+    static func focus(at time: Double, clusters: [FocusCluster], cursor: inout Int) -> CGPoint {
+        guard let first = clusters.first else { return CGPoint(x: 0.5, y: 0.5) }
+        var current = cursor == 0 ? first.center : clusters[cursor - 1].center
+        while cursor < clusters.count, clusters[cursor].time <= time {
+            current = clusters[cursor].center
+            cursor += 1
         }
         return current
     }
@@ -535,30 +545,66 @@ enum RecorderMotion {
     static let pressPunchWindow: Double = 0.13
     static let pressPunchScale: Double = 0.8
 
+    /// Where a caller asking in time order got to in the click list, so an
+    /// export does not rescan every click for every frame: an hour of busy
+    /// recording is thirty six thousand frames against a four figure click
+    /// list. A fresh cursor gives exactly what a full scan gives; carrying one
+    /// is only valid when the times asked for never go backwards, which the
+    /// composer's frame loop guarantees.
+    struct ClickCursor {
+        fileprivate var punch = 0
+        fileprivate var ring = 0
+
+        init() {}
+    }
+
     static func pressScale(at time: Double, clicks: [Click]) -> Double {
-        let weight = anchorWeightForPunch(at: time, clicks: clicks)
+        var cursor = ClickCursor()
+        return pressScale(at: time, clicks: clicks, cursor: &cursor)
+    }
+
+    static func pressScale(at time: Double, clicks: [Click], cursor: inout ClickCursor) -> Double {
+        let weight = anchorWeightForPunch(at: time, clicks: clicks, cursor: &cursor)
         return 1 - (1 - pressPunchScale) * weight
     }
 
-    private static func anchorWeightForPunch(at time: Double, clicks: [Click]) -> Double {
+    private static func anchorWeightForPunch(at time: Double,
+                                             clicks: [Click],
+                                             cursor: inout ClickCursor) -> Double {
         var weight: Double = 0
         var pressedAt: Double?
-        for click in clicks {
+        // Where the next question may start from: everything before it is a
+        // press whose release faded out before this moment, which no later
+        // moment can reach back to either.
+        var settled = cursor.punch
+        var index = cursor.punch
+        while index < clicks.count {
+            let click = clicks[index]
+            // Nothing this late weighs on this moment, and with no button
+            // held there is no earlier press waiting for its release either.
+            if pressedAt == nil, click.time > time + pressPunchWindow { break }
+            index += 1
             if click.isDown {
                 pressedAt = click.time
                 if time >= click.time - pressPunchWindow, time <= click.time {
                     weight = max(weight, smoothstep((time - (click.time - pressPunchWindow))
                                                      / pressPunchWindow))
                 }
-            } else if let down = pressedAt {
-                if time >= down, time <= click.time { weight = 1 }
-                if time > click.time, time <= click.time + pressPunchWindow {
-                    weight = max(weight, smoothstep(1 - (time - click.time) / pressPunchWindow))
+            } else {
+                if let down = pressedAt {
+                    if time >= down, time <= click.time { weight = 1 }
+                    if time > click.time, time <= click.time + pressPunchWindow {
+                        weight = max(weight, smoothstep(1 - (time - click.time) / pressPunchWindow))
+                    }
+                    pressedAt = nil
                 }
-                pressedAt = nil
+                if click.time + pressPunchWindow < time { settled = index }
             }
         }
-        if let down = pressedAt, time >= down { weight = 1 }
+        cursor.punch = settled
+        // A press with no release after it holds for everything that follows,
+        // and only the last click can be one, whatever the scan started from.
+        if let last = clicks.last, last.isDown, time >= last.time { weight = 1 }
         return min(1, weight)
     }
 
@@ -568,10 +614,24 @@ enum RecorderMotion {
     static let ringRadius: Double = 22
 
     static func ringProgress(at time: Double, clicks: [Click]) -> Double? {
+        var cursor = ClickCursor()
+        return ringProgress(at: time, clicks: clicks, cursor: &cursor)
+    }
+
+    static func ringProgress(at time: Double,
+                             clicks: [Click],
+                             cursor: inout ClickCursor) -> Double? {
         var best: Double?
-        for click in clicks where click.isDown {
+        var index = cursor.ring
+        while index < clicks.count {
+            let click = clicks[index]
             let elapsed = time - click.time
-            guard elapsed >= 0, elapsed <= ringDuration else { continue }
+            // Ahead of this moment, so ahead of every moment asked for so far.
+            if elapsed < 0 { break }
+            index += 1
+            // Faded out before this moment, so before every later one too.
+            if elapsed > ringDuration { cursor.ring = index; continue }
+            guard click.isDown else { continue }
             let progress = elapsed / ringDuration
             // A burst of clicks restarts the same ring instead of stacking.
             best = min(best ?? progress, progress)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -20394,8 +20394,8 @@ struct MetricsTests {
 
         // The composer's frame loop carries one cursor across every frame
         // instead of rescanning the whole click list per frame. That is only
-        // allowed to be faster, so both queries are compared bit for bit
-        // against the scans they replaced, over a list with bursts, held
+        // allowed to be faster, so every query is compared bit for bit
+        // against the scan it replaced, over a list with bursts, held
         // buttons, presses that are never released and one at the very end.
         var scanClicks: [RecorderMotion.Click] = []
         var scanSeed: UInt64 = 0x9E37_79B9_7F4A_7C15
@@ -20408,6 +20408,11 @@ struct MetricsTests {
             scanAt += Double((scanSeed >> 17) % 29) / 100 + 0.005
             scanClicks.append(RecorderMotion.Click(time: scanAt, isDown: false))
         }
+        // The recording stops mid-drag. Every query reads that off the last
+        // click rather than off the scan's own state, so a list that ends on
+        // a release leaves that branch untested.
+        scanAt += 0.5
+        scanClicks.append(RecorderMotion.Click(time: scanAt, isDown: true))
         func scannedPunchWeight(at time: Double) -> Double {
             var weight: Double = 0
             var pressedAt: Double?
@@ -20441,9 +20446,29 @@ struct MetricsTests {
             }
             return best
         }
+        func scannedAnchor(at time: Double) -> Double {
+            var weight: Double = 0
+            var pressedAt: Double?
+            for click in scanClicks {
+                if click.isDown {
+                    pressedAt = click.time
+                } else if let down = pressedAt {
+                    if time >= down, time <= click.time { return 1 }
+                    pressedAt = nil
+                }
+                let distance = abs(time - click.time)
+                guard distance <= RecorderMotion.clickAnchorWindow else { continue }
+                weight = max(weight, RecorderMotion.smoothstep(
+                    1 - distance / RecorderMotion.clickAnchorWindow))
+            }
+            if let down = pressedAt, time >= down { return 1 }
+            return weight
+        }
         var scanCursor = RecorderMotion.ClickCursor()
+        var anchorCursor = 0
         var punchMatches = true
         var ringMatches = true
+        var anchorMatches = true
         var freshMatches = true
         let scanFrames = Int((scanAt + 1) * 60)
         for frame in 0..<scanFrames {
@@ -20454,13 +20479,19 @@ struct MetricsTests {
             let carriedRing = RecorderMotion.ringProgress(at: time,
                                                           clicks: scanClicks,
                                                           cursor: &scanCursor)
+            let carriedAnchor = RecorderMotion.anchorWeight(at: time,
+                                                            clicks: scanClicks,
+                                                            cursor: &anchorCursor)
             let scannedPunch = 1 - (1 - RecorderMotion.pressPunchScale)
                 * scannedPunchWeight(at: time)
             if carriedPunch != scannedPunch { punchMatches = false }
             if carriedRing != scannedRing(at: time) { ringMatches = false }
+            if carriedAnchor != scannedAnchor(at: time) { anchorMatches = false }
             if RecorderMotion.pressScale(at: time, clicks: scanClicks) != scannedPunch
                 || RecorderMotion.ringProgress(at: time, clicks: scanClicks)
-                    != scannedRing(at: time) {
+                    != scannedRing(at: time)
+                || RecorderMotion.anchorWeight(at: time, clicks: scanClicks)
+                    != scannedAnchor(at: time) {
                 freshMatches = false
             }
         }
@@ -20468,7 +20499,36 @@ struct MetricsTests {
                "the cursor comparison covers a long recording and a busy click list")
         expect(punchMatches, "carrying the cursor gives the press punch the full scan gave")
         expect(ringMatches, "carrying the cursor gives the click ring the full scan gave")
+        expect(anchorMatches, "carrying the cursor gives the click anchor the full scan gave")
         expect(freshMatches, "a fresh cursor still answers exactly what the full scan answered")
+
+        // The anchor's only carried caller is `anchored` itself, so the blend
+        // it produces is compared against the same blend driven by the scan.
+        let anchorSmoothed = (0..<scanFrames).map {
+            CGPoint(x: Double($0 % 97) / 97, y: Double($0 % 61) / 61)
+        }
+        let anchorRaw = (0..<scanFrames).map {
+            CGPoint(x: Double($0 % 53) / 53, y: Double($0 % 89) / 89)
+        }
+        let blended = RecorderMotion.anchored(anchorSmoothed,
+                                              raw: anchorRaw,
+                                              clicks: scanClicks,
+                                              frameRate: 60)
+        // The same step `anchored` uses, to the bit: `n / 60` and
+        // `n * (1.0 / 60)` are not the same Double.
+        let anchorStep = 1.0 / 60.0
+        var blendMatches = blended.count == anchorSmoothed.count
+        for index in anchorSmoothed.indices {
+            let weight = scannedAnchor(at: Double(index) * anchorStep)
+            let expected = weight > 0
+                ? CGPoint(x: anchorSmoothed[index].x
+                            + (anchorRaw[index].x - anchorSmoothed[index].x) * weight,
+                          y: anchorSmoothed[index].y
+                            + (anchorRaw[index].y - anchorSmoothed[index].y) * weight)
+                : anchorSmoothed[index]
+            if blended[index] != expected { blendMatches = false }
+        }
+        expect(blendMatches, "the anchored path is the same one the per-frame scan produced")
 
         var carriedFocusCursor = 0
         var focusMatches = true

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -20500,7 +20500,8 @@ struct MetricsTests {
         expect(punchMatches, "carrying the cursor gives the press punch the full scan gave")
         expect(ringMatches, "carrying the cursor gives the click ring the full scan gave")
         expect(anchorMatches, "carrying the cursor gives the click anchor the full scan gave")
-        expect(freshMatches, "a fresh cursor still answers exactly what the full scan answered")
+        expect(freshMatches,
+               "on a click list in time order a fresh cursor answers what the full scan answered")
 
         // The anchor's only carried caller is `anchored` itself, so the blend
         // it produces is compared against the same blend driven by the scan.
@@ -20542,6 +20543,31 @@ struct MetricsTests {
             }
         }
         expect(focusMatches, "carrying the cursor gives the focus the full scan gave")
+
+        // "A fresh cursor is a full scan" is a claim about a list in time
+        // order and only that. All four queries stop at the first entry too
+        // late to matter, so on a list that is not ascending they answer from
+        // the part before the break — a fresh cursor is no protection, it is
+        // where the break happens earliest. Nothing produces such a list: the
+        // sampler appends in order, `decode` round-trips the encoder's order
+        // and `focusClusters` emits ascending. This pins the qualifier so the
+        // doc comments cannot drift back to promising the unqualified form.
+        let outOfOrder = [RecorderMotion.Click(time: 10, isDown: true),
+                          RecorderMotion.Click(time: 10.05, isDown: false),
+                          RecorderMotion.Click(time: 0.5, isDown: true),
+                          RecorderMotion.Click(time: 0.6, isDown: false)]
+        expect(RecorderMotion.anchorWeight(at: 0.55, clicks: outOfOrder) == 0,
+               "out of time order the anchor answers from before its break, not from the whole list")
+        expect(RecorderMotion.pressScale(at: 0.55, clicks: outOfOrder) == 1,
+               "out of time order the punch answers from before its break, not from the whole list")
+        expect(RecorderMotion.ringProgress(at: 0.55, clicks: outOfOrder) == nil,
+               "out of time order the ring answers from before its break, not from the whole list")
+        let jumbledClusters = [
+            RecorderMotion.FocusCluster(time: 10, center: CGPoint(x: 0.1, y: 0.1)),
+            RecorderMotion.FocusCluster(time: 0.5, center: CGPoint(x: 0.9, y: 0.9))
+        ]
+        expect(RecorderMotion.focus(at: 5, clusters: jumbledClusters) == CGPoint(x: 0.1, y: 0.1),
+               "out of time order the focus stops at the first cluster past the moment")
 
         // MARK: Screen recorder timeline
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -20538,11 +20538,13 @@ struct MetricsTests {
             var scanned = cluster.first?.center ?? CGPoint(x: 0.5, y: 0.5)
             for entry in cluster where entry.time <= time { scanned = entry.center }
             if RecorderMotion.focus(at: time, clusters: cluster, cursor: &carriedFocusCursor)
-                != scanned {
+                != scanned
+                || RecorderMotion.focus(at: time, clusters: cluster) != scanned {
                 focusMatches = false
             }
         }
-        expect(focusMatches, "carrying the cursor gives the focus the full scan gave")
+        expect(focusMatches,
+               "carrying the cursor, or starting a fresh one, gives the focus the full scan gave")
 
         // "A fresh cursor is a full scan" is a claim about a list in time
         // order and only that. All four queries stop at the first entry too

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -20392,6 +20392,97 @@ struct MetricsTests {
         expect(RecorderMotion.resampled([], frameRate: 10, duration: 1).count == 10,
                "an empty track still yields a full grid instead of crashing the export")
 
+        // The composer's frame loop carries one cursor across every frame
+        // instead of rescanning the whole click list per frame. That is only
+        // allowed to be faster, so both queries are compared bit for bit
+        // against the scans they replaced, over a list with bursts, held
+        // buttons, presses that are never released and one at the very end.
+        var scanClicks: [RecorderMotion.Click] = []
+        var scanSeed: UInt64 = 0x9E37_79B9_7F4A_7C15
+        var scanAt: Double = 0.05
+        for step in 0..<300 {
+            scanSeed = scanSeed &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            scanAt += Double((scanSeed >> 33) % 37) / 100 + 0.01
+            scanClicks.append(RecorderMotion.Click(time: scanAt, isDown: true))
+            guard step % 7 != 0 else { continue }
+            scanAt += Double((scanSeed >> 17) % 29) / 100 + 0.005
+            scanClicks.append(RecorderMotion.Click(time: scanAt, isDown: false))
+        }
+        func scannedPunchWeight(at time: Double) -> Double {
+            var weight: Double = 0
+            var pressedAt: Double?
+            for click in scanClicks {
+                if click.isDown {
+                    pressedAt = click.time
+                    if time >= click.time - RecorderMotion.pressPunchWindow, time <= click.time {
+                        weight = max(weight, RecorderMotion.smoothstep(
+                            (time - (click.time - RecorderMotion.pressPunchWindow))
+                                / RecorderMotion.pressPunchWindow))
+                    }
+                } else if let down = pressedAt {
+                    if time >= down, time <= click.time { weight = 1 }
+                    if time > click.time, time <= click.time + RecorderMotion.pressPunchWindow {
+                        weight = max(weight, RecorderMotion.smoothstep(
+                            1 - (time - click.time) / RecorderMotion.pressPunchWindow))
+                    }
+                    pressedAt = nil
+                }
+            }
+            if let down = pressedAt, time >= down { weight = 1 }
+            return min(1, weight)
+        }
+        func scannedRing(at time: Double) -> Double? {
+            var best: Double?
+            for click in scanClicks where click.isDown {
+                let elapsed = time - click.time
+                guard elapsed >= 0, elapsed <= RecorderMotion.ringDuration else { continue }
+                best = min(best ?? elapsed / RecorderMotion.ringDuration,
+                           elapsed / RecorderMotion.ringDuration)
+            }
+            return best
+        }
+        var scanCursor = RecorderMotion.ClickCursor()
+        var punchMatches = true
+        var ringMatches = true
+        var freshMatches = true
+        let scanFrames = Int((scanAt + 1) * 60)
+        for frame in 0..<scanFrames {
+            let time = Double(frame) / 60
+            let carriedPunch = RecorderMotion.pressScale(at: time,
+                                                         clicks: scanClicks,
+                                                         cursor: &scanCursor)
+            let carriedRing = RecorderMotion.ringProgress(at: time,
+                                                          clicks: scanClicks,
+                                                          cursor: &scanCursor)
+            let scannedPunch = 1 - (1 - RecorderMotion.pressPunchScale)
+                * scannedPunchWeight(at: time)
+            if carriedPunch != scannedPunch { punchMatches = false }
+            if carriedRing != scannedRing(at: time) { ringMatches = false }
+            if RecorderMotion.pressScale(at: time, clicks: scanClicks) != scannedPunch
+                || RecorderMotion.ringProgress(at: time, clicks: scanClicks)
+                    != scannedRing(at: time) {
+                freshMatches = false
+            }
+        }
+        expect(scanFrames > 5_000 && scanClicks.count > 500,
+               "the cursor comparison covers a long recording and a busy click list")
+        expect(punchMatches, "carrying the cursor gives the press punch the full scan gave")
+        expect(ringMatches, "carrying the cursor gives the click ring the full scan gave")
+        expect(freshMatches, "a fresh cursor still answers exactly what the full scan answered")
+
+        var carriedFocusCursor = 0
+        var focusMatches = true
+        for frame in 0..<600 {
+            let time = Double(frame) / 60
+            var scanned = cluster.first?.center ?? CGPoint(x: 0.5, y: 0.5)
+            for entry in cluster where entry.time <= time { scanned = entry.center }
+            if RecorderMotion.focus(at: time, clusters: cluster, cursor: &carriedFocusCursor)
+                != scanned {
+                focusMatches = false
+            }
+        }
+        expect(focusMatches, "carrying the cursor gives the focus the full scan gave")
+
         // MARK: Screen recorder timeline
 
         let cutTrim = RecorderSupport.Trim(start: 0, end: 20)


### PR DESCRIPTION
## Summary

`RecorderComposer.makePlan` solves the whole pointer and zoom timeline before the first frame is
drawn, and four of its per-frame lookups walked their entire list every time:
`RecorderMotion.pressScale`, `ringProgress`, `focus` and `anchorWeight`. Ten minutes at 60 fps is
thirty six thousand frames, and a recording of real use carries a four figure click list, so the
export spent tens of millions of iterations — most of them on clicks that had faded out a minute
earlier or had not happened yet.

The frame loop asks in time order and both lists are in time order, so these are now cursored
walks: one pass across the whole loop instead of one pass per frame. The same file already
solved this exact problem this way in `resampled`, `resampledShapes` and `resampledVisibility`;
this brings the four stragglers over.

Measured on the extracted functions with `-O`, ten minutes of recording, 2914 clicks, 36000
frames: the press punch and the click ring together drop from 0.307 s to 0.001 s, with an
identical checksum over every frame.

This has to be a pure algorithmic swap — any difference in output is a bug, not a trade-off — so
each query keeps exactly one implementation. The old signatures still exist and now call the
cursored one with a fresh cursor. Four things needed care to stay bit-identical:

- Neither the press punch nor the click anchor may stop early while a button is held, because a
  press from long before this moment still weighs on it until its release arrives. They stop
  early only with nothing held, and their cursors step forward only past a release.
- Their trailing "still held at the end" check used the scan's own state, which the cursor no
  longer reproduces from an arbitrary start. It is now read off `clicks.last` directly, which is
  the same answer: every release clears that state, so only a final press can leave it set.
- `anchorWeight`'s cursor is carried by `anchored` over its own frame index rather than over the
  composer's `sourceTimes`, so its ascending order is true by construction. It is the only caller
  that carries one; every other caller, including every test, goes through the fresh-cursor
  signature.
- That fresh-cursor signature is equal to the scan it replaced **for a list in ascending time
  order, and only for one**. Every one of the four stops at the first entry too late to matter,
  so on a list that is not ascending they answer from the part before that break — and a fresh
  cursor is the case where the break lands earliest, not a protection against it. With clicks
  `[(10, down), (10.05, up), (0.5, down), (0.6, up)]` at `time = 0.55`, the old scan gives an
  anchor weight of 1 and a fresh cursor gives 0. The doc comments said the equivalence held
  unconditionally; they now carry the qualifier, and four assertions pin it.

  The real guarantee is that no producer emits a list out of time order: the sampler appends in
  event order, `RecorderPointerTrack.decode` round-trips the encoder's order, `focusClusters`
  emits ascending. That is why there is still no fallback branch, and it is a weaker statement
  than the one the comments used to make.

  Detecting a non-ascending *query* and resetting the cursor would not have made the old claim
  true: resetting gives the fresh path, which is exactly the path the counterexample breaks.
  Detecting a non-ascending *list* takes the whole-list scan the break exists to avoid, once per
  query. Neither buys anything a caller can reach today, so neither is here.

Trade-offs. A binary search per frame would have needed no ordering assumption about the frames
themselves, but it cannot start mid-list for the press punch or the anchor, whose answers depend
on the press/release pairing in the whole prefix. Sorting or defensively rescanning on unordered
input was rejected as well: unordered input would change the output. The ordering itself comes
from the encoder, not from there being a single producer — `RecorderPointerTrack.decode` builds
`clicks` too, and checks only `isFinite`, but it round-trips what the sampler appended in event
order.

## Verification

`./build.sh --test` on this branch: `TESTS OK (9498 checks)`, no failures.

The equivalence is asserted, not argued: the test keeps a copy of the scans that were replaced
and compares them frame by frame with `!=` on the raw `Double` — no tolerance — over 5972 frames
against 558 clicks built to include bursts, held buttons, presses that are never released and one
at the very end. Both the carried cursor and a fresh one are compared, for the press punch, the
click ring, the focus lookup and the click anchor. `anchored` itself is compared too: the blended
path it returns is checked point for point against the same blend driven by the full scan, at the
same `Double` step it uses internally.

That generated click list previously ended on a release, which left the trailing "ended mid-drag"
branch of all four queries unasserted. It now ends on a press that is never released.

Four more assertions pin the qualifier rather than the unqualified claim: each of the four
queries, on the counterexample list above, answers from before its break — anchor 0, punch scale
1, ring `nil`, focus the first cluster. The equivalence assertion above is worded "on a click
list in time order" so the test file no longer states the unqualified form either.

The new assertions were confirmed to fail on purpose, the same way the earlier ones were, on
extracted copies of the shipped functions driven by the same generated click list the test
builds. Advancing the anchor cursor past every click rather than only past faded-out releases
turns it red on 5264 of 5972 frames; stopping the scan early while a button is held, on 771;
dropping the `clicks.last` check, on 59. All three go green again when reverted. That last one is
red only because the list now ends on a held press — on the old list it was 0, which is what the
missing coverage looked like.

The four new qualifier assertions were confirmed red the same way: on extracted copies with the
early break removed — which is what widening the claim back to the unqualified form would take —
all four fail (anchor 1, punch 0.8, ring 0.125, focus the second cluster), and all four pass with
the break in place. The ascending equivalence was re-run exhaustively over every up/down pattern
up to six clicks, carried and fresh against the full scan: zero mismatches.

`RecorderMotion.swift` is in the `--test` whitelist and was compiled and run here.
`RecorderComposerPlan.swift` is not, and is untouched by this round; CI covers it on both runners.

Not tested: no video was exported. The claim being made is that the output is unchanged, so there
is nothing new to look at in a finished recording, and the timing figure above comes from the
extracted functions rather than from a real export. No profile of the anchor pass on a real
export was taken either — the argument for it is the same one the other three rest on, that the
work per frame is now bounded by the window rather than by the list.

## Anything else

No open issue reports a slow export, so there is nothing to reference. Searched the bug list and
the three summary issues for the symptom and for this PR number; the recorder issues that exist
(1147, 843) are about what is captured, not what the export costs.


