### PR TITLE
feat(monitor): add SSD temperature and all-sensors view

### DIFF
--- a/Sources/Vorssaint/Core/Localization.swift
+++ b/Sources/Vorssaint/Core/Localization.swift
@@ -181,6 +181,8 @@ struct Strings {
     let cpuLabel: String
     let gpuLabel: String
     let batteryLabel: String
+    let ssdLabel: String
+    let allSensorsLabel: String
     let usageSection: String
     let memorySection: String
     let memoryPressure: String
@@ -1204,6 +1206,8 @@ extension Strings {
         cpuLabel: "CPU",
         gpuLabel: "GPU",
         batteryLabel: "Bateria",
+        ssdLabel: "SSD",
+        allSensorsLabel: "Todos os sensores",
         usageSection: "Uso de hardware",
         memorySection: "Memória",
         memoryPressure: "Pressão",
@@ -2190,6 +2194,8 @@ extension Strings {
         cpuLabel: "CPU",
         gpuLabel: "GPU",
         batteryLabel: "Battery",
+        ssdLabel: "SSD",
+        allSensorsLabel: "All sensors",
         usageSection: "Hardware usage",
         memorySection: "Memory",
         memoryPressure: "Pressure",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
@@ -76,6 +76,8 @@ extension Strings {
         cpuLabel: "CPU",
         gpuLabel: "GPU",
         batteryLabel: "电池",
+        ssdLabel: "SSD",
+        allSensorsLabel: "所有传感器",
         usageSection: "硬件占用",
         memorySection: "内存",
         memoryPressure: "压力",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
@@ -76,6 +76,8 @@ extension Strings {
         cpuLabel: "CPU",
         gpuLabel: "GPU",
         batteryLabel: "電池",
+        ssdLabel: "SSD",
+        allSensorsLabel: "所有感應器",
         usageSection: "硬件使用量",
         memorySection: "記憶體",
         memoryPressure: "壓力",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
@@ -76,6 +76,8 @@ extension Strings {
         cpuLabel: "CPU",
         gpuLabel: "GPU",
         batteryLabel: "電池",
+        ssdLabel: "SSD",
+        allSensorsLabel: "所有感測器",
         usageSection: "硬體使用率",
         memorySection: "記憶體",
         memoryPressure: "壓力",

--- a/Sources/Vorssaint/Core/Localizations/Strings+French.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+French.swift
@@ -76,6 +76,8 @@ extension Strings {
         cpuLabel: "CPU",
         gpuLabel: "GPU",
         batteryLabel: "Batterie",
+        ssdLabel: "SSD",
+        allSensorsLabel: "Tous les capteurs",
         usageSection: "Utilisation du matériel",
         memorySection: "Mémoire",
         memoryPressure: "Pression",

--- a/Sources/Vorssaint/Core/Localizations/Strings+German.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+German.swift
@@ -76,6 +76,8 @@ extension Strings {
         cpuLabel: "CPU",
         gpuLabel: "GPU",
         batteryLabel: "Batterie",
+        ssdLabel: "SSD",
+        allSensorsLabel: "Alle Sensoren",
         usageSection: "Hardware-Auslastung",
         memorySection: "Speicher",
         memoryPressure: "Speicherdruck",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
@@ -76,6 +76,8 @@ extension Strings {
         cpuLabel: "CPU",
         gpuLabel: "GPU",
         batteryLabel: "Batteria",
+        ssdLabel: "SSD",
+        allSensorsLabel: "Tutti i sensori",
         usageSection: "Utilizzo hardware",
         memorySection: "Memoria",
         memoryPressure: "Pressione",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
@@ -76,6 +76,8 @@ extension Strings {
         cpuLabel: "CPU",
         gpuLabel: "GPU",
         batteryLabel: "バッテリー",
+        ssdLabel: "SSD",
+        allSensorsLabel: "全センサー",
         usageSection: "ハードウェア使用状況",
         memorySection: "メモリ",
         memoryPressure: "プレッシャー",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
@@ -76,6 +76,8 @@ extension Strings {
         cpuLabel: "CPU",
         gpuLabel: "GPU",
         batteryLabel: "배터리",
+        ssdLabel: "SSD",
+        allSensorsLabel: "모든 센서",
         usageSection: "하드웨어 사용량",
         memorySection: "메모리",
         memoryPressure: "압력",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
@@ -76,6 +76,8 @@ extension Strings {
         cpuLabel: "CPU",
         gpuLabel: "GPU",
         batteryLabel: "Батарея",
+        ssdLabel: "SSD",
+        allSensorsLabel: "Все датчики",
         usageSection: "Нагрузка",
         memorySection: "Память",
         memoryPressure: "Давление",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
@@ -76,6 +76,8 @@ extension Strings {
         cpuLabel: "CPU",
         gpuLabel: "GPU",
         batteryLabel: "Batería",
+        ssdLabel: "SSD",
+        allSensorsLabel: "Todos los sensores",
         usageSection: "Uso del hardware",
         memorySection: "Memoria",
         memoryPressure: "Presión",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
@@ -76,6 +76,8 @@ extension Strings {
         cpuLabel: "CPU",
         gpuLabel: "GPU",
         batteryLabel: "Pil",
+        ssdLabel: "SSD",
+        allSensorsLabel: "Tüm sensörler",
         usageSection: "Donanım kullanımı",
         memorySection: "Bellek",
         memoryPressure: "Basınç",

--- a/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
@@ -36,6 +36,10 @@ struct SystemSnapshot {
     /// The uptime timestamp of the last real battery sensor read. Cached values
     /// keep their original timestamp so they cannot age into a sustained alert.
     var batteryTemperatureReadAt: TimeInterval?
+    var ssdTemperature: Double?
+    /// All discovered temperature sensors (name + value), refreshed alongside
+    /// the other temperature readings. Empty when the full-sensor view is off.
+    var allTemperatures: [(name: String, value: Double)] = []
     var cpuUsage: Double?          // 0...1
     /// When `cpuUsage` was last really read, on the system uptime clock; the
     /// value is carried over failed reads, and the hot CPU alert has to tell
@@ -93,13 +97,16 @@ struct SystemMonitorPanelNeeds: Equatable {
     var cpuTemperature = false
     var gpuTemperature = false
     var batteryTemperature = false
+    var ssdTemperature = false
+    var allTemperatures = false
     var fanSpeed = false
 
     static let none = SystemMonitorPanelNeeds()
 
     var any: Bool {
         system || network || disk || power || cpu || gpu || memory || battery ||
-            peripheralBattery || cpuTemperature || gpuTemperature || batteryTemperature || fanSpeed
+            peripheralBattery || cpuTemperature || gpuTemperature || batteryTemperature ||
+            ssdTemperature || allTemperatures || fanSpeed
     }
 }
 
@@ -136,6 +143,8 @@ final class SystemMonitor: ObservableObject {
     private var fallbackCPUKeys: [SMCClient.Key] = []
     private var gpuKeys: [SMCClient.Key] = []
     private var batteryKeys: [SMCClient.Key] = []
+    private var ssdKeys: [SMCClient.Key] = []
+    private var otherTempKeys: [SMCClient.Key] = []
     private var fanKeys: [SMCClient.Key] = []
     private var tempKeysPrepared = false
     private var fanKeysPrepared = false
@@ -409,12 +418,15 @@ final class SystemMonitor: ObservableObject {
         var needCPUTemperature = false
         var needGPUTemperature = false
         var needBatteryTemperature = false
+        var needSSDTemperature = false
+        var needAllTemperatures = false
         var needFanSpeed = false
 
         var needSMC: Bool { needPower || needTemperature || needFanSpeed }
 
         var needTemperature: Bool {
             needCPUTemperature || needGPUTemperature || needBatteryTemperature
+                || needSSDTemperature || needAllTemperatures
         }
 
         var any: Bool {
@@ -478,6 +490,8 @@ final class SystemMonitor: ObservableObject {
             defaults.bool(forKey: DefaultsKey.menuBarGPUTemperature)
         plan.needBatteryTemperature = hasInternalBattery && (panelTemps || menuPanelNeeds.batteryTemperature ||
             defaults.bool(forKey: DefaultsKey.menuBarBatteryTemperature) || alertBatteryTemperature)
+        plan.needSSDTemperature = panelTemps || menuPanelNeeds.ssdTemperature
+        plan.needAllTemperatures = panelTemps || menuPanelNeeds.allTemperatures
         if defaults.bool(forKey: AppFeature.fanControl.availabilityKey),
            Self.fanTelemetryAvailable {
             plan.needFanSpeed = fullMonitorVisible || menuPanelNeeds.fanSpeed
@@ -772,6 +786,20 @@ final class SystemMonitor: ObservableObject {
                 }
                 next.batteryTemperatureReadAt = self.batteryTemperatureCache?.updatedAt
             }
+            if plan.needSSDTemperature || plan.needAllTemperatures {
+                if take(.temperature) {
+                    next.ssdTemperature = self.maxTemperature(of: self.ssdKeys)
+                }
+            }
+            if plan.needAllTemperatures {
+                if take(.temperature) {
+                    let allKeys = self.cpuKeys + self.gpuKeys + self.batteryKeys
+                        + self.ssdKeys + self.otherTempKeys
+                    next.allTemperatures = self.temperatureReadings(of: allKeys)
+                        .filter { $0.value > 1 && $0.value < 125 }
+                        .map { (name: $0.key, value: $0.value) }
+                }
+            }
             if plan.needFanSpeed {
                 if take(.fanSpeed) {
                     if let speeds = self.readFanSpeeds() {
@@ -902,6 +930,8 @@ final class SystemMonitor: ObservableObject {
             TemperatureSensorSelector.isCPUTemperatureKey(name, platform: cpuTemperaturePlatform)
                 || name.hasPrefix("Tg")
                 || name.range(of: "^TB[0-9]T$", options: .regularExpression) != nil
+                || name.hasPrefix("Ts")
+                || name.hasPrefix("TN")
         }
         cpuKeys = all.filter {
             TemperatureSensorSelector.isCPUTemperatureKey($0.name,
@@ -916,6 +946,9 @@ final class SystemMonitor: ObservableObject {
             : cpuKeys.filter { !preferredNames.contains($0.name) }
         gpuKeys = all.filter { $0.name.hasPrefix("Tg") }
         batteryKeys = all.filter { $0.name.hasPrefix("TB") }
+        ssdKeys = all.filter { $0.name.hasPrefix("Ts") || $0.name.hasPrefix("TN") }
+        let knownNames = Set(cpuKeys.map(\.name) + gpuKeys.map(\.name) + batteryKeys.map(\.name) + ssdKeys.map(\.name))
+        otherTempKeys = all.filter { !knownNames.contains($0.name) }
     }
 
     static let fanTelemetryCount: Int = {

--- a/Sources/Vorssaint/UI/MenuPanel/SystemSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/SystemSection.swift
@@ -270,10 +270,33 @@ struct SystemSection: View {
                         temperatureCell(icon: "battery.100", label: l10n.s.batteryLabel,
                                         value: monitor.snapshot.batteryTemperature)
                     }
+                    if monitor.snapshot.ssdTemperature != nil {
+                        temperatureCell(icon: "internaldrive", label: l10n.s.ssdLabel,
+                                        value: monitor.snapshot.ssdTemperature)
+                    }
+                }
+                if !monitor.snapshot.allTemperatures.isEmpty {
+                    DisclosureGroup(l10n.s.allSensorsLabel) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            ForEach(monitor.snapshot.allTemperatures.sorted(by: { $0.value > $1.value }), id: \.name) { sensor in
+                                HStack {
+                                    Text(sensor.name)
+                                        .font(.system(size: 10, design: .monospaced))
+                                        .foregroundStyle(.secondary)
+                                    Spacer()
+                                    Text(MetricFormat.temperature(sensor.value, unit: displayTemperatureUnit))
+                                        .font(.system(size: 10, design: .monospaced))
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                    .font(.system(size: 10))
                 }
                 if monitor.snapshot.cpuTemperature == nil,
                    monitor.snapshot.gpuTemperature == nil,
-                   monitor.snapshot.batteryTemperature == nil {
+                   monitor.snapshot.batteryTemperature == nil,
+                   monitor.snapshot.ssdTemperature == nil {
                     Text(l10n.s.monitorUnavailable)
                         .font(.system(size: 10))
                         .foregroundStyle(.tertiary)


### PR DESCRIPTION
## What

Extend the System Monitor temperature section to discover SSD (Ts*/TN*) and all remaining SMC temperature sensors. Add an SSD temperature cell and a collapsible "All sensors" list to the System panel.

## Why

The current implementation only reads CPU (Tp/Te), GPU (Tg), and battery (TB) temperature keys. Many Macs expose additional sensors (SSD, platform controller, etc.) that are useful for thermal monitoring but invisible in the UI.

## Changes

- **SystemSnapshot**: add `ssdTemperature` and `allTemperatures` fields
- **SystemMonitorPanelNeeds**: add `ssdTemperature` / `allTemperatures` visibility flags
- **SamplingPlan**: add `needSSDTemperature` / `needAllTemperatures`
- **prepareSensorsIfNeeded()**: extend SMC key filter to include `Ts*` and `TN*` prefixes
- **refresh()**: read SSD temperature and collect all sensor readings when enabled
- **SystemSection**: add SSD temperature cell alongside CPU/GPU/Battery, plus a DisclosureGroup listing all discovered sensors sorted by temperature
- **Localization**: add `ssdLabel` and `allSensorsLabel` in all 13 languages

## Verification

- `./build.sh` compiles cleanly (release, no warnings)
- `./build/Vorssaint --selftest` → SELFTEST OK
- 14 files changed, 86 insertions, 2 deletions

## Notes

- SSD sensors show only when the hardware exposes them (nil = hidden, matching existing CPU/GPU/Battery behavior)
- The all-sensors view is gated behind a DisclosureGroup to avoid clutter
- No new dependencies; no changes to SMCClient, FanControl, or build system