### PR TITLE
perf(window-layout): look up the focused target's app by pid

### DIFF
--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
@@ -287,7 +287,14 @@ final class WindowLayoutService: ObservableObject {
         guard let onScreenWindowIDs = onScreenWindowIDs() else { return nil }
         for pid in pids {
             let isFocusedOwnApp = pid == ownPID && hasFocusedResizableOwnWindow
-            guard let app = NSWorkspace.shared.runningApplications.first(where: { $0.processIdentifier == pid }),
+            // One lookup by pid, not a fresh bridge of every running app on
+            // each turn of a list that can hold dozens of them. The edge-snap
+            // drag in this same file already resolves its app this way.
+            // isTerminated is explicit because runningApplications drops a dead
+            // pid on its own and NSRunningApplication(processIdentifier:) does
+            // not: it answers with a terminated instance.
+            guard let app = NSRunningApplication(processIdentifier: pid),
+                  !app.isTerminated,
                   isFocusedOwnApp
                     || (app.activationPolicy == .regular && !app.isHidden
                         && app.bundleIdentifier != ownBundleID)


### PR DESCRIPTION
## Summary

`focusedTarget(for:)` walks a pid list — the frontmost app plus the window-use
MRU, which can hold dozens of entries — and asked
`NSWorkspace.shared.runningApplications` on every turn, bridging the whole
process table each time to find one pid. Five other call sites in this same
file, `makeEdgeSnapDrag` among them, already use
`NSRunningApplication(processIdentifier:)`, which is the direct lookup.

One behaviour difference is worth naming rather than hiding: the two are not
the same on a process that has just died. `runningApplications` drops a
terminated app from the array, so the old form skipped that pid; the direct
lookup answers with a terminated instance instead, whose `activationPolicy`
and `isHidden` are not meaningful. `!app.isTerminated` restores the old
outcome, and is written out rather than folded into the condition below it so
the reason stays visible.

**Not measured, and no assertion covers it.** The list is short in the common
case, and this runs on a layout shortcut rather than per event, so the win is
a smaller constant on an already cheap path rather than something a profile
would show. It is here because the file answers this question five other ways
already. If that is not reason enough on its own, this is the change to drop.

Split out of #1233, which had it as a rider under `### Also in this file`.
That branch is about handing the window taps back across a fast user switch
and none of its assertions reached this line, so it is on its own here rather
than merged on the strength of a session-gate review.

## Verification

MacBook Pro, macOS 26.

```
./build.sh --test      TESTS OK (9533 checks)
swiftc -typecheck      exit 0, whole module
```

`--test` compiles a whitelist that does not include `WindowLayoutService.swift`,
so the whole of `Sources/Vorssaint/**` was type-checked separately with the
same target and SDK `build.sh` uses. The full `./build.sh` was not run: with
the signing keychain locked, `codesign` blocks on an unlock dialog.

**What was not tested.**

- No before/after timing. See above — this is not offered as a measured win.
- The terminated-pid case. Reaching it needs an app in the window-use MRU to
  exit between the MRU read and this loop. `!app.isTerminated` is written to
  match what the old form did, not to fix an observed failure.

## Anything else

Split out of #1233; carries no fix for the user-switch stall (issue 1153), it is a lookup change only.


