### PR TITLE
fix(radial-menu): hand the side-button tap back across a user switch

### DIFF
--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
@@ -72,7 +72,19 @@ final class RadialMenuService: ObservableObject {
     private var activationObserver: NSObjectProtocol?
     private var promptedForAccessibility = false
 
-    private init() {}
+    private init() {
+        // A filter tap owned by a switched-away login session keeps its place
+        // in the chain, so the account on screen waits out this tap's timeout
+        // on every extra-button click it makes (issue #1075). Hand the tap
+        // back on resign and build it again from preferences on the way in.
+        // The open wheel goes with it: this tap is the only thing that sees a
+        // held summoner released, so a wheel still up when the tap is handed
+        // back would come back stuck in hold phase with no release coming.
+        SessionActivity.shared.onChange { [weak self] active in
+            if !active { self?.endSession() }
+            self?.syncMouseTap()
+        }
+    }
 
     var sessionActive: Bool { !stack.isEmpty }
 
@@ -128,7 +140,13 @@ final class RadialMenuService: ObservableObject {
     // app under the pointer; alive only while a button is configured, torn
     // down with the feature)
 
-    private func syncMouseTap(profiles: [RadialMenuProfile]? = nil) {
+    /// Whether the button tap has a job right now. The feature check is here
+    /// rather than only in `syncWithPreferences`, because the resign handler
+    /// and the capture row call the sync directly and so never pass that
+    /// guard. The capture row wants the tap even with the feature switched
+    /// off, so it can tell a button this app cannot see from one that is
+    /// simply set to something else.
+    private func mouseTapWanted(profiles: [RadialMenuProfile]?) -> Bool {
         let defaults = UserDefaults.standard
         // Asked of the stored buttons alone when the caller has no profiles in
         // hand: this only needs to know whether any wheel is bound to a button,
@@ -139,7 +157,21 @@ final class RadialMenuService: ObservableObject {
             defaults.data(forKey: DefaultsKey.radialMenuProfiles),
             defaults: defaults
         ).isEmpty
-        guard hasAnyButton || isReportingMouseButtons else {
+        let enabled = AppFeature.radialMenu.isAvailable
+            && defaults.bool(forKey: DefaultsKey.radialMenuEnabled)
+        return (hasAnyButton && enabled) || isReportingMouseButtons
+    }
+
+    private func syncMouseTap(profiles: [RadialMenuProfile]? = nil) {
+        // Accessibility is asked of the system and not of `Permissions.shared`,
+        // whose answer is a poll up to `PermissionPollingSupport.interval` old.
+        // The re-arm hands a tap it declines to put back to this sync to be
+        // stopped, and a stale grant here would install it straight back.
+        guard SessionActivitySupport.tapShouldRun(
+            featureWanted: mouseTapWanted(profiles: profiles),
+            accessibilityGranted: AXIsProcessTrusted(),
+            sessionIsActive: SessionActivity.shared.isActive
+        ) else {
             tearDownMouseTap()
             return
         }
@@ -148,7 +180,7 @@ final class RadialMenuService: ObservableObject {
         if let mouseTap, !CGEvent.tapIsEnabled(tap: mouseTap) {
             tearDownMouseTap()
         }
-        guard mouseTap == nil, AXIsProcessTrusted() else { return }
+        guard mouseTap == nil else { return }
         let mask = (CGEventMask(1) << CGEventType.otherMouseDown.rawValue)
             | (CGEventMask(1) << CGEventType.otherMouseUp.rawValue)
         guard let tap = CGEvent.tapCreate(
@@ -186,7 +218,23 @@ final class RadialMenuService: ObservableObject {
 
     private func handleMouseTap(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let mouseTap { CGEvent.tapEnable(tap: mouseTap, enable: true) }
+            // This tap's callback runs on the main run loop, so the session
+            // flag is read where it is written. A tap put straight back is a
+            // tap put back into whatever session is on screen now, which is
+            // the stall the gate exists to end (issue #1075). Accessibility is
+            // asked for the same reason as the sync: this tap swallows the
+            // click, so a revoked grant has to end it rather than put it back.
+            if SessionActivitySupport.tapShouldRun(
+                featureWanted: mouseTapWanted(profiles: nil),
+                accessibilityGranted: AXIsProcessTrusted(),
+                sessionIsActive: SessionActivity.shared.isActive
+            ), let mouseTap {
+                CGEvent.tapEnable(tap: mouseTap, enable: true)
+            } else {
+                // Invalidating the port from its own callback stack is unsafe;
+                // finish this callback fail-open, then release the tap.
+                DispatchQueue.main.async { [weak self] in self?.syncMouseTap() }
+            }
             return Unmanaged.passUnretained(event)
         }
         let pressed = Int(event.getIntegerValueField(.mouseEventButtonNumber))

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15299,6 +15299,17 @@ struct MetricsTests {
             .components(separatedBy: "private func hotkeyPressed").first ?? ""
         expect(!radialClaimedClick.isEmpty && !radialClaimedClick.contains("passUnretained"),
                "a claimed side button keeps both halves of its click whatever the full decode says")
+
+        // The tap is the only thing that ends a button-held wheel, so handing
+        // it back on resign has to end the session too; a wheel left open
+        // across the switch would come back in hold phase with no release
+        // coming for it.
+        let radialSessionResign = radialServiceCode
+            .components(separatedBy: "SessionActivity.shared.onChange")
+            .dropFirst().first?
+            .components(separatedBy: "var sessionActive").first ?? ""
+        expect(radialSessionResign.contains("endSession()"),
+               "the radial menu ends its session when the mouse tap is handed back on resign")
         expect(RadialMenuFaviconFetcher.faviconURL(
             for: "https://example.com:8443/path?q=1#part")?.absoluteString
                 == "https://example.com:8443/favicon.ico"
@@ -21880,7 +21891,8 @@ struct MetricsTests {
                          "Sources/Vorssaint/Services/MouseNavigation/MouseNavigationService.swift",
                          "Sources/Vorssaint/Services/MouseButtons/MouseButtonShortcutService.swift",
                          "Sources/Vorssaint/Services/MiddleClick/MiddleClickService.swift",
-                         "Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift"] {
+                         "Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift",
+                         "Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift"] {
             let source = (try? String(contentsOfFile: tapOwner, encoding: .utf8)) ?? ""
             expect(!source.isEmpty, "\(tapOwner) reads back for its session-switch check")
             let code = source.components(separatedBy: "\n")
@@ -21895,7 +21907,8 @@ struct MetricsTests {
             if tapOwner.contains("MouseNavigation")
                 || tapOwner.contains("MouseButtonShortcut")
                 || tapOwner.contains("MiddleClick")
-                || tapOwner.contains("QuitProtection") {
+                || tapOwner.contains("QuitProtection")
+                || tapOwner.contains("RadialMenu") {
                 expect(code.contains("AXIsProcessTrusted()"),
                        "\(tapOwner) does not keep a modifying tap alive after Accessibility is lost")
             }


### PR DESCRIPTION
## Summary

The wheel's mouse tap is a `.defaultTap` on `otherMouseDown` and
`otherMouseUp`, created while any profile is bound to a mouse button. It did
not follow the login session.

After a fast user switch this process keeps running in the session that left
the screen, and a filter tap created there keeps its place in the chain. The
window server still routes every extra-button click the account on screen
makes through a process that cannot answer, and waits out the tap timeout on
each one.

Both places that can put the tap into the chain — `syncMouseTap` and the
`tapDisabledByTimeout` re-arm — now ask `SessionActivitySupport.tapShouldRun`,
and `SessionActivity.shared.onChange` brings the tap back with the session.
The callback runs on the main run loop, so the session flag is read on the
thread that writes it, the same way `MouseNavigationService` and the other
main-run-loop taps do; the taps that run a thread of their own hop to the main
queue for the same answer.

Two things travel with the gate because it does not work without them:

- **The open wheel.** This tap is the only thing that sees a held summoner
  released, so a wheel still up on resign would come back stuck in hold phase
  with no release coming for it. The resign handler calls `endSession()`
  before the sync tears the tap down.
- **The feature check.** `syncWithPreferences` guards on
  `AppFeature.radialMenu.isAvailable && radialMenuEnabled` and calls
  `suspend()`, but the resign handler and the capture row call `syncMouseTap`
  directly and never pass that guard. Without it the tap would come back on a
  session switch with the feature switched off.

Accessibility also moves into that gate from the tap-creation guard, and is
asked of the system rather than of `Permissions.shared`, whose answer is a
poll up to `PermissionPollingSupport.interval` old. The re-arm hands a tap it
declines to put back to the sync to be stopped, so a stale grant there would
install it straight back. That matches what the keyboard, Finder, switcher,
snippet, volume, Dock and window taps ask in the same position.

`RadialMenuService.swift` joins the existing tap-owner sweep in
`MetricsTests.swift` rather than carrying its own copy of those checks. One
assertion is its own, because the sweep has no reason to know it: the resign
path has to end the session, not only the tap.

Split out of #1228, which had this and the cheap side-button decode in one
branch. They reference different issues, share no premise, and this half
carries a **Not tested** note the other does not.

## Verification

MacBook Pro, macOS 26.

```
./build.sh --test      TESTS OK (9543 checks)
swiftc -typecheck      exit 0, whole module
```

`--test` compiles a whitelist that does not include `RadialMenuService.swift`,
so the whole of `Sources/Vorssaint/**` was type-checked separately with the
same target and SDK `build.sh` uses. The full `./build.sh` was not run: with
the signing keychain locked, `codesign` blocks on an unlock dialog.

The resign assertion was verified both ways. Dropping `endSession()` from the
`onChange` handler turns it red on its own; restored, the suite is green.

**What was not tested.**

- **The behaviour itself. There is no second logged-in account on this
  machine**, so the fast user switch this change is about was never performed.
  What is verified is that the wiring matches the services that already carry
  it.
- The stuck-hold-phase case. Reaching it needs a wheel held open by a mouse
  button at the moment the session resigns.
- The revoke race. Reaching it needs the window server to disable this tap
  inside the polling interval that follows a revoked Accessibility grant.

## Anything else

Refs #1153

