### PR TITLE
perf: build the process tree from one ps and skip the same-volume rehash

### DIFF
--- a/Sources/Vorssaint/Services/KillProcess/KillProcessService.swift
+++ b/Sources/Vorssaint/Services/KillProcess/KillProcessService.swift
@@ -293,9 +293,9 @@ final class KillProcessService: ObservableObject {
     /// the per-pid `pgrep` walk raced the same way, and `killBatch` still
     /// re-checks every target's identity before it signals anything.
     private static func descendants(of pid: pid_t) -> [pid_t] {
-        let result = Shell.run("/bin/ps", ["-eo", "pid,ppid"])
-        guard result.status == 0 else { return [] }
-        let parents: [(pid: pid_t, ppid: pid_t)] = result.output
+        let listing = Shell.run("/bin/ps", ["-eo", "pid,ppid"])
+        guard listing.status == 0 else { return [] }
+        let parents: [(pid: pid_t, ppid: pid_t)] = listing.output
             .split(separator: "\n").dropFirst().compactMap { line in
                 let columns = line.split(separator: " ", omittingEmptySubsequences: true)
                 guard columns.count >= 2, let child = pid_t(columns[0]),

--- a/Sources/Vorssaint/Services/KillProcess/KillProcessService.swift
+++ b/Sources/Vorssaint/Services/KillProcess/KillProcessService.swift
@@ -283,24 +283,26 @@ final class KillProcessService: ObservableObject {
         }
     }
 
-    /// BFS over `pgrep -P` to collect every descendant of `pid`. Capped well
-    /// above any real process tree, so a pathological environment can't spin
-    /// this forever.
+    /// Every descendant of `pid`, walked in memory from a single `ps` parent
+    /// table. The BFS used to run `pgrep -P` once per pid it had found, so
+    /// tearing down a tree of a few hundred processes forked that many short
+    /// lived helpers one after another - seconds of stalling while the list
+    /// had already dropped the rows.
+    ///
+    /// A grandchild forked between this snapshot and the signal is missed;
+    /// the per-pid `pgrep` walk raced the same way, and `killBatch` still
+    /// re-checks every target's identity before it signals anything.
     private static func descendants(of pid: pid_t) -> [pid_t] {
-        var result: [pid_t] = []
-        var frontier = [pid]
-        while !frontier.isEmpty, result.count < 4096 {
-            var next: [pid_t] = []
-            for parent in frontier {
-                let output = Shell.run("/usr/bin/pgrep", ["-P", String(parent)]).output
-                next.append(contentsOf: output.split(separator: "\n").compactMap {
-                    pid_t($0.trimmingCharacters(in: .whitespaces))
-                })
+        let result = Shell.run("/bin/ps", ["-eo", "pid,ppid"])
+        guard result.status == 0 else { return [] }
+        let parents: [(pid: pid_t, ppid: pid_t)] = result.output
+            .split(separator: "\n").dropFirst().compactMap { line in
+                let columns = line.split(separator: " ", omittingEmptySubsequences: true)
+                guard columns.count >= 2, let child = pid_t(columns[0]),
+                      let parent = pid_t(columns[1]) else { return nil }
+                return (child, parent)
             }
-            result.append(contentsOf: next)
-            frontier = next
-        }
-        return result
+        return KillProcessSupport.descendants(of: pid, parents: parents)
     }
 
     // MARK: - Restart

--- a/Sources/Vorssaint/Services/KillProcess/KillProcessSupport.swift
+++ b/Sources/Vorssaint/Services/KillProcess/KillProcessSupport.swift
@@ -25,6 +25,31 @@ enum KillProcessSupport {
         return ascending ? comparison == .orderedAscending : comparison == .orderedDescending
     }
 
+    /// Every descendant of `root` from a flat parent table, breadth first so
+    /// the caller can reverse it and kill deepest first. A pid is visited
+    /// once, so a self-parenting or circular row cannot loop, and the total
+    /// is capped well above any real process tree.
+    static func descendants(of root: pid_t, parents: [(pid: pid_t, ppid: pid_t)]) -> [pid_t] {
+        var children: [pid_t: [pid_t]] = [:]
+        for row in parents {
+            children[row.ppid, default: []].append(row.pid)
+        }
+        var result: [pid_t] = []
+        var seen: Set<pid_t> = [root]
+        var frontier = [root]
+        while !frontier.isEmpty, result.count < 4096 {
+            var next: [pid_t] = []
+            for parent in frontier {
+                for child in children[parent] ?? [] where seen.insert(child).inserted {
+                    next.append(child)
+                }
+            }
+            result.append(contentsOf: next)
+            frontier = next
+        }
+        return result
+    }
+
     static func normalizedStartDescription(_ value: String) -> String? {
         let normalized = value.split(whereSeparator: \.isWhitespace).joined(separator: " ")
         guard !normalized.isEmpty,

--- a/Sources/Vorssaint/Services/ManagedDownloads/WhatsAppDownloadOrganizer.swift
+++ b/Sources/Vorssaint/Services/ManagedDownloads/WhatsAppDownloadOrganizer.swift
@@ -519,11 +519,11 @@ final class WhatsAppDownloadOrganizer: ObservableObject {
 
         if let sourceVolume, let destinationVolume,
            String(describing: sourceVolume) == String(describing: destinationVolume) {
+            // Same volume: this is a rename, so no byte ever moves and the
+            // digest cannot change. Re-hashing here read a second full copy of
+            // every file - on a multi-gigabyte video, longer than the move.
+            // The cross-volume branch below copies and must still verify.
             try fm.moveItem(at: source, to: destination)
-            guard (try? sha256(of: destination)) == digest else {
-                try? fm.moveItem(at: destination, to: source)
-                throw CocoaError(.fileReadCorruptFile)
-            }
             return [.init(kind: .move, currentPath: destination.path,
                           restorePath: source.path)]
         }

--- a/Sources/Vorssaint/Services/ManagedDownloads/WhatsAppDownloadOrganizer.swift
+++ b/Sources/Vorssaint/Services/ManagedDownloads/WhatsAppDownloadOrganizer.swift
@@ -513,12 +513,13 @@ final class WhatsAppDownloadOrganizer: ObservableObject {
                                      destination: URL,
                                      digest: String) throws -> [UndoTransaction.Action] {
         let fm = FileManager.default
-        let sourceVolume = try? source.resourceValues(forKeys: [.volumeIdentifierKey]).volumeIdentifier
-        let destinationVolume = try? destination.deletingLastPathComponent()
-            .resourceValues(forKeys: [.volumeIdentifierKey]).volumeIdentifier
+        let sourceVolume = (try? source.resourceValues(forKeys: [.volumeIdentifierKey]))?
+            .volumeIdentifier as? NSObject
+        let destinationVolume = (try? destination.deletingLastPathComponent()
+            .resourceValues(forKeys: [.volumeIdentifierKey]))?.volumeIdentifier as? NSObject
 
-        if let sourceVolume, let destinationVolume,
-           String(describing: sourceVolume) == String(describing: destinationVolume) {
+        if WhatsAppDownloadSupport.isSameVolume(source: sourceVolume,
+                                                destination: destinationVolume) {
             // Same volume: this is a rename, so no byte ever moves and the
             // digest cannot change. Re-hashing here read a second full copy of
             // every file - on a multi-gigabyte video, longer than the move.

--- a/Sources/Vorssaint/Services/ManagedDownloads/WhatsAppDownloadSupport.swift
+++ b/Sources/Vorssaint/Services/ManagedDownloads/WhatsAppDownloadSupport.swift
@@ -107,6 +107,19 @@ enum WhatsAppDownloadSupport {
         return age >= 0 && age < organizerUndoLifetime
     }
 
+    /// Whether an organizer move stays on one volume, which is the only case
+    /// where the move is a rename and the destination needs no re-hash.
+    /// `volumeIdentifier` is opaque and only `isEqual` is defined on it, so
+    /// that is what decides here. An unknown identity answers "not the same
+    /// volume": guessing wrong that way only costs a verified copy, while the
+    /// opposite guess would let a real cross-volume copy through unchecked.
+    /// The inverse fallback in `CutPasteProgressSupport.isCrossVolume` is
+    /// deliberate - there an unknown identity only hides a progress bar.
+    static func isSameVolume(source: NSObject?, destination: NSObject?) -> Bool {
+        guard let source, let destination else { return false }
+        return source.isEqual(destination)
+    }
+
     static func organizerCategoryFolder(_ category: WhatsAppDownloadCategory) -> String {
         switch category {
         case .image: return "Images"

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -4239,6 +4239,21 @@ struct MetricsTests {
                     layout: .month, category: .image, date: whatsNow,
                     calendar: utcCalendar) == ["2026", "07"],
                "the organizer produces stable flat, type and month folder layouts")
+        let volumeA = NSData(bytes: [0x67, 0x45, 0x64, 0x00] as [UInt8], length: 4)
+        let volumeB = NSData(bytes: [0x69, 0x98, 0x66, 0x00] as [UInt8], length: 4)
+        expect(WhatsAppDownloadSupport.isSameVolume(
+                    source: volumeA,
+                    destination: NSData(bytes: [0x67, 0x45, 0x64, 0x00] as [UInt8], length: 4)),
+               "two equal volume identifiers are one volume even as separate objects")
+        expect(!WhatsAppDownloadSupport.isSameVolume(source: volumeA, destination: volumeB),
+               "two different volume identifiers never skip the destination check")
+        expect(!WhatsAppDownloadSupport.isSameVolume(source: NSNumber(value: 1),
+                                                     destination: NSString(string: "1")),
+               "unequal identities that print the same string still take the verified path")
+        expect(!WhatsAppDownloadSupport.isSameVolume(source: volumeA, destination: nil)
+                && !WhatsAppDownloadSupport.isSameVolume(source: nil, destination: volumeB)
+                && !WhatsAppDownloadSupport.isSameVolume(source: nil, destination: nil),
+               "an unknown volume identity keeps the verified copy rather than an unchecked rename")
         expect(WhatsAppDownloadSupport.nextAutomaticCheck(
                     after: scheduleDate(20, 8, 0), calendar: utcCalendar) == scheduleDate(20, 9, 0)
                 && WhatsAppDownloadSupport.nextAutomaticCheck(

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -13472,6 +13472,17 @@ struct MetricsTests {
                 == "Thu Aug 27 10:20:30 2026"
                && KillProcessSupport.normalizedStartDescription("bad'; kill 1") == nil,
                "Kill Process accepts only safe normalized start identities for the admin command")
+        // pid 1 -> 10 -> {20, 21} -> 30, with 40 on an unrelated branch, 50
+        // its own parent and 21 <-> 22 pointing at each other.
+        let processTable: [(pid: pid_t, ppid: pid_t)] = [
+            (10, 1), (20, 10), (21, 10), (30, 20), (40, 1), (50, 50), (22, 21), (21, 22),
+        ]
+        let treeBelowTen = KillProcessSupport.descendants(of: 10, parents: processTable)
+        expect(treeBelowTen == [20, 21, 30, 22],
+               "Kill Process collects a whole process tree breadth first so the caller kills deepest first")
+        expect(KillProcessSupport.descendants(of: 30, parents: processTable).isEmpty
+               && KillProcessSupport.descendants(of: 50, parents: processTable).isEmpty,
+               "Kill Process reports no descendants for a leaf and never follows a self-parenting row")
 
         for language in AppLanguage.allCases {
             let categoryValues = Mirror(reflecting: FeatureStrings.settingsCategories(language)).children


### PR DESCRIPTION
# Two pieces of work neither feature needs

## Summary

Both changes remove work whose result is already known.

**Killing a process tree forked a helper per process.**
`KillProcessService.descendants(of:)` ran a BFS in which every pid in the
frontier got its own `Shell.run("/usr/bin/pgrep", ["-P", pid])`. Tearing down a
tree of a few hundred processes meant that many fork/exec round trips, run one
after another on a background queue, while the list had already optimistically
removed the rows — so the interface says the processes are gone and the app is
busy spawning `pgrep`.

The parent/child edges were already available: `snapshot()` runs
`ps -eo pid,ppid,pcpu,rss,comm`, `KillProcessEntry.ppid` is the parsed result,
and `groupedByApp` builds its tree from those edges in memory. `descendants` now
runs one `ps -eo pid,ppid` and hands the rows to a new pure
`KillProcessSupport.descendants(of:parents:)`, which does the BFS with no
subprocesses at all.

**Organizing a WhatsApp download hashed the same bytes twice.** The same-volume
branch of `moveVerified` called `moveItem` — a rename on one volume, pure
metadata, not a single byte read or written — and then ran SHA-256 over the
destination to check it against the digest. The digest was already taken from
the source at `WhatsAppDownloadOrganizer.swift:368`, and the destination path is
one nothing can be sitting at: `moveVerified`'s two callers pass either a path
from `uniqueDestination`, which only returns a name that does not exist, or, from
`replaceVerified`, the existing file's own path — which `replaceVerified` has
already emptied by moving that file to a staging name before it calls in.
`moveItem` throws rather than overwrite in either case. Organizing a 4 GB video
therefore read 8 GB to learn something a rename cannot change.

**The volume comparison is the whole guarantee, so it uses `isEqual`.** Skipping
the hash makes the same-volume decision a safety check rather than a hint: get it
wrong and `moveItem` falls back to a real cross-device copy that nothing then
verifies. That decision was comparing `String(describing:)` on two
`volumeIdentifier` objects. The type is opaque and defines only `isEqual`; its
`description` is an implementation detail, and two different volumes whose
identifiers happen to print alike would have taken the unverified path. It now
goes through a pure `WhatsAppDownloadSupport.isSameVolume(source:destination:)`
that calls `isEqual` and answers false when either identity is unknown — a wrong
answer there costs a verified copy, which is the direction worth being wrong in.

That is the app's second volume comparison. The first,
`CutPasteProgressSupport.isCrossVolume` behind `FinderCutPaste.volumeIdentity`,
already used `isEqual` and is untouched; its opposite fallback for an unknown
identity is right for what it decides, which is only whether a progress bar
appears. Those two are the only readers of `.volumeIdentifierKey` in the app.

### Trade-offs

**The `ps` snapshot races the same way `pgrep` did.** A grandchild forked
between the snapshot and the signal is missed. That is not new: the per-pid walk
had exactly the same window, only wider, because it took longer. Every target
still goes through `killBatch`, which re-checks `identityMatches` before it
signals anything, so a reused pid is not at risk either way. Reading
`self.entries` instead of shelling out at all was considered and rejected: with
grouping on, `groupedByApp` collapses rows, so the ppid edges there are
incomplete.

The in-memory BFS visits each pid once. That is slightly stricter than the
`pgrep` version, which relied only on the 4096 cap, and it means a circular or
self-parenting row in a malformed table terminates instead of burning the cap.

**`descendants` still reports an empty tree when `ps` fails.** A failed `ps`
gives `[]`, so `killTree` signals the parent alone and reports success, where
`snapshot()` in the same file returns `nil` for that case. Making it `[pid_t]?`
so `killTree` can bail is the better shape, and it is deliberately not in this
PR: it changes what killing a tree does when the system is in trouble, which is a
behaviour change with its own test surface, and the current text is not a
regression — the `pgrep` walk ignored exit status too.

**Only the same-volume verification is removed.** The cross-volume branch copies
real bytes and can genuinely corrupt them; its `sha256` check and its cleanup
are untouched. The two branches were answering the same question with the same
answer when only one of them had a reason to ask.

## Verification

`./build.sh --test` on macOS 26 (Darwin 25.6.0), Apple silicon: `TESTS OK (9493
checks)`, clean. Two checks drive `KillProcessSupport.descendants(of:parents:)`
from an explicit parent table — not from this machine's process list — covering
breadth-first order, a leaf, an unrelated branch, a self-parenting row and a
two-node cycle. Four more pin `WhatsAppDownloadSupport.isSameVolume`: equal
identifiers held by two different objects, two different identifiers, either or
both identities unknown, and two identities that print the same string while
being unequal.

Both sets were confirmed to fail before they were trusted. Replacing the
visited-set guard with a parent comparison turned the `descendants` checks red,
and they went green on revert; while doing that I found the separate self-parent
filter I had first written was dead — the visited set already covers it — so it
is gone rather than sitting there untested. For the volume checks I compiled the
real `WhatsAppDownloadSupport.swift` with `isEqual` swapped back to
`String(describing:) ==` and drove the same four assertions: the printed-alike
pair failed and the other three passed, and all four passed again with `isEqual`
restored. That last one is the check that pins the fix.

**What was not compiled here.** `KillProcessService.swift` and
`WhatsAppDownloadOrganizer.swift` are outside the `--test` whitelist, so the test
binary never builds them; CI covers them on both runners. The full `./build.sh`
was not run.

## Anything else

Nothing was exercised against a live system. I did not kill a real process tree,
so the claim that `ps -eo pid,ppid` yields the same descendants `pgrep -P` did is
read off the two implementations rather than compared on a running Mac, and I
have no before/after timing — the stalling figure is inferred from fork/exec
cost, not profiled. I did not move a real WhatsApp download, within a volume or
across two, so the same-volume claim still rests on rename semantics rather than
on an observed transfer.

What the removed hash actually protected against is worth stating, because it
sets what is now unverified. On a genuine same-volume move it could not fail: the
rename touches no bytes and the destination path is empty before it. Its only
real job was covering a wrong same-volume answer — a `moveItem` that quietly fell
back to copying across devices. That is exactly the case `isEqual` now decides,
so the remaining risk is not a bad comparison but a correct one on identifiers
the filesystem itself reports wrongly: two distinct volumes handing out one
identity, or a path whose volume changes between the two `resourceValues` reads.
Neither is checked, here or anywhere else in the app.

I did not verify what `String(describing:)` printed on volumes other than this
machine's. Locally the identifier arrives as `NSData` and its description is its
bytes, so the old comparison agreed with `isEqual` on APFS here — which is the
point: that agreement was a property of one class on one machine, not of the API.
