### PR TITLE
fix(homebrew): bound the streaming command's wait

### DIFF
--- a/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
@@ -682,8 +682,10 @@ final class HomebrewManager: ObservableObject {
     /// make them stall indefinitely.
     private static let brewReadTimeout: TimeInterval = 30
     /// Install/upgrade/uninstall run on the same serial queue as every read, so a
-    /// hung one must end eventually; a large cask on a slow line takes minutes, not hours.
-    private static let brewOperationTimeout: TimeInterval = 30 * 60
+    /// hung one must end eventually. A big download, a source build and a copy into
+    /// Applications are all slow but never silent, so the bound is on silence: a cap
+    /// on total time would end work that was still going.
+    private static let brewSilenceTimeout: TimeInterval = 15 * 60
     private static let processTerminationGrace: TimeInterval = 2
 
     /// SIGTERM is cooperative. Escalate only when a command ignores it so a
@@ -761,6 +763,7 @@ final class HomebrewManager: ObservableObject {
             process.standardOutput = pipe
             process.standardError = pipe
             var output = Data()
+            var lastOutput = Date()
             let lock = NSLock()
             let drained = DispatchSemaphore(value: 0)
             pipe.fileHandleForReading.readabilityHandler = { handle in
@@ -771,6 +774,7 @@ final class HomebrewManager: ObservableObject {
                 }
                 lock.lock()
                 output.append(data)
+                lastOutput = Date()
                 lock.unlock()
                 if let chunk = String(data: data, encoding: .utf8) {
                     DispatchQueue.main.async { onOutput(chunk) }
@@ -790,8 +794,14 @@ final class HomebrewManager: ObservableObject {
                 self.activeProcess = process
                 if self.cancelRequested { Self.stop(process) }
             }
-            if finished.wait(timeout: .now() + Self.brewOperationTimeout) == .timedOut {
-                Self.stop(process, finished: finished)
+            while finished.wait(timeout: .now() + Self.brewSilenceTimeout) == .timedOut {
+                lock.lock()
+                let silence = Date().timeIntervalSince(lastOutput)
+                lock.unlock()
+                if silence >= Self.brewSilenceTimeout {
+                    Self.stop(process, finished: finished)
+                    break
+                }
             }
             _ = drained.wait(timeout: .now() + 1)
             pipe.fileHandleForReading.readabilityHandler = nil

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
@@ -666,6 +666,9 @@ final class HomebrewManager: ObservableObject {
     /// These are normally fast, but a hung NFS share or locked database can
     /// make them stall indefinitely.
     private static let brewReadTimeout: TimeInterval = 30
+    /// Install/upgrade/uninstall run on the same serial queue as every read, so a
+    /// hung one must end eventually; a large cask on a slow line takes minutes, not hours.
+    private static let brewOperationTimeout: TimeInterval = 30 * 60
     private static let processTerminationGrace: TimeInterval = 2
 
     /// SIGTERM is cooperative. Escalate only when a command ignores it so a
@@ -758,6 +761,8 @@ final class HomebrewManager: ObservableObject {
                     DispatchQueue.main.async { onOutput(chunk) }
                 }
             }
+            let finished = DispatchSemaphore(value: 0)
+            process.terminationHandler = { _ in finished.signal() }
             do {
                 try process.run()
             } catch {
@@ -770,14 +775,16 @@ final class HomebrewManager: ObservableObject {
                 self.activeProcess = process
                 if self.cancelRequested { Self.stop(process) }
             }
-            process.waitUntilExit()
+            if finished.wait(timeout: .now() + Self.brewOperationTimeout) == .timedOut {
+                Self.stop(process, finished: finished)
+            }
             _ = drained.wait(timeout: .now() + 1)
             pipe.fileHandleForReading.readabilityHandler = nil
             try? pipe.fileHandleForReading.close()
             lock.lock()
             let finalOutput = String(data: output, encoding: .utf8) ?? ""
             lock.unlock()
-            completion(process.terminationStatus, finalOutput)
+            completion(process.isRunning ? -1 : process.terminationStatus, finalOutput)
         }
     }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11583,6 +11583,15 @@ struct MetricsTests {
 
         // MARK: Homebrew command building and parsing
 
+        let homebrewManagerSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift",
+            encoding: .utf8)) ?? ""
+        let homebrewRunStreaming = homebrewManagerSource.components(separatedBy: "func runStreaming(")
+            .dropFirst().first?.components(separatedBy: "private func appendLog").first ?? ""
+        expect(homebrewRunStreaming.contains("brewOperationTimeout")
+                && !homebrewRunStreaming.contains("waitUntilExit"),
+               "Homebrew operations wait on a bounded semaphore, not waitUntilExit")
+
         expect(HomebrewPackageKind.allCases == [.cask, .formula],
                "Homebrew package kinds keep casks before formulae")
         expect(HomebrewCommandBuilder.isValidToken("jq"), "simple Homebrew token is valid")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11737,7 +11737,7 @@ struct MetricsTests {
             encoding: .utf8)) ?? ""
         let homebrewRunStreaming = homebrewManagerSource.components(separatedBy: "func runStreaming(")
             .dropFirst().first?.components(separatedBy: "private func appendLog").first ?? ""
-        expect(homebrewRunStreaming.contains("brewOperationTimeout")
+        expect(homebrewRunStreaming.contains("brewSilenceTimeout")
                 && !homebrewRunStreaming.contains("waitUntilExit"),
                "Homebrew operations wait on a bounded semaphore, not waitUntilExit")
 


### PR DESCRIPTION
## Summary

`runStreaming` waited on the child with `waitUntilExit()`, which takes no timeout. That wait runs on `HomebrewManager`'s serial `workQueue`, so one stuck `brew install` parked every later `refreshInstalled`, `search`, `refreshOutdated`, `select` and `packageManagingApplication` behind it for good.

`runStreaming` now waits on a semaphore its `terminationHandler` signals, bounded by a new `brewOperationTimeout` of 30 minutes, and escalates through the existing `stop(_:finished:)` when the bound expires. This is the same shape `run` already uses a few lines above with `brewReadTimeout`. The completion status is `-1` if the child somehow survives the escalation, again as in `run`. When the bound trips the operation card goes to Failed, not Cancelled, because nobody cancelled it.

This is the same unbounded-wait shape #971 describes, at a site that issue never names. It starves this one serial queue rather than the shared pool, so it is not referenced as a fix for #971. After this lands `main` still has two bare `waitUntilExit()` calls, in `JunkCleaner` and `DiskImageInstallerService`, so #971 is not one change away from done.

Considered and not done, compared with #1237: the 4 MB output tail, the 64 KB log cap and the `static let` regex hoist. None of them had an observed need. The output buffer is a local of one operation and is released when it ends, the log is already cleared by `scheduleCompletedOperationCleanup` a few seconds after every outcome, and the regex cost was never measured. They are separate changes if anyone sees them bite.

## Verification

Mac17,3, macOS 26.6.2 (25G83), local build from this head.

```sh
./build.sh                     # 0 warnings
./build/Vorssaint --selftest   # SELFTEST OK
./build.sh --test              # TESTS OK (9609 checks)
```

`./build.sh --test` does not compile `HomebrewManager.swift`, so the new assertion is a source-shape check: `runStreaming` contains `brewOperationTimeout` and no `waitUntilExit`. It is red on `main`, where neither holds.

Not tested: none of it against a real slow or hung `brew`. The timeout path and the SIGTERM/SIGKILL escalation were read from `run` and `stop(_:finished:)`, not exercised, and the Failed-not-Cancelled routing was traced through `perform` rather than observed. No GUI testing was done.

## Anything else

Supersedes #1237.