### PR TITLE
refactor(switcher): move the session state machine out of the event tap

### DIFF
--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -8,28 +8,6 @@ import Combine
 import CoreGraphics
 import SwiftUI
 
-private struct SwitcherSourceContext {
-    let itemID: String?
-    let pid: pid_t
-    let windowID: CGWindowID?
-    let windowOwnerPID: pid_t?
-    let isFullscreen: Bool
-    /// Window server bounds of the source window; `.zero` for an app-only entry.
-    let frame: CGRect
-}
-
-/// A shortcut press already owned by the switcher while the window list is
-/// being assembled. The tap thread can cancel or add repeated navigation
-/// without ever waiting for the main thread or Accessibility.
-private struct SwitcherPendingSessionStart {
-    let generation: UInt64
-    let shortcut: GlobalShortcut
-    let scope: SwitcherSessionScope
-    let reversed: Bool
-    var additionalNavigation = 0
-    var commitWhenReady = false
-}
-
 /// The window switcher: a global event tap takes over the configured shortcut,
 /// and while its modifiers are held a non-activating panel cycles through real
 /// windows. Releasing commits, middle-clicking a card or pressing W closes the
@@ -38,6 +16,13 @@ private struct SwitcherPendingSessionStart {
 /// needs the modifier held). Esc and a click outside cancel. The panel joins
 /// every Space and fullscreen app, so the switcher is available wherever the
 /// user is.
+///
+/// What a session *is* lives in `SwitcherSession`; this class is the adapter
+/// around it. It owns the event tap, the panel and the observers, turns real
+/// input into session events, and performs the effects the session hands back.
+/// The `@Published` properties below are the session's state projected for
+/// SwiftUI: they are written only while performing an effect, never as a
+/// decision of their own.
 final class AppSwitcher: ObservableObject {
     static let shared = AppSwitcher()
 
@@ -59,23 +44,22 @@ final class AppSwitcher: ObservableObject {
     /// index by one when the pointer parks on the last visible icon.
     @Published private(set) var iconRowFirstVisibleIndex = 0
     @Published private(set) var searchQuery = ""
-    /// True once S pinned the search field open. While set, releasing the
-    /// session's modifier no longer commits — search text can then be typed
-    /// with no modifier held, so a letter never comes out as the modifier's
-    /// special character (⌥ on its own types symbols on layouts like US,
-    /// e.g. ⌥S types "ß").
     @Published private(set) var isSearchPinned = false
     @Published private(set) var totalWindowCount = 0
+    @Published private(set) var sessionScope: SwitcherSessionScope = .allApps
 
-    /// Single source of truth for "a session is open": the stored value lives
-    /// under `routeLock` because the tap thread routes every keystroke by it.
-    /// Written only on the main thread.
+    /// The session state machine. Main thread only.
+    private var session = SwitcherSession()
+
+    /// Whether a session is open, as the tap thread sees it: the stored value
+    /// lives under `routeLock` because the tap routes every keystroke by it.
+    /// `session.isActive` is the authority; this is its cross-thread copy, and
+    /// both are written on the main thread in the same breath.
     private var sessionActive: Bool {
         get { routeLock.withLock { routeSessionActive } }
         set { routeLock.withLock { routeSessionActive = newValue } }
     }
     private var panel: NSPanel?
-    private var sessionItems: [SwitcherItem] = []
 
     // The tap lives on a dedicated thread: an active keyDown tap makes the
     // window server hold every keystroke in the login session until this
@@ -103,16 +87,13 @@ final class AppSwitcher: ObservableObject {
     private var routeWindowShortcut = GlobalShortcut.switcherWindowDefault
     private var routeCapturing = false
     private var routeCanStartSession = false
-    private var routePendingSessionStart: SwitcherPendingSessionStart?
-    private var sessionStartGeneration: UInt64 = 0
+    private var routePending = SwitcherPendingStarts()
 
     /// Enumeration touches every regular app through Accessibility, so it runs
     /// away from the event tap on one serial queue.
     private let enumerationQueue = DispatchQueue(label: "com.vorssaint.switcher.enumeration",
                                                   qos: .userInitiated)
     private var pendingShow: DispatchWorkItem?
-    /// True once the user moved the selection themselves.
-    private var userNavigated = false
     /// Mouse position when the panel appeared; hover is inert until it moves.
     private var hoverAnchor: NSPoint?
     /// The card currently under the pointer. Kept separate from selection so
@@ -122,28 +103,6 @@ final class AppSwitcher: ObservableObject {
     /// Fires while the pointer stays on the last visible overflow icon.
     private var iconRowEdgeHoverWork: DispatchWorkItem?
     private var iconRowEdgeHoverIndex: Int?
-
-    /// The on-screen window when the current session opened — becomes the
-    /// second-most-recent window on commit, so a flick toggles straight back.
-    /// Cleared if that window is closed during the session: a window the user
-    /// just got rid of is not somewhere to send them back to.
-    private var sessionStartWindowID: CGWindowID?
-    private var sessionSourceContext: SwitcherSourceContext?
-    private var sessionShortcut: GlobalShortcut?
-    @Published private(set) var sessionScope: SwitcherSessionScope = .allApps
-    private var shiftBackNavigationHeld = false
-    /// Pressing Shift mid-session already steps back once, so the Tab landing
-    /// in that same physical chord must not step again — but later Tabs during
-    /// the same Shift hold must keep walking the list (issue #784). The chord
-    /// is recognized by time: anything after this deadline is a deliberate
-    /// separate press.
-    private var shiftBackChordDeadline: TimeInterval = 0
-
-    /// Windows already asked to close, still listed until they are really
-    /// gone. Releasing the shortcut skips them, so they are never raised on
-    /// the way out.
-    private var closingItemIDs: Set<String> = []
-    private var commitPendingForClose = false
 
     // Virtual key codes handled during a session.
     private enum KeyCode {
@@ -230,7 +189,7 @@ final class AppSwitcher: ObservableObject {
         routeLock.withLock {
             routeCapturing = capturing
             if capturing {
-                routePendingSessionStart = nil
+                routePending.clear()
             }
         }
     }
@@ -322,7 +281,7 @@ final class AppSwitcher: ObservableObject {
 
     private func removeTap() {
         if sessionActive { cancelSession() }
-        routeLock.withLock { routePendingSessionStart = nil }
+        routeLock.withLock { routePending.clear() }
         let snapshot = lifecycleLock.withLock {
             () -> (runLoop: CFRunLoop?, tap: CFMachPort?, threadExists: Bool) in
             shouldStopTapThread = true
@@ -456,7 +415,7 @@ final class AppSwitcher: ObservableObject {
             // Never resurrect a tap that removeTap is already tearing down.
             let currentTap = lifecycleLock.withLock { shouldStopTapThread ? nil : tap }
             if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
-            routeLock.withLock { routePendingSessionStart = nil }
+            routeLock.withLock { routePending.clear() }
             DispatchQueue.main.async { [weak self] in
                 guard let self, self.sessionActive else { return }
                 self.cancelSession()
@@ -466,7 +425,7 @@ final class AppSwitcher: ObservableObject {
 
         let (active, shortcut, windowShortcut, capturing, canStartSession, hasPendingStart) = routeLock.withLock {
             (routeSessionActive, routeShortcut, routeWindowShortcut, routeCapturing,
-             routeCanStartSession, routePendingSessionStart != nil)
+             routeCanStartSession, routePending.isPending)
         }
         // A shortcut field in Settings has the keyboard: hand every key
         // straight through so the user can record this feature's own
@@ -477,12 +436,11 @@ final class AppSwitcher: ObservableObject {
             if type == .flagsChanged {
                 let stillInactive = routeLock.withLock { () -> Bool in
                     guard !routeSessionActive else { return false }
-                    if var pending = routePendingSessionStart,
+                    if let pending = routePending.current,
                        !pending.shortcut.requiredModifiersHeld(in: event.flags) {
                         // A quick flick still commits once enumeration finishes,
                         // but can never flash a panel after the key was released.
-                        pending.commitWhenReady = true
-                        routePendingSessionStart = pending
+                        routePending.noteShortcutModifiersReleased()
                     }
                     return true
                 }
@@ -496,7 +454,7 @@ final class AppSwitcher: ObservableObject {
             if type == .leftMouseDown || type == .rightMouseDown || type == .otherMouseDown || type == .otherMouseUp {
                 let stillInactive = routeLock.withLock { () -> Bool in
                     guard !routeSessionActive else { return false }
-                    routePendingSessionStart = nil
+                    routePending.clear()
                     return true
                 }
                 if stillInactive { return Unmanaged.passUnretained(event) }
@@ -518,12 +476,12 @@ final class AppSwitcher: ObservableObject {
             let pendingKeyDecision = routeLock.withLock { () -> SwitcherPendingKeyDecision in
                 let decision = SwitcherSupport.pendingKeyDecision(
                     sessionIsActive: routeSessionActive,
-                    hasPendingStart: routePendingSessionStart != nil,
-                    commitWhenReady: routePendingSessionStart?.commitWhenReady ?? false,
+                    hasPendingStart: routePending.isPending,
+                    commitWhenReady: routePending.current?.commitWhenReady ?? false,
                     matchesShortcut: matchesShortcut
                 )
                 if decision == .cancelAndSwallow {
-                    routePendingSessionStart = nil
+                    routePending.clear()
                 }
                 return decision
             }
@@ -552,35 +510,9 @@ final class AppSwitcher: ObservableObject {
                 var generationToSchedule: UInt64?
                 let claimedWhileInactive = routeLock.withLock { () -> Bool in
                     guard !routeSessionActive else { return false }
-                    if var pending = routePendingSessionStart {
-                        if pending.commitWhenReady {
-                            sessionStartGeneration &+= 1
-                            let generation = sessionStartGeneration
-                            routePendingSessionStart = SwitcherPendingSessionStart(
-                                generation: generation,
-                                shortcut: requestedShortcut,
-                                scope: requestedScope,
-                                reversed: reversed
-                            )
-                            generationToSchedule = generation
-                            return true
-                        }
-                        if pending.scope == requestedScope {
-                            let next = pending.additionalNavigation + (reversed ? -1 : 1)
-                            pending.additionalNavigation = max(-64, min(64, next))
-                            routePendingSessionStart = pending
-                        }
-                        return true
-                    }
-                    sessionStartGeneration &+= 1
-                    let generation = sessionStartGeneration
-                    routePendingSessionStart = SwitcherPendingSessionStart(
-                        generation: generation,
-                        shortcut: requestedShortcut,
-                        scope: requestedScope,
-                        reversed: reversed
-                    )
-                    generationToSchedule = generation
+                    generationToSchedule = routePending.claim(shortcut: requestedShortcut,
+                                                              scope: requestedScope,
+                                                              reversed: reversed)
                     return true
                 }
                 if claimedWhileInactive {
@@ -616,17 +548,18 @@ final class AppSwitcher: ObservableObject {
 
         switch type {
         case .keyDown:
-            return handleKeyDown(event)
+            let swallows = perform(session.apply(.keyDown(decodeKey(event)),
+                                                 environment: sessionEnvironment()))
+            return swallows ? nil : Unmanaged.passUnretained(event)
         case .flagsChanged:
-            if sessionActive, !isSearchPinned {
-                if let shortcut = sessionShortcut,
-                   !shortcut.requiredModifiersHeld(in: event.flags) {
-                    commitSession()
-                } else if handleShiftBackNavigation(flags: event.flags) {
-                    return nil
-                }
-            }
-            return Unmanaged.passUnretained(event)
+            let outcome = session.apply(
+                .modifiersChanged(shortcutModifiersHeld: session.shortcut.map {
+                                      $0.requiredModifiersHeld(in: event.flags)
+                                  },
+                                  shiftHeld: event.flags.contains(.maskShift),
+                                  now: ProcessInfo.processInfo.systemUptime),
+                environment: sessionEnvironment())
+            return perform(outcome) ? nil : Unmanaged.passUnretained(event)
         case .leftMouseDown, .rightMouseDown, .otherMouseDown:
             if type == .otherMouseDown,
                let panel,
@@ -664,108 +597,183 @@ final class AppSwitcher: ObservableObject {
         }
     }
 
-    private func handleKeyDown(_ event: CGEvent) -> Unmanaged<CGEvent>? {
+    /// Resolves one keystroke against the shortcuts this session answers to.
+    /// The order is a priority order: the session's own shortcut wins over the
+    /// Apps shortcut, which wins over the window shortcut, which wins over the
+    /// arrows — a window shortcut bound to an arrow key still steps windows.
+    ///
+    /// The session shortcut's modifiers are necessarily held while the panel
+    /// is up, so they never disqualify the window key (a window shortcut like
+    /// ⌥Tab works during a ⌘Tab session). Matching by character too keeps the
+    /// default ⌘` on the key that actually types ` on ABNT2, German and other
+    /// non-US layouts (#187). Shift only means "backward" on a positional
+    /// match: on a character match it may be part of typing the character.
+    private func decodeKey(_ event: CGEvent) -> SwitcherKeyEvent {
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
         let flags = event.flags
-
-        // Initial presses are claimed directly on the tap thread and queued
-        // asynchronously. Reaching main after that session ended is only a
-        // race with teardown; the already-claimed key must stay swallowed.
-        guard sessionActive else { return nil }
-
         let (appsShortcut, windowShortcut) = routeLock.withLock {
             (routeShortcut, routeWindowShortcut)
         }
-        let shortcut = sessionShortcut ?? appsShortcut
-        switch keyCode {
-        case _ where keyCode == shortcut.keyCode && shortcut.matches(event: event, allowingExtraShift: true):
-            if shortcut.shiftIsNavigationModifier, flags.contains(.maskShift), consumesShiftBackChordTab() {
-                break
-            }
-            let delta = shortcut.shiftIsNavigationModifier && flags.contains(.maskShift) ? -1 : 1
-            // Holding the key stops at the list's end instead of wrapping, like
-            // the system switcher; a fresh press wraps around (issue #187).
-            let isRepeat = event.getIntegerValueField(.keyboardEventAutorepeat) != 0
-            advanceSelection(by: delta, wrapping: !isRepeat)
-        case _ where sessionScope == .frontmostApp
-            && keyCode == appsShortcut.keyCode
-            && appsShortcut.matches(event: event,
-                                    allowingExtraShift: true,
-                                    tolerating: shortcut.modifiers):
-            // A window-scoped session keeps its list when the Apps shortcut is
-            // pressed with overlapping modifiers instead of expanding to all apps.
-            if appsShortcut.shiftIsNavigationModifier, flags.contains(.maskShift), consumesShiftBackChordTab() {
-                break
-            }
-            let delta = appsShortcut.shiftIsNavigationModifier && flags.contains(.maskShift) ? -1 : 1
-            let isRepeat = event.getIntegerValueField(.keyboardEventAutorepeat) != 0
-            advanceSelection(by: delta, wrapping: !isRepeat)
-        case _ where searchQuery.isEmpty
-            && (windowShortcut.matches(event: event, allowingExtraShift: true,
-                                       tolerating: shortcut.modifiers)
-                || windowShortcut.matchesByCharacter(event: event,
-                                                     tolerating: shortcut.modifiers)):
-            // Jumps between the selected app's windows. In the icon row mode
-            // that is the grouped app; in the plain grid it hops across the
-            // same app's thumbnails, so the key works in both looks. The
-            // session shortcut's modifiers are necessarily held while the
-            // panel is up, so they never disqualify the window key (a window
-            // shortcut like ⌥Tab works during a ⌘Tab session). Matching by
-            // character too keeps the default ⌘` on the key that actually
-            // types ` on ABNT2, German and other non-US layouts (#187). Shift
-            // only means "backward" on a positional match: on a character
-            // match it may be part of typing the character itself.
+        let shortcut = session.shortcut ?? appsShortcut
+
+        let kind: SwitcherKeyEvent.Kind
+        if keyCode == shortcut.keyCode, shortcut.matches(event: event, allowingExtraShift: true) {
+            kind = .sessionShortcut(shiftIsNavigationModifier: shortcut.shiftIsNavigationModifier)
+        } else if session.scope == .frontmostApp,
+                  keyCode == appsShortcut.keyCode,
+                  appsShortcut.matches(event: event,
+                                       allowingExtraShift: true,
+                                       tolerating: shortcut.modifiers) {
+            kind = .appsShortcutInWindowScope(
+                shiftIsNavigationModifier: appsShortcut.shiftIsNavigationModifier)
+        } else if session.searchQuery.isEmpty,
+                  windowShortcut.matches(event: event, allowingExtraShift: true,
+                                         tolerating: shortcut.modifiers)
+                      || windowShortcut.matchesByCharacter(event: event,
+                                                           tolerating: shortcut.modifiers) {
             let positional = windowShortcut.matches(event: event, allowingExtraShift: true,
                                                     tolerating: shortcut.modifiers)
-            let delta = SwitcherSupport.windowNavigationDelta(
-                positionalMatch: positional,
-                shiftIsNavigationModifier: windowShortcut.shiftIsNavigationModifier,
-                shiftHeld: flags.contains(.maskShift)
-            )
-            if sessionScope == .frontmostApp {
-                let isRepeat = event.getIntegerValueField(.keyboardEventAutorepeat) != 0
-                advanceSelection(by: delta, wrapping: !isRepeat)
-            } else {
-                advanceWindowInSelectedApp(by: delta)
+            kind = .windowShortcut(positionalMatch: positional,
+                                   shiftIsNavigationModifier: windowShortcut.shiftIsNavigationModifier)
+        } else {
+            switch keyCode {
+            case KeyCode.rightArrow: kind = .rightArrow
+            case KeyCode.leftArrow: kind = .leftArrow
+            case KeyCode.downArrow: kind = .downArrow
+            case KeyCode.upArrow: kind = .upArrow
+            case KeyCode.delete: kind = .delete
+            case KeyCode.escape: kind = .escape
+            case KeyCode.enter: kind = .enter
+            default: kind = .other
             }
-        case KeyCode.rightArrow:
-            advanceSelection(by: 1)
-        case KeyCode.leftArrow:
-            advanceSelection(by: -1)
-        case KeyCode.downArrow:
-            moveSelection(by: grid.columns)
-        case KeyCode.upArrow:
-            moveSelection(by: -grid.columns)
-        case KeyCode.delete:
-            removeLastSearchCharacter()
-        case KeyCode.escape:
-            cancelSession()
-        case KeyCode.enter:
-            commitSession()
-        default:
-            let text = printableSearchText(from: event)
-            // The first letter typed is a command: W closes the highlighted
-            // window, Q quits its app, S pins the search field open so typing
-            // no longer needs the session's modifier held. Once a search is
-            // under way (or already pinned) every key belongs to the query,
-            // so all three letters can still be typed.
-            if searchQuery.isEmpty, !isSearchPinned,
-               let action = SwitcherSupport.letterAction(typedCharacter: text, keyCode: keyCode, pinSearchEnabled: searchPinEnabled) {
-                // One window per press: holding the key down must never walk
-                // through the list closing or quitting everything on the way.
-                if event.getIntegerValueField(.keyboardEventAutorepeat) == 0 {
-                    switch action {
-                    case .closeWindow: closeSelectedWindow()
-                    case .quitApp: quitSelectedApp()
-                    case .pinSearch: isSearchPinned = true
-                    }
-                }
-            } else if let text {
-                appendSearchText(text)
-            }
-            // Swallow stray keys so they never leak into the focused app.
         }
-        return nil
+
+        return SwitcherKeyEvent(kind: kind,
+                                shiftHeld: flags.contains(.maskShift),
+                                isRepeat: event.getIntegerValueField(.keyboardEventAutorepeat) != 0,
+                                keyCode: keyCode,
+                                typedText: kind == .other ? printableSearchText(from: event) : nil,
+                                now: ProcessInfo.processInfo.systemUptime)
+    }
+
+    // MARK: - Session effects
+
+    /// The preferences and measurements the session reads, sampled at the
+    /// moment the event arrives — the same moment the switcher read them
+    /// before. The scope is deliberately not part of it: the session answers
+    /// the scope-dependent layout questions from its own scope, so a caller
+    /// cannot measure a session against a scope it no longer has.
+    private func sessionEnvironment() -> SwitcherSessionEnvironment {
+        SwitcherSessionEnvironment(
+            iconRowMode: iconRowModeEnabled,
+            simpleMode: simpleModeEnabled,
+            mergeWindowsByApp: UserDefaults.standard.bool(forKey: DefaultsKey.switcherMergeTabs),
+            gridColumns: grid.columns,
+            searchPinEnabled: searchPinEnabled
+        )
+    }
+
+    @discardableResult
+    private func perform(_ outcome: SwitcherSessionOutcome) -> Bool {
+        perform(outcome.effects)
+        return outcome.swallowsEvent
+    }
+
+    private func perform(_ effects: [SwitcherSessionEffect]) {
+        for effect in effects { perform(effect) }
+    }
+
+    private func perform(_ effect: SwitcherSessionEffect) {
+        switch effect {
+        case .publishSession:
+            windows = session.visibleItems
+            totalWindowCount = session.itemCount
+            searchQuery = session.searchQuery
+            isSearchPinned = session.isSearchPinned
+            sessionScope = session.scope
+        case .publishSelection:
+            selectedIndex = session.selectedIndex
+        case .recomputeLayouts:
+            recomputeLayouts(for: session.visibleItems)
+        case .resizePanel:
+            resizePanel()
+        case .schedulePanel:
+            scheduleShowPanel()
+        case .seedPreviews:
+            guard capturesPreviews else {
+                previews = [:]
+                return
+            }
+            previews = Dictionary(uniqueKeysWithValues: session.visibleItems.compactMap { item in
+                item.previewWindowID.flatMap { id in
+                    WindowPreviewProvider.shared.cachedPreview(for: id).map { (id, $0) }
+                }
+            })
+        case .refreshPreviews:
+            guard capturesPreviews else { return }
+            WindowPreviewProvider.shared.refreshPreviews(
+                for: session.visibleItems,
+                maxPixelSize: 640 * PreviewSizing.scale
+            ) { [weak self] windowID, image in
+                guard let self,
+                      self.session.isActive,
+                      self.session.items.contains(where: { $0.previewWindowID == windowID })
+                else { return }
+                self.previews[windowID] = image
+            }
+        case .prunePreviewsToVisible(let dropping):
+            let remaining = Set(session.visibleItems.compactMap(\.previewWindowID))
+            previews = previews.filter { remaining.contains($0.key) && $0.key != dropping }
+        case .removePreview(let windowID):
+            previews.removeValue(forKey: windowID)
+        case .replayNavigation(let delta, let times):
+            for _ in 0..<times {
+                perform(session.apply(.navigate(delta: delta, wrapping: true),
+                                      environment: sessionEnvironment()))
+            }
+        case .cancelIconRowEdgeHover:
+            cancelIconRowEdgeHover()
+        case .teardown:
+            performTeardown()
+        case .activate(let item, let source, let previousWindowID):
+            recordUse(item, previous: previousWindowID)
+            WindowActivator.activate(item,
+                                     sourceWasFullscreen: source?.isFullscreen ?? false,
+                                     sourcePID: source?.pid,
+                                     sourceWindowID: source?.isFullscreen == true ? nil : source?.windowID,
+                                     sourceWindowOwnerPID: source?.windowOwnerPID)
+        case .closeWindow(let item):
+            beginClosingWindow(item)
+        case .closeSelectedWindow:
+            closeSelectedWindow()
+        case .quitSelectedApp:
+            quitSelectedApp()
+        case .commit:
+            commitSession()
+        }
+    }
+
+    /// Drops everything this class holds for a session that has just ended.
+    /// The session itself is already reset; this is only the panel side.
+    private func performTeardown() {
+        sessionActive = false
+        pendingShow?.cancel()
+        pendingShow = nil
+        WindowPreviewProvider.shared.cancel()
+        panel?.orderOut(nil)
+        windows = []
+        previews = [:]
+        selectedIndex = 0
+        grid = .empty
+        iconRowLayout = .empty
+        searchQuery = ""
+        isSearchPinned = false
+        totalWindowCount = 0
+        hoverAnchor = nil
+        hoveredWindowIndex = nil
+        cancelIconRowEdgeHover()
+        iconRowFirstVisibleIndex = 0
+        sessionScope = .allApps
     }
 
     // MARK: - Session lifecycle
@@ -774,12 +782,7 @@ final class AppSwitcher: ObservableObject {
     /// wait on bounded AX calls, while modifier-up turns the pending result
     /// into a no-panel commit without waiting for this work to finish.
     private func beginPendingSession(generation: UInt64) {
-        guard routeLock.withLock({
-            SwitcherSupport.isCurrentSessionStart(
-                generation: generation,
-                pendingGeneration: routePendingSessionStart?.generation
-            )
-        }) else { return }
+        guard routeLock.withLock({ routePending.isCurrent(generation) }) else { return }
         guard Permissions.shared.accessibility,
               AXIsProcessTrusted(),
               lifecycleLock.withLock({ tap != nil && !shouldStopTapThread })
@@ -789,11 +792,8 @@ final class AppSwitcher: ObservableObject {
         }
 
         guard let requested = routeLock.withLock({ () -> SwitcherPendingSessionStart? in
-            guard SwitcherSupport.isCurrentSessionStart(
-                generation: generation,
-                pendingGeneration: routePendingSessionStart?.generation
-            ) else { return nil }
-            return routePendingSessionStart
+            guard routePending.isCurrent(generation) else { return nil }
+            return routePending.current
         }) else { return }
         let allApps = requested.scope == .allApps
         let mergeWindowsByApp = UserDefaults.standard.bool(forKey: DefaultsKey.switcherMergeTabs)
@@ -810,12 +810,7 @@ final class AppSwitcher: ObservableObject {
         let enumerationSnapshot = WindowEnumerator.snapshot()
         enumerationQueue.async { [weak self] in
             guard let self,
-                  self.routeLock.withLock({
-                      SwitcherSupport.isCurrentSessionStart(
-                          generation: generation,
-                          pendingGeneration: self.routePendingSessionStart?.generation
-                      )
-                  })
+                  self.routeLock.withLock({ self.routePending.isCurrent(generation) })
             else { return }
             let allWindows = WindowEnumerator.enumerateSwitcherWindows(
                 groupByApp: groupByApp,
@@ -823,20 +818,10 @@ final class AppSwitcher: ObservableObject {
                 snapshot: enumerationSnapshot,
                 isCancelled: { [weak self] in
                     guard let self else { return true }
-                    return !self.routeLock.withLock {
-                        SwitcherSupport.isCurrentSessionStart(
-                            generation: generation,
-                            pendingGeneration: self.routePendingSessionStart?.generation
-                        )
-                    }
+                    return !self.routeLock.withLock { self.routePending.isCurrent(generation) }
                 }
             )
-            guard self.routeLock.withLock({
-                SwitcherSupport.isCurrentSessionStart(
-                    generation: generation,
-                    pendingGeneration: self.routePendingSessionStart?.generation
-                )
-            }) else { return }
+            guard self.routeLock.withLock({ self.routePending.isCurrent(generation) }) else { return }
             let sessionWindows: [SwitcherItem]
             switch requested.scope {
             case .allApps:
@@ -867,175 +852,26 @@ final class AppSwitcher: ObservableObject {
                                       reportedFrontPID: pid_t,
                                       focusedSourceWindowID: CGWindowID?,
                                       windows: [SwitcherItem]) {
-        guard routeLock.withLock({
-            SwitcherSupport.isCurrentSessionStart(
-                generation: generation,
-                pendingGeneration: routePendingSessionStart?.generation
-            )
-        }) else { return }
+        guard routeLock.withLock({ routePending.isCurrent(generation) }) else { return }
         guard !windows.isEmpty else {
             discardPendingSessionStart(generation: generation)
             return
         }
-        // The foreground window is what a session is measured against, and it
-        // does not always exist: an app left with no windows, or with all of
-        // them minimized or on another Space, still owns the keyboard. The
-        // switcher opens either way. Bailing out here handed ⌘Tab back to the
-        // system, so the shortcut looked dead until it was pressed a second
-        // time (issue #324).
-        let source = SwitcherSupport.sessionSourceItem(frontmostPID: reportedFrontPID,
-                                                       focusedWindowID: focusedSourceWindowID,
-                                                       items: windows)
-
-        let list = orderedForSession(windows, currentID: source?.id)
         guard let pending = routeLock.withLock({ () -> SwitcherPendingSessionStart? in
-            guard SwitcherSupport.isCurrentSessionStart(
-                generation: generation,
-                pendingGeneration: routePendingSessionStart?.generation
-            ) else { return nil }
-            let pending = routePendingSessionStart
-            routePendingSessionStart = nil
+            guard let pending = routePending.take(generation: generation) else { return nil }
             routeSessionActive = true
             return pending
         }) else { return }
-        sessionItems = list
-        totalWindowCount = list.count
-        searchQuery = ""
-        isSearchPinned = false
-        self.windows = list
-        // Optional.map: a session that starts with no source clears the
-        // context instead of keeping the previous session's.
-        sessionSourceContext = source.map { source in
-            SwitcherSourceContext(itemID: source.id,
-                                  pid: source.pid,
-                                  windowID: source.windowID,
-                                  windowOwnerPID: source.windowOwnerPID,
-                                  isFullscreen: source.isFullscreen,
-                                  frame: source.frame)
-        }
-        sessionStartWindowID = source?.windowID
-        // The layout pass below reads usesWindowRow, which depends on the
-        // session scope; teardown resets it to .allApps, so assigning it after
-        // recomputeLayouts would size a window-scoped panel for the grouped
-        // layout on its first frame.
-        sessionScope = pending.scope
-        recomputeLayouts(for: list)
-        if !capturesPreviews {
-            previews = [:]
-        } else {
-            previews = Dictionary(uniqueKeysWithValues: list.compactMap { item in
-                item.previewWindowID.flatMap { id in
-                    WindowPreviewProvider.shared.cachedPreview(for: id).map { (id, $0) }
-                }
-            })
-        }
-        userNavigated = false
-        // Index 0 is the on-screen window; index 1 is the most-recently-used
-        // other window — the toggle target, which may be another window of the
-        // same app. Shift starts from the far end. With no on-screen window
-        // the session opens on the first entry from another app.
-        selectedIndex = pending.scope == .frontmostApp
-            ? SwitcherSupport.initialWindowScopedSelectionIndex(itemCount: list.count,
-                                                                hasForegroundItem: source != nil,
-                                                                reversed: pending.reversed)
-            : initialSelectionIndex(in: list,
-                                    reversed: pending.reversed,
-                                    hasForegroundItem: source != nil,
-                                    frontmostPID: SwitcherSupport.appPID(forFrontmost: reportedFrontPID,
-                                                                         items: list))
-        sessionShortcut = pending.shortcut
-        shiftBackNavigationHeld = pending.reversed && pending.shortcut.shiftIsNavigationModifier
 
-        if pending.additionalNavigation != 0 {
-            let delta = pending.additionalNavigation < 0 ? -1 : 1
-            for _ in 0..<abs(pending.additionalNavigation) {
-                advanceSelection(by: delta)
-            }
-        }
-
-        if pending.commitWhenReady {
-            commitSession()
-        } else if capturesPreviews {
-            WindowPreviewProvider.shared.refreshPreviews(for: list, maxPixelSize: 640 * PreviewSizing.scale) { [weak self] windowID, image in
-                guard let self,
-                      self.sessionActive,
-                      self.sessionItems.contains(where: { $0.previewWindowID == windowID }) else { return }
-                self.previews[windowID] = image
-            }
-        }
-        if !pending.commitWhenReady {
-            scheduleShowPanel()
-        }
+        let start = SwitcherSessionStart(windows: windows,
+                                         frontmostPID: reportedFrontPID,
+                                         focusedSourceWindowID: focusedSourceWindowID,
+                                         pending: pending)
+        perform(session.apply(.begin(start), environment: sessionEnvironment()))
     }
 
     private func discardPendingSessionStart(generation: UInt64) {
-        routeLock.withLock {
-            guard SwitcherSupport.isCurrentSessionStart(
-                generation: generation,
-                pendingGeneration: routePendingSessionStart?.generation
-            ) else { return }
-            routePendingSessionStart = nil
-        }
-    }
-
-    private func handleShiftBackNavigation(flags: CGEventFlags) -> Bool {
-        let shiftHeld = flags.contains(.maskShift)
-        defer { shiftBackNavigationHeld = shiftHeld }
-        guard let shortcut = sessionShortcut,
-              SwitcherSupport.shouldNavigateBackwardOnShiftPress(shiftIsNavigationModifier: shortcut.shiftIsNavigationModifier,
-                                                                  wasShiftHeld: shiftBackNavigationHeld,
-                                                                  isShiftHeld: shiftHeld)
-        else { return false }
-        advanceSelection(by: -1)
-        shiftBackChordDeadline = ProcessInfo.processInfo.systemUptime
-            + SwitcherSupport.shiftBackChordWindow
-        return true
-    }
-
-    /// True exactly once for the Tab that belongs to the Shift press that just
-    /// stepped back; consuming it keeps a Shift+Tab chord at one step.
-    private func consumesShiftBackChordTab() -> Bool {
-        guard ProcessInfo.processInfo.systemUptime < shiftBackChordDeadline else { return false }
-        shiftBackChordDeadline = 0
-        return true
-    }
-
-    /// Puts the window the user is looking at first. The enumerator already
-    /// ordered everything else by how recently it was used, so the entry right
-    /// after the current one is the window they came from — this only has to
-    /// make sure the current one leads, even in the moment right after a
-    /// switch, when the window server has not caught up yet.
-    private func orderedForSession(_ items: [SwitcherItem], currentID: String?) -> [SwitcherItem] {
-        guard let currentID, let index = items.firstIndex(where: { $0.id == currentID }) else { return items }
-        var ordered = items
-        ordered.insert(ordered.remove(at: index), at: 0)
-        return ordered
-    }
-
-    private func initialSelectionIndex(in items: [SwitcherItem],
-                                       reversed: Bool,
-                                       hasForegroundItem: Bool,
-                                       frontmostPID: pid_t) -> Int {
-        guard !items.isEmpty else { return 0 }
-        guard SwitcherSupport.usesAppGroupsForMainShortcut(
-            iconRowLayout: usesIconRowLayout,
-            windowRow: usesWindowRow
-        ) else {
-            return SwitcherSupport.initialSelectionPosition(pids: items.map(\.pid),
-                                                            hasForegroundEntry: hasForegroundItem,
-                                                            frontmostPID: frontmostPID,
-                                                            reversed: reversed)
-        }
-
-        // The icon row steps app by app, so the same rule runs over the groups
-        // and lands on the chosen group's representative window.
-        let groups = SwitcherSupport.appGroups(items: items)
-        guard !groups.isEmpty else { return 0 }
-        let groupIndex = SwitcherSupport.initialSelectionPosition(pids: groups.map(\.pid),
-                                                                  hasForegroundEntry: hasForegroundItem,
-                                                                  frontmostPID: frontmostPID,
-                                                                  reversed: reversed)
-        return groups[groupIndex].representativeIndex
+        routeLock.withLock { routePending.discard(generation: generation) }
     }
 
     private func focusedWindowID(for pid: pid_t, accessibilityGranted: Bool) -> CGWindowID? {
@@ -1060,17 +896,26 @@ final class AppSwitcher: ObservableObject {
         WindowUseTracker.shared.recordSwitch(to: activated.windowID, from: previous)
     }
 
+    /// Activates the current selection. Also used by the panel on click.
+    func commitSession() {
+        perform(session.apply(.commit, environment: sessionEnvironment()))
+    }
+
+    private func cancelSession() {
+        perform(session.apply(.cancel, environment: sessionEnvironment()))
+    }
+
+    // MARK: - Selection and hover
+
     func select(index: Int) {
-        guard sessionActive, windows.indices.contains(index) else { return }
-        userNavigated = true
-        selectedIndex = index
+        perform(session.apply(.select(index: index), environment: sessionEnvironment()))
     }
 
     /// Hover-selection from the panel. Ignored until the mouse really moves:
     /// the panel may open centered on the cursor's screen, and the card that
     /// happens to sit under a stationary pointer must not steal the selection.
     func hoverSelect(index: Int) {
-        guard sessionActive, windows.indices.contains(index) else { return }
+        guard session.isActive, windows.indices.contains(index) else { return }
         hoveredWindowIndex = index
         let mouse = NSEvent.mouseLocation
         if let anchor = hoverAnchor {
@@ -1098,27 +943,7 @@ final class AppSwitcher: ObservableObject {
         cancelIconRowEdgeHover()
     }
 
-    private var selectedItemID: String? {
-        guard windows.indices.contains(selectedIndex) else { return nil }
-        return windows[selectedIndex].id
-    }
-
-    private func appendSearchText(_ text: String) {
-        let clean = sanitizedSearchInput(text)
-        guard !clean.isEmpty else { return }
-        let preferredID = selectedItemID
-        let remaining = max(0, 64 - searchQuery.count)
-        guard remaining > 0 else { return }
-        searchQuery += String(clean.prefix(remaining))
-        applySearchFilter(preferredItemID: preferredID)
-    }
-
-    private func removeLastSearchCharacter() {
-        guard !searchQuery.isEmpty else { return }
-        let preferredID = selectedItemID
-        searchQuery.removeLast()
-        applySearchFilter(preferredItemID: preferredID)
-    }
+    // MARK: - Search input
 
     private func printableSearchText(from event: CGEvent) -> String? {
         var length = 0
@@ -1127,42 +952,42 @@ final class AppSwitcher: ObservableObject {
                                        actualStringLength: &length,
                                        unicodeString: &chars)
         guard length > 0 else { return nil }
-        return sanitizedSearchInput(String(utf16CodeUnits: chars, count: length))
+        return SwitcherSession.sanitizedSearchInput(String(utf16CodeUnits: chars, count: length))
     }
 
-    private func sanitizedSearchInput(_ text: String) -> String {
-        String(String.UnicodeScalarView(text.unicodeScalars.filter { scalar in
-            !CharacterSet.controlCharacters.contains(scalar)
-                && !CharacterSet.newlines.contains(scalar)
-        }))
-    }
-
-    private func applySearchFilter(preferredItemID: String?) {
-        let records = sessionItems.map { item in
-            SwitcherSearchRecord(id: item.id, title: item.title, appName: item.appName)
-        }
-        let visibleIDs = Set(SwitcherSupport.filteredSearchIDs(records: records, query: searchQuery))
-        windows = sessionItems.filter { visibleIDs.contains($0.id) }
-        selectedIndex = SwitcherSupport.searchSelectionIndex(itemIDs: windows.map(\.id),
-                                                             preferredID: preferredItemID,
-                                                             previousIndex: selectedIndex)
-        recomputeLayouts(for: windows)
-        resizePanel()
-    }
+    // MARK: - Closing and quitting
 
     func closeWindow(_ item: SwitcherItem) {
-        guard sessionActive,
-              windows.contains(where: { $0.id == item.id }),
-              !closingItemIDs.contains(item.id),
-              let windowID = item.windowID
-        else { return }
+        perform(session.apply(.requestClose(item), environment: sessionEnvironment()))
+    }
 
-        closingItemIDs.insert(item.id)
+    /// Closes the highlighted window (⌘Tab → W) and keeps the session open, so
+    /// the app stays running and the panel moves on to the next window. Same
+    /// path as the card's close button.
+    private func closeSelectedWindow() {
+        guard let item = session.selectedItem else { return }
+        closeWindow(item)
+    }
+
+    /// Quits the app owning the selected window (⌘Tab → Q). The session drops
+    /// its windows once the terminate request is out, mirroring the system
+    /// switcher.
+    private func quitSelectedApp() {
+        guard let selected = session.selectedItem else { return }
+        let pid = selected.pid
+        guard let app = NSRunningApplication(processIdentifier: pid),
+              app.bundleIdentifier != Defaults.finderBundleIdentifier else { return }
+        app.terminate()
+        perform(session.apply(.appTerminated(pid: pid), environment: sessionEnvironment()))
+    }
+
+    private func beginClosingWindow(_ item: SwitcherItem) {
+        guard let windowID = item.windowID else { return }
         WindowActivator.closeWindowIncludingHiddenState(item) { [weak self] didClose in
             guard let self else { return }
             guard didClose else {
-                self.closingItemIDs.remove(item.id)
-                self.resumePendingCommitAfterClose()
+                self.perform(self.session.apply(.closeAbandoned(itemID: item.id),
+                                                environment: self.sessionEnvironment()))
                 return
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) { [weak self] in
@@ -1174,85 +999,10 @@ final class AppSwitcher: ObservableObject {
         }
     }
 
-    private func advanceSelection(by delta: Int, wrapping: Bool = true) {
-        cancelIconRowEdgeHover()
-        guard !windows.isEmpty else { return }
-        if SwitcherSupport.usesAppGroupsForMainShortcut(
-            iconRowLayout: usesIconRowLayout,
-            windowRow: usesWindowRow
-        ), sessionScope == .allApps {
-            advanceAppSelection(by: delta, wrapping: wrapping)
-            return
-        }
-        userNavigated = true
-        let next = selectedIndex + delta
-        if !wrapping, !windows.indices.contains(next) { return }
-        selectedIndex = (next + windows.count) % windows.count
-    }
-
-    private func advanceAppSelection(by delta: Int, wrapping: Bool = true) {
-        cancelIconRowEdgeHover()
-        userNavigated = true
-        selectedIndex = SwitcherSupport.nextAppSelectionIndex(items: windows,
-                                                              selectedIndex: selectedIndex,
-                                                              delta: delta,
-                                                              wrapping: wrapping)
-    }
-
-    private func advanceWindowInSelectedApp(by delta: Int) {
-        userNavigated = true
-        selectedIndex = SwitcherSupport.nextWindowSelectionIndexWithinApp(items: windows,
-                                                                          selectedIndex: selectedIndex,
-                                                                          delta: delta)
-    }
-
-    /// Closes the highlighted window (⌘Tab → W) and keeps the session open, so
-    /// the app stays running and the panel moves on to the next window. Same
-    /// path as the card's close button.
-    private func closeSelectedWindow() {
-        guard windows.indices.contains(selectedIndex) else { return }
-        closeWindow(windows[selectedIndex])
-    }
-
-    /// Quits the app owning the selected window (⌘Tab → Q), removes its windows
-    /// from the grid and keeps the session open — mirroring the system switcher.
-    private func quitSelectedApp() {
-        guard windows.indices.contains(selectedIndex) else { return }
-        let pid = windows[selectedIndex].pid
-        guard let app = NSRunningApplication(processIdentifier: pid),
-              app.bundleIdentifier != Defaults.finderBundleIdentifier else { return }
-        app.terminate()
-
-        let removedIDs = Set(sessionItems.lazy.filter { $0.pid == pid }.map(\.id))
-        closingItemIDs.subtract(removedIDs)
-        let removedBeforeSelection = windows[..<selectedIndex].filter { $0.pid == pid }.count
-        sessionItems.removeAll { $0.pid == pid }
-        totalWindowCount = sessionItems.count
-        windows.removeAll { $0.pid == pid }
-        let remaining = Set(windows.compactMap(\.previewWindowID))
-        previews = previews.filter { remaining.contains($0.key) }
-
-        guard !sessionItems.isEmpty else {
-            endSession()
-            return
-        }
-        guard !windows.isEmpty else {
-            selectedIndex = 0
-            recomputeLayouts(for: windows)
-            resizePanel()
-            resumePendingCommitAfterClose()
-            return
-        }
-        selectedIndex = min(max(0, selectedIndex - removedBeforeSelection), windows.count - 1)
-        recomputeLayouts(for: windows)
-        resizePanel()
-        resumePendingCommitAfterClose()
-    }
-
     private func finishClosingWindow(itemID: String, windowID: CGWindowID, pid: pid_t, attempt: Int) {
-        guard sessionActive else { return }
-        guard sessionItems.contains(where: { $0.id == itemID }) else {
-            finishTrackingClose(itemID: itemID)
+        guard session.isActive else { return }
+        guard session.contains(itemID: itemID) else {
+            perform(session.apply(.closeAbandoned(itemID: itemID), environment: sessionEnvironment()))
             return
         }
 
@@ -1261,8 +1011,8 @@ final class AppSwitcher: ObservableObject {
             // Still there after the retries: the app kept it, so it is a
             // normal entry again and the release may raise it.
             guard attempt < 2 else {
-                closingItemIDs.remove(itemID)
-                resumePendingCommitAfterClose()
+                perform(session.apply(.closeAbandoned(itemID: itemID),
+                                      environment: sessionEnvironment()))
                 return
             }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
@@ -1274,147 +1024,10 @@ final class AppSwitcher: ObservableObject {
             return
         }
 
-        applyClosedWindowRemoval(itemID: itemID, windowID: windowID)
+        perform(session.apply(.closeConfirmed(itemID: itemID, windowID: windowID),
+                              environment: sessionEnvironment()))
     }
 
-    private func applyClosedWindowRemoval(itemID: String, windowID: CGWindowID) {
-        let state = SwitcherSupport.closeState(afterRemoving: itemID,
-                                               itemIDs: windows.map(\.id),
-                                               selectedIndex: selectedIndex)
-        guard state.didRemove else {
-            sessionItems.removeAll { $0.id == itemID }
-            totalWindowCount = sessionItems.count
-            previews.removeValue(forKey: windowID)
-            closingItemIDs.remove(itemID)
-            if sessionSourceContext?.itemID == itemID {
-                sessionStartWindowID = nil
-            }
-            guard !sessionItems.isEmpty else {
-                endSession()
-                return
-            }
-            applySearchFilter(preferredItemID: selectedItemID)
-            resumePendingCommitAfterClose()
-            return
-        }
-
-        sessionItems.removeAll { $0.id == itemID }
-        totalWindowCount = sessionItems.count
-        let remaining = Set(state.remainingItemIDs)
-        windows = windows.filter { remaining.contains($0.id) }
-        let remainingPreviews = Set(windows.compactMap(\.previewWindowID))
-        previews = previews.filter { remainingPreviews.contains($0.key) && $0.key != windowID }
-        closingItemIDs.remove(itemID)
-        if sessionSourceContext?.itemID == itemID {
-            sessionStartWindowID = nil
-        }
-
-        guard !state.shouldEndSession else {
-            if sessionItems.isEmpty || searchQuery.isEmpty {
-                endSession()
-            } else {
-                selectedIndex = 0
-                recomputeLayouts(for: windows)
-                resizePanel()
-                resumePendingCommitAfterClose()
-            }
-            return
-        }
-
-        selectedIndex = state.selectedIndex
-        recomputeLayouts(for: windows)
-        resizePanel()
-        resumePendingCommitAfterClose()
-    }
-
-    private func finishTrackingClose(itemID: String) {
-        closingItemIDs.remove(itemID)
-        resumePendingCommitAfterClose()
-    }
-
-    /// Row jump (↑/↓): moves without wrapping so the selection stays put at
-    /// the grid edges.
-    private func moveSelection(by delta: Int) {
-        if usesIconRowLayout {
-            advanceWindowInSelectedApp(by: delta < 0 ? -1 : 1)
-            return
-        }
-        guard delta != 0 else { return }
-        let target = SwitcherSupport.gridSelectionIndex(after: selectedIndex,
-                                                        itemCount: windows.count,
-                                                        columns: grid.columns,
-                                                        movingDown: delta > 0)
-        guard target != selectedIndex else { return }
-        userNavigated = true
-        selectedIndex = target
-    }
-
-    /// Activates the current selection. Also used by the panel on click.
-    func commitSession() {
-        guard sessionActive else { return }
-        guard closingItemIDs.isEmpty else {
-            commitPendingForClose = true
-            return
-        }
-        // A window that was just closed is still listed for a moment; letting
-        // go right after must land on what takes its place, never on it.
-        let selection = SwitcherSupport.commitTargetID(itemIDs: windows.map(\.id),
-                                                       selectedIndex: selectedIndex,
-                                                       closingItemIDs: closingItemIDs)
-            .flatMap { id in windows.first { $0.id == id } }
-        let source = sessionSourceContext
-        let previousWindowID = sessionStartWindowID
-        endSession()
-        if let selection {
-            recordUse(selection, previous: previousWindowID)
-            WindowActivator.activate(selection,
-                                     sourceWasFullscreen: source?.isFullscreen ?? false,
-                                     sourcePID: source?.pid,
-                                     sourceWindowID: source?.isFullscreen == true ? nil : source?.windowID,
-                                     sourceWindowOwnerPID: source?.windowOwnerPID)
-        }
-    }
-
-    private func resumePendingCommitAfterClose() {
-        guard commitPendingForClose, closingItemIDs.isEmpty, sessionActive else { return }
-        commitPendingForClose = false
-        commitSession()
-    }
-
-    private func cancelSession() {
-        guard sessionActive else { return }
-        endSession()
-    }
-
-    private func endSession() {
-        sessionActive = false
-        pendingShow?.cancel()
-        pendingShow = nil
-        WindowPreviewProvider.shared.cancel()
-        panel?.orderOut(nil)
-        sessionItems = []
-        windows = []
-        previews = [:]
-        selectedIndex = 0
-        grid = .empty
-        iconRowLayout = .empty
-        searchQuery = ""
-        isSearchPinned = false
-        totalWindowCount = 0
-        hoverAnchor = nil
-        hoveredWindowIndex = nil
-        cancelIconRowEdgeHover()
-        iconRowFirstVisibleIndex = 0
-        userNavigated = false
-        sessionStartWindowID = nil
-        sessionSourceContext = nil
-        sessionShortcut = nil
-        sessionScope = .allApps
-        shiftBackNavigationHeld = false
-        shiftBackChordDeadline = 0
-        closingItemIDs = []
-        commitPendingForClose = false
-    }
 
     // MARK: - Panel
 
@@ -1423,7 +1036,7 @@ final class AppSwitcher: ObservableObject {
     private func scheduleShowPanel() {
         pendingShow?.cancel()
         let work = DispatchWorkItem { [weak self] in
-            guard let self, self.sessionActive else { return }
+            guard let self, self.session.isActive else { return }
             self.showPanel()
         }
         pendingShow = work
@@ -1449,7 +1062,7 @@ final class AppSwitcher: ObservableObject {
     /// release from committing the highlighted window first (issues #384 and
     /// #539).
     private func dismissForClickOutsidePanel() {
-        guard sessionActive, let panel else { return }
+        guard session.isActive, let panel else { return }
         guard SwitcherSupport.shouldDismissForClick(panelIsVisible: panel.isVisible,
                                                     panelFrame: panel.frame,
                                                     location: NSEvent.mouseLocation)
@@ -1488,7 +1101,7 @@ final class AppSwitcher: ObservableObject {
         SwitcherSupport.usesWindowRow(
             simpleMode: simpleModeEnabled,
             mergeWindowsByApp: UserDefaults.standard.bool(forKey: DefaultsKey.switcherMergeTabs),
-            sessionScope: sessionScope
+            sessionScope: session.scope
         )
     }
 
@@ -1536,7 +1149,7 @@ final class AppSwitcher: ObservableObject {
     /// session began. The source frame comes from the window server, so it is
     /// matched against `CGDisplayBounds` rather than the flipped AppKit frames.
     private var activeWindowScreen: NSScreen? {
-        guard let frame = sessionSourceContext?.frame else { return nil }
+        guard let frame = session.source?.frame else { return nil }
         let screens = NSScreen.screens
         let bounds = screens.map { CGDisplayBounds($0.displayID) }
         guard let index = SwitcherSupport.displayIndex(showingMostOf: frame, displayBounds: bounds) else {
@@ -1633,7 +1246,7 @@ final class AppSwitcher: ObservableObject {
     }
 
     private func stepIconRowFromEdgeHover() {
-        guard sessionActive, usesIconRowLayout,
+        guard session.isActive, usesIconRowLayout,
               let hovered = iconRowEdgeHoverIndex,
               let delta = SwitcherSupport.iconRowEdgeHoverDelta(
                 hoveredIndex: hovered,
@@ -1667,8 +1280,7 @@ final class AppSwitcher: ObservableObject {
         iconRowEdgeHoverIndex = nextIcon
         iconRowFirstVisibleIndex = nextFirst
         if let nextSelection = selectionIndex(forIconRowIndex: nextIcon) {
-            userNavigated = true
-            selectedIndex = nextSelection
+            select(index: nextSelection)
         }
 
         let work = DispatchWorkItem { [weak self] in

--- a/Sources/Vorssaint/Services/Switcher/SwitcherSession.swift
+++ b/Sources/Vorssaint/Services/Switcher/SwitcherSession.swift
@@ -1,0 +1,806 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import CoreGraphics
+import Foundation
+
+/// The window that was in front when a session opened. Kept as a value so the
+/// session survives the window disappearing mid-session.
+struct SwitcherSessionSource: Equatable {
+    let itemID: String?
+    let pid: pid_t
+    let windowID: CGWindowID?
+    let windowOwnerPID: pid_t?
+    let isFullscreen: Bool
+    /// Window server bounds of the source window; `.zero` for an app-only entry.
+    let frame: CGRect
+
+    init(item: SwitcherItem) {
+        itemID = item.id
+        pid = item.pid
+        windowID = item.windowID
+        windowOwnerPID = item.windowOwnerPID
+        isFullscreen = item.isFullscreen
+        frame = item.frame
+    }
+}
+
+/// A shortcut press already owned by the switcher while the window list is
+/// being assembled. The tap thread can cancel or add repeated navigation
+/// without ever waiting for the main thread or Accessibility.
+struct SwitcherPendingSessionStart: Equatable {
+    let generation: UInt64
+    let shortcut: GlobalShortcut
+    let scope: SwitcherSessionScope
+    let reversed: Bool
+    var additionalNavigation = 0
+    var commitWhenReady = false
+}
+
+/// The presses the event tap owns before the window list exists. Every method
+/// is pure state, so the caller keeps it under its own lock and the tap thread
+/// never waits on anything.
+struct SwitcherPendingStarts: Equatable {
+    /// A press may repeat this many times before the list is ready; beyond
+    /// that the extra steps cannot mean anything the user can see.
+    static let navigationLimit = 64
+
+    private(set) var current: SwitcherPendingSessionStart?
+    private var generation: UInt64 = 0
+
+    var isPending: Bool { current != nil }
+
+    /// A quick flick still commits once enumeration finishes, but can never
+    /// flash a panel after the key was released.
+    mutating func noteShortcutModifiersReleased() {
+        guard var pending = current else { return }
+        pending.commitWhenReady = true
+        current = pending
+    }
+
+    mutating func clear() {
+        current = nil
+    }
+
+    /// Claims a shortcut press. Returns the generation to schedule when this
+    /// press opens a new start, or `nil` when it only folds into one that is
+    /// already on its way.
+    mutating func claim(shortcut: GlobalShortcut,
+                        scope: SwitcherSessionScope,
+                        reversed: Bool) -> UInt64? {
+        if var pending = current {
+            // The previous press was already released: this one is a fresh
+            // session rather than another step through the old one.
+            guard !pending.commitWhenReady else { return start(shortcut: shortcut, scope: scope, reversed: reversed) }
+            if pending.scope == scope {
+                let next = pending.additionalNavigation + (reversed ? -1 : 1)
+                pending.additionalNavigation = max(-Self.navigationLimit, min(Self.navigationLimit, next))
+                current = pending
+            }
+            return nil
+        }
+        return start(shortcut: shortcut, scope: scope, reversed: reversed)
+    }
+
+    private mutating func start(shortcut: GlobalShortcut,
+                                scope: SwitcherSessionScope,
+                                reversed: Bool) -> UInt64 {
+        generation &+= 1
+        current = SwitcherPendingSessionStart(generation: generation,
+                                              shortcut: shortcut,
+                                              scope: scope,
+                                              reversed: reversed)
+        return generation
+    }
+
+    func isCurrent(_ generation: UInt64) -> Bool {
+        SwitcherSupport.isCurrentSessionStart(generation: generation,
+                                              pendingGeneration: current?.generation)
+    }
+
+    /// Hands over the pending start and closes it out, so the session that
+    /// follows can never be started twice from the same press.
+    mutating func take(generation: UInt64) -> SwitcherPendingSessionStart? {
+        guard isCurrent(generation) else { return nil }
+        let pending = current
+        current = nil
+        return pending
+    }
+
+    mutating func discard(generation: UInt64) {
+        guard isCurrent(generation) else { return }
+        current = nil
+    }
+}
+
+/// Everything the panel needs from outside the session: the preferences and
+/// the grid the adapter has already measured. Read fresh for each event, the
+/// same moment the switcher read them before.
+///
+/// The two layout questions are answered here rather than passed in, because
+/// both depend on the session's own scope. Handing them in pre-answered is how
+/// a window-scoped session used to get sized for the grouped layout on its
+/// first frame: the scope the caller measured with was the one teardown had
+/// reset, not the one the session was opening with.
+struct SwitcherSessionEnvironment: Equatable {
+    let iconRowMode: Bool
+    let simpleMode: Bool
+    let mergeWindowsByApp: Bool
+    let gridColumns: Int
+    let searchPinEnabled: Bool
+
+    var usesIconRowLayout: Bool {
+        SwitcherSupport.usesIconRowLayout(iconRowMode: iconRowMode, simpleMode: simpleMode)
+    }
+
+    func usesWindowRow(scope: SwitcherSessionScope) -> Bool {
+        SwitcherSupport.usesWindowRow(simpleMode: simpleMode,
+                                      mergeWindowsByApp: mergeWindowsByApp,
+                                      sessionScope: scope)
+    }
+
+    func usesAppGroupsForMainShortcut(scope: SwitcherSessionScope) -> Bool {
+        SwitcherSupport.usesAppGroupsForMainShortcut(iconRowLayout: usesIconRowLayout,
+                                                     windowRow: usesWindowRow(scope: scope))
+    }
+}
+
+/// What starts a session, once the window list has been enumerated.
+struct SwitcherSessionStart {
+    let windows: [SwitcherItem]
+    let frontmostPID: pid_t
+    let focusedSourceWindowID: CGWindowID?
+    let shortcut: GlobalShortcut
+    let scope: SwitcherSessionScope
+    let reversed: Bool
+    let additionalNavigation: Int
+    let commitWhenReady: Bool
+
+    init(windows: [SwitcherItem],
+         frontmostPID: pid_t,
+         focusedSourceWindowID: CGWindowID?,
+         pending: SwitcherPendingSessionStart) {
+        self.windows = windows
+        self.frontmostPID = frontmostPID
+        self.focusedSourceWindowID = focusedSourceWindowID
+        shortcut = pending.shortcut
+        scope = pending.scope
+        reversed = pending.reversed
+        additionalNavigation = pending.additionalNavigation
+        commitWhenReady = pending.commitWhenReady
+    }
+
+    init(windows: [SwitcherItem],
+         frontmostPID: pid_t,
+         focusedSourceWindowID: CGWindowID? = nil,
+         shortcut: GlobalShortcut,
+         scope: SwitcherSessionScope = .allApps,
+         reversed: Bool = false,
+         additionalNavigation: Int = 0,
+         commitWhenReady: Bool = false) {
+        self.windows = windows
+        self.frontmostPID = frontmostPID
+        self.focusedSourceWindowID = focusedSourceWindowID
+        self.shortcut = shortcut
+        self.scope = scope
+        self.reversed = reversed
+        self.additionalNavigation = additionalNavigation
+        self.commitWhenReady = commitWhenReady
+    }
+}
+
+/// One keystroke, already resolved against the session's shortcuts. Turning a
+/// `CGEvent` into this is the adapter's job; deciding what it means is not.
+struct SwitcherKeyEvent {
+    /// Which of the session's keys this is, in the order the switcher resolves
+    /// them: the session's own shortcut wins over the Apps shortcut, which
+    /// wins over the window shortcut, which wins over the arrows.
+    enum Kind: Equatable {
+        case sessionShortcut(shiftIsNavigationModifier: Bool)
+        /// The Apps shortcut pressed during a window-scoped session.
+        case appsShortcutInWindowScope(shiftIsNavigationModifier: Bool)
+        case windowShortcut(positionalMatch: Bool, shiftIsNavigationModifier: Bool)
+        case rightArrow
+        case leftArrow
+        case downArrow
+        case upArrow
+        case delete
+        case escape
+        case enter
+        /// Anything else: a command letter or search text.
+        case other
+    }
+
+    let kind: Kind
+    let shiftHeld: Bool
+    let isRepeat: Bool
+    let keyCode: Int64
+    /// The printable text this keystroke typed, already stripped of control
+    /// characters. Only read for `.other`.
+    let typedText: String?
+    let now: TimeInterval
+
+    init(kind: Kind,
+         shiftHeld: Bool = false,
+         isRepeat: Bool = false,
+         keyCode: Int64 = 0,
+         typedText: String? = nil,
+         now: TimeInterval = 0) {
+        self.kind = kind
+        self.shiftHeld = shiftHeld
+        self.isRepeat = isRepeat
+        self.keyCode = keyCode
+        self.typedText = typedText
+        self.now = now
+    }
+}
+
+/// What the session asks the adapter to do. The order in an outcome is the
+/// order the switcher performed these in before, and it matters: the panel is
+/// resized off published state, and publishing the selection re-measures the
+/// icon row.
+enum SwitcherSessionEffect: Equatable {
+    /// Mirror the list, counts, search and scope into the published state.
+    case publishSession
+    /// Mirror the selection, which re-measures the icon row and the panel.
+    case publishSelection
+    case recomputeLayouts
+    case resizePanel
+    case schedulePanel
+    /// Fill the preview map from what the capture cache already holds.
+    case seedPreviews
+    case refreshPreviews
+    /// Keep only previews still backing a listed window, dropping one more.
+    case prunePreviewsToVisible(dropping: CGWindowID?)
+    case removePreview(CGWindowID)
+    /// Presses that landed before the list was ready, replayed one at a time
+    /// so each step measures the icon row the way a live press would.
+    case replayNavigation(delta: Int, times: Int)
+    case cancelIconRowEdgeHover
+    /// Drop the panel and everything the adapter holds for this session.
+    case teardown
+    case activate(item: SwitcherItem, source: SwitcherSessionSource?, previousWindowID: CGWindowID?)
+    case closeWindow(SwitcherItem)
+    case closeSelectedWindow
+    case quitSelectedApp
+    /// Commit once the effects before it have been performed.
+    case commit
+}
+
+/// The result of feeding one event to the session.
+struct SwitcherSessionOutcome: Equatable {
+    /// True when the event must not reach the app underneath. Key events the
+    /// session owns are always swallowed; a modifier change only when it
+    /// stepped the selection.
+    var swallowsEvent = false
+    var effects: [SwitcherSessionEffect] = []
+
+    static let ignored = SwitcherSessionOutcome()
+}
+
+/// One switcher session: the list it opened with, where the selection is, what
+/// the search has narrowed it to, which windows are on their way out, and how
+/// it ends. No panel, no event tap, no Accessibility — `AppSwitcher` owns all
+/// of that and feeds this events.
+struct SwitcherSession {
+    enum Event {
+        case begin(SwitcherSessionStart)
+        case keyDown(SwitcherKeyEvent)
+        /// `shortcutModifiersHeld` is nil when the session has no shortcut,
+        /// which is how a session opened without a key held stays open.
+        case modifiersChanged(shortcutModifiersHeld: Bool?, shiftHeld: Bool, now: TimeInterval)
+        case select(index: Int)
+        case navigate(delta: Int, wrapping: Bool)
+        case requestClose(SwitcherItem)
+        /// The close did not take, or the window outlived the retries.
+        case closeAbandoned(itemID: String)
+        case closeConfirmed(itemID: String, windowID: CGWindowID)
+        case appTerminated(pid: pid_t)
+        case commit
+        case cancel
+    }
+
+    /// Longest search a switcher panel accepts; past this the query is no
+    /// longer narrowing anything.
+    static let searchQueryLimit = 64
+
+    private(set) var isActive = false
+    /// Everything the session opened with, before the search narrowed it.
+    private(set) var items: [SwitcherItem] = []
+    /// What the panel shows: `items` minus whatever the search filtered out.
+    private(set) var visibleItems: [SwitcherItem] = []
+    private(set) var selectedIndex = 0
+    private(set) var searchQuery = ""
+    /// True once S pinned the search field open. While set, releasing the
+    /// session's modifier no longer commits — search text can then be typed
+    /// with no modifier held, so a letter never comes out as the modifier's
+    /// special character (⌥ on its own types symbols on layouts like US,
+    /// e.g. ⌥S types "ß").
+    private(set) var isSearchPinned = false
+    private(set) var scope: SwitcherSessionScope = .allApps
+    private(set) var shortcut: GlobalShortcut?
+    /// The on-screen window when the session opened — becomes the
+    /// second-most-recent window on commit, so a flick toggles straight back.
+    /// Cleared if that window is closed during the session: a window the user
+    /// just got rid of is not somewhere to send them back to.
+    private(set) var startWindowID: CGWindowID?
+    private(set) var source: SwitcherSessionSource?
+    /// Windows already asked to close, still listed until they are really
+    /// gone. Releasing the shortcut skips them, so they are never raised on
+    /// the way out.
+    private(set) var closingItemIDs: Set<String> = []
+    private(set) var commitPendingForClose = false
+
+    private var shiftBackNavigationHeld = false
+    /// Pressing Shift mid-session already steps back once, so the Tab landing
+    /// in that same physical chord must not step again — but later Tabs during
+    /// the same Shift hold must keep walking the list (issue #784). The chord
+    /// is recognized by time: anything after this deadline is a deliberate
+    /// separate press.
+    private var shiftBackChordDeadline: TimeInterval = 0
+    /// True once the user moved the selection themselves.
+    private var userNavigated = false
+
+    var itemCount: Int { items.count }
+
+    var selectedItem: SwitcherItem? {
+        visibleItems.indices.contains(selectedIndex) ? visibleItems[selectedIndex] : nil
+    }
+
+    var selectedItemID: String? { selectedItem?.id }
+
+    func contains(itemID: String) -> Bool {
+        items.contains { $0.id == itemID }
+    }
+
+    // MARK: - Interface
+
+    mutating func apply(_ event: Event, environment: SwitcherSessionEnvironment) -> SwitcherSessionOutcome {
+        switch event {
+        case .begin(let start):
+            return SwitcherSessionOutcome(effects: begin(start, environment: environment))
+        case .keyDown(let key):
+            return handleKeyDown(key, environment: environment)
+        case .modifiersChanged(let held, let shiftHeld, let now):
+            return handleModifiersChanged(shortcutModifiersHeld: held,
+                                          shiftHeld: shiftHeld,
+                                          now: now,
+                                          environment: environment)
+        case .select(let index):
+            return SwitcherSessionOutcome(effects: select(index: index))
+        case .navigate(let delta, let wrapping):
+            return SwitcherSessionOutcome(effects: navigate(by: delta,
+                                                            wrapping: wrapping,
+                                                            environment: environment))
+        case .requestClose(let item):
+            return SwitcherSessionOutcome(effects: requestClose(item))
+        case .closeAbandoned(let itemID):
+            closingItemIDs.remove(itemID)
+            return SwitcherSessionOutcome(effects: resumePendingCommitAfterClose())
+        case .closeConfirmed(let itemID, let windowID):
+            return SwitcherSessionOutcome(effects: applyClosedWindowRemoval(itemID: itemID,
+                                                                            windowID: windowID))
+        case .appTerminated(let pid):
+            return SwitcherSessionOutcome(effects: applyTerminatedApp(pid: pid))
+        case .commit:
+            return SwitcherSessionOutcome(effects: commit())
+        case .cancel:
+            guard isActive else { return .ignored }
+            return SwitcherSessionOutcome(effects: teardown())
+        }
+    }
+
+    // MARK: - Session lifecycle
+
+    private mutating func begin(_ start: SwitcherSessionStart,
+                                environment: SwitcherSessionEnvironment) -> [SwitcherSessionEffect] {
+        // The foreground window is what a session is measured against, and it
+        // does not always exist: an app left with no windows, or with all of
+        // them minimized or on another Space, still owns the keyboard. The
+        // switcher opens either way (issue #324).
+        let sourceItem = SwitcherSupport.sessionSourceItem(frontmostPID: start.frontmostPID,
+                                                          focusedWindowID: start.focusedSourceWindowID,
+                                                          items: start.windows)
+        let list = Self.ordered(start.windows, currentID: sourceItem?.id)
+
+        isActive = true
+        items = list
+        searchQuery = ""
+        isSearchPinned = false
+        visibleItems = list
+        // Optional.map: a session that starts with no source clears the
+        // context instead of keeping the previous session's.
+        source = sourceItem.map(SwitcherSessionSource.init)
+        startWindowID = sourceItem?.windowID
+        scope = start.scope
+        closingItemIDs = []
+        commitPendingForClose = false
+        userNavigated = false
+        // Index 0 is the on-screen window; index 1 is the most-recently-used
+        // other window — the toggle target, which may be another window of the
+        // same app. Shift starts from the far end. With no on-screen window
+        // the session opens on the first entry from another app.
+        selectedIndex = start.scope == .frontmostApp
+            ? SwitcherSupport.initialWindowScopedSelectionIndex(itemCount: list.count,
+                                                                hasForegroundItem: sourceItem != nil,
+                                                                reversed: start.reversed)
+            : Self.initialSelectionIndex(
+                in: list,
+                reversed: start.reversed,
+                hasForegroundItem: sourceItem != nil,
+                frontmostPID: SwitcherSupport.appPID(forFrontmost: start.frontmostPID, items: list),
+                // `scope` above is already the new one, so the icon row can
+                // never be measured against the scope teardown left behind.
+                usesAppGroups: environment.usesAppGroupsForMainShortcut(scope: scope))
+        shortcut = start.shortcut
+        shiftBackNavigationHeld = start.reversed && start.shortcut.shiftIsNavigationModifier
+        shiftBackChordDeadline = 0
+
+        var effects: [SwitcherSessionEffect] = [.publishSession, .recomputeLayouts,
+                                                .seedPreviews, .publishSelection]
+        if start.additionalNavigation != 0 {
+            effects.append(.replayNavigation(delta: start.additionalNavigation < 0 ? -1 : 1,
+                                             times: abs(start.additionalNavigation)))
+        }
+        if start.commitWhenReady {
+            effects.append(.commit)
+        } else {
+            effects.append(.refreshPreviews)
+            effects.append(.schedulePanel)
+        }
+        return effects
+    }
+
+    /// Puts the window the user is looking at first. The enumerator already
+    /// ordered everything else by how recently it was used, so the entry right
+    /// after the current one is the window they came from — this only has to
+    /// make sure the current one leads, even in the moment right after a
+    /// switch, when the window server has not caught up yet.
+    static func ordered(_ items: [SwitcherItem], currentID: String?) -> [SwitcherItem] {
+        guard let currentID, let index = items.firstIndex(where: { $0.id == currentID }) else { return items }
+        var ordered = items
+        ordered.insert(ordered.remove(at: index), at: 0)
+        return ordered
+    }
+
+    static func initialSelectionIndex(in items: [SwitcherItem],
+                                      reversed: Bool,
+                                      hasForegroundItem: Bool,
+                                      frontmostPID: pid_t,
+                                      usesAppGroups: Bool) -> Int {
+        guard !items.isEmpty else { return 0 }
+        guard usesAppGroups else {
+            return SwitcherSupport.initialSelectionPosition(pids: items.map(\.pid),
+                                                            hasForegroundEntry: hasForegroundItem,
+                                                            frontmostPID: frontmostPID,
+                                                            reversed: reversed)
+        }
+
+        // The icon row steps app by app, so the same rule runs over the groups
+        // and lands on the chosen group's representative window.
+        let groups = SwitcherSupport.appGroups(items: items)
+        guard !groups.isEmpty else { return 0 }
+        let groupIndex = SwitcherSupport.initialSelectionPosition(pids: groups.map(\.pid),
+                                                                  hasForegroundEntry: hasForegroundItem,
+                                                                  frontmostPID: frontmostPID,
+                                                                  reversed: reversed)
+        return groups[groupIndex].representativeIndex
+    }
+
+    /// Activates the current selection.
+    private mutating func commit() -> [SwitcherSessionEffect] {
+        guard isActive else { return [] }
+        guard closingItemIDs.isEmpty else {
+            commitPendingForClose = true
+            return []
+        }
+        // A window that was just closed is still listed for a moment; letting
+        // go right after must land on what takes its place, never on it.
+        let selection = SwitcherSupport.commitTargetID(itemIDs: visibleItems.map(\.id),
+                                                       selectedIndex: selectedIndex,
+                                                       closingItemIDs: closingItemIDs)
+            .flatMap { id in visibleItems.first { $0.id == id } }
+        let committedSource = source
+        let previousWindowID = startWindowID
+        var effects = teardown()
+        if let selection {
+            effects.append(.activate(item: selection,
+                                     source: committedSource,
+                                     previousWindowID: previousWindowID))
+        }
+        return effects
+    }
+
+    private mutating func resumePendingCommitAfterClose() -> [SwitcherSessionEffect] {
+        guard commitPendingForClose, closingItemIDs.isEmpty, isActive else { return [] }
+        commitPendingForClose = false
+        return commit()
+    }
+
+    private mutating func teardown() -> [SwitcherSessionEffect] {
+        isActive = false
+        items = []
+        visibleItems = []
+        selectedIndex = 0
+        searchQuery = ""
+        isSearchPinned = false
+        startWindowID = nil
+        source = nil
+        shortcut = nil
+        scope = .allApps
+        shiftBackNavigationHeld = false
+        shiftBackChordDeadline = 0
+        closingItemIDs = []
+        commitPendingForClose = false
+        userNavigated = false
+        return [.teardown]
+    }
+
+    // MARK: - Keys
+
+    private mutating func handleKeyDown(_ key: SwitcherKeyEvent,
+                                        environment: SwitcherSessionEnvironment) -> SwitcherSessionOutcome {
+        // Initial presses are claimed directly on the tap thread and queued
+        // asynchronously. Reaching here after that session ended is only a
+        // race with teardown; the already-claimed key must stay swallowed.
+        guard isActive else { return SwitcherSessionOutcome(swallowsEvent: true) }
+
+        var effects: [SwitcherSessionEffect] = []
+        switch key.kind {
+        case .sessionShortcut(let shiftIsNavigationModifier),
+             .appsShortcutInWindowScope(let shiftIsNavigationModifier):
+            // A window-scoped session keeps its list when the Apps shortcut is
+            // pressed with overlapping modifiers instead of expanding to all apps.
+            if shiftIsNavigationModifier, key.shiftHeld, consumesShiftBackChordTab(now: key.now) {
+                break
+            }
+            let delta = shiftIsNavigationModifier && key.shiftHeld ? -1 : 1
+            // Holding the key stops at the list's end instead of wrapping, like
+            // the system switcher; a fresh press wraps around (issue #187).
+            effects = navigate(by: delta, wrapping: !key.isRepeat, environment: environment)
+        case .windowShortcut(let positionalMatch, let shiftIsNavigationModifier):
+            // Jumps between the selected app's windows. In the icon row mode
+            // that is the grouped app; in the plain grid it hops across the
+            // same app's thumbnails, so the key works in both looks.
+            let delta = SwitcherSupport.windowNavigationDelta(
+                positionalMatch: positionalMatch,
+                shiftIsNavigationModifier: shiftIsNavigationModifier,
+                shiftHeld: key.shiftHeld
+            )
+            if scope == .frontmostApp {
+                effects = navigate(by: delta, wrapping: !key.isRepeat, environment: environment)
+            } else {
+                effects = navigateWindowInSelectedApp(by: delta)
+            }
+        case .rightArrow:
+            effects = navigate(by: 1, wrapping: true, environment: environment)
+        case .leftArrow:
+            effects = navigate(by: -1, wrapping: true, environment: environment)
+        case .downArrow:
+            effects = moveRow(by: environment.gridColumns, environment: environment)
+        case .upArrow:
+            effects = moveRow(by: -environment.gridColumns, environment: environment)
+        case .delete:
+            effects = removeLastSearchCharacter()
+        case .escape:
+            effects = teardown()
+        case .enter:
+            effects = commit()
+        case .other:
+            // The first letter typed is a command: W closes the highlighted
+            // window, Q quits its app, S pins the search field open so typing
+            // no longer needs the session's modifier held. Once a search is
+            // under way (or already pinned) every key belongs to the query,
+            // so all three letters can still be typed.
+            if searchQuery.isEmpty, !isSearchPinned,
+               let action = SwitcherSupport.letterAction(typedCharacter: key.typedText,
+                                                         keyCode: key.keyCode,
+                                                         pinSearchEnabled: environment.searchPinEnabled) {
+                // One window per press: holding the key down must never walk
+                // through the list closing or quitting everything on the way.
+                guard !key.isRepeat else { break }
+                switch action {
+                case .closeWindow: effects = [.closeSelectedWindow]
+                case .quitApp: effects = [.quitSelectedApp]
+                case .pinSearch:
+                    isSearchPinned = true
+                    effects = [.publishSession]
+                }
+            } else if let text = key.typedText {
+                effects = appendSearch(text)
+            }
+            // Swallow stray keys so they never leak into the focused app.
+        }
+        return SwitcherSessionOutcome(swallowsEvent: true, effects: effects)
+    }
+
+    private mutating func handleModifiersChanged(shortcutModifiersHeld: Bool?,
+                                                 shiftHeld: Bool,
+                                                 now: TimeInterval,
+                                                 environment: SwitcherSessionEnvironment) -> SwitcherSessionOutcome {
+        guard isActive, !isSearchPinned else { return .ignored }
+        if let shortcutModifiersHeld, !shortcutModifiersHeld {
+            return SwitcherSessionOutcome(effects: commit())
+        }
+        defer { shiftBackNavigationHeld = shiftHeld }
+        guard let shortcut,
+              SwitcherSupport.shouldNavigateBackwardOnShiftPress(
+                shiftIsNavigationModifier: shortcut.shiftIsNavigationModifier,
+                wasShiftHeld: shiftBackNavigationHeld,
+                isShiftHeld: shiftHeld)
+        else { return .ignored }
+        let effects = navigate(by: -1, wrapping: true, environment: environment)
+        shiftBackChordDeadline = now + SwitcherSupport.shiftBackChordWindow
+        return SwitcherSessionOutcome(swallowsEvent: true, effects: effects)
+    }
+
+    /// True exactly once for the Tab that belongs to the Shift press that just
+    /// stepped back; consuming it keeps a Shift+Tab chord at one step.
+    private mutating func consumesShiftBackChordTab(now: TimeInterval) -> Bool {
+        guard now < shiftBackChordDeadline else { return false }
+        shiftBackChordDeadline = 0
+        return true
+    }
+
+    // MARK: - Selection
+
+    private mutating func navigate(by delta: Int,
+                                   wrapping: Bool,
+                                   environment: SwitcherSessionEnvironment) -> [SwitcherSessionEffect] {
+        var effects: [SwitcherSessionEffect] = [.cancelIconRowEdgeHover]
+        guard !visibleItems.isEmpty else { return effects }
+        userNavigated = true
+        if environment.usesAppGroupsForMainShortcut(scope: scope), scope == .allApps {
+            selectedIndex = SwitcherSupport.nextAppSelectionIndex(items: visibleItems,
+                                                                  selectedIndex: selectedIndex,
+                                                                  delta: delta,
+                                                                  wrapping: wrapping)
+            effects.append(.publishSelection)
+            return effects
+        }
+        let next = selectedIndex + delta
+        if !wrapping, !visibleItems.indices.contains(next) { return effects }
+        selectedIndex = (next + visibleItems.count) % visibleItems.count
+        effects.append(.publishSelection)
+        return effects
+    }
+
+    private mutating func navigateWindowInSelectedApp(by delta: Int) -> [SwitcherSessionEffect] {
+        userNavigated = true
+        selectedIndex = SwitcherSupport.nextWindowSelectionIndexWithinApp(items: visibleItems,
+                                                                          selectedIndex: selectedIndex,
+                                                                          delta: delta)
+        return [.publishSelection]
+    }
+
+    /// Row jump (↑/↓): moves without wrapping so the selection stays put at
+    /// the grid edges.
+    private mutating func moveRow(by delta: Int,
+                                  environment: SwitcherSessionEnvironment) -> [SwitcherSessionEffect] {
+        if environment.usesIconRowLayout {
+            return navigateWindowInSelectedApp(by: delta < 0 ? -1 : 1)
+        }
+        guard delta != 0 else { return [] }
+        let target = SwitcherSupport.gridSelectionIndex(after: selectedIndex,
+                                                        itemCount: visibleItems.count,
+                                                        columns: environment.gridColumns,
+                                                        movingDown: delta > 0)
+        guard target != selectedIndex else { return [] }
+        userNavigated = true
+        selectedIndex = target
+        return [.publishSelection]
+    }
+
+    private mutating func select(index: Int) -> [SwitcherSessionEffect] {
+        guard isActive, visibleItems.indices.contains(index) else { return [] }
+        userNavigated = true
+        selectedIndex = index
+        return [.publishSelection]
+    }
+
+    // MARK: - Search
+
+    private mutating func appendSearch(_ text: String) -> [SwitcherSessionEffect] {
+        let clean = Self.sanitizedSearchInput(text)
+        guard !clean.isEmpty else { return [] }
+        let preferredID = selectedItemID
+        let remaining = max(0, Self.searchQueryLimit - searchQuery.count)
+        guard remaining > 0 else { return [] }
+        searchQuery += String(clean.prefix(remaining))
+        return applySearchFilter(preferredItemID: preferredID)
+    }
+
+    private mutating func removeLastSearchCharacter() -> [SwitcherSessionEffect] {
+        guard !searchQuery.isEmpty else { return [] }
+        let preferredID = selectedItemID
+        searchQuery.removeLast()
+        return applySearchFilter(preferredItemID: preferredID)
+    }
+
+    static func sanitizedSearchInput(_ text: String) -> String {
+        String(String.UnicodeScalarView(text.unicodeScalars.filter { scalar in
+            !CharacterSet.controlCharacters.contains(scalar)
+                && !CharacterSet.newlines.contains(scalar)
+        }))
+    }
+
+    private mutating func applySearchFilter(preferredItemID: String?) -> [SwitcherSessionEffect] {
+        let records = items.map { item in
+            SwitcherSearchRecord(id: item.id, title: item.title, appName: item.appName)
+        }
+        let visibleIDs = Set(SwitcherSupport.filteredSearchIDs(records: records, query: searchQuery))
+        visibleItems = items.filter { visibleIDs.contains($0.id) }
+        selectedIndex = SwitcherSupport.searchSelectionIndex(itemIDs: visibleItems.map(\.id),
+                                                             preferredID: preferredItemID,
+                                                             previousIndex: selectedIndex)
+        return [.publishSession, .publishSelection, .recomputeLayouts, .resizePanel]
+    }
+
+    // MARK: - Closing and quitting
+
+    private mutating func requestClose(_ item: SwitcherItem) -> [SwitcherSessionEffect] {
+        guard isActive,
+              visibleItems.contains(where: { $0.id == item.id }),
+              !closingItemIDs.contains(item.id),
+              item.windowID != nil
+        else { return [] }
+        closingItemIDs.insert(item.id)
+        return [.closeWindow(item)]
+    }
+
+    /// Removes the app's windows from the list and keeps the session open —
+    /// mirroring the system switcher.
+    private mutating func applyTerminatedApp(pid: pid_t) -> [SwitcherSessionEffect] {
+        let removedIDs = Set(items.lazy.filter { $0.pid == pid }.map(\.id))
+        closingItemIDs.subtract(removedIDs)
+        let removedBeforeSelection = visibleItems[..<min(selectedIndex, visibleItems.count)]
+            .filter { $0.pid == pid }.count
+        items.removeAll { $0.pid == pid }
+        visibleItems.removeAll { $0.pid == pid }
+
+        guard !items.isEmpty else { return teardown() }
+        guard !visibleItems.isEmpty else {
+            selectedIndex = 0
+            return [.publishSession, .prunePreviewsToVisible(dropping: nil), .publishSelection,
+                    .recomputeLayouts, .resizePanel] + resumePendingCommitAfterClose()
+        }
+        selectedIndex = min(max(0, selectedIndex - removedBeforeSelection), visibleItems.count - 1)
+        return [.publishSession, .prunePreviewsToVisible(dropping: nil), .publishSelection,
+                .recomputeLayouts, .resizePanel] + resumePendingCommitAfterClose()
+    }
+
+    private mutating func applyClosedWindowRemoval(itemID: String,
+                                                   windowID: CGWindowID) -> [SwitcherSessionEffect] {
+        let state = SwitcherSupport.closeState(afterRemoving: itemID,
+                                               itemIDs: visibleItems.map(\.id),
+                                               selectedIndex: selectedIndex)
+        guard state.didRemove else {
+            // Filtered out of the visible list by a search: only the session's
+            // own bookkeeping has to catch up.
+            items.removeAll { $0.id == itemID }
+            closingItemIDs.remove(itemID)
+            if source?.itemID == itemID { startWindowID = nil }
+            guard !items.isEmpty else { return teardown() }
+            return [.publishSession, .removePreview(windowID)]
+                + applySearchFilter(preferredItemID: selectedItemID)
+                + resumePendingCommitAfterClose()
+        }
+
+        items.removeAll { $0.id == itemID }
+        let remaining = Set(state.remainingItemIDs)
+        visibleItems = visibleItems.filter { remaining.contains($0.id) }
+        closingItemIDs.remove(itemID)
+        if source?.itemID == itemID { startWindowID = nil }
+
+        guard !state.shouldEndSession else {
+            if items.isEmpty || searchQuery.isEmpty { return teardown() }
+            selectedIndex = 0
+            return [.publishSession, .prunePreviewsToVisible(dropping: windowID), .publishSelection,
+                    .recomputeLayouts, .resizePanel] + resumePendingCommitAfterClose()
+        }
+
+        selectedIndex = state.selectedIndex
+        return [.publishSession, .prunePreviewsToVisible(dropping: windowID), .publishSelection,
+                .recomputeLayouts, .resizePanel] + resumePendingCommitAfterClose()
+    }
+}

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -2308,34 +2308,18 @@ struct MetricsTests {
                                                   mergeWindowsByApp: false,
                                                   sessionScope: .allApps),
                "App Switcher groups all-app sessions but keeps window-scoped simple sessions per-window")
-        // The session-start layout pass reads usesWindowRow, which now depends
-        // on the session scope; teardown resets the scope to .allApps, so the
-        // scope must be assigned before the layout pass or a window-scoped
-        // panel is sized for the grouped layout on its first frame.
-        let switcherSource = (try? String(
-            contentsOfFile: "Sources/Vorssaint/Services/Switcher/AppSwitcher.swift",
-            encoding: .utf8)) ?? ""
-        // Ends on whatever declaration comes next rather than naming the
-        // neighbour: a rename would find no separator, leave the slice running
-        // to end of file, and quietly restore the whole-file search this
-        // replaced — a failure that makes the slice bigger, so an empty check
-        // cannot see it. Hence the count assertion below.
-        let finishSessionParts = (switcherSource.components(separatedBy: "private func finishPendingSession")
-            .last ?? "").components(separatedBy: "\n    private func ")
-        let finishSessionBody = finishSessionParts.first ?? ""
-        expect(finishSessionParts.count > 1,
-               "the App Switcher ordering guard finds the end of finishPendingSession")
-        let switcherCode = finishSessionBody
-            .split(separator: "\n", omittingEmptySubsequences: false)
-            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
-            .joined(separator: "\n")
-        let scopeAssign = switcherCode.range(of: "sessionScope = pending.scope")
-        let startLayout = switcherCode.range(of: "recomputeLayouts(for: list)")
-        expect(!finishSessionBody.isEmpty,
-               "the App Switcher session-start ordering guard finds finishPendingSession")
-        expect(scopeAssign != nil && startLayout != nil
-               && scopeAssign!.lowerBound < startLayout!.lowerBound,
-               "the App Switcher session scope is assigned before the session-start layout pass")
+        // The session-start layout pass reads usesWindowRow, which depends on
+        // the session scope; teardown resets the scope to .allApps, so a
+        // window-scoped panel used to risk being sized for the grouped layout
+        // on its first frame. That ordering was guarded by reading the source
+        // of AppSwitcher, because the sequencing lived in a singleton no test
+        // could reach. It is now a property of SwitcherSession, which begins a
+        // session by adopting the scope before it emits a single effect, and
+        // answers the scope-dependent layout questions from that scope rather
+        // than from anything a caller measured. The runnable replacements are
+        // in switcherSessionChecks(): "a window-scoped session opens on the
+        // front app's next window" and "a session publishes its list and
+        // measures the layout before publishing the selection".
         expect(!SwitcherSupport.usesAppGroupsForMainShortcut(iconRowLayout: true,
                                                               windowRow: true)
                && SwitcherSupport.usesAppGroupsForMainShortcut(iconRowLayout: true,
@@ -22021,6 +22005,9 @@ struct MetricsTests {
             let guarded = offset("guard changed else { return }")
             expect(stored >= 0 && guarded > stored,
                    "\(pass) stores the whole sample before it decides whether the rows changed")
+
+        for switcherCheck in switcherSessionChecks() {
+            expect(switcherCheck.passed, switcherCheck.label)
         }
 
         if failures.isEmpty {
@@ -22031,6 +22018,468 @@ struct MetricsTests {
             failures.forEach { print("  - \($0)") }
             exit(1)
         }
+    }
+
+    /// Real key sequences driven through the switcher's session state machine.
+    /// Kept in one function so the checks live beside each other rather than
+    /// interleaved with the rest of the suite.
+    private static func switcherSessionChecks() -> [(passed: Bool, label: String)] {
+        var results: [(passed: Bool, label: String)] = []
+        func check(_ passed: Bool, _ label: String) { results.append((passed: passed, label: label)) }
+
+        func window(_ id: CGWindowID, _ app: String, pid: pid_t, onScreen: Bool = false) -> SwitcherItem {
+            SwitcherItem.window(id: id, title: "\(app) \(id)", appName: app, pid: pid,
+                                isOnScreen: onScreen, frame: .zero)
+        }
+        // One front window, then two apps behind it, one of them with two
+        // windows: enough to tell app steps from window steps.
+        let front = window(1, "Front", pid: 1, onScreen: true)
+        let bee = window(2, "Bee", pid: 2)
+        let cee = window(3, "Cee", pid: 3)
+        let beeSecond = window(4, "Bee", pid: 2)
+        let list = [front, bee, cee, beeSecond]
+
+        let gridEnvironment = SwitcherSessionEnvironment(iconRowMode: false, simpleMode: false,
+                                                         mergeWindowsByApp: false,
+                                                         gridColumns: 3, searchPinEnabled: false)
+        let pinEnvironment = SwitcherSessionEnvironment(iconRowMode: false, simpleMode: false,
+                                                        mergeWindowsByApp: false,
+                                                        gridColumns: 3, searchPinEnabled: true)
+        let iconRowEnvironment = SwitcherSessionEnvironment(iconRowMode: true, simpleMode: false,
+                                                           mergeWindowsByApp: false,
+                                                           gridColumns: 3, searchPinEnabled: false)
+
+        func start(_ items: [SwitcherItem],
+                   reversed: Bool = false,
+                   additionalNavigation: Int = 0,
+                   commitWhenReady: Bool = false) -> SwitcherSessionStart {
+            SwitcherSessionStart(windows: items,
+                                 frontmostPID: 1,
+                                 shortcut: .switcherDefault,
+                                 reversed: reversed,
+                                 additionalNavigation: additionalNavigation,
+                                 commitWhenReady: commitWhenReady)
+        }
+        func opened(_ items: [SwitcherItem] = list,
+                    environment: SwitcherSessionEnvironment) -> SwitcherSession {
+            var session = SwitcherSession()
+            _ = session.apply(.begin(start(items)), environment: environment)
+            return session
+        }
+        func tab(shift: Bool = false, repeats: Bool = false,
+                 at now: TimeInterval = 0) -> SwitcherSession.Event {
+            .keyDown(SwitcherKeyEvent(kind: .sessionShortcut(shiftIsNavigationModifier: true),
+                                      shiftHeld: shift, isRepeat: repeats, keyCode: 48, now: now))
+        }
+        func typed(_ text: String, keyCode: Int64) -> SwitcherSession.Event {
+            .keyDown(SwitcherKeyEvent(kind: .other, keyCode: keyCode, typedText: text))
+        }
+        func arrow(_ kind: SwitcherKeyEvent.Kind) -> SwitcherSession.Event {
+            .keyDown(SwitcherKeyEvent(kind: kind))
+        }
+
+        // MARK: a session opens on the toggle target
+
+        var session = SwitcherSession()
+        let openEffects = session.apply(.begin(start(list)), environment: gridEnvironment).effects
+        check(session.isActive, "beginning a session opens it")
+        check(session.visibleItems.map(\.id) == ["w:1", "w:2", "w:3", "w:4"],
+              "a session lists the front window first")
+        check(session.selectedIndex == 1,
+              "a session opens on the toggle target, one step past the front window")
+        check(session.itemCount == 4, "a session counts every window it opened with")
+        check(Array(openEffects.prefix(4)) == [.publishSession, .recomputeLayouts,
+                                               .seedPreviews, .publishSelection],
+              "a session publishes its list and measures the layout before publishing the selection")
+        check(openEffects.contains(.schedulePanel) && openEffects.contains(.refreshPreviews),
+              "a session that is still held asks for the panel and fresh previews")
+
+        // MARK: holding the shortcut and tabbing
+
+        check(session.apply(tab(), environment: gridEnvironment).swallowsEvent,
+              "a key the switcher owns never reaches the app underneath")
+        check(session.selectedIndex == 2, "Tab steps forward")
+        _ = session.apply(tab(), environment: gridEnvironment)
+        check(session.selectedIndex == 3, "Tab keeps stepping forward")
+        _ = session.apply(tab(), environment: gridEnvironment)
+        check(session.selectedIndex == 0, "a fresh Tab press wraps around the end of the list")
+        _ = session.apply(tab(), environment: gridEnvironment)
+        _ = session.apply(tab(), environment: gridEnvironment)
+        _ = session.apply(tab(), environment: gridEnvironment)
+        check(session.selectedIndex == 3, "Tab reaches the last entry")
+        _ = session.apply(tab(repeats: true), environment: gridEnvironment)
+        check(session.selectedIndex == 3, "a held Tab stops at the end instead of wrapping")
+        _ = session.apply(tab(shift: true), environment: gridEnvironment)
+        check(session.selectedIndex == 2, "Shift-Tab steps backward")
+        _ = session.apply(tab(shift: true), environment: gridEnvironment)
+        _ = session.apply(tab(shift: true), environment: gridEnvironment)
+        _ = session.apply(tab(shift: true), environment: gridEnvironment)
+        check(session.selectedIndex == 3, "Shift-Tab wraps around the start of the list")
+
+        // MARK: the Shift-back chord (issue #784)
+
+        session = opened(environment: gridEnvironment)
+        let shiftPress = session.apply(.modifiersChanged(shortcutModifiersHeld: true,
+                                                         shiftHeld: true, now: 100),
+                                       environment: gridEnvironment)
+        check(shiftPress.swallowsEvent, "the Shift that steps back is swallowed")
+        check(session.selectedIndex == 0, "pressing Shift mid-session steps back once")
+        _ = session.apply(tab(shift: true, at: 100.1), environment: gridEnvironment)
+        check(session.selectedIndex == 0,
+              "the Tab in the same Shift chord does not step a second time")
+        _ = session.apply(tab(shift: true, at: 100.2), environment: gridEnvironment)
+        check(session.selectedIndex == 3,
+              "a later Tab during the same Shift hold keeps walking the list")
+
+        session = opened(environment: gridEnvironment)
+        _ = session.apply(.modifiersChanged(shortcutModifiersHeld: true, shiftHeld: true, now: 100),
+                          environment: gridEnvironment)
+        _ = session.apply(tab(shift: true, at: 100.4), environment: gridEnvironment)
+        check(session.selectedIndex == 3,
+              "a Tab past the chord window is a deliberate press and steps again")
+
+        session = opened(environment: gridEnvironment)
+        _ = session.apply(.modifiersChanged(shortcutModifiersHeld: true, shiftHeld: true, now: 100),
+                          environment: gridEnvironment)
+        _ = session.apply(.modifiersChanged(shortcutModifiersHeld: true, shiftHeld: false, now: 101),
+                          environment: gridEnvironment)
+        _ = session.apply(.modifiersChanged(shortcutModifiersHeld: true, shiftHeld: true, now: 102),
+                          environment: gridEnvironment)
+        check(session.selectedIndex == 3, "releasing and pressing Shift again steps back again")
+        let held = session.apply(.modifiersChanged(shortcutModifiersHeld: true,
+                                                   shiftHeld: true, now: 103),
+                                 environment: gridEnvironment)
+        check(session.selectedIndex == 3 && !held.swallowsEvent,
+              "a modifier change with Shift already down changes nothing")
+
+        // MARK: releasing the shortcut commits
+
+        session = opened(environment: gridEnvironment)
+        let release = session.apply(.modifiersChanged(shortcutModifiersHeld: false,
+                                                      shiftHeld: false, now: 100),
+                                    environment: gridEnvironment)
+        check(!release.swallowsEvent, "the modifier release still reaches the app underneath")
+        check(release.effects == [.teardown,
+                                  .activate(item: bee, source: SwitcherSessionSource(item: front),
+                                            previousWindowID: 1)],
+              "releasing the shortcut raises the highlighted window and closes the session")
+        check(!session.isActive && session.visibleItems.isEmpty && session.itemCount == 0
+                && session.shortcut == nil && session.source == nil && session.startWindowID == nil
+                && session.selectedIndex == 0 && session.scope == .allApps
+                && session.searchQuery.isEmpty && !session.isSearchPinned
+                && session.closingItemIDs.isEmpty && !session.commitPendingForClose,
+              "committing leaves nothing of the session behind for the next one to inherit")
+
+        session = opened(environment: gridEnvironment)
+        check(session.apply(arrow(.escape), environment: gridEnvironment).effects == [.teardown],
+              "Esc closes the session without raising anything")
+
+        session = opened(environment: gridEnvironment)
+        _ = session.apply(tab(), environment: gridEnvironment)
+        check(session.apply(arrow(.enter), environment: gridEnvironment).effects.last
+                == .activate(item: cee, source: SwitcherSessionSource(item: front),
+                             previousWindowID: 1),
+              "Return raises the highlighted window")
+
+        // MARK: presses that land before the window list is ready
+
+        var pending = SwitcherPendingStarts()
+        let firstGeneration = pending.claim(shortcut: .switcherDefault, scope: .allApps, reversed: false)
+        check(firstGeneration != nil && pending.isPending,
+              "the first press claims the shortcut and schedules a session")
+        check(pending.claim(shortcut: .switcherDefault, scope: .allApps, reversed: false) == nil,
+              "a second press folds into the start already on its way")
+        check(pending.current?.additionalNavigation == 1,
+              "a press before the list is ready is replayed as one more step")
+        _ = pending.claim(shortcut: .switcherDefault, scope: .allApps, reversed: true)
+        check(pending.current?.additionalNavigation == 0,
+              "a reversed press before the list is ready steps back")
+        for _ in 0 ..< 200 {
+            _ = pending.claim(shortcut: .switcherDefault, scope: .allApps, reversed: false)
+        }
+        check(pending.current?.additionalNavigation == SwitcherPendingStarts.navigationLimit,
+              "a held shortcut cannot queue unbounded navigation")
+        check(pending.current?.scope == .allApps,
+              "folding a press keeps the scope the first press asked for")
+
+        pending = SwitcherPendingStarts()
+        let flickGeneration = pending.claim(shortcut: .switcherDefault, scope: .allApps, reversed: false)
+        pending.noteShortcutModifiersReleased()
+        check(pending.current?.commitWhenReady == true,
+              "letting go before the list is ready turns the start into a commit")
+        let afterFlick = pending.claim(shortcut: .switcherDefault, scope: .allApps, reversed: false)
+        check(afterFlick != nil && afterFlick != flickGeneration,
+              "a press after the flick was released starts a new session, not another step")
+        check(pending.current?.commitWhenReady == false && pending.current?.additionalNavigation == 0,
+              "the new start does not inherit the released one")
+        check(!pending.isCurrent(flickGeneration ?? 0),
+              "the released start's generation is stale and can never open a session")
+        check(pending.take(generation: flickGeneration ?? 0) == nil,
+              "a stale generation cannot take the pending start")
+        check(pending.take(generation: afterFlick ?? 0) != nil && !pending.isPending,
+              "starting a session consumes the pending press exactly once")
+
+        // A tap disabled by the window server, and the wake recovery behind
+        // it, drop the pending press: whatever was scheduled must find nothing.
+        pending = SwitcherPendingStarts()
+        let droppedGeneration = pending.claim(shortcut: .switcherDefault, scope: .allApps, reversed: false)
+        pending.clear()
+        check(!pending.isPending && !pending.isCurrent(droppedGeneration ?? 0),
+              "clearing the pending press strands the session that was scheduled for it")
+        let keptGeneration = pending.claim(shortcut: .switcherDefault, scope: .allApps, reversed: false)
+        pending.discard(generation: droppedGeneration ?? 0)
+        check(pending.isCurrent(keptGeneration ?? 0),
+              "discarding a stale generation leaves a newer press alone")
+
+        // MARK: the quick flick that never shows a panel
+
+        session = SwitcherSession()
+        let flickEffects = session.apply(.begin(start(list, commitWhenReady: true)),
+                                         environment: gridEnvironment).effects
+        check(flickEffects.contains(.commit),
+              "a shortcut released before the list was ready commits as soon as it is")
+        check(!flickEffects.contains(.schedulePanel) && !flickEffects.contains(.refreshPreviews),
+              "a quick flick never asks for a panel it would only flash")
+
+        session = SwitcherSession()
+        let replayForward = session.apply(.begin(start(list, additionalNavigation: 2)),
+                                          environment: gridEnvironment).effects
+        check(replayForward.contains(.replayNavigation(delta: 1, times: 2)),
+              "presses that landed early are replayed one step at a time")
+        session = SwitcherSession()
+        let replayBack = session.apply(.begin(start(list, additionalNavigation: -3)),
+                                       environment: gridEnvironment).effects
+        check(replayBack.contains(.replayNavigation(delta: -1, times: 3)),
+              "reversed presses that landed early are replayed backwards")
+
+        session = SwitcherSession()
+        _ = session.apply(.begin(start(list, reversed: true)), environment: gridEnvironment)
+        check(session.selectedIndex == 3, "a reversed session opens at the far end of the list")
+
+        // MARK: closing an item mid-session
+
+        session = opened(environment: gridEnvironment)
+        check(session.apply(.requestClose(cee), environment: gridEnvironment).effects
+                == [.closeWindow(cee)],
+              "closing a card asks the window to close")
+        check(session.closingItemIDs == ["w:3"], "a window on its way out is tracked")
+        check(session.apply(.requestClose(cee), environment: gridEnvironment).effects.isEmpty,
+              "a window already closing is never asked twice")
+        _ = session.apply(.closeConfirmed(itemID: "w:3", windowID: 3), environment: gridEnvironment)
+        check(session.itemCount == 3 && !session.visibleItems.contains(where: { $0.id == "w:3" })
+                && session.closingItemIDs.isEmpty,
+              "a confirmed close drops the window from the session")
+        check(session.isActive && session.selectedIndex == 1,
+              "closing a window below the selection leaves the session where it was")
+
+        session = opened(environment: gridEnvironment)
+        _ = session.apply(.requestClose(cee), environment: gridEnvironment)
+        check(session.apply(.commit, environment: gridEnvironment).effects.isEmpty,
+              "letting go while a window is closing does not raise anything yet")
+        check(session.isActive && session.commitPendingForClose,
+              "the commit waits for the close to settle instead of being dropped")
+        let settled = session.apply(.closeConfirmed(itemID: "w:3", windowID: 3),
+                                    environment: gridEnvironment)
+        check(settled.effects.last == .activate(item: bee,
+                                                source: SwitcherSessionSource(item: front),
+                                                previousWindowID: 1),
+              "the waiting commit runs once the close settles")
+        check(!session.isActive, "the waiting commit also closes the session")
+
+        session = opened(environment: gridEnvironment)
+        _ = session.apply(.select(index: 2), environment: gridEnvironment)
+        _ = session.apply(.requestClose(cee), environment: gridEnvironment)
+        _ = session.apply(.commit, environment: gridEnvironment)
+        let onClosed = session.apply(.closeConfirmed(itemID: "w:3", windowID: 3),
+                                     environment: gridEnvironment)
+        check(onClosed.effects.last == .activate(item: beeSecond,
+                                                 source: SwitcherSessionSource(item: front),
+                                                 previousWindowID: 1),
+              "letting go on a window that was just closed lands on what took its place")
+
+        session = opened(environment: gridEnvironment)
+        _ = session.apply(.requestClose(cee), environment: gridEnvironment)
+        _ = session.apply(.closeAbandoned(itemID: "w:3"), environment: gridEnvironment)
+        check(session.closingItemIDs.isEmpty && session.itemCount == 4,
+              "a close that did not take leaves the window listed")
+        check(session.apply(.commit, environment: gridEnvironment).effects.last
+                == .activate(item: bee, source: SwitcherSessionSource(item: front),
+                             previousWindowID: 1),
+              "a session recovers from a close that did not take")
+
+        session = opened([front, bee], environment: gridEnvironment)
+        _ = session.apply(.requestClose(bee), environment: gridEnvironment)
+        _ = session.apply(.closeConfirmed(itemID: "w:2", windowID: 2), environment: gridEnvironment)
+        check(session.isActive && session.visibleItems.map(\.id) == ["w:1"] && session.selectedIndex == 0,
+              "closing a window leaves the session on what is left")
+
+        session = opened([front], environment: gridEnvironment)
+        _ = session.apply(.requestClose(front), environment: gridEnvironment)
+        _ = session.apply(.closeConfirmed(itemID: "w:1", windowID: 1), environment: gridEnvironment)
+        check(!session.isActive, "closing the only window ends the session")
+
+        session = opened(environment: gridEnvironment)
+        _ = session.apply(.requestClose(front), environment: gridEnvironment)
+        _ = session.apply(.closeConfirmed(itemID: "w:1", windowID: 1), environment: gridEnvironment)
+        check(session.startWindowID == nil,
+              "a window the user just closed is not somewhere to send them back to")
+
+        // MARK: quitting an app mid-session
+
+        session = opened(environment: gridEnvironment)
+        _ = session.apply(.appTerminated(pid: 2), environment: gridEnvironment)
+        check(session.visibleItems.map(\.id) == ["w:1", "w:3"],
+              "quitting an app takes all of its windows out of the list")
+        check(session.selectedIndex == 1 && session.isActive,
+              "the session stays open on a window that is still there")
+        _ = session.apply(.appTerminated(pid: 1), environment: gridEnvironment)
+        check(session.selectedIndex == 0, "the selection follows the entries removed before it")
+        _ = session.apply(.appTerminated(pid: 3), environment: gridEnvironment)
+        check(!session.isActive, "quitting the last listed app ends the session")
+
+        // MARK: search
+
+        session = opened(environment: gridEnvironment)
+        _ = session.apply(typed("c", keyCode: 8), environment: gridEnvironment)
+        check(session.searchQuery == "c" && session.visibleItems.map(\.id) == ["w:3"],
+              "typing narrows the list")
+        check(session.selectedIndex == 0, "the selection lands inside the narrowed list")
+        _ = session.apply(arrow(.delete), environment: gridEnvironment)
+        check(session.searchQuery.isEmpty && session.visibleItems.count == 4,
+              "deleting the query brings the list back")
+        check(session.selectedIndex == 2, "the selection stays on the window it was on")
+
+        session = opened(environment: gridEnvironment)
+        check(session.apply(typed("w", keyCode: 13), environment: gridEnvironment).effects
+                == [.closeSelectedWindow],
+              "W closes the highlighted window while the query is empty")
+        check(session.apply(typed("q", keyCode: 12), environment: gridEnvironment).effects
+                == [.quitSelectedApp],
+              "Q quits the highlighted window's app while the query is empty")
+        check(session.apply(.keyDown(SwitcherKeyEvent(kind: .other, isRepeat: true,
+                                                      keyCode: 13, typedText: "w")),
+                            environment: gridEnvironment).effects.isEmpty,
+              "holding W closes one window, not every window on the way")
+
+        session = opened(environment: gridEnvironment)
+        _ = session.apply(typed("b", keyCode: 11), environment: gridEnvironment)
+        _ = session.apply(typed("w", keyCode: 13), environment: gridEnvironment)
+        check(session.searchQuery == "bw",
+              "once a search is under way W is a letter of the query again")
+
+        session = opened(environment: gridEnvironment)
+        _ = session.apply(typed("s", keyCode: 1), environment: gridEnvironment)
+        check(session.searchQuery == "s" && !session.isSearchPinned,
+              "S is search text until the pin preference is on")
+        session = opened(environment: pinEnvironment)
+        check(session.apply(typed("s", keyCode: 1), environment: pinEnvironment).effects
+                == [.publishSession],
+              "S pins the search field open when the preference is on")
+        check(session.isSearchPinned && session.searchQuery.isEmpty,
+              "pinning the search field types nothing")
+        let pinnedRelease = session.apply(.modifiersChanged(shortcutModifiersHeld: false,
+                                                            shiftHeld: false, now: 100),
+                                          environment: pinEnvironment)
+        check(pinnedRelease.effects.isEmpty && session.isActive,
+              "a pinned search field survives the shortcut being released")
+
+        session = opened(environment: gridEnvironment)
+        _ = session.apply(typed(String(repeating: "b", count: 200), keyCode: 11),
+                          environment: gridEnvironment)
+        check(session.searchQuery.count == SwitcherSession.searchQueryLimit,
+              "the search query is capped")
+        _ = session.apply(typed("b", keyCode: 11), environment: gridEnvironment)
+        check(session.searchQuery.count == SwitcherSession.searchQueryLimit,
+              "typing past the cap adds nothing")
+        _ = session.apply(typed("\u{0001}", keyCode: 11), environment: gridEnvironment)
+        check(session.searchQuery.count == SwitcherSession.searchQueryLimit,
+              "control characters never reach the query")
+
+        // MARK: arrows and the window key
+
+        session = opened(environment: gridEnvironment)
+        _ = session.apply(.select(index: 0), environment: gridEnvironment)
+        _ = session.apply(arrow(.downArrow), environment: gridEnvironment)
+        check(session.selectedIndex == 3, "Down jumps a row of the grid")
+        _ = session.apply(arrow(.upArrow), environment: gridEnvironment)
+        check(session.selectedIndex == 0, "Up jumps back a row")
+        _ = session.apply(.select(index: 3), environment: gridEnvironment)
+        check(session.apply(arrow(.downArrow), environment: gridEnvironment).effects.isEmpty,
+              "Down on the last row leaves the selection where it is")
+
+        session = opened(environment: gridEnvironment)
+        _ = session.apply(arrow(.rightArrow), environment: gridEnvironment)
+        check(session.selectedIndex == 2, "Right steps forward")
+        _ = session.apply(arrow(.leftArrow), environment: gridEnvironment)
+        check(session.selectedIndex == 1, "Left steps back")
+
+        session = opened(environment: gridEnvironment)
+        _ = session.apply(.keyDown(SwitcherKeyEvent(kind: .windowShortcut(positionalMatch: true,
+                                                                          shiftIsNavigationModifier: true))),
+                          environment: gridEnvironment)
+        check(session.selectedIndex == 3,
+              "the window key hops between the selected app's own windows")
+
+        // MARK: the icon row steps app by app
+
+        session = opened(environment: iconRowEnvironment)
+        check(session.selectedIndex == 1, "the icon row opens on the next app")
+        _ = session.apply(tab(), environment: iconRowEnvironment)
+        check(session.selectedIndex == 2, "Tab in the icon row skips the app's second window")
+        _ = session.apply(arrow(.downArrow), environment: iconRowEnvironment)
+        check(session.selectedIndex == 2,
+              "Down in the icon row moves inside the app, and a lone window stays put")
+        _ = session.apply(.select(index: 1), environment: iconRowEnvironment)
+        _ = session.apply(arrow(.downArrow), environment: iconRowEnvironment)
+        check(session.selectedIndex == 3, "Down in the icon row walks the app's windows")
+
+        // MARK: a session that opened with nothing in front
+
+        session = SwitcherSession()
+        _ = session.apply(.begin(SwitcherSessionStart(windows: [bee, cee],
+                                                      frontmostPID: 9,
+                                                      shortcut: .switcherDefault)),
+                          environment: gridEnvironment)
+        check(session.isActive && session.selectedIndex == 0 && session.source == nil,
+              "a session with no window in front opens on the first entry (issue #324)")
+
+        // MARK: a window-scoped session
+
+        session = SwitcherSession()
+        _ = session.apply(.begin(SwitcherSessionStart(windows: [front, window(5, "Front", pid: 1)],
+                                                      frontmostPID: 1,
+                                                      shortcut: .switcherWindowDefault,
+                                                      scope: .frontmostApp)),
+                          environment: gridEnvironment)
+        check(session.scope == .frontmostApp && session.selectedIndex == 1,
+              "a window-scoped session opens on the front app's next window")
+        check(iconRowEnvironment.usesAppGroupsForMainShortcut(scope: .allApps)
+                && !SwitcherSessionEnvironment(iconRowMode: false, simpleMode: true,
+                                               mergeWindowsByApp: true, gridColumns: 3,
+                                               searchPinEnabled: false)
+                      .usesAppGroupsForMainShortcut(scope: .frontmostApp),
+              "the layout mode is answered from the scope the session actually has")
+        _ = session.apply(.keyDown(SwitcherKeyEvent(kind: .appsShortcutInWindowScope(
+                                                        shiftIsNavigationModifier: true))),
+                          environment: gridEnvironment)
+        check(session.scope == .frontmostApp && session.selectedIndex == 0,
+              "the Apps shortcut steps a window-scoped session instead of widening it")
+
+        // MARK: events that arrive after the session is gone
+
+        session = SwitcherSession()
+        check(session.apply(tab(), environment: gridEnvironment).swallowsEvent,
+              "a key claimed for a session that already ended stays swallowed")
+        check(session.apply(tab(), environment: gridEnvironment).effects.isEmpty,
+              "a key arriving after teardown changes nothing")
+        check(session.apply(.commit, environment: gridEnvironment).effects.isEmpty,
+              "committing with no session open does nothing")
+        check(session.apply(.select(index: 0), environment: gridEnvironment).effects.isEmpty,
+              "selecting with no session open does nothing")
+        check(session.apply(.requestClose(bee), environment: gridEnvironment).effects.isEmpty,
+              "closing with no session open does nothing")
+
+        return results
     }
 
     private static func formatSpecifiers(in format: String) -> [String] {

--- a/build.sh
+++ b/build.sh
@@ -344,6 +344,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseSupport.swift \
         Sources/Vorssaint/Services/Switcher/SwitcherModels.swift \
         Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift \
+        Sources/Vorssaint/Services/Switcher/SwitcherSession.swift \
         Sources/Vorssaint/Services/Switcher/SpaceHopSupport.swift \
         Sources/Vorssaint/Services/Switcher/WindowUseOrder.swift \
         Sources/Vorssaint/Services/Metrics/MetricFormat.swift \


### PR DESCRIPTION
## Summary

`AppSwitcher` owned the session state machine and the machinery around it in the same object: roughly 40 mutable fields (selection, generation counters, the Shift-back chord, pending closes, search query, scope) sitting next to a `CGEventTap` on its own thread, the `NSPanel` lifecycle, and the wake and keyboard-layout observers. Nothing could drive the state machine without standing up an event tap and a panel, so nothing tested it.

The decisions were already testable — `SwitcherSupport` is in the `--test` source list and holds 75 pure functions. The *ordering* of those decisions was not, and that is where the bugs are: of 53 `Services/Switcher` files touched by fix commits in the last 200, 29 landed in files the test binary does not compile.

This moves the session into `SwitcherSession.swift`, a value type with one entry point:

```swift
mutating func apply(_ event: Event, environment: SwitcherSessionEnvironment) -> SwitcherSessionOutcome
```

11 event cases in; an outcome carrying 16 effect cases plus `swallowsEvent` out. `AppSwitcher` keeps the tap, the panel, `NSScreen` placement, preview images, pointer hover and `decodeKey`, and becomes the thing that feeds events in and performs the effects that come back. `SwitcherSession` imports only `CoreGraphics` and `Foundation`.

Behaviour is unchanged. No timing, debouncing or ordering was altered.

**What did not move, and why.** The `@Published` mirrors `SwitcherView` binds to stay on `AppSwitcher` — they are now written only while performing a publish effect, and `SwitcherView` has a zero-line diff. `routeSessionActive` stays under `routeLock` because the tap thread routes every keystroke by it. The icon-row slide stays on the adapter because it reads a layout measured from `NSScreen`; its selection writes now route through the session so it cannot drift.

**On the size.** +1,558 / −689, which the template flags as the range where things stall. I could not find a smaller honest split: a partly-extracted state machine, with the fields divided between two owners, is worse than either end state. The 806 new lines are one file that did not exist; the deletions are the same logic leaving `AppSwitcher` (1,708 → 1,320).

**Trade-off considered and rejected.** Folding the `SwitcherSupport` statics into the session physically. Four of the 20 it uses (`appGroups`, `usesIconRowLayout`, `usesWindowRow`, `windowNavigationDelta`) are also called by `WindowEnumerator`, `WindowActivator` and the views, so moving them would have broken those callers for no gain. The other 16 now have no callers outside `SwitcherSession`.

## Verification

MacBook (Mac17,3, Apple M5), macOS 26.6.2 (25G83), single built-in display, one Space. Release build via `./build.sh`, not a signed distribution build.

```
./build.sh                      exit 0, no warnings
./build/Vorssaint --selftest    SELFTEST OK
./build.sh --test               TESTS OK (9621 checks)   — main is 9526, so +95
```

The +95 is 98 new checks minus 3 removed. The 3 removed were a source-shape assertion that read `AppSwitcher.swift` as text and compared string offsets to prove the scope was assigned before the session-start layout pass. That hazard is now designed out rather than guarded: `SwitcherSessionEnvironment` answers the scope-dependent layout questions from the scope the session holds, instead of taking a pre-answered value.

The new checks drive sequences, not individual functions: open → Tab ×3 → wrap → held-Tab → Shift-Tab ×4; the Shift-back chord at three different inter-key delays plus release and re-press; presses claimed before the window list exists, folded, bounded at 200, and discarded on release; close → close-again → commit → confirm, and commit landing on the item being closed; app termination walking the selection; letter commands versus an in-progress search; grid arrows with 3 columns; a window-scoped session receiving the Apps shortcut.

I checked the tests can fail rather than assuming it: six deliberate regressions introduced into `SwitcherSession`, five turned the suite red across nine labels. The sixth — teardown leaking `isSearchPinned` into the next session — was not caught, so the reset assertion was widened to cover all 12 fields, then the regression was reverted and the suite re-run green.

**What I could not test.** No interactive run. Everything above is the harness and a release build; I did not hold Shift and Tab through a real session, and I did not exercise it across multiple displays, multiple Spaces, a fast user switch, or wake from sleep — all paths this code touches. One built-in display and one Space is the whole of the hardware coverage here. That gap is the useful part of this section: the sequences are asserted, the real input path is not.

Rebased onto `5a4afb15`, which includes #882 (system Command-Tab takeover). That PR changed the same file. I checked each symbol it introduced (`applyNativeHotkeySuppression`, `applyNativeHotkeySuppressionIfTapLive`, `reconcileTakeover`, `restoreNativeHotkeys`, `nativeHotkeysToSuppress`, `SwitcherNativeHotkeys.apply`, `SwitcherNativeHotkeys.configuredShortcuts`) still appears the same number of times after the rebase as before it.

## Anything else

Three defects were found while extracting and deliberately left alone, since this change is meant to preserve behaviour:

- `SwitcherSupport.commitTargetID`'s closing-window branch is unreachable from the app. `commitSession()` guards `closingItemIDs.isEmpty` before calling it, so the argument is provably empty at the only call site and the function always returns `itemIDs[selectedIndex]`. What its comment describes is actually delivered by `commitPendingForClose` deferring the commit. `MetricsTests` exercises the branch directly, which is why it reads as live.
- `userNavigated` has 7 writes and no reads, before and after.
- `KeyCode.tab` is unused.

One defensive change that is not behaviour-preserving in the strictest sense: the old `quitSelectedApp` did `windows[..<selectedIndex]`, which traps if `selectedIndex > windows.count`. I could not find a reachable path to it and clamped it in `applyTerminatedApp`. No reachable behaviour changes.

No issue reference — I did not find an existing issue for this.
