### PR TITLE
perf(command-bar): stop refolding the query and rereading preferences on every keystroke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project are documented here. The format follows
 ## [Unreleased]
 
 ### Summary
-Vorssaint adds quit and close protections, expands screen text recognition, capture magnifier, clipboard, Super key, Dock Preview, App Switcher, Window Layout, mouse controls and snippet controls, broadens app update and safe cleanup discovery, and hardens shortcut capture and key caps, permission guide recovery, input session switching, Accessibility timeouts, Volume Mixer audio rendering, helper process attribution and teardown, Super key shutdown, process termination, update and uninstallation teardown, window handling and shared on-screen parsing, pasteboard restoration, sensor selection, Cleaning Mode unlock and favicon downloads. It also improves mouse scrolling feel, disk space and system monitor metrics, Settings, Scratchpad, Screenshot Editor, floating panels and several menu bar behaviors.
+Vorssaint adds quit and close protections, expands screen text recognition, capture magnifier, clipboard, Super key, Dock Preview, App Switcher, Window Layout, mouse controls and snippet controls, broadens app update and safe cleanup discovery, and hardens shortcut capture and key caps, permission guide recovery, input session switching, Accessibility timeouts, Volume Mixer audio rendering, helper process attribution and teardown, Super key shutdown, process termination, update and uninstallation teardown, window handling and shared on-screen parsing, pasteboard restoration, sensor selection, Cleaning Mode unlock and favicon downloads. It also improves mouse scrolling feel, disk space and system monitor metrics, Command Bar responsiveness, Settings, Scratchpad, Screenshot Editor, floating panels and several menu bar behaviors.
 
 ### Added
 - Settings now includes optional protections for Command-Q and Command-W with customizable hold duration, double press, extra modifier requirements and per-app scopes. Thanks to @RuanMD.
@@ -29,6 +29,7 @@ Vorssaint adds quit and close protections, expands screen text recognition, capt
 
 ### Changed
 - Window controls, Dock clicks and mouse exceptions now share consistent on-screen window parsing while preserving their existing behavior. Thanks to @PathGao.
+- The Command Bar now stays responsive while typing, doing less work on each keystroke and reading the battery and memory levels in the background. Thanks to @PathGao.
 - System monitor process breakdowns now normalize per-app CPU usage against total active processor cores and cap grouped GPU and energy percentages at 100%. Thanks to @pergioa.
 - The docked shelf now uses a calibrated trigger area and requires a brief hover over the collapsed pill before expanding, preventing fast drags across the menu bar from opening the full card.
 - Smooth scrolling now feels consistent on standard and high-refresh displays, with adjustable speed and response and no lost wheel distance.

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarCatalog.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarCatalog.swift
@@ -1059,7 +1059,7 @@ enum CommandBarCatalog {
                                     bar: CommandBarFeatureStrings) -> [CommandBarEntry] {
         var entries: [CommandBarEntry] = []
 
-        if let battery = SystemInfo.batterySnapshot() {
+        if let battery = cachedBattery {
             let value = "\(battery.percent)%"
             let detail = battery.isCharging
                 ? bar.answerBatteryCharging
@@ -1075,7 +1075,7 @@ enum CommandBarCatalog {
         }
 
         if AppFeature.monitorMemory.isAvailable,
-           let memory = SystemInfo.memoryUsage(), memory.total > 0 {
+           let memory = cachedMemory, memory.total > 0 {
             let metric = Defaults.sanitizedMonitorMemoryMetric(
                 UserDefaults.standard.string(forKey: DefaultsKey.monitorMemoryMetric) ?? "")
             let selected = MetricFormat.selectedMemory(used: memory.used,
@@ -1150,6 +1150,13 @@ enum CommandBarCatalog {
     /// Filled in by the service from a background pass; nil until the first
     /// one lands, which simply means the row is not offered yet.
     static var cachedBootVolumeSpace: (free: UInt64, total: UInt64)?
+
+    /// The battery and the memory pressure are read the same way and for the
+    /// same reason: both cross into the kernel (IOKit power sources, the mach
+    /// VM statistics), and the bar opens on a keystroke.
+    static var cachedBattery: BatteryInfo?
+    static var cachedMemory: (used: UInt64, appUsed: UInt64, total: UInt64,
+                              compressed: UInt64, cached: UInt64, swapUsed: UInt64?)?
 
     static func readBootVolumeSpace() -> (free: UInt64, total: UInt64)? {
         let url = URL(fileURLWithPath: "/")

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarPreferences.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarPreferences.swift
@@ -194,7 +194,12 @@ enum CommandBarPreferences {
     }
 
     static func aliasHit(_ alias: String, query: String) -> AliasHit? {
-        let normalizedQuery = CommandBarSearch.normalized(query)
+        aliasHit(alias, normalizedQuery: CommandBarSearch.normalized(query))
+    }
+
+    /// The same answer for letters the caller has already folded, so a pass
+    /// over the pool folds the query once instead of once per named row.
+    static func aliasHit(_ alias: String, normalizedQuery: String) -> AliasHit? {
         guard !normalizedQuery.isEmpty else { return nil }
         var best: AliasHit?
         for word in CommandBarSearch.normalized(alias).split(separator: " ").map(String.init)

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarQueryMemory.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarQueryMemory.swift
@@ -97,14 +97,11 @@ struct CommandBarQueryMemory: Equatable {
     /// What this row is worth for exactly these letters. Nothing at all for a
     /// row that was never chosen after them.
     func boost(query: String, id: String) -> Int {
-        guard !picks.isEmpty else { return 0 }
-        return boost(normalizedQuery: CommandBarSearch.normalized(query), id: id)
+        boost(normalizedQuery: CommandBarSearch.normalized(query), id: id)
     }
 
-    /// The same answer for letters the caller has already folded. The ranking
-    /// asks this once per row, and folding one query a thousand times over is
-    /// the whole cost of asking; a session that has chosen nothing yet answers
-    /// zero without folding at all.
+    /// The same answer for letters the caller has already folded, so a pass
+    /// over the pool folds the query once instead of once per row.
     func boost(normalizedQuery: String, id: String) -> Int {
         guard !normalizedQuery.isEmpty, let pick = picks[normalizedQuery]?[id] else { return 0 }
         return min(pick.count, 3) * (Self.maximumBoost / 3)

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarQueryMemory.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarQueryMemory.swift
@@ -97,8 +97,16 @@ struct CommandBarQueryMemory: Equatable {
     /// What this row is worth for exactly these letters. Nothing at all for a
     /// row that was never chosen after them.
     func boost(query: String, id: String) -> Int {
-        let prefix = CommandBarSearch.normalized(query)
-        guard !prefix.isEmpty, let pick = picks[prefix]?[id] else { return 0 }
+        guard !picks.isEmpty else { return 0 }
+        return boost(normalizedQuery: CommandBarSearch.normalized(query), id: id)
+    }
+
+    /// The same answer for letters the caller has already folded. The ranking
+    /// asks this once per row, and folding one query a thousand times over is
+    /// the whole cost of asking; a session that has chosen nothing yet answers
+    /// zero without folding at all.
+    func boost(normalizedQuery: String, id: String) -> Int {
+        guard !normalizedQuery.isEmpty, let pick = picks[normalizedQuery]?[id] else { return 0 }
         return min(pick.count, 3) * (Self.maximumBoost / 3)
     }
 

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
@@ -314,6 +314,7 @@ final class CommandBarService: ObservableObject {
         refreshAutomationStatus(for: id)
         refreshStorageAnswer(for: id)
         refreshWiFiState(for: id)
+        refreshSystemAnswers(for: id)
         loadAppsIfNeeded(for: id)
         loadMacSettingsIfNeeded(for: id)
         loadWindowsIfNeeded(for: id)
@@ -404,16 +405,18 @@ final class CommandBarService: ObservableObject {
 
     // MARK: - What the person decided
 
-    private var disabledSourcesRaw: String {
-        UserDefaults.standard.string(forKey: DefaultsKey.commandBarDisabledSources) ?? ""
-    }
-
-    private var aliases: [String: String] {
+    /// Straight from disk, and named so. Only the helpers that change one of
+    /// these lists may read them: a read-modify-write has to start from what
+    /// is stored, or it would write back a copy taken before Settings edited
+    /// it. Everything that only reads - the ranking, the chips, the browse
+    /// list - uses the caches below, which is what keeps one keystroke from
+    /// decoding the same handful of strings over and over.
+    private var storedAliases: [String: String] {
         CommandBarPreferences.decodeAliases(
             UserDefaults.standard.string(forKey: DefaultsKey.commandBarAliases))
     }
 
-    private var pins: [String] {
+    private var storedPins: [String] {
         CommandBarPreferences.decodePins(
             UserDefaults.standard.string(forKey: DefaultsKey.commandBarPins) ?? "")
     }
@@ -481,7 +484,7 @@ final class CommandBarService: ObservableObject {
         finish(entry, value: nil)
     }
 
-    private var hiddenKeys: Set<String> {
+    private var storedHiddenKeys: Set<String> {
         CommandBarPreferences.decodeHidden(
             UserDefaults.standard.string(forKey: DefaultsKey.commandBarHidden) ?? "")
     }
@@ -579,13 +582,13 @@ final class CommandBarService: ObservableObject {
         case .clipboard:
             return !categoryContent(source, bar: bar, limit: 1).isEmpty
         case .emoji:
-            let hidden = hiddenKeys
+            let hidden = hiddenCache
             return emojiEntries.contains { !hidden.contains($0.stableKey) }
         case .actions, .settingsPages, .snippets, .folders, .links:
             // Asked once per chip on every pass with an empty field, so it
             // stops at the first row that qualifies instead of building a copy
             // of the catalog five times over.
-            let hidden = hiddenKeys
+            let hidden = hiddenCache
             return catalog.contains {
                 CommandBarPreferences.source(ofRowID: $0.id) == source
                     && !hidden.contains($0.stableKey)
@@ -602,7 +605,7 @@ final class CommandBarService: ObservableObject {
     private func categoryContent(_ source: CommandBarSource,
                                  bar: CommandBarFeatureStrings,
                                  limit: Int = 60) -> [CommandBarEntry] {
-        let hidden = hiddenKeys
+        let hidden = hiddenCache
         let rows: [CommandBarEntry]
         switch source {
         case .actions:
@@ -659,14 +662,22 @@ final class CommandBarService: ObservableObject {
     }
 
     func isEnabled(_ source: CommandBarSource) -> Bool {
-        CommandBarPreferences.isEnabled(source, disabledRaw: disabledSourcesRaw)
+        source.isAlwaysOn || !disabledCache.contains(source)
     }
 
     /// What the person pinned and what they bound, kept in memory. Both are
     /// asked once per row on every single render of the list, and reading them
     /// from disk there means parsing the same JSON ninety times for one frame.
     private var pinCache: Set<String> = []
+    private var pinOrderCache: [String] = []
     private var shortcutCache: [String: GlobalShortcut] = [:]
+    /// The rest of what the person decided, cached for the same reason and
+    /// with the same lifetime: read once when the bar opens, asked for by
+    /// every row on every keystroke after that.
+    private var aliasCache: [String: String] = [:]
+    private var hiddenCache: Set<String> = []
+    private var disabledCache: Set<CommandBarSource> = []
+    private var usageCache: [String: CommandBarUse] = [:]
     /// Cached like the pins: read once per open, checked on every keystroke.
     private var compactMode = false
     /// The list was asked for anyway, through `peekHome()`. Cleared on the
@@ -681,7 +692,16 @@ final class CommandBarService: ObservableObject {
     private var fileScopeLoadGeneration = 0
 
     private func reloadPreferenceCaches() {
-        pinCache = Set(pins)
+        pinOrderCache = storedPins
+        pinCache = Set(pinOrderCache)
+        aliasCache = storedAliases
+        hiddenCache = storedHiddenKeys
+        // Before `reloadFileSearchCaches()`, which asks whether the Files
+        // source is on.
+        disabledCache = CommandBarPreferences.disabledSources(
+            from: UserDefaults.standard.string(forKey: DefaultsKey.commandBarDisabledSources) ?? "")
+        usageCache = CommandBarUsage.decode(
+            UserDefaults.standard.string(forKey: DefaultsKey.commandBarUsage))
         shortcutCache = rowShortcuts
         compactMode = UserDefaults.standard.bool(forKey: DefaultsKey.commandBarCompactMode)
         hasCustomPosition = positionOffset != .zero
@@ -761,19 +781,19 @@ final class CommandBarService: ObservableObject {
     }
 
     func alias(for entry: CommandBarEntry) -> String? {
-        aliases[entry.stableKey]
+        aliasCache[entry.stableKey]
     }
 
     /// Pinning, naming, hiding and forgetting all write through here so the
     /// list refreshes the instant the person changes their mind.
     func togglePin(_ entry: CommandBarEntry) {
-        let next = CommandBarPreferences.togglingPin(entry.stableKey, in: pins)
+        let next = CommandBarPreferences.togglingPin(entry.stableKey, in: storedPins)
         UserDefaults.standard.set(CommandBarPreferences.encodePins(next), forKey: DefaultsKey.commandBarPins)
         refreshAfterPreferenceChange()
     }
 
     func setAlias(_ alias: String, for entry: CommandBarEntry) {
-        let next = CommandBarPreferences.settingAlias(alias, for: entry.stableKey, in: aliases)
+        let next = CommandBarPreferences.settingAlias(alias, for: entry.stableKey, in: storedAliases)
         UserDefaults.standard.set(CommandBarPreferences.encodeAliases(next),
                                   forKey: DefaultsKey.commandBarAliases)
         refreshAfterPreferenceChange()
@@ -782,14 +802,14 @@ final class CommandBarService: ObservableObject {
     /// The row that already answers to this name, so the bar can say so
     /// instead of quietly taking the name away from it.
     func rowAlreadyNamed(_ alias: String, excluding entry: CommandBarEntry) -> String? {
-        guard let key = CommandBarPreferences.rowUsingAlias(alias, in: aliases,
+        guard let key = CommandBarPreferences.rowUsingAlias(alias, in: aliasCache,
                                                             excluding: entry.stableKey)
         else { return nil }
         return entriesByStableKey[key]?.title
     }
 
     func toggleHidden(_ entry: CommandBarEntry) {
-        let next = CommandBarPreferences.togglingHidden(entry.stableKey, in: hiddenKeys)
+        let next = CommandBarPreferences.togglingHidden(entry.stableKey, in: storedHiddenKeys)
         UserDefaults.standard.set(CommandBarPreferences.encodeHidden(next),
                                   forKey: DefaultsKey.commandBarHidden)
         refreshAfterPreferenceChange()
@@ -865,7 +885,7 @@ final class CommandBarService: ObservableObject {
         // rebuild.
         normalizedByID = [:]
         entriesByStableKey = [:]
-        let names = aliases
+        let names = aliasCache
         for entry in entries {
             entriesByStableKey[entry.stableKey] = entry
             // A name the person gave is searchable text like any other, so the
@@ -918,9 +938,8 @@ final class CommandBarService: ObservableObject {
                     hasCategory: activeCategory != nil,
                     isPeeking: isPeekingHome)
                 if showsBrowse {
-                    let disabled = CommandBarPreferences.disabledSources(from: disabledSourcesRaw)
                     categoryChips = Self.chipOrder.filter {
-                        !disabled.contains($0) && categoryHasContent($0)
+                        !disabledCache.contains($0) && categoryHasContent($0)
                     }
                 } else {
                     // Skipped, not just hidden: this is the walk of the whole
@@ -1014,13 +1033,9 @@ final class CommandBarService: ObservableObject {
 
     private func suggestionRows() -> (rows: [CommandBarEntry], titles: [Int: String]) {
         let bar = FeatureStrings.commandBar(L10n.shared.language)
-        let hidden = hiddenKeys
-        // Read once. The browse list walks the whole catalog, and asking the
-        // preferences for every row would parse the same string ninety times.
-        let disabled = CommandBarPreferences.disabledSources(from: disabledSourcesRaw)
+        let hidden = hiddenCache
         func allowed(_ entry: CommandBarEntry) -> Bool {
-            let source = CommandBarPreferences.source(ofRowID: entry.id)
-            return source.isAlwaysOn || !disabled.contains(source)
+            isEnabled(CommandBarPreferences.source(ofRowID: entry.id))
         }
         var rows: [CommandBarEntry] = []
         var titles: [Int: String] = [:]
@@ -1042,15 +1057,14 @@ final class CommandBarService: ObservableObject {
         // pinned leads, in the order they pinned it.
         let byKey = Dictionary(offerable.map { ($0.stableKey, $0) },
                                uniquingKeysWith: { first, _ in first })
-        let pinnedRows = CommandBarPreferences.leadingPins(pins, available: Set(byKey.keys))
+        let pinnedRows = CommandBarPreferences.leadingPins(pinOrderCache, available: Set(byKey.keys))
             .compactMap { byKey[$0] }
         if !pinnedRows.isEmpty {
             titles[rows.count] = bar.pinnedTitle
             rows.append(contentsOf: pinnedRows)
         }
 
-        let usage = CommandBarUsage.decode(
-            UserDefaults.standard.string(forKey: DefaultsKey.commandBarUsage))
+        let usage = usageCache
         let pinnedIDs = Set(pinnedRows.map(\.id))
         let ids = CommandBarUsage.suggestionIDs(usage: usage,
                                                 available: offerable.map(\.id).filter { !pinnedIDs.contains($0) },
@@ -1092,7 +1106,7 @@ final class CommandBarService: ObservableObject {
         // What was copied comes last, behind a scroll: it belongs in the bar,
         // but not on screen over whatever the person is doing every time it
         // opens.
-        if !disabled.contains(.clipboard) {
+        if isEnabled(.clipboard) {
             let copied = CommandBarCatalog.clipboardBrowseEntries(limit: 6, bar: bar) {
                 [weak self] entry in
                 self?.paste(entry)
@@ -1161,7 +1175,7 @@ final class CommandBarService: ObservableObject {
             // pending one goes: it would land on a list that has no room for
             // it and refresh the bar for nothing.
             fileSearch.cancelPending()
-            let hidden = hiddenKeys
+            let hidden = hiddenCache
             let pool = category == .clipboard
                 ? CommandBarCatalog.clipboardEntries(matching: trimmed, bar: bar, limit: 40) {
                     [weak self] entry in self?.paste(entry)
@@ -1203,7 +1217,7 @@ final class CommandBarService: ObservableObject {
             ? CommandBarLinks.matchingScriptLink(in: savedLinks, query: trimmed)
             : nil
         var scriptAnswer: CommandBarEntry?
-        if let scriptMatch, !hiddenKeys.contains("link.\(scriptMatch.link.id.uuidString)") {
+        if let scriptMatch, !hiddenCache.contains("link.\(scriptMatch.link.id.uuidString)") {
             if let result = scriptRunner.cachedResult(linkID: scriptMatch.link.id,
                                                        argument: scriptMatch.argument) {
                 scriptRunner.cancelPending()
@@ -1241,8 +1255,7 @@ final class CommandBarService: ObservableObject {
             ? split.text
             : trimmed
 
-        let usage = CommandBarUsage.decode(
-            UserDefaults.standard.string(forKey: DefaultsKey.commandBarUsage))
+        let usage = usageCache
         let now = Date().timeIntervalSince1970
 
         // The clipboard is searched with everything that was typed: digits
@@ -1252,9 +1265,9 @@ final class CommandBarService: ObservableObject {
             self?.paste(entry)
         }
 
-        let names = aliases
-        let pinnedKeys = Set(pins)
-        let hidden = hiddenKeys
+        let names = aliasCache
+        let pinnedKeys = pinCache
+        let hidden = hiddenCache
 
         // What is selected comes first, so a tie goes to the thing the person
         // is already looking at.
@@ -1288,28 +1301,31 @@ final class CommandBarService: ObservableObject {
         pool.append(contentsOf: clipboard)
         pool.append(contentsOf: fileRows)
 
-        // The kind of each surviving row, worked out once: the switches are
-        // read from disk here instead of once per row per keystroke, and the
-        // ranking below needs the same answer.
-        let disabled = CommandBarPreferences.disabledSources(from: disabledSourcesRaw)
+        // The kind of each surviving row, worked out once: the ranking below
+        // needs the same answer and working it out twice would double a walk
+        // of the whole pool.
         var sources: [CommandBarSource] = []
         var kept: [CommandBarEntry] = []
         kept.reserveCapacity(pool.count)
         sources.reserveCapacity(pool.count)
         for entry in pool where !hidden.contains(entry.stableKey) {
             let source = CommandBarPreferences.source(ofRowID: entry.id)
-            guard source.isAlwaysOn || !disabled.contains(source) else { continue }
+            guard isEnabled(source) else { continue }
             kept.append(entry)
             sources.append(source)
         }
         pool = kept
 
+        // Folded once for the whole pass. Every named row and every row this
+        // session remembers asks the same question of the same few letters,
+        // and folding is four allocations a time.
+        let foldedQuery = CommandBarSearch.normalized(effectiveQuery)
         let candidates = pool.enumerated().map { index, entry in
             let folded = normalizedByID[entry.id]
             // A name the person gave outranks every title in the catalog:
             // that is the whole point of giving it.
             let aliasBoost = names[entry.stableKey]
-                .flatMap { CommandBarPreferences.aliasHit($0, query: effectiveQuery)?.rawValue } ?? 0
+                .flatMap { CommandBarPreferences.aliasHit($0, normalizedQuery: foldedQuery)?.rawValue } ?? 0
             return CommandBarCandidate(index: index,
                                 normalizedTitle: rankingTitle(for: entry, folded: folded,
                                                               query: effectiveQuery),
@@ -1326,7 +1342,7 @@ final class CommandBarService: ObservableObject {
                                     // What this session already answered with
                                     // for exactly these letters.
                                     + (entry.countsUsage
-                                        ? queryMemory.boost(query: effectiveQuery, id: entry.id)
+                                        ? queryMemory.boost(normalizedQuery: foldedQuery, id: entry.id)
                                         : 0)
                                     // What the Mac itself holds leads what is
                                     // borrowed from the app in front.
@@ -1341,8 +1357,7 @@ final class CommandBarService: ObservableObject {
 
         // A fact about the Mac only shows when it was asked for by name:
         // "st" must not answer "Storage" over what the person meant.
-        let firstToken = CommandBarSearch.normalized(effectiveQuery)
-            .split(separator: " ").first.map(String.init) ?? ""
+        let firstToken = foldedQuery.split(separator: " ").first.map(String.init) ?? ""
 
         var counts: [String: Int] = [:]
         var result: [CommandBarEntry] = []
@@ -1977,6 +1992,7 @@ final class CommandBarService: ObservableObject {
                                                  id: entry.id,
                                                  now: Date().timeIntervalSince1970)
             UserDefaults.standard.set(CommandBarUsage.encode(next), forKey: DefaultsKey.commandBarUsage)
+            usageCache = next
         }
         // Handed over before hiding, which wipes the field and the selection.
         queryWhenRun = query
@@ -2320,6 +2336,33 @@ final class CommandBarService: ObservableObject {
                 guard let self, CommandBarCatalog.cachedBootVolumeSpace?.free != space?.free
                 else { return }
                 CommandBarCatalog.cachedBootVolumeSpace = space
+                if self.presentationLifecycle.acceptsSharedCacheCompletion(
+                    startedBy: id, currentID: self.presentationID,
+                    isVisible: self.isVisible) {
+                    self.rebuildCatalog()
+                    self.refreshResults()
+                }
+            }
+        }
+    }
+
+    /// The battery and the memory pressure both cross into the kernel, and
+    /// they are read together so one background pass answers both rows. Same
+    /// reason as the storage and Wi-Fi passes: none of it belongs on the
+    /// keystroke that opens the bar.
+    private func refreshSystemAnswers(for id: UUID) {
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let battery = SystemInfo.batterySnapshot()
+            let memory = AppFeature.monitorMemory.isAvailable ? SystemInfo.memoryUsage() : nil
+            DispatchQueue.main.async {
+                guard let self else { return }
+                let changed = CommandBarCatalog.cachedBattery != battery
+                    || CommandBarCatalog.cachedMemory?.used != memory?.used
+                    || CommandBarCatalog.cachedMemory?.appUsed != memory?.appUsed
+                    || CommandBarCatalog.cachedMemory?.total != memory?.total
+                guard changed else { return }
+                CommandBarCatalog.cachedBattery = battery
+                CommandBarCatalog.cachedMemory = memory
                 if self.presentationLifecycle.acceptsSharedCacheCompletion(
                     startedBy: id, currentID: self.presentationID,
                     isVisible: self.isVisible) {

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
@@ -2333,9 +2333,13 @@ final class CommandBarService: ObservableObject {
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let space = CommandBarCatalog.readBootVolumeSpace()
             DispatchQueue.main.async {
-                guard let self, CommandBarCatalog.cachedBootVolumeSpace?.free != space?.free
-                else { return }
+                guard let self else { return }
+                // The whole sample is stored before the comparison decides
+                // whether anything has to be redrawn, or the fields the guard
+                // does not compare would keep a reading from an older sample.
+                let changed = CommandBarCatalog.cachedBootVolumeSpace?.free != space?.free
                 CommandBarCatalog.cachedBootVolumeSpace = space
+                guard changed else { return }
                 if self.presentationLifecycle.acceptsSharedCacheCompletion(
                     startedBy: id, currentID: self.presentationID,
                     isVisible: self.isVisible) {
@@ -2356,13 +2360,17 @@ final class CommandBarService: ObservableObject {
             let memory = AppFeature.monitorMemory.isAvailable ? SystemInfo.memoryUsage() : nil
             DispatchQueue.main.async {
                 guard let self else { return }
+                // Stored first, compared after, for the reason the storage
+                // pass above gives: the guard names the three fields the row
+                // shows, and the rest of the sample would otherwise be left
+                // behind at whatever it was when those three last moved.
                 let changed = CommandBarCatalog.cachedBattery != battery
                     || CommandBarCatalog.cachedMemory?.used != memory?.used
                     || CommandBarCatalog.cachedMemory?.appUsed != memory?.appUsed
                     || CommandBarCatalog.cachedMemory?.total != memory?.total
-                guard changed else { return }
                 CommandBarCatalog.cachedBattery = battery
                 CommandBarCatalog.cachedMemory = memory
+                guard changed else { return }
                 if self.presentationLifecycle.acceptsSharedCacheCompletion(
                     startedBy: id, currentID: self.presentationID,
                     isVisible: self.isVisible) {

--- a/Sources/Vorssaint/Services/SystemInfo.swift
+++ b/Sources/Vorssaint/Services/SystemInfo.swift
@@ -5,7 +5,7 @@ import Darwin
 import Foundation
 import IOKit.ps
 
-struct BatteryInfo {
+struct BatteryInfo: Equatable {
     let percent: Int
     let isCharging: Bool
     let isOnBattery: Bool

--- a/Sources/Vorssaint/UI/Settings/CommandBarSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/CommandBarSettings.swift
@@ -406,6 +406,7 @@ struct CommandBarSettings: View {
             var current = CommandBarPreferences.disabledSources(from: disabledSources)
             if isOn { current.remove(source) } else { current.insert(source) }
             disabledSources = CommandBarPreferences.storageValue(for: current)
+            CommandBarService.shared.syncWithPreferences()
         }
     }
 
@@ -480,21 +481,28 @@ struct CommandBarSettings: View {
         CommandBarService.shared.syncWithPreferences()
     }
 
+    /// These four write the same defaults the bar keeps in memory while it is
+    /// open, so each one tells the service, the way the file scopes and the row
+    /// shortcuts above already do. Writing the key alone would leave a switch
+    /// that only takes effect the next time the bar is opened.
     private func removeAlias(_ key: String) {
         var aliases = CommandBarPreferences.decodeAliases(aliasesRaw)
         aliases.removeValue(forKey: key)
         aliasesRaw = CommandBarPreferences.encodeAliases(aliases) ?? ""
+        CommandBarService.shared.syncWithPreferences()
     }
 
     private func removePin(_ key: String) {
         pinsRaw = CommandBarPreferences.encodePins(
             CommandBarPreferences.decodePins(pinsRaw).filter { $0 != key })
+        CommandBarService.shared.syncWithPreferences()
     }
 
     private func unhide(_ key: String) {
         var keys = CommandBarPreferences.decodeHidden(hiddenRaw)
         keys.remove(key)
         hiddenRaw = CommandBarPreferences.encodeHidden(keys)
+        CommandBarService.shared.syncWithPreferences()
     }
 }
 

--- a/Sources/Vorssaint/UI/Settings/CommandBarSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/CommandBarSettings.swift
@@ -406,7 +406,6 @@ struct CommandBarSettings: View {
             var current = CommandBarPreferences.disabledSources(from: disabledSources)
             if isOn { current.remove(source) } else { current.insert(source) }
             disabledSources = CommandBarPreferences.storageValue(for: current)
-            CommandBarService.shared.syncWithPreferences()
         }
     }
 
@@ -481,28 +480,21 @@ struct CommandBarSettings: View {
         CommandBarService.shared.syncWithPreferences()
     }
 
-    /// These four write the same defaults the bar keeps in memory while it is
-    /// open, so each one tells the service, the way the file scopes and the row
-    /// shortcuts above already do. Writing the key alone would leave a switch
-    /// that only takes effect the next time the bar is opened.
     private func removeAlias(_ key: String) {
         var aliases = CommandBarPreferences.decodeAliases(aliasesRaw)
         aliases.removeValue(forKey: key)
         aliasesRaw = CommandBarPreferences.encodeAliases(aliases) ?? ""
-        CommandBarService.shared.syncWithPreferences()
     }
 
     private func removePin(_ key: String) {
         pinsRaw = CommandBarPreferences.encodePins(
             CommandBarPreferences.decodePins(pinsRaw).filter { $0 != key })
-        CommandBarService.shared.syncWithPreferences()
     }
 
     private func unhide(_ key: String) {
         var keys = CommandBarPreferences.decodeHidden(hiddenRaw)
         keys.remove(key)
         hiddenRaw = CommandBarPreferences.encodeHidden(keys)
-        CommandBarService.shared.syncWithPreferences()
     }
 }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21745,6 +21745,26 @@ struct MetricsTests {
                     == CommandBarPreferences.aliasHit("Códex", query: "CÓD"),
                "folded letters ask an alias the same question the raw ones do")
 
+        // Both background passes guard on a few fields of a tuple they store
+        // whole. Returning before the store would leave every field the guard
+        // does not name at the reading it had when the named ones last moved.
+        for (pass, marker) in [("refreshStorageAnswer", "cachedBootVolumeSpace = space"),
+                               ("refreshSystemAnswers", "cachedMemory = memory")] {
+            let parts = (commandBarCode
+                .components(separatedBy: "private func \(pass)(").last ?? "")
+                .components(separatedBy: "\n    private func ")
+            let body = parts.first ?? ""
+            expect(parts.count > 1, "\(pass) finds the end of its own body")
+            func offset(_ needle: String) -> Int {
+                body.range(of: needle)
+                    .map { body.distance(from: body.startIndex, to: $0.lowerBound) } ?? -1
+            }
+            let stored = offset(marker)
+            let guarded = offset("guard changed else { return }")
+            expect(stored >= 0 && guarded > stored,
+                   "\(pass) stores the whole sample before it decides whether the rows changed")
+        }
+
         if failures.isEmpty {
             print("TESTS OK (\(checks) checks)")
             exit(0)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21725,6 +21725,26 @@ struct MetricsTests {
                          "\(language.rawValue) quit protection modifier HUD format")
         }
 
+        // The ranking folds what was typed once and hands the folded letters to
+        // every row in the pool. Both readings have to agree, or a name the
+        // person gave would rank differently depending on which one asked.
+        var foldedMemory = CommandBarQueryMemory()
+        expect(foldedMemory.boost(normalizedQuery: "pri", id: "app.primary") == 0,
+               "a memory holding nothing is worth nothing for folded letters either")
+        foldedMemory.record(query: "Primary", id: "app.primary", step: 1)
+        expect(foldedMemory.boost(normalizedQuery: CommandBarSearch.normalized("PRÍ"),
+                                  id: "app.primary") > 0
+                && foldedMemory.boost(normalizedQuery: CommandBarSearch.normalized("PRÍ"),
+                                      id: "app.primary")
+                    == foldedMemory.boost(query: "PRÍ", id: "app.primary"),
+               "folded letters ask the query memory the same question the raw ones do")
+        expect(CommandBarPreferences.aliasHit(
+                    "Códex", normalizedQuery: CommandBarSearch.normalized("CÓD")) == .prefix
+                && CommandBarPreferences.aliasHit(
+                    "Códex", normalizedQuery: CommandBarSearch.normalized("CÓD"))
+                    == CommandBarPreferences.aliasHit("Códex", query: "CÓD"),
+               "folded letters ask an alias the same question the raw ones do")
+
         if failures.isEmpty {
             print("TESTS OK (\(checks) checks)")
             exit(0)


### PR DESCRIPTION
## Summary

Three things the command bar did on the main thread that it did not have to do.

**Every keystroke folded the query about a thousand times.** `searchRows`
builds one candidate per pooled row (900-1200 of them), and two of the things
it asks for each row started by folding what was typed:
`CommandBarQueryMemory.boost(query:)` and `CommandBarPreferences.aliasHit(_:query:)`.
Folding strips invisibles, folds diacritics, lowercases, splits and joins - four
heap allocations - so one keystroke paid for about a thousand foldings of the
same few letters, and the session memory returned zero for all of them until the
person had chosen something. Both now take an already-folded query, `searchRows`
folds once for the whole pass, and an empty memory answers without folding at
all. The comment three hundred lines above already said folding a thousand
titles per keystroke is the one thing that could make typing feel heavy; this is
the same cost, arriving through the query instead of the titles.

**Every keystroke re-read six preferences from disk.** The pins, the aliases,
the hidden keys, the usage counts and the switched-off sources are all computed
properties that hit `UserDefaults` and decode a string or a JSON blob on each
access, and `searchRows` runs off the field's `didSet`. The class already keeps
`pinCache` and `shortcutCache` for exactly this reason ("parsing the same JSON
ninety times for one frame") - `isPinned` used the cache while `searchRows` used
the raw property. The remaining four join the same cache, filled by
`reloadPreferenceCaches()` on every opening. The raw properties are renamed
`storedPins` / `storedAliases` / `storedHiddenKeys` and are now only read by the
four helpers that change one of those lists, where a read-modify-write has to
start from disk; `disabledSourcesRaw` is gone, since nothing outside the cache
wanted it.

**The battery and the memory pressure were read on the main thread.** Both sit
in `systemAnswerEntries`, which `rebuildCatalog()` calls synchronously one to
four times per opening, and both cross into the kernel (IOKit power sources, the
mach VM statistics). The three neighbouring facts in the same list - storage,
Wi-Fi, the Finder automation check - were already read in the background and
picked up on the next pass. These two now follow `refreshWiFiState`, sharing one
background hop.

**A background pass now stores its whole sample before it decides whether to
redraw.** `refreshSystemAnswers` compares the three memory fields the row shows
- `used`, `appUsed`, `total` - and returned before the assignment when they
matched, so `compressed`, `cached` and `swapUsed` would have kept whatever
reading they had when those three last moved. Nothing reads those three today,
which makes it a trap rather than a bug, and the fix is to assign first and
guard after. The same shape was already next door on `main`:
`refreshStorageAnswer` guards on `free` alone and stores a tuple that also
carries `total`, which the storage row does show, in its caption and in the
percentage. Both are reordered, since fixing only the one this branch
introduced would leave the shape standing one function above it.
`refreshWiFiState` and `refreshAutomationStatus` compare the whole value they
store, so they are already correct and are untouched.

Trade-offs:

- The four new caches take the lifetime the pins already had: read when the bar
  opens, trusted until it opens again. Nothing in Settings announces a write to
  them, and nothing needs to. `show()` calls `reloadPreferenceCaches()`, so
  every edit is picked up the next time the bar opens, and the bar is not on
  screen while those edits are made - a mouse-down anywhere outside the panel
  hides it, including one in another window of this app, so the click that
  flips a switch or presses a remove button has already hidden the bar. This is
  the lifetime the compact-mode toggle in the same view already relies on, and
  its comment says exactly that. No Settings-side callback is added here.
- The links blob is still decoded per keystroke, and so is the per-item fold on
  top of it: `scriptArgument` folds the query once per saved script link, and
  `matchingScriptLinks` walks the saved links twice per keystroke - once inside
  `matchingScriptLink`, once for the set of rows the answer replaces. Neither is
  fixed here. The cost is bounded by how many scripts the person saved, not by
  the pool, and the filter tests `kind == .script` before it folds anything, so
  a person with no scripts pays nothing and a person with five pays ten foldings
  against the roughly two thousand this removes. `CommandBarCatalog.build()`
  also still decodes the same blob from disk on every rebuild, so the fix worth
  making is one that removes that duplicate decode rather than adding a seventh
  cache beside it - a follow-up, not half of one here.
- The battery and memory rows now show the values from the previous opening for
  the moment before the background pass lands, which is what the storage row has
  always done. The alternative - keeping them synchronous and accepting the
  kernel calls - is the thing being fixed.

## Verification

`./build.sh --test` → `TESTS OK (9494 checks)`. The branch's own base,
`ed882cd3`, was run in a throwaway worktree and reports `TESTS OK (9487
checks)`; the seven added are the ones below, and there were no failures on
either side.

The two folded-query overloads are pinned by assertions that the folded and the
unfolded reading agree on an accented query, and that an empty memory is worth
nothing. The assign-before-guard order is pinned by a source-shape check over
both passes, in the style the file already uses for the shortcut-capture pair:
it slices `refreshStorageAnswer` and `refreshSystemAnswers` out of
`CommandBarService.swift` and asserts the store appears before
`guard changed else { return }`. All of these were confirmed to fail first -
making each overload look up the wrong key turns those red, and putting the
guard back in front of either assignment turns the ordering checks red with one
named failure per pass. Restoring both turns everything green.

`--test` compiles a whitelist. Of the files changed here it contains
`CommandBarPreferences.swift` and `CommandBarQueryMemory.swift` only;
`CommandBarService.swift`, `CommandBarCatalog.swift` and `SystemInfo.swift` are
not compiled here and CI covers them on both runners. The source-shape assertion
reads `CommandBarService.swift` as text, so it runs against the real file either
way.

Not tested: no run on real hardware. The main-thread cost this removes was read
off the call graph, not off a profile, so the claim is that the work is gone,
not a measured millisecond count. The background hop itself - the timing of the
battery and memory rows filling in - was not exercised by hand, and no GUI
testing was done.

## Anything else

#1245 depends on this branch and has to land after it.

Refs #887
