### PR TITLE
fix(switcher): self-activate before yielding activation to the target app

### DIFF
--- a/Sources/Vorssaint/Services/ActivationHandoff.swift
+++ b/Sources/Vorssaint/Services/ActivationHandoff.swift
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+
+/// Hands this app's activation to another one.
+///
+/// Cooperative activation only lets an app pass on activation it currently
+/// holds. Vorssaint is `LSUIElement`, and the surfaces that trigger a handoff —
+/// the switcher panel, the Dock click tap, the process list — are all
+/// non-activating, so at the moment a handoff commits Vorssaint usually is not
+/// the active app. `yieldActivation(to:)` then gives away nothing, the
+/// `activate(from:)` that follows is refused, and the target never comes
+/// forward: its windows may rise but the menu bar stays with whatever app was
+/// already active. Self-activating first is what gives the yield something to
+/// hand over; it runs in direct response to the user's own key or click, which
+/// the system accepts as a real gesture.
+///
+/// Every yield in the app goes through here. A bare `NSApp.yieldActivation`
+/// added elsewhere would reintroduce the bug on that path alone, so
+/// `Tests/MetricsTests.swift` scans `Sources` and fails if one appears.
+enum ActivationHandoff {
+    /// Call on the main thread, synchronously with the gesture that asked for
+    /// the switch. The caller still activates `app` itself afterwards — this
+    /// only clears the way.
+    static func yield(to app: NSRunningApplication) {
+        // The self-activation below posts a real activation notification for
+        // our own process; tell the use tracker it is ours so it does not rank
+        // Vorssaint ahead of the app the user is switching away from.
+        WindowUseTracker.shared.expectSelfActivationHandoff()
+        NSApp.activate(ignoringOtherApps: true)
+        NSApp.yieldActivation(to: app)
+    }
+}

--- a/Sources/Vorssaint/Services/ActivationHandoff.swift
+++ b/Sources/Vorssaint/Services/ActivationHandoff.swift
@@ -16,9 +16,10 @@ import AppKit
 /// hand over; it runs in direct response to the user's own key or click, which
 /// the system accepts as a real gesture.
 ///
-/// Every yield in the app goes through here. A bare `NSApp.yieldActivation`
-/// added elsewhere would reintroduce the bug on that path alone, so
-/// `Tests/MetricsTests.swift` scans `Sources` and fails if one appears.
+/// Every yield in the app goes through here. A bare `yieldActivation(to:)`
+/// added elsewhere, whatever the receiver is spelled, would reintroduce the bug
+/// on that path alone, so `Tests/MetricsTests.swift` scans `Sources` and fails
+/// if one appears.
 enum ActivationHandoff {
     /// Call on the main thread, synchronously with the gesture that asked for
     /// the switch. The caller still activates `app` itself afterwards — this

--- a/Sources/Vorssaint/Services/ActivationHandoff.swift
+++ b/Sources/Vorssaint/Services/ActivationHandoff.swift
@@ -27,8 +27,9 @@ enum ActivationHandoff {
     static func yield(to app: NSRunningApplication) {
         // The self-activation below posts a real activation notification for
         // our own process; tell the use tracker it is ours so it does not rank
-        // Vorssaint ahead of the app the user is switching away from.
-        WindowUseTracker.shared.expectSelfActivationHandoff()
+        // Vorssaint ahead of the app the user is switching away from. Keyed to
+        // the target so only that app's activation, or ours, can clear it.
+        WindowUseTracker.shared.expectSelfActivationHandoff(clearedBy: app.processIdentifier)
         NSApp.activate(ignoringOtherApps: true)
         NSApp.yieldActivation(to: app)
     }

--- a/Sources/Vorssaint/Services/DockClick/DockClickService.swift
+++ b/Sources/Vorssaint/Services/DockClick/DockClickService.swift
@@ -695,9 +695,9 @@ final class DockClickService {
     /// the click precisely so the Dock would not act — so nobody else is going
     /// to. The restore then half-lands: unminimizing needs no activation
     /// rights, so the windows come back and are immediately stacked under
-    /// whichever app is still active. Yielding this app's activation first is
-    /// what makes the request cooperative, the same sequence the Switcher,
-    /// Space hop and process list already use.
+    /// whichever app is still active. `ActivationHandoff` is what makes the
+    /// request cooperative, the same sequence the Switcher, Space hop and
+    /// process list use.
     ///
     /// Options stay empty on purpose: `restoreBackToFront` earns the batch's
     /// stacking one window at a time, and `.activateAllWindows` would re-raise
@@ -705,7 +705,7 @@ final class DockClickService {
     private static func activate(pid: pid_t) {
         DispatchQueue.main.async {
             guard let app = NSRunningApplication(processIdentifier: pid), !app.isTerminated else { return }
-            NSApp.yieldActivation(to: app)
+            ActivationHandoff.yield(to: app)
             if !app.activate(from: NSRunningApplication.current, options: []) {
                 app.activate(options: [])
             }

--- a/Sources/Vorssaint/Services/Switcher/SpaceHop.swift
+++ b/Sources/Vorssaint/Services/Switcher/SpaceHop.swift
@@ -87,7 +87,7 @@ final class SpaceHop {
         // Space forward too; when the app has one here, activate quietly and
         // let the travel decide what comes up.
         let appIsAlreadyHere = appHasWindowOnVisibleSpace()
-        NSApp.yieldActivation(to: app)
+        ActivationHandoff.yield(to: app)
         if !app.activate(from: NSRunningApplication.current,
                          options: appIsAlreadyHere ? [] : [.activateAllWindows]) {
             app.activate(options: appIsAlreadyHere ? [] : [.activateAllWindows])

--- a/Sources/Vorssaint/Services/Switcher/WindowActivator.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowActivator.swift
@@ -364,7 +364,7 @@ enum WindowActivator {
     }
 
     private static func activateApp(_ app: NSRunningApplication, allWindows: Bool = true) {
-        NSApp.yieldActivation(to: app)
+        ActivationHandoff.yield(to: app)
         if allWindows {
             if !app.activate(from: NSRunningApplication.current, options: [.activateAllWindows]) {
                 app.activate(options: [.activateAllWindows])
@@ -593,7 +593,7 @@ enum WindowActivator {
         if let windowID {
             prepareWindowForActivation(windowID: windowID, pid: windowOwnerPID ?? pid)
         }
-        NSApp.yieldActivation(to: sourceApp)
+        ActivationHandoff.yield(to: sourceApp)
         if !sourceApp.activate(from: NSRunningApplication.current, options: []) {
             sourceApp.activate(options: [])
         }

--- a/Sources/Vorssaint/Services/Switcher/WindowUseTracker.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowUseTracker.swift
@@ -99,7 +99,7 @@ final class WindowUseTracker {
         }
     }
 
-    /// Arms the next activation of our own process to be ignored. Called by
+    /// Arms the next activation of our own process to go unrecorded. Called by
     /// `ActivationHandoff` immediately before it self-activates so it can yield
     /// activation onward: recording that would rank Vorssaint ahead of the app
     /// the user is switching away from, and a quick toggle back would land on
@@ -207,12 +207,19 @@ final class WindowUseTracker {
     @objc private func appActivated(_ note: Notification) {
         guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { return }
         let pid = app.processIdentifier
-        if pid == ProcessInfo.processInfo.processIdentifier, consumeSelfActivationHandoff() { return }
+        // An armed handoff suppresses only the recording: the app here, and the
+        // focused-window read the retarget would file, since a titled window of
+        // Vorssaint's would otherwise rank second and catch a quick toggle back.
+        // The observer still follows. Vorssaint really is front after
+        // self-activating, and if the yield does not take it stays there, with
+        // the observer otherwise left on the app the user came from; when it
+        // does take, the target's own notification retargets it a turn later.
+        let selfHandoff = pid == ProcessInfo.processInfo.processIdentifier && consumeSelfActivationHandoff()
         // The application half is exact and free, so it lands right away; the
         // window half needs Accessibility and happens on the watcher thread.
-        promote(app: pid)
+        if !selfHandoff { promote(app: pid) }
         lifecycleLock.withLock { requestedPID = pid }
-        performOnWatcher { [weak self] in self?.retargetObserver() }
+        performOnWatcher { [weak self] in self?.retargetObserver(filingFocusedWindow: !selfHandoff) }
     }
 
     @objc private func appTerminated(_ note: Notification) {
@@ -320,11 +327,11 @@ final class WindowUseTracker {
     /// activation being posted solely inside the application that already has
     /// the keyboard, so one observer at a time covers every case the
     /// activation notifications miss — for the cost of a single one.
-    private func retargetObserver() {
+    private func retargetObserver(filingFocusedWindow: Bool = true) {
         guard !lifecycleLock.withLock({ shouldStopWatcher }) else { return }
         guard let pid = lifecycleLock.withLock({ requestedPID }) else { return }
         guard pid != observedPID else {
-            readFocusedWindow(of: pid)
+            if filingFocusedWindow { readFocusedWindow(of: pid) }
             return
         }
         detachObserver()
@@ -346,8 +353,9 @@ final class WindowUseTracker {
 
         // Activation itself posts no focus change, so the window the app came
         // back to has to be asked for once. Any change that races this arrives
-        // through the observer, which is already installed.
-        readFocusedWindow(of: pid)
+        // through the observer, which is already installed. Not for a handoff's
+        // own self-activation: nobody came back to that window.
+        if filingFocusedWindow { readFocusedWindow(of: pid) }
     }
 
     private func detachObserver() {

--- a/Sources/Vorssaint/Services/Switcher/WindowUseTracker.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowUseTracker.swift
@@ -47,16 +47,20 @@ final class WindowUseTracker {
     /// which is not the user coming to Vorssaint, or the target's, by which
     /// point the self-activation has either been posted or never will be.
     ///
-    /// Whichever arrives first clears it. macOS posts no activation when
-    /// Vorssaint already held it, so an arm cleared only by our own pid would
-    /// stay live past the target's notification and swallow the next real
-    /// activation of Vorssaint — and the quick one is `activateOwnWindow`,
-    /// the switcher landing on one of our own windows right after a handoff.
-    /// The deadline is the backstop for when neither notification arrives,
-    /// which takes both the self-activation and the target's activate being
-    /// refused; a second covers the trip to the next main run loop turn many
-    /// times over.
+    /// Whichever of those two arrives first clears it. macOS posts no
+    /// activation when Vorssaint already held it, so an arm cleared only by our
+    /// own pid would stay live past the target's notification and swallow the
+    /// next real activation of Vorssaint — and the quick one is
+    /// `activateOwnWindow`, the switcher landing on one of our own windows
+    /// right after a handoff. Any other pid leaves it alone: an activation
+    /// already queued when the handoff ran (a Space hop's travel posts some)
+    /// drains before our own, and letting it consume the arm would record the
+    /// self-activation it was meant to hide. The deadline is the backstop for
+    /// when neither notification arrives, which takes both the self-activation
+    /// and the target's activate being refused; a second covers the trip to
+    /// the next main run loop turn many times over.
     private var selfActivationHandoffUntil: TimeInterval = 0
+    private var selfActivationHandoffTarget: pid_t = 0
     private static let selfActivationHandoffWindow: TimeInterval = 1
 
     private let lifecycleLock = NSLock()
@@ -114,19 +118,23 @@ final class WindowUseTracker {
     /// ignoring our process unconditionally would also erase clicking
     /// Vorssaint's Dock icon, opening Settings and switching onto one of its
     /// windows, none of which are handoffs.
-    func expectSelfActivationHandoff() {
+    func expectSelfActivationHandoff(clearedBy target: pid_t) {
         stateLock.withLock {
             selfActivationHandoffUntil = ProcessInfo.processInfo.systemUptime
                 + Self.selfActivationHandoffWindow
+            selfActivationHandoffTarget = target
         }
     }
 
-    /// True once per armed handoff, and only while it is fresh. Every
-    /// activation calls this, so the first one after arming clears it whatever
-    /// its pid.
-    private func consumeSelfActivationHandoff() -> Bool {
+    /// True once per armed handoff, and only while it is fresh, for an
+    /// activation of our own process or of the app the handoff is yielding to.
+    /// Every activation calls this; one of any other app passes through with
+    /// the arm untouched.
+    private func consumeSelfActivationHandoff(activating pid: pid_t) -> Bool {
         stateLock.withLock {
-            guard ProcessInfo.processInfo.systemUptime < selfActivationHandoffUntil else { return false }
+            guard ProcessInfo.processInfo.systemUptime < selfActivationHandoffUntil,
+                  pid == ProcessInfo.processInfo.processIdentifier || pid == selfActivationHandoffTarget
+            else { return false }
             selfActivationHandoffUntil = 0
             return true
         }
@@ -213,12 +221,13 @@ final class WindowUseTracker {
     @objc private func appActivated(_ note: Notification) {
         guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { return }
         let pid = app.processIdentifier
-        // Any activation clears an armed handoff, not just our own: when
+        // Our own activation or the target's clears an armed handoff: when
         // Vorssaint already held activation the self-activation posts nothing,
         // the first notification to arrive is the target's, and an arm still
         // live after it would swallow the next real activation of Vorssaint.
-        // Consumed before the pid check so the target's arrival clears it too.
-        let handoffArmed = consumeSelfActivationHandoff()
+        // Consumed before the pid check so the target's arrival clears it too;
+        // any other app's activation leaves it for the self-activation behind.
+        let handoffArmed = consumeSelfActivationHandoff(activating: pid)
         // An armed handoff suppresses only the recording: the app here, and the
         // focused-window read the retarget would file, since a titled window of
         // Vorssaint's would otherwise rank second and catch a quick toggle back.

--- a/Sources/Vorssaint/Services/Switcher/WindowUseTracker.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowUseTracker.swift
@@ -42,6 +42,19 @@ final class WindowUseTracker {
     /// just cleared.
     private var recording = false
 
+    /// Uptime until which one activation of Vorssaint's own process is read as
+    /// the self-activation `ActivationHandoff` performs on its way to another
+    /// app, rather than as the user coming to Vorssaint.
+    ///
+    /// A deadline instead of a plain flag: macOS posts no activation when
+    /// Vorssaint already held it, and a flag left armed would then swallow the
+    /// next real activation instead. The window only has to cover the trip from
+    /// `NSApp.activate` to the notification arriving on the next main run loop
+    /// turn; a second is far more than that and expires long before a person
+    /// could reach the Dock icon.
+    private var selfActivationHandoffUntil: TimeInterval = 0
+    private static let selfActivationHandoffWindow: TimeInterval = 1
+
     private let lifecycleLock = NSLock()
     private var started = false
     private var watcherThread: Thread?
@@ -83,6 +96,33 @@ final class WindowUseTracker {
             windowHistory = WindowUseOrder.promoting(target: windowID,
                                                      previous: previous,
                                                      in: windowHistory)
+        }
+    }
+
+    /// Arms the next activation of our own process to be ignored. Called by
+    /// `ActivationHandoff` immediately before it self-activates so it can yield
+    /// activation onward: recording that would rank Vorssaint ahead of the app
+    /// the user is switching away from, and a quick toggle back would land on
+    /// Vorssaint's own window instead of the previous app.
+    ///
+    /// Narrow on purpose. `appActivated` is the only place an application is
+    /// recorded as used at all — `recordSwitch` files windows, not apps — so
+    /// ignoring our process unconditionally would also erase clicking
+    /// Vorssaint's Dock icon, opening Settings and switching onto one of its
+    /// windows, none of which are handoffs.
+    func expectSelfActivationHandoff() {
+        stateLock.withLock {
+            selfActivationHandoffUntil = ProcessInfo.processInfo.systemUptime
+                + Self.selfActivationHandoffWindow
+        }
+    }
+
+    /// True once per armed handoff, and only while it is fresh.
+    private func consumeSelfActivationHandoff() -> Bool {
+        stateLock.withLock {
+            guard ProcessInfo.processInfo.systemUptime < selfActivationHandoffUntil else { return false }
+            selfActivationHandoffUntil = 0
+            return true
         }
     }
 
@@ -167,6 +207,7 @@ final class WindowUseTracker {
     @objc private func appActivated(_ note: Notification) {
         guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { return }
         let pid = app.processIdentifier
+        if pid == ProcessInfo.processInfo.processIdentifier, consumeSelfActivationHandoff() { return }
         // The application half is exact and free, so it lands right away; the
         // window half needs Accessibility and happens on the watcher thread.
         promote(app: pid)

--- a/Sources/Vorssaint/Services/Switcher/WindowUseTracker.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowUseTracker.swift
@@ -42,16 +42,20 @@ final class WindowUseTracker {
     /// just cleared.
     private var recording = false
 
-    /// Uptime until which one activation of Vorssaint's own process is read as
-    /// the self-activation `ActivationHandoff` performs on its way to another
-    /// app, rather than as the user coming to Vorssaint.
+    /// Uptime until which the next activation notification is read as part of
+    /// the handoff `ActivationHandoff` is performing: its own self-activation,
+    /// which is not the user coming to Vorssaint, or the target's, by which
+    /// point the self-activation has either been posted or never will be.
     ///
-    /// A deadline instead of a plain flag: macOS posts no activation when
-    /// Vorssaint already held it, and a flag left armed would then swallow the
-    /// next real activation instead. The window only has to cover the trip from
-    /// `NSApp.activate` to the notification arriving on the next main run loop
-    /// turn; a second is far more than that and expires long before a person
-    /// could reach the Dock icon.
+    /// Whichever arrives first clears it. macOS posts no activation when
+    /// Vorssaint already held it, so an arm cleared only by our own pid would
+    /// stay live past the target's notification and swallow the next real
+    /// activation of Vorssaint — and the quick one is `activateOwnWindow`,
+    /// the switcher landing on one of our own windows right after a handoff.
+    /// The deadline is the backstop for when neither notification arrives,
+    /// which takes both the self-activation and the target's activate being
+    /// refused; a second covers the trip to the next main run loop turn many
+    /// times over.
     private var selfActivationHandoffUntil: TimeInterval = 0
     private static let selfActivationHandoffWindow: TimeInterval = 1
 
@@ -99,9 +103,9 @@ final class WindowUseTracker {
         }
     }
 
-    /// Arms the next activation of our own process to go unrecorded. Called by
-    /// `ActivationHandoff` immediately before it self-activates so it can yield
-    /// activation onward: recording that would rank Vorssaint ahead of the app
+    /// Arms the next activation: if it is our own process it goes unrecorded.
+    /// Called by `ActivationHandoff` immediately before it self-activates so it
+    /// can yield activation onward: recording that would rank Vorssaint ahead of the app
     /// the user is switching away from, and a quick toggle back would land on
     /// Vorssaint's own window instead of the previous app.
     ///
@@ -117,7 +121,9 @@ final class WindowUseTracker {
         }
     }
 
-    /// True once per armed handoff, and only while it is fresh.
+    /// True once per armed handoff, and only while it is fresh. Every
+    /// activation calls this, so the first one after arming clears it whatever
+    /// its pid.
     private func consumeSelfActivationHandoff() -> Bool {
         stateLock.withLock {
             guard ProcessInfo.processInfo.systemUptime < selfActivationHandoffUntil else { return false }
@@ -207,6 +213,12 @@ final class WindowUseTracker {
     @objc private func appActivated(_ note: Notification) {
         guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else { return }
         let pid = app.processIdentifier
+        // Any activation clears an armed handoff, not just our own: when
+        // Vorssaint already held activation the self-activation posts nothing,
+        // the first notification to arrive is the target's, and an arm still
+        // live after it would swallow the next real activation of Vorssaint.
+        // Consumed before the pid check so the target's arrival clears it too.
+        let handoffArmed = consumeSelfActivationHandoff()
         // An armed handoff suppresses only the recording: the app here, and the
         // focused-window read the retarget would file, since a titled window of
         // Vorssaint's would otherwise rank second and catch a quick toggle back.
@@ -214,7 +226,7 @@ final class WindowUseTracker {
         // self-activating, and if the yield does not take it stays there, with
         // the observer otherwise left on the app the user came from; when it
         // does take, the target's own notification retargets it a turn later.
-        let selfHandoff = pid == ProcessInfo.processInfo.processIdentifier && consumeSelfActivationHandoff()
+        let selfHandoff = handoffArmed && pid == ProcessInfo.processInfo.processIdentifier
         // The application half is exact and free, so it lands right away; the
         // window half needs Accessibility and happens on the watcher thread.
         if !selfHandoff { promote(app: pid) }

--- a/Sources/Vorssaint/Services/SystemMonitor/ProcessUsageService.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/ProcessUsageService.swift
@@ -164,7 +164,7 @@ final class ProcessUsageService {
         guard canActivate(row),
               let app = NSRunningApplication(processIdentifier: row.pid)
         else { return }
-        NSApp.yieldActivation(to: app)
+        ActivationHandoff.yield(to: app)
         if !app.activate(from: NSRunningApplication.current, options: []) {
             app.activate(options: [])
         }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9885,9 +9885,14 @@ struct MetricsTests {
         let useTrackerSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/Services/Switcher/WindowUseTracker.swift",
             encoding: .utf8)) ?? ""
-        expect(useTrackerSource.contains(
-                    "let selfHandoff = pid == ProcessInfo.processInfo.processIdentifier && consumeSelfActivationHandoff()"),
-               "the use tracker skips recording our own activation only when a handoff armed it")
+        // Whichever activation arrives first clears the arm: when Vorssaint
+        // already held activation its own self-activation posts nothing, the
+        // first arrival is the target's, and an arm cleared only by our pid
+        // would stay live and swallow the next real activation of Vorssaint.
+        expect(useTrackerSource.contains("let handoffArmed = consumeSelfActivationHandoff()")
+                && useTrackerSource.contains(
+                    "let selfHandoff = handoffArmed && pid == ProcessInfo.processInfo.processIdentifier"),
+               "any activation clears an armed handoff, and only our own is then left unrecorded")
         expect(useTrackerSource.contains("if !selfHandoff { promote(app: pid) }")
                 && useTrackerSource.contains("self?.retargetObserver(filingFocusedWindow: !selfHandoff)"),
                "an armed handoff skips only the recording, the observer still follows Vorssaint")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9851,8 +9851,10 @@ struct MetricsTests {
         expect(selfActivation != nil && yieldOnward != nil
                 && selfActivation!.lowerBound < yieldOnward!.lowerBound,
                "the activation handoff self-activates before it yields onward")
-        expect(activationHandoffSource.contains("WindowUseTracker.shared.expectSelfActivationHandoff()"),
-               "the activation handoff tells the use tracker its self-activation is not a real switch")
+        expect(activationHandoffSource.contains(
+                "WindowUseTracker.shared.expectSelfActivationHandoff(clearedBy: app.processIdentifier)"),
+               "the activation handoff tells the use tracker its self-activation is not a real switch, "
+               + "keyed to the app it is handing over to")
         // Reports how many files it read: an enumerator that finds nothing (the
         // tests run from somewhere other than the repo root) would leave the
         // list empty and pass while guarding nothing. Matches the method name
@@ -9885,14 +9887,20 @@ struct MetricsTests {
         let useTrackerSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/Services/Switcher/WindowUseTracker.swift",
             encoding: .utf8)) ?? ""
-        // Whichever activation arrives first clears the arm: when Vorssaint
-        // already held activation its own self-activation posts nothing, the
-        // first arrival is the target's, and an arm cleared only by our pid
-        // would stay live and swallow the next real activation of Vorssaint.
-        expect(useTrackerSource.contains("let handoffArmed = consumeSelfActivationHandoff()")
+        // Our own activation or the target's clears the arm, nothing else does:
+        // when Vorssaint already held activation its own self-activation posts
+        // nothing and the first arrival is the target's, so an arm cleared only
+        // by our pid would stay live and swallow the next real activation of
+        // Vorssaint; an arm cleared by any pid would be eaten by an activation
+        // already queued when the handoff ran, and the self-activation behind
+        // it would then be recorded.
+        expect(useTrackerSource.contains("let handoffArmed = consumeSelfActivationHandoff(activating: pid)")
                 && useTrackerSource.contains(
                     "let selfHandoff = handoffArmed && pid == ProcessInfo.processInfo.processIdentifier"),
-               "any activation clears an armed handoff, and only our own is then left unrecorded")
+               "our own or the target's activation clears an armed handoff, and only our own is then left unrecorded")
+        expect(useTrackerSource.contains(
+                "pid == ProcessInfo.processInfo.processIdentifier || pid == selfActivationHandoffTarget"),
+               "an activation of some other app leaves an armed handoff in place")
         expect(useTrackerSource.contains("if !selfHandoff { promote(app: pid) }")
                 && useTrackerSource.contains("self?.retargetObserver(filingFocusedWindow: !selfHandoff)"),
                "an armed handoff skips only the recording, the observer still follows Vorssaint")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9855,7 +9855,9 @@ struct MetricsTests {
                "the activation handoff tells the use tracker its self-activation is not a real switch")
         // Reports how many files it read: an enumerator that finds nothing (the
         // tests run from somewhere other than the repo root) would leave the
-        // list empty and pass while guarding nothing.
+        // list empty and pass while guarding nothing. Matches the method name
+        // alone: `NSApplication.shared.yieldActivation(to:)` is the same call
+        // as `NSApp.yieldActivation(to:)`, and the receiver is not the contract.
         var bareActivationYields: [String] = []
         var scannedActivationFiles = 0
         if let sources = FileManager.default.enumerator(atPath: "Sources") {
@@ -9863,7 +9865,7 @@ struct MetricsTests {
                 let text = (try? String(contentsOfFile: "Sources/" + path, encoding: .utf8)) ?? ""
                 scannedActivationFiles += 1
                 guard (path as NSString).lastPathComponent != "ActivationHandoff.swift" else { continue }
-                if text.contains("NSApp.yieldActivation") {
+                if text.contains("yieldActivation") {
                     bareActivationYields.append((path as NSString).lastPathComponent)
                 }
             }
@@ -9877,13 +9879,18 @@ struct MetricsTests {
         // own process. The tracker has to drop that one without dropping every
         // activation of Vorssaint: `appActivated` is the only place an app is
         // recorded, so an unconditional guard would also erase the Dock icon
-        // and Settings.
+        // and Settings. Only the recording is dropped: the observer still
+        // follows, or a yield that does not take would leave it on the app the
+        // user came from while Vorssaint is front.
         let useTrackerSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/Services/Switcher/WindowUseTracker.swift",
             encoding: .utf8)) ?? ""
         expect(useTrackerSource.contains(
-                    "if pid == ProcessInfo.processInfo.processIdentifier, consumeSelfActivationHandoff() { return }"),
-               "the use tracker skips our own activation only when a handoff armed it")
+                    "let selfHandoff = pid == ProcessInfo.processInfo.processIdentifier && consumeSelfActivationHandoff()"),
+               "the use tracker skips recording our own activation only when a handoff armed it")
+        expect(useTrackerSource.contains("if !selfHandoff { promote(app: pid) }")
+                && useTrackerSource.contains("self?.retargetObserver(filingFocusedWindow: !selfHandoff)"),
+               "an armed handoff skips only the recording, the observer still follows Vorssaint")
         expect(useTrackerSource.contains("selfActivationHandoffUntil = 0"),
                "an armed handoff is consumed once, so the next activation of Vorssaint is recorded")
         expect(useTrackerSource.contains("guard ProcessInfo.processInfo.systemUptime < selfActivationHandoffUntil"),

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9832,10 +9832,62 @@ struct MetricsTests {
         let dockClickSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/Services/DockClick/DockClickService.swift",
             encoding: .utf8)) ?? ""
-        expect(dockClickSource.contains("NSApp.yieldActivation(to: app)"),
+        expect(dockClickSource.contains("ActivationHandoff.yield(to: app)"),
                "a Dock click restore yields this app's activation first")
         expect(dockClickSource.contains("app.activate(from: NSRunningApplication.current, options: [])"),
                "a Dock click restore asks cooperatively before falling back")
+
+        // Yielding activation only hands over activation this app currently
+        // holds, and every surface that yields is non-activating, so the yield
+        // has to be preceded by a self-activation or it gives away nothing and
+        // the target never comes forward. That ordering lives in exactly one
+        // place; the scan below is what keeps it that way, because the bug is
+        // reintroduced by adding a call site, not by editing an existing one.
+        let activationHandoffSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/ActivationHandoff.swift",
+            encoding: .utf8)) ?? ""
+        let selfActivation = activationHandoffSource.range(of: "\n        NSApp.activate(ignoringOtherApps: true)")
+        let yieldOnward = activationHandoffSource.range(of: "\n        NSApp.yieldActivation(to: app)")
+        expect(selfActivation != nil && yieldOnward != nil
+                && selfActivation!.lowerBound < yieldOnward!.lowerBound,
+               "the activation handoff self-activates before it yields onward")
+        expect(activationHandoffSource.contains("WindowUseTracker.shared.expectSelfActivationHandoff()"),
+               "the activation handoff tells the use tracker its self-activation is not a real switch")
+        // Reports how many files it read: an enumerator that finds nothing (the
+        // tests run from somewhere other than the repo root) would leave the
+        // list empty and pass while guarding nothing.
+        var bareActivationYields: [String] = []
+        var scannedActivationFiles = 0
+        if let sources = FileManager.default.enumerator(atPath: "Sources") {
+            for case let path as String in sources where path.hasSuffix(".swift") {
+                let text = (try? String(contentsOfFile: "Sources/" + path, encoding: .utf8)) ?? ""
+                scannedActivationFiles += 1
+                guard (path as NSString).lastPathComponent != "ActivationHandoff.swift" else { continue }
+                if text.contains("NSApp.yieldActivation") {
+                    bareActivationYields.append((path as NSString).lastPathComponent)
+                }
+            }
+        }
+        expect(scannedActivationFiles > 0 && bareActivationYields.isEmpty,
+               "activation is yielded only through ActivationHandoff, "
+               + "found a bare yield in \(bareActivationYields.sorted()) "
+               + "across \(scannedActivationFiles) scanned files")
+
+        // The self-activation above posts an activation notification for our
+        // own process. The tracker has to drop that one without dropping every
+        // activation of Vorssaint: `appActivated` is the only place an app is
+        // recorded, so an unconditional guard would also erase the Dock icon
+        // and Settings.
+        let useTrackerSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Switcher/WindowUseTracker.swift",
+            encoding: .utf8)) ?? ""
+        expect(useTrackerSource.contains(
+                    "if pid == ProcessInfo.processInfo.processIdentifier, consumeSelfActivationHandoff() { return }"),
+               "the use tracker skips our own activation only when a handoff armed it")
+        expect(useTrackerSource.contains("selfActivationHandoffUntil = 0"),
+               "an armed handoff is consumed once, so the next activation of Vorssaint is recorded")
+        expect(useTrackerSource.contains("guard ProcessInfo.processInfo.systemUptime < selfActivationHandoffUntil"),
+               "an armed handoff expires, so a yield that posts no activation cannot swallow a later one")
         expect(DockClickSupport.action(appIsFrontmost: true,
                                        hasUnminimizedWindows: false,
                                        hasMinimizedWindows: true,


### PR DESCRIPTION
## Summary

Selecting an app in the switcher often left it behind the app you came from. Its
windows would rise but the menu bar stayed put, so the switch had not really
happened.

Cooperative activation only lets an app hand over activation it currently holds.
Vorssaint is `LSUIElement` and every surface that yields is non-activating — the
switcher panel, the Dock click tap, the process list — so at the moment a handoff
commits Vorssaint is usually not the active app. `NSApp.yieldActivation` then gave
away nothing, the `activate(from:)` that followed was refused, and the target
never came forward.

Self-activate first, so the yield has something to hand over.

Adopts #845 by @pboucher, which fixed two of the five yield sites. `SpaceHop.swift`,
`ProcessUsageService.swift` and `DockClickService.swift` were still yielding bare.
All five now go through one `ActivationHandoff` helper instead of repeating the
sequence, and a test walks `Sources` and fails if a bare `yieldActivation`
appears anywhere else, whichever way the receiver is spelled — this bug comes back
by adding a call site, not by editing one. `DockClickService` already described its sequence as "the same sequence the
Switcher, Space hop and process list already use", so the five were one pattern
before this change; now they share the code as well as the comment.

The self-activation posts an activation notification for Vorssaint's own process.
`WindowUseTracker.appActivated` is the only place an app is recorded as used at all
— `recordSwitch` files windows, not apps — so recording it is skipped only when
the handoff armed it, and only for one fresh notification. Guarding on our own pid
unconditionally, as the original did, would also stop the Dock icon, Settings and
switching onto one of Vorssaint's own windows from ever being recorded.

Only the recording is skipped: the app, and the focused-window read the observer
retarget would otherwise file, since the switcher lists Vorssaint's titled windows
and one of them would rank second after a handoff that took. The observer still
retargets. After self-activating Vorssaint really is front, and if the yield does
not take it stays there — an early return would have left the observer on the app
the user came from. When the yield does take, the target's own notification moves
it on a turn later.

The arm is keyed to two pids, our own and the target's, and is cleared by
whichever of those two activations arrives first. When Vorssaint already holds
activation `NSApp.activate` posts nothing and the first arrival is the target's; an
arm cleared only on our pid would stay live for the rest of its window and swallow
the next real activation of Vorssaint. The quick one is `activateOwnWindow`, the
switcher landing on one of Vorssaint's own windows right after a handoff — exactly
the case the narrow guard exists to keep recorded. By the time the target's
notification is in, the self-activation it was armed for has either been posted or
never will be, so clearing on it loses nothing. Any other app's activation leaves
the arm alone: one already queued when the handoff ran (a Space hop's travel posts
some) drains before our own, and letting it consume the arm would record the
self-activation it was meant to hide. The one-second deadline stays as the backstop
for when neither notification arrives at all.

Refs #961
Refs #868

## Verification

macOS 26.5.2, Apple Silicon.

- `./build.sh` — finishes with no warnings
- `./build/Vorssaint --selftest` — `SELFTEST OK`
- `./build.sh --test` — `TESTS OK (9606 checks)`

The selftest line is from the first head. The current head was verified with a full
`./build.sh` (bundle ready, no errors) and `./build.sh --test`; the tracker and the
handoff helper are outside the `--test` whitelist, so the full build is what
compiles them.

Eight new source-shape assertions: the handoff self-activates before it yields (the
first version of this test passed for the wrong reason and was fixed — both
patterns began with a newline, so the strict ordering compare could never hold);
it arms the tracker; a walk of every `.swift` under `Sources` finds no
`yieldActivation` outside `ActivationHandoff.swift`, reporting the offenders
and the scanned-file count so an enumerator that finds nothing cannot pass
vacuously; and the tracker's skip is conditional on the armed handoff rather than
on the pid alone, the arm is consumed before the pid check by our own activation or
the target's, an activation of any other app leaves it in place, it covers only the
recording while the observer still retargets, is consumed once, and expires.

**Not tested:** whether macOS actually grants the self-activation when the handoff
is triggered by a mouse click rather than a hotkey release. That needs the app
running on a real desktop with a window server and a genuine user gesture, and
cannot be checked from a build. The reasoning is that `NSApp.activate` runs
synchronously inside the event that requested the switch, which is what the system
accepts as a real gesture — but that is an argument, not a measurement. Worth
confirming on a Dock click and a process-list click before merging.

**Not changed:** `RadialNowPlayingService.open` and
`ClipboardHistoryService.pasteIntoPreviousApp` activate another app from a
non-activating panel with no yield. Neither asks cooperatively — both call
`activate(options:)` without `from:` — so neither is a handoff and the scan does
not cover them. Whether they should go through `ActivationHandoff` is a separate
call: the clipboard one posts ⌘V 120 ms after the activate, so if that activate
is refused the paste lands in whatever is front. Left on their current path here.

**Trade-off:** self-activating first changes the failure path. Before, a yield
that gave away nothing left the user on the app they came from. Now, if macOS
grants the self-activation but the yield still does not take, the user lands on
Vorssaint and has to click back. No mitigation is added: the callers own the
`activate` call and its result, a retry onto the previous app would go through the
same yield that just failed, and hiding Vorssaint to hand activation back would
drop its windows. When the self-activation is refused the behaviour is today's.
This is the trade #845 made, and the mouse-click case above is where it needs
checking.

The added tests are source-shape assertions. They pin the ordering and pin the
single call site; they cannot prove the activation is granted.

#868 is referenced because it reports the same symptom and is already closed — the
fix for it did not hold, and this records the recurrence.



