### PR TITLE
fix(screenshot): let the visibility preference reach the content windows

### DIFF
--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotCapturePolicy.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotCapturePolicy.swift
@@ -13,6 +13,19 @@ enum ScreenshotCapturePolicy {
         hideVorssaintWindows ? ownWindowIDs : ownWindowIDs.intersection(protectedWindowIDs)
     }
 
+    /// The own windows the capture paths keep out of the shot before the
+    /// visibility preference says anything (issue #780). The workflow
+    /// surfaces — the selection overlays and the countdown and scrolling
+    /// HUDs — are always excluded: they are the tool taking the capture,
+    /// never its subject. Content windows (editors, pins, the quick preview)
+    /// follow the preference, so with "Hide Vorssaint windows" off they stay
+    /// capturable instead of silently joining the protected list.
+    static func protectedWindowIDs(hideVorssaintWindows: Bool,
+                                   workflowWindowIDs: Set<CGWindowID>,
+                                   contentWindowIDs: Set<CGWindowID>) -> Set<CGWindowID> {
+        hideVorssaintWindows ? workflowWindowIDs.union(contentWindowIDs) : workflowWindowIDs
+    }
+
     static func canPickWindow(_ windowID: CGWindowID,
                               isOwnWindow: Bool,
                               hideVorssaintWindows: Bool,

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotService.swift
@@ -44,20 +44,30 @@ final class ScreenshotService: ObservableObject {
     }
 
     private var protectedWindowIDs: Set<CGWindowID> {
-        var ids = session?.protectedWindowIDs ?? []
-        ids.formUnion(preview?.protectedWindowIDs ?? [])
-        for editor in editors {
-            ids.formUnion(editor.protectedWindowIDs)
-        }
-        ids.formUnion(ScreenshotPinController.shared.protectedWindowIDs)
-        ids.formUnion(ScreenCaptureService.shared.protectedWindowIDs)
+        // The selection overlays and the countdown and scrolling HUDs are the
+        // tool taking the capture, so they stay excluded whatever the
+        // preference says.
+        var workflowIDs = session?.protectedWindowIDs ?? []
+        workflowIDs.formUnion(ScreenCaptureService.shared.protectedWindowIDs)
         if let number = QuickToolHUD.currentWindowNumber, number > 0 {
-            ids.insert(CGWindowID(number))
+            workflowIDs.insert(CGWindowID(number))
         }
         if let number = QuickToolHUD.currentScrollingWindowNumber, number > 0 {
-            ids.insert(CGWindowID(number))
+            workflowIDs.insert(CGWindowID(number))
         }
-        return ids
+        // Editors, pins and the quick preview are content, and the visibility
+        // preference governs them: with "Hide Vorssaint windows" off they
+        // stay capturable (issue #780) instead of silently joining the
+        // protected list.
+        var contentIDs = preview?.protectedWindowIDs ?? []
+        for editor in editors {
+            contentIDs.formUnion(editor.protectedWindowIDs)
+        }
+        contentIDs.formUnion(ScreenshotPinController.shared.protectedWindowIDs)
+        return ScreenshotCapturePolicy.protectedWindowIDs(
+            hideVorssaintWindows: hideVorssaintWindows,
+            workflowWindowIDs: workflowIDs,
+            contentWindowIDs: contentIDs)
     }
 
     var protectedWindowIDsForCapture: Set<CGWindowID> { protectedWindowIDs }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15448,6 +15448,30 @@ struct MetricsTests {
             protectedWindowIDs: protectedScreenshotWindows
         ), "screenshot cannot pick its own protected capture UI")
 
+        // The workflow's own surfaces — the selection overlays and the
+        // countdown and scrolling HUDs — stay excluded whatever the preference
+        // says, while editors, pins and the quick preview are content and
+        // follow it: with "Hide Vorssaint windows" off they stay capturable
+        // instead of silently joining the protected list (issue #780).
+        expect(ScreenshotCapturePolicy.protectedWindowIDs(
+            hideVorssaintWindows: false,
+            workflowWindowIDs: [12],
+            contentWindowIDs: [11, 13]
+        ) == [12],
+        "screenshot keeps only the capture workflow excluded when Vorssaint windows are visible")
+        expect(ScreenshotCapturePolicy.protectedWindowIDs(
+            hideVorssaintWindows: true,
+            workflowWindowIDs: [12],
+            contentWindowIDs: [11, 13]
+        ) == [11, 12, 13],
+        "screenshot excludes the whole app when hiding Vorssaint windows")
+        expect(ScreenshotCapturePolicy.protectedWindowIDs(
+            hideVorssaintWindows: true,
+            workflowWindowIDs: [],
+            contentWindowIDs: []
+        ).isEmpty,
+        "screenshot protected list is empty when nothing is on screen")
+
         // A sheet or dialog the app stacked on the clicked window is a window
         // of its own, so a single-window capture leaves it out of a shot it is
         // plainly part of (issue #1098). Same app, in front, and lying wholly


### PR DESCRIPTION
Refs #780.

## Problem

`ScreenshotService.protectedWindowIDs` unioned every window the app puts on screen — selection overlays, the countdown and scrolling HUDs, editors, pins, the quick preview and the capture panels — before the "Hide Vorssaint windows" preference was ever consulted. The capture paths themselves honour the preference (`ScreenshotCapturePolicy.excludedWindowIDs` excludes everything when it is on, and otherwise only the protected list), so with the preference off the protected list re-excluded the editors, pins and panels anyway: the switch could never reach them. That matches the clarification on the issue — the Settings window, which was never in the protected list, was already capturable, while the screenshot and screen-recording windows were not.

## Change

The protected list now splits the app's own windows by role:

- **Workflow surfaces** — the screenshot selection overlay, the shared capture tool's selection overlay, the countdown HUD and the scrolling HUD — stay excluded whatever the preference says: they are the tool taking the capture, never its subject.
- **Content windows** — editors, pins, the quick preview — join the protected list only when "Hide Vorssaint windows" is on; with it off they stay capturable.

The decision lives in `ScreenshotCapturePolicy.protectedWindowIDs(hideVorssaintWindows:workflowWindowIDs:contentWindowIDs:)` beside the other capture-policy decisions, so `./build.sh --test` reaches it; `ScreenshotService.protectedWindowIDs` assembles the two sets and calls it.

The screen recorder builds its chrome from the same list (`ScreenRecorderService`), so its behaviour follows the preference too: preference on, the recording excludes the whole app as before; preference off, the capture panels stop being silently erased from recordings as well.

## Tests

Three behaviour tests against the new policy function: preference off keeps only the workflow excluded; preference on excludes the whole app; nothing on screen yields an empty list. Reverting the split to an unconditional union turns the first one red.

## What I could not test

This branch was written on a Windows machine, so it was not compiled or run here — not `./build.sh`, not `--selftest`, not `--test`. The whole path was read instead: both capture engines, the scrolling capture, the selection controller, the recorder's chrome assembly and the window picker. Two things most need a real Mac: that the migrated HUD and overlay window numbers resolve identically through `SCShareableContent` (the mechanics are unchanged, but I cannot run it), and a direction call on the recorder side — with the preference off, an open editor or a pinned capture will now appear in recordings, which is what the preference says but is a slightly wider effect than the issue's screenshots-only framing.