### PR TITLE
feat(utilities): add port manager

### DIFF
--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -566,6 +566,7 @@ enum DefaultsKey {
     static let recorderEditorPresets = "recorderEditorPresets"
     static let recorderSharingEnabled = "recorderSharingEnabled"
     static let panelUtilityScreenRecorder = "panelUtilityScreenRecorder"
+    static let panelUtilityPortManager = "panelUtilityPortManager"
 
     // Window Layout — snapping, global shortcuts and optional pointer gestures.
     static let windowLayoutShortcutsEnabled = "windowLayoutShortcutsEnabled"

--- a/Sources/Vorssaint/Core/PortManagerStrings.swift
+++ b/Sources/Vorssaint/Core/PortManagerStrings.swift
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+struct PortManagerFeatureStrings {
+    let title: String
+    let filter: String
+    let openFormat: String
+    let empty: String
+    let emptyHint: String
+    let listeningCaption: String
+    let kill: String
+    let forceKill: String
+    let refresh: String
+    let back: String
+    let terminateFormat: String
+    let terminateMessageFormat: String
+}
+
+extension FeatureStrings {
+    static func portManager(_ language: AppLanguage) -> PortManagerFeatureStrings {
+        switch language {
+        case .enUS: return .enUS
+        case .ptBR: return .ptBR
+        case .tr: return .tr
+        case .ru: return .ru
+        case .es: return .es
+        case .de: return .de
+        case .fr: return .fr
+        case .it: return .it
+        case .ja: return .ja
+        case .ko: return .ko
+        case .zhHans: return .zhHans
+        case .zhTW: return .zhTW
+        case .zhHK: return .zhHK
+        }
+    }
+}
+
+extension PortManagerFeatureStrings {
+    static let enUS = PortManagerFeatureStrings(title: "Port Manager", filter: "Filter by port, process, or PID", openFormat: "%d open", empty: "No listening ports found", emptyHint: "Try refreshing or changing your search.", listeningCaption: "Listening ports", kill: "Kill", forceKill: "Force Kill", refresh: "Refresh", back: "Back", terminateFormat: "Terminate %@?", terminateMessageFormat: "This closes port %d by terminating PID %d.")
+    static let ptBR = PortManagerFeatureStrings(title: "Gerenciador de portas", filter: "Filtrar por porta, processo ou PID", openFormat: "%d abertas", empty: "Nenhuma porta de escuta encontrada", emptyHint: "Atualize ou altere a busca.", listeningCaption: "Portas de escuta", kill: "Encerrar", forceKill: "Forçar encerramento", refresh: "Atualizar", back: "Voltar", terminateFormat: "Encerrar %@?", terminateMessageFormat: "Isso fecha a porta %d encerrando o PID %d.")
+    static let tr = PortManagerFeatureStrings(title: "Port Yöneticisi", filter: "Port, işlem veya PID ile filtrele", openFormat: "%d açık", empty: "Dinleyen port bulunamadı", emptyHint: "Yenilemeyi veya aramanızı değiştirmeyi deneyin.", listeningCaption: "Dinleyen portlar", kill: "Sonlandır", forceKill: "Zorla sonlandır", refresh: "Yenile", back: "Geri", terminateFormat: "%@ sonlandırılsın mı?", terminateMessageFormat: "Bu işlem PID %d sonlandırılarak %d portunu kapatır.")
+    static let ru = PortManagerFeatureStrings(title: "Диспетчер портов", filter: "Фильтр по порту, процессу или PID", openFormat: "%d открыто", empty: "Прослушиваемые порты не найдены", emptyHint: "Обновите список или измените поиск.", listeningCaption: "Прослушиваемые порты", kill: "Завершить", forceKill: "Завершить принудительно", refresh: "Обновить", back: "Назад", terminateFormat: "Завершить %@?", terminateMessageFormat: "Порт %d будет закрыт завершением PID %d.")
+    static let es = PortManagerFeatureStrings(title: "Gestor de puertos", filter: "Filtrar por puerto, proceso o PID", openFormat: "%d abiertos", empty: "No se encontraron puertos de escucha", emptyHint: "Actualiza o cambia la búsqueda.", listeningCaption: "Puertos de escucha", kill: "Cerrar", forceKill: "Forzar cierre", refresh: "Actualizar", back: "Atrás", terminateFormat: "¿Cerrar %@?", terminateMessageFormat: "Esto cierra el puerto %d terminando el PID %d.")
+    static let de = PortManagerFeatureStrings(title: "Portverwaltung", filter: "Nach Port, Prozess oder PID filtern", openFormat: "%d offen", empty: "Keine lauschenden Ports gefunden", emptyHint: "Aktualisiere die Liste oder ändere die Suche.", listeningCaption: "Lauschende Ports", kill: "Beenden", forceKill: "Sofort beenden", refresh: "Aktualisieren", back: "Zurück", terminateFormat: "%@ beenden?", terminateMessageFormat: "Port %d wird durch Beenden von PID %d geschlossen.")
+    static let fr = PortManagerFeatureStrings(title: "Gestionnaire de ports", filter: "Filtrer par port, processus ou PID", openFormat: "%d ouverts", empty: "Aucun port en écoute trouvé", emptyHint: "Actualisez ou modifiez votre recherche.", listeningCaption: "Ports en écoute", kill: "Quitter", forceKill: "Forcer l’arrêt", refresh: "Actualiser", back: "Retour", terminateFormat: "Arrêter %@ ?", terminateMessageFormat: "Le port %d sera fermé en arrêtant le PID %d.")
+    static let it = PortManagerFeatureStrings(title: "Gestore porte", filter: "Filtra per porta, processo o PID", openFormat: "%d aperte", empty: "Nessuna porta in ascolto trovata", emptyHint: "Aggiorna o modifica la ricerca.", listeningCaption: "Porte in ascolto", kill: "Termina", forceKill: "Termina forzatamente", refresh: "Aggiorna", back: "Indietro", terminateFormat: "Terminare %@?", terminateMessageFormat: "La porta %d verrà chiusa terminando il PID %d.")
+    static let ja = PortManagerFeatureStrings(title: "ポートマネージャー", filter: "ポート、プロセス、PIDで絞り込む", openFormat: "%d 個が開いています", empty: "待ち受けポートがありません", emptyHint: "更新するか検索条件を変更してください。", listeningCaption: "待ち受けポート", kill: "終了", forceKill: "強制終了", refresh: "更新", back: "戻る", terminateFormat: "%@を終了しますか？", terminateMessageFormat: "PID %dを終了してポート%dを閉じます。")
+    static let ko = PortManagerFeatureStrings(title: "포트 관리자", filter: "포트, 프로세스 또는 PID로 필터링", openFormat: "%d개 열림", empty: "수신 대기 중인 포트가 없습니다", emptyHint: "새로 고치거나 검색어를 변경해 보세요.", listeningCaption: "수신 대기 포트", kill: "종료", forceKill: "강제 종료", refresh: "새로 고침", back: "뒤로", terminateFormat: "%@을(를) 종료할까요?", terminateMessageFormat: "PID %d을(를) 종료하여 포트 %d을(를) 닫습니다.")
+    static let zhHans = PortManagerFeatureStrings(title: "端口管理器", filter: "按端口、进程或 PID 筛选", openFormat: "%d 个开放", empty: "未找到监听端口", emptyHint: "尝试刷新或更改搜索条件。", listeningCaption: "监听端口", kill: "终止", forceKill: "强制终止", refresh: "刷新", back: "返回", terminateFormat: "要终止 %@ 吗？", terminateMessageFormat: "终止 PID %d 将关闭端口 %d。")
+    static let zhTW = PortManagerFeatureStrings(title: "連接埠管理器", filter: "依連接埠、程序或 PID 篩選", openFormat: "%d 個開啟", empty: "找不到監聽中的連接埠", emptyHint: "請嘗試重新整理或變更搜尋條件。", listeningCaption: "監聽中的連接埠", kill: "結束", forceKill: "強制結束", refresh: "重新整理", back: "返回", terminateFormat: "要結束 %@ 嗎？", terminateMessageFormat: "結束 PID %d 將關閉連接埠 %d。")
+    static let zhHK = PortManagerFeatureStrings(title: "連接埠管理員", filter: "按連接埠、程序或 PID 篩選", openFormat: "%d 個開啟", empty: "找不到監聽中的連接埠", emptyHint: "請嘗試重新整理或更改搜尋條件。", listeningCaption: "監聽中的連接埠", kill: "結束", forceKill: "強制結束", refresh: "重新整理", back: "返回", terminateFormat: "要結束 %@ 嗎？", terminateMessageFormat: "結束 PID %d 會關閉連接埠 %d。")
+}

--- a/Sources/Vorssaint/Services/PortManager/PortManagerService.swift
+++ b/Sources/Vorssaint/Services/PortManager/PortManagerService.swift
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+import Darwin
+
+struct PortManagerEntry: Identifiable, Equatable {
+    let port: Int
+    let protocolName: String
+    let address: String
+    let pid: Int32
+    let processName: String
+    var id: String { "\(protocolName)-\(port)-\(pid)-\(address)" }
+}
+
+final class PortManagerService: ObservableObject {
+    static let shared = PortManagerService()
+    @Published private(set) var entries: [PortManagerEntry] = []
+    @Published var query = ""
+    @Published private(set) var isRefreshing = false
+
+    var filteredEntries: [PortManagerEntry] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return entries }
+        return entries.filter { "\($0.port) \($0.processName) \($0.pid) \($0.address)".lowercased().contains(q) }
+    }
+
+    func refresh() {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            let result = Self.snapshot()
+            DispatchQueue.main.async {
+                self.entries = result
+                self.isRefreshing = false
+            }
+        }
+    }
+
+    func terminate(_ entry: PortManagerEntry, force: Bool) {
+        guard entry.pid > 1, entry.pid != Int32(ProcessInfo.processInfo.processIdentifier) else { return }
+        _ = Darwin.kill(entry.pid, force ? SIGKILL : SIGTERM)
+        refresh()
+    }
+
+    private static func snapshot() -> [PortManagerEntry] {
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
+        process.arguments = ["-nP", "-iTCP", "-sTCP:LISTEN", "-F", "pcnPT"]
+        process.standardOutput = output
+        try? process.run()
+        process.waitUntilExit()
+        let text = String(data: output.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        var name = "", pid: Int32 = 0, address = "", port = 0, proto = "TCP"
+        var rows: [PortManagerEntry] = []
+        for line in text.split(separator: "\n").map(String.init) {
+            guard let type = line.first else { continue }
+            let value = String(line.dropFirst())
+            switch type {
+            case "p":
+                if pid > 0 && port > 0 { rows.append(.init(port: port, protocolName: proto, address: address, pid: pid, processName: name)) }
+                pid = Int32(value) ?? 0; port = 0; address = ""
+            case "c": name = value
+            case "P": proto = value
+            case "n":
+                address = value
+                if let last = value.split(separator: ":").last, let parsed = Int(last) { port = parsed }
+            case "T": continue
+            default: continue
+            }
+        }
+        if pid > 0 && port > 0 { rows.append(.init(port: port, protocolName: proto, address: address, pid: pid, processName: name)) }
+        return rows.sorted { $0.port == $1.port ? $0.processName < $1.processName : $0.port < $1.port }
+    }
+}

--- a/Sources/Vorssaint/UI/KillProcess/PortManagerView.swift
+++ b/Sources/Vorssaint/UI/KillProcess/PortManagerView.swift
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import SwiftUI
+
+struct PortManagerView: View {
+    var onClose: (() -> Void)? = nil
+    @ObservedObject private var service = PortManagerService.shared
+    @State private var pending: PortManagerEntry?
+    @State private var force = false
+    @ObservedObject private var l10n = L10n.shared
+
+    private var strings: PortManagerFeatureStrings { FeatureStrings.portManager(l10n.language) }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 9) {
+                if let onClose {
+                    Button(action: onClose) {
+                        Image(systemName: "chevron.backward.circle.fill")
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(strings.back)
+                }
+                Image(systemName: "network")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+                Text(strings.title).font(.headline)
+                Spacer()
+                Text(String(format: strings.openFormat, service.filteredEntries.count))
+                    .font(.system(size: 11, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 8).padding(.vertical, 5)
+                    .background(Color.primary.opacity(0.07), in: Capsule())
+                Button { service.refresh() } label: { Image(systemName: "arrow.clockwise") }
+                    .buttonStyle(.plain).help(strings.refresh)
+            }
+            .padding(.horizontal, 14).padding(.top, 10).padding(.bottom, 8)
+            HStack(spacing: 8) { Image(systemName: "magnifyingglass").foregroundStyle(.secondary); TextField(strings.filter, text: $service.query).textFieldStyle(.plain) }
+                .padding(9).background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 9))
+                .padding(.horizontal, 14).padding(.bottom, 8)
+            Divider()
+            if service.filteredEntries.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "network.slash").font(.system(size: 25)).foregroundStyle(.tertiary)
+                    Text(strings.empty).font(.callout).foregroundStyle(.secondary)
+                    Text(strings.emptyHint).font(.caption).foregroundStyle(.tertiary)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView(showsIndicators: false) {
+                    LazyVStack(spacing: 8) {
+                        ForEach(service.filteredEntries) { entry in
+                            portRow(entry)
+                        }
+                    }
+                    .padding(.horizontal, 14).padding(.vertical, 7)
+                }
+                .frame(height: 245)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onAppear { service.refresh() }
+        .alert(pending.map { String(format: strings.terminateFormat, $0.processName) } ?? "",
+               isPresented: Binding(get: { pending != nil }, set: { if !$0 { pending = nil } })) {
+            Button(l10n.s.uninstallerCancel, role: .cancel) { pending = nil }
+            Button(force ? strings.forceKill : strings.kill, role: .destructive) {
+                if let pending { service.terminate(pending, force: force) }
+                pending = nil
+            }
+        } message: {
+            Text(String(format: strings.terminateMessageFormat,
+                        pending?.port ?? 0, pending?.pid ?? 0))
+        }
+    }
+
+    private func portRow(_ entry: PortManagerEntry) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "network")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 1) {
+                HStack(spacing: 7) {
+                    Text("\(entry.port)")
+                        .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                    Text(entry.protocolName)
+                        .font(.system(size: 9, weight: .bold, design: .rounded))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 5).padding(.vertical, 2)
+                        .background(Color.primary.opacity(0.08), in: Capsule())
+                }
+                Text(entry.processName)
+                    .font(.system(size: 11))
+                    .lineLimit(1)
+                Text("PID \(entry.pid)  •  \(entry.address)")
+                    .font(.system(size: 9, design: .monospaced))
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: 4)
+            HStack(spacing: 6) {
+                Button(strings.kill) { force = false; pending = entry }
+                    .buttonStyle(.bordered).controlSize(.small)
+                Button { force = true; pending = entry } label: { Image(systemName: "bolt.fill") }
+                    .buttonStyle(.bordered).controlSize(.small)
+                    .accessibilityLabel(strings.forceKill)
+            }
+        }
+        .padding(.vertical, 3)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(Color.primary.opacity(0.08)).frame(height: 1)
+        }
+    }
+}

--- a/Sources/Vorssaint/UI/MenuPanel/MenuPanelView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/MenuPanelView.swift
@@ -500,7 +500,7 @@ private enum UtilityPanelItem: String, PanelOrderItem, Identifiable {
     // are migrated once without disturbing the rest of the user's layout.
     case screenshot, quickLauncher, appUpdates, cleaner, homebrew, media, clipboard, windowLayout,
          uninstaller, cleanURL, cleaning, screenOCR, colorPicker, cameraPreview, scratchpad,
-         commandBar, screenRecorder
+         commandBar, screenRecorder, portManager
 
     var id: String { rawValue }
 
@@ -525,6 +525,7 @@ private enum UtilityPanelItem: String, PanelOrderItem, Identifiable {
         case .cameraPreview: return .cameraPreview
         case .scratchpad: return .scratchpad
         case .commandBar: return .commandBar
+        case .portManager: return .killProcess
         }
     }
 }
@@ -542,6 +543,7 @@ struct UtilitiesSection: View {
     @State private var showClipboardPanel = false
     @State private var showRecentCapturesPanel = false
     @State private var showWindowLayoutPanel = false
+    @State private var showPortManagerPanel = false
     @AppStorage(DefaultsKey.panelUtilityCleaning) private var showCleaning = true
     @AppStorage(DefaultsKey.panelUtilityURLCleaner) private var showCleanURL = true
     @AppStorage(DefaultsKey.panelUtilityUninstaller) private var showUninstallerAction = true
@@ -559,6 +561,7 @@ struct UtilitiesSection: View {
     @AppStorage(DefaultsKey.panelUtilityScratchpad) private var showScratchpad = true
     @AppStorage(DefaultsKey.panelUtilityCommandBar) private var showCommandBar = true
     @AppStorage(DefaultsKey.panelUtilityScreenRecorder) private var showScreenRecorder = true
+    @AppStorage(DefaultsKey.panelUtilityPortManager) private var showPortManager = true
     @ObservedObject private var recorder = ScreenRecorderService.shared
     @AppStorage(DefaultsKey.clipboardHistoryEnabled) private var clipboardEnabled = false
     @AppStorage(DefaultsKey.panelUtilityOrder) private var utilityOrderRaw = ""
@@ -612,6 +615,11 @@ struct UtilitiesSection: View {
                     PanelInteractionState.shared.viewKeepsPopoverOpen = false
                     showAppUpdatesPanel = false
                 }
+            } else if showPortManagerPanel {
+                PortManagerView {
+                    PanelInteractionState.shared.viewKeepsPopoverOpen = false
+                    showPortManagerPanel = false
+                }
             } else {
                 VStack(alignment: .leading, spacing: 8) {
                     ForEach(items(editing: editing)) { item in
@@ -653,6 +661,7 @@ struct UtilitiesSection: View {
         if showRecentCapturesPanel { return .screenshot }
         if showWindowLayoutPanel { return .windowLayout }
         if showAppUpdatesPanel { return .appUpdates }
+        if showPortManagerPanel { return .portManager }
         return nil
     }
 
@@ -662,7 +671,7 @@ struct UtilitiesSection: View {
     private var isHostingUtility: Bool {
         showUninstaller || showCleanerPanel || showURLCleaner || showHomebrewPanel
             || showMediaPanel || showClipboardPanel || showRecentCapturesPanel
-            || showWindowLayoutPanel || showAppUpdatesPanel
+            || showWindowLayoutPanel || showAppUpdatesPanel || showPortManagerPanel
     }
 
     /// Homebrew browsing behaves like an ordinary popover. Other hosted tools
@@ -695,7 +704,7 @@ struct UtilitiesSection: View {
     }
 
     private func items(editing: Bool) -> [UtilityPanelItem] {
-        orderedItems.filter { $0.feature.isAvailable && (editing || isVisible($0)) }
+        orderedItems.filter { ($0 == .portManager || $0.feature.isAvailable) && (editing || isVisible($0)) }
     }
 
     private func isVisible(_ item: UtilityPanelItem) -> Bool {
@@ -717,6 +726,7 @@ struct UtilitiesSection: View {
         case .quickLauncher: return showQuickLauncher
         case .screenshot: return showScreenshot
         case .screenRecorder: return showScreenRecorder
+        case .portManager: return showPortManager
         }
     }
 
@@ -951,6 +961,14 @@ struct UtilitiesSection: View {
                                         CommandBarService.shared.show()
                                     }
                                 })
+        case .portManager:
+            UtilityActionButton(title: FeatureStrings.portManager(l10n.language).title,
+                                caption: FeatureStrings.portManager(l10n.language).listeningCaption,
+                                systemImage: "network",
+                                isEditing: editing,
+                                showsDragHandle: true,
+                                visibility: $showPortManager,
+                                action: { showPortManagerPanel = true })
         }
     }
 
@@ -1027,6 +1045,7 @@ struct UtilitiesSection: View {
         showScratchpad = true
         showQuickLauncher = true
         showCommandBar = true
+        showPortManager = true
     }
 
     private func grantAccessibility() {

--- a/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
@@ -8,7 +8,7 @@ import Foundation
 /// below and the unit tests can reason about pages without pulling UI in.
 enum SettingsPage: Hashable {
     case general, features, energy, monitor
-    case mouse, switcher, keyDebounce, superKey, cutPaste, autoQuit, quitProtection, cleaner, uninstaller, urlCleaner, homebrew, appUpdates, media, clipboard, windowLayout, shelf, quickTools, textSnippets, screenshot, radialMenu, commandBar, killProcess
+    case mouse, switcher, keyDebounce, superKey, cutPaste, autoQuit, quitProtection, cleaner, uninstaller, urlCleaner, homebrew, appUpdates, media, clipboard, windowLayout, shelf, quickTools, textSnippets, screenshot, radialMenu, commandBar, killProcess, portManager
     case shortcuts, advanced, about, releaseNotes, support
 }
 
@@ -285,6 +285,7 @@ enum FeatureVisibilitySupport {
         case .appUpdates: return [.appUpdates]
         case .uninstaller: return [.uninstaller]
         case .killProcess: return [.killProcess]
+        case .portManager: return []
         case .keyDebounce: return [.keyboardDebounce]
         case .superKey: return [.superKey]
         case .textSnippets: return [.textSnippets]

--- a/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
@@ -207,6 +207,10 @@ enum SettingsDirectory {
                                       title: FeatureStrings.killProcess(language).pageTitle,
                                       icon: "xmark.octagon",
                                       keywords: ["force quit", "process", "cpu", "memory", "kill"]),
+                SettingsDirectoryItem(page: .portManager,
+                                      title: FeatureStrings.portManager(language).title,
+                                      icon: "network",
+                                      keywords: ["port", "ports", "listening", "socket", "PID", "kill port"]),
             ]),
             (categories.utilities, [
                 SettingsDirectoryItem(page: .commandBar,

--- a/Sources/Vorssaint/UI/Settings/SettingsView.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsView.swift
@@ -361,6 +361,7 @@ struct SettingsView: View {
         case .quitProtection: QuitProtectionSettings()
         case .uninstaller: UninstallerView()
         case .killProcess: KillProcessView()
+        case .portManager: PortManagerView()
         case .urlCleaner: URLCleanerSettings()
         case .cleaner: CleanerSettings()
         case .homebrew: HomebrewSettings()


### PR DESCRIPTION
## Summary

Adds a compact Port Manager utility for viewing TCP listening ports and the
processes using them.

Users can:

- View listening ports, protocols, addresses, processes, and PIDs
- Search by port, process, PID, or address
- Refresh the port list
- Gracefully terminate a process
- Force terminate a process after confirmation

The feature uses macOS's built-in `lsof` command and Darwin process signals,
with no runtime dependencies or external services. It is available both from
the Utilities panel and Settings.

## Verification

Tested on a MacBook Air with Apple M4 running macOS 26.6.1, build 25G76.

- Built the developer app successfully
- Ran the app and verified Port Manager behavior
- Verified port listing and filtering
- Verified normal and force-kill confirmation flows
- Verified the compact scrollable UI
- `SELFTEST OK`
- `git diff --check` passes

