### PR TITLE
perf(shelf): stop recomputing settled drag facts on every dragged event

### DIFF
--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -429,15 +429,16 @@ final class ShelfService: ObservableObject {
                 self.endDockedDrag()
                 self.endEdgePeekDrag()
             default:
+                // Where the gesture started is settled at `beginDragGesture`,
+                // which asks the Dock question once for this event; re-asking
+                // costs a window-list copy plus a running-app lookup on every
+                // dragged event. A Dock stack whose mouse-down never reached
+                // the monitor can still surface its window number a few events
+                // late, so keep asking for a short while, starting from the
+                // next event rather than asking this one twice.
                 if !self.sawGestureStart {
                     self.beginDragGesture(with: event)
-                }
-                // Where the gesture started is settled at `beginDragGesture`;
-                // re-asking costs a window-list copy plus a running-app lookup
-                // on every dragged event. A Dock stack whose mouse-down never
-                // reached the monitor can still surface its window number a
-                // few events late, so keep asking for a short while.
-                if !self.dragBeganInDock, self.dockOriginProbes < Self.dockOriginProbeLimit {
+                } else if !self.dragBeganInDock, self.dockOriginProbes < Self.dockOriginProbeLimit {
                     self.dockOriginProbes += 1
                     self.dragBeganInDock = self.eventBelongsToDock(event)
                 }

--- a/Sources/Vorssaint/Services/Shelf/ShelfService.swift
+++ b/Sources/Vorssaint/Services/Shelf/ShelfService.swift
@@ -201,6 +201,15 @@ final class ShelfService: ObservableObject {
     /// as a content drag (issue #240).
     private var sawGestureStart = false
     private var dragBeganInDock = false
+    /// Dragged events spent re-asking whether this gesture started in the
+    /// Dock, capped so a long drag does not pay for the answer at event rate.
+    private var dockOriginProbes = 0
+    private static let dockOriginProbeLimit = 5
+    /// One gesture's answer to "does the drag pasteboard hold something the
+    /// Shelf can keep", remembered against the change count that produced it.
+    /// The contents cannot change while the count stands still, so enumerating
+    /// them once per gesture is enough.
+    private var droppableContentAnswer: (changeCount: Int, hasContent: Bool)?
     private var dragSourceBundleIdentifier: String?
     private var activeInternalDragIDs: [UUID] = []
     private var internalDragWasMerged = false
@@ -423,7 +432,15 @@ final class ShelfService: ObservableObject {
                 if !self.sawGestureStart {
                     self.beginDragGesture(with: event)
                 }
-                self.dragBeganInDock = self.dragBeganInDock || self.eventBelongsToDock(event)
+                // Where the gesture started is settled at `beginDragGesture`;
+                // re-asking costs a window-list copy plus a running-app lookup
+                // on every dragged event. A Dock stack whose mouse-down never
+                // reached the monitor can still surface its window number a
+                // few events late, so keep asking for a short while.
+                if !self.dragBeganInDock, self.dockOriginProbes < Self.dockOriginProbeLimit {
+                    self.dockOriginProbes += 1
+                    self.dragBeganInDock = self.eventBelongsToDock(event)
+                }
                 let defaults = UserDefaults.standard
                 if defaults.bool(forKey: DefaultsKey.shelfShakeToOpen) {
                     self.handleDrag(event)
@@ -494,11 +511,19 @@ final class ShelfService: ObservableObject {
 
     private func isContentDragActive() -> Bool {
         let pasteboard = NSPasteboard(name: .drag)
+        let changeCount = pasteboard.changeCount
         return ShelfInteractionSupport.isContentDrag(
             baselineChangeCount: dragBaselineChangeCount,
-            changeCount: pasteboard.changeCount,
+            changeCount: changeCount,
             beganInDock: dragBeganInDock,
-            hasDroppableContent: { pasteboardHasDroppableContent(pasteboard) })
+            hasDroppableContent: {
+                if let answer = droppableContentAnswer, answer.changeCount == changeCount {
+                    return answer.hasContent
+                }
+                let hasContent = pasteboardHasDroppableContent(pasteboard)
+                droppableContentAnswer = (changeCount, hasContent)
+                return hasContent
+            })
     }
 
     /// Opens a gesture at its first observed event: the mouse-down when it
@@ -507,6 +532,7 @@ final class ShelfService: ObservableObject {
     private func beginDragGesture(with event: NSEvent) {
         sawGestureStart = true
         dragBaselineChangeCount = NSPasteboard(name: .drag).changeCount
+        dockOriginProbes = 0
         dragBeganInDock = eventBelongsToDock(event)
         dragSourceBundleIdentifier = sourceBundleIdentifier(for: event)
     }


### PR DESCRIPTION
## Summary

The Shelf's global mouse monitor recomputes two things on every
`leftMouseDragged` event that are settled once the gesture is open. Nothing
here is meant to change an answer, only how often it is asked.

**The drag pasteboard was enumerated per caller per event.**
`isContentDragActive()` calls `pasteboardHasDroppableContent`, which walks
every `NSPasteboardItem` and every type on it against a twelve-entry string
set and then against six `UTType` conformance tests. Three paths ask it on a
dragged event — shake-to-open through `handleDrag`, the drop zone through
`handleDragForDock`, and the edge peek through `handleDragForEdge` — so a
gesture with all three features on pays the whole walk three times per event
for a pasteboard that cannot have changed. `NSPasteboard.changeCount` is
documented to increment on every change of ownership, and `isContentDrag`
already reads it one line above for the baseline test, so the answer is now
remembered against the count that produced it: one walk per gesture instead of
one per caller per event. A later gesture that sees the same count is looking
at the same contents, so the memo needs no reset of its own.

**Where the gesture started was re-asked per event.** `dragBeganInDock` was
latched with `dragBeganInDock || eventBelongsToDock(event)`, and until it
latches, `eventBelongsToDock` costs a `CGWindowListCopyWindowInfo` for the
event's window number plus an `NSRunningApplication(processIdentifier:)`
lookup — on every dragged event of every drag that did not start in the Dock,
which is most of them. `beginDragGesture` already asks the same question at
the gesture's first observed event. Asking only there would be the honest
shape, but it is not obviously safe: a Dock stack whose mouse-down never
reached the global monitor opens its gesture on the first dragged event, and
that event can carry `windowNumber == 0` and surface the real number a few
events later. So the question is still asked past the start, capped at five
dragged events.

### The five is a guess, and it is the part to look at

`dockOriginProbeLimit = 5` is reasoning about event rate, not a measurement: a
`leftMouseDragged` stream runs at roughly 60–125 Hz, so five events is on the
order of 40–80 ms. Nothing here counted how late a Dock stack actually
surfaces its window number, and there is no list of gestures the old code
recognised as Dock drags that this one does not.

That matters because `dragBeganInDock` feeds
`ShelfInteractionSupport.isContentDrag(beganInDock:)`, which is the only
reason a Dock drag with an unchanged change count counts as content at all —
the shape that came out of #240. A cap guessed too low turns that back off,
and the symptom is the Shelf not appearing for a drag out of a Dock stack.
That is user-visible, and no check in this branch or in the suite covers it.

What would settle the number: a Mac where a drag out of a Dock stack reaches
the monitor with its mouse-down consumed, instrumented to log
`event.windowNumber` and the `eventBelongsToDock` answer per dragged event,
and a count of how many events pass before it first answers true. If that is
zero or one on real hardware the cap can be far smaller; if it is ever above
five, this change is a regression as written. I do not have that measurement,
and I would rather hand over the number's provenance than dress it up.

### Tradeoffs

- Counting events is the wrong unit for what the cap is protecting against.
  The concern is how long after the gesture opens, and the event rate that
  converts one into the other varies with the device and the load. Two shapes
  that need no magic count: stop probing once `event.timestamp` is more than a
  fixed interval past the gesture's start, which states the thing directly;
  or probe only while `event.windowNumber == 0`, since a gesture that already
  reported a window number has nothing further to reveal and one that never
  reports one can never answer true from the window list either. Neither is
  done here — swapping the design blind trades one unmeasured rule for
  another, and the second changes which gestures get asked at all rather than
  only how many times. If either is the preferred shape, say which and it goes
  in with the measurement behind it.
- Leaving `eventBelongsToDock` on every event is the safe option and is what
  `main` does. The two halves of this branch are independent: if the answer is
  that the pasteboard memo is worth taking and the Dock probe is not, the
  probe hunk drops out on its own and the memo stands.
- The memo trusts `changeCount` as the only thing that can invalidate the
  answer. That is what the documentation says and what the baseline test one
  line above already depends on, so it adds no assumption the file was not
  making already. Keying on the count rather than on gesture identity is also
  what makes a source that writes the pasteboard mid-gesture re-answer instead
  of being served a stale yes.

## Verification

macOS 26.x on Apple silicon. Branched from `origin/main` at `ea374e1e`.

- `./build.sh --test`: `TESTS OK (9528 checks)`, no failures. The count is the
  same as the base, because this branch adds no assertion.
- `ShelfService.swift` is not in the file list `--test` compiles, so
  `swiftc -typecheck` was run over the whole `Sources/Vorssaint` set with the
  target, SDK and compat flags `build.sh` uses (`arm64-apple-macosx14.0`, the
  pinned `MacOSX26.sdk`, `-interface-compiler-version 6.3.2`, and both compat
  include paths): clean, no diagnostics.
- `./build.sh` was not run here: with the signing keychain locked, `codesign`
  blocks on an unlock dialog and never exits, so the release build and the
  zero-warning check are left to CI.

**Not tested.** I did not run the app, and nothing here was exercised as
behaviour. Neither half carries a check: `ShelfService` is outside the
`--test` set, and both changes are about how often existing code runs rather
than what it returns, so a source-shape assertion would pin the shape without
testing the claim. Named specifically, because these are the ways this can be
wrong: that a drag out of a Dock stack still opens the Shelf under the
five-event cap; that the memo returns on a real drag what the uncached walk
would have; and the cost claims themselves — there is no before-and-after
count of pasteboard walks or window-list copies from a running app, only the
call sites read above. No second display, no second Space, no external
volume.

## Anything else

This is the drag half of #1229, taken back off that branch and sent on its
own. The two share no code — that branch is about the persisted store — and
this one is cut from `main`, so it does not depend on it.

No issue in the tracker asks for this. #240 is the report the `beganInDock`
path exists for; it is closed and this does not change the behaviour it asked
for, so it is not referenced as a fix here.
