### PR TITLE
fix(window-layout): keep the directional gesture's feedback running under a held button

### DIFF
--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
@@ -732,9 +732,16 @@ final class WindowLayoutService: ObservableObject {
                                                       action: nil,
                                                       manualOverride: nil)
         showDirectionalIndicator(at: NSEvent.mouseLocation, action: nil)
-        directionalTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) {
+        // The gesture's own tap takes leftMouseDown and rightMouseDown, so a
+        // held mouse button puts the main run loop into event tracking and a
+        // default-mode timer stops firing: the indicator and the snap preview
+        // hold the frame from before the press. The settle timer in this same
+        // service is already in common modes; the feedback timer now is too.
+        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) {
             [weak self] _ in self?.updateDirectionalGesture()
         }
+        directionalTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
         startDirectionalTap()
     }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21808,6 +21808,27 @@ struct MetricsTests {
             .dropFirst().first?.components(separatedBy: "Permissions.shared.$screenRecording").first ?? ""
         expect(accessibilitySink.contains(".quitWindowProtection"),
                "granting Accessibility starts quit protection without a relaunch")
+        // The directional gesture's own tap takes leftMouseDown, so holding a
+        // button puts the main run loop into event tracking. A feedback timer
+        // scheduled in the default mode alone stops firing there and the
+        // indicator holds the frame from before the press. Sliced to the
+        // gesture's own start, so the settle timer in the same file — which has
+        // been in common modes all along — cannot answer for it.
+        let directionalStart = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift",
+            encoding: .utf8)) ?? "")
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.hasPrefix("//") }
+            .joined(separator: "\n")
+            .components(separatedBy: "showDirectionalIndicator(at: NSEvent.mouseLocation, action: nil)")
+            .dropFirst().first?
+            .components(separatedBy: "startDirectionalTap()").first ?? ""
+        expect(!directionalStart.isEmpty
+                && directionalStart.contains("RunLoop.main.add(timer, forMode: .common)")
+                && !directionalStart.contains("Timer.scheduledTimer"),
+               "the directional gesture's feedback timer keeps firing while a mouse button is held")
+
         let smoothSchedulerSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/Services/SmoothScrollService.swift",
             encoding: .utf8)) ?? ""


### PR DESCRIPTION
## Summary

The directional gesture's indicator and snap preview freeze while a mouse
button is held.

`beginDirectionalGesture` drives both from a 60 Hz timer created with
`Timer.scheduledTimer`, which schedules only in the default run loop mode. The
gesture's own tap takes `leftMouseDown` and `rightMouseDown`, so pressing a
button during the gesture moves the main run loop into event tracking,
`updateDirectionalGesture()` stops firing, and the indicator and the preview
hold the frame from before the press until the button comes back up.

`RunLoop.main.add(timer, forMode: .common)` is what `scheduleSettleCheck` in
this same service already does. The feedback timer now does it too. No
tolerance was added — slack in a 60 Hz feedback timer is the thing being
fixed.

`WindowLayoutService.swift` is outside the `--test` whitelist, so a source
check pins the mode. It is sliced to the gesture's own start, between
`showDirectionalIndicator` and `startDirectionalTap`, so the settle timer that
has been in common modes all along cannot answer for it.

Split out of #1233, which had it as a rider under `### Also in this file`.
That change is about handing the window taps back across a fast user switch;
this one is an independent UI defect visible without any second account, and
none of that branch's assertions reached it.

## Verification

MacBook Pro, macOS 26.

```
./build.sh --test      TESTS OK (9534 checks)
swiftc -typecheck      exit 0, whole module
```

`--test` compiles a whitelist that does not include `WindowLayoutService.swift`,
so the whole of `Sources/Vorssaint/**` was type-checked separately with the
same target and SDK `build.sh` uses. The full `./build.sh` was not run: with
the signing keychain locked, `codesign` blocks on an unlock dialog.

The new check was verified both ways. Reverting the timer to
`Timer.scheduledTimer` turns it red on its own; restored, the suite is green.

**What was not tested.** The freeze itself was not reproduced on screen, and
the fix was not watched working. What is verified is the mechanism — a
default-mode timer does not fire during event tracking, the tap that starts
that tracking is this gesture's own, and the sibling timer in the same file
already answers it this way.

## Anything else

Refs #1153
