### PR TITLE
perf(command-bar): fold each list of rows once per opening

### DIFF
--- a/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
@@ -888,8 +888,7 @@ final class CommandBarService: ObservableObject {
     /// Each list's folded copy, dropped by the `didSet` when that list is
     /// assigned again. The lists land from separate background passes, each
     /// calling `indexEntries()`, so one opening indexes seven to ten times.
-    private var foldedSections: [PoolSection: [(entry: CommandBarEntry,
-                                                folded: (title: String, keywords: String))]] = [:]
+    private var foldedSections: [PoolSection: [(title: String, keywords: String)]] = [:]
 
     private func indexEntries() {
         index()
@@ -912,9 +911,8 @@ final class CommandBarService: ObservableObject {
                 // the row surfaces even when its real title shares nothing with it.
                 let alias = names[entry.stableKey]
                     .map { " " + CommandBarSearch.normalized($0) } ?? ""
-                return (entry,
-                        (CommandBarSearch.normalized(entry.matchTitle ?? entry.title),
-                         CommandBarSearch.normalized(entry.keywords) + alias))
+                return (CommandBarSearch.normalized(entry.matchTitle ?? entry.title),
+                        CommandBarSearch.normalized(entry.keywords) + alias)
             }
         }
         // The three maps are built from nothing every time, so a row that left
@@ -924,10 +922,10 @@ final class CommandBarService: ObservableObject {
         normalizedByID = [:]
         entriesByStableKey = [:]
         for section in PoolSection.allCases {
-            for row in foldedSections[section] ?? [] {
-                entriesByID[row.entry.id] = row.entry
-                entriesByStableKey[row.entry.stableKey] = row.entry
-                normalizedByID[row.entry.id] = row.folded
+            for (entry, folded) in zip(entries(in: section), foldedSections[section] ?? []) {
+                entriesByID[entry.id] = entry
+                entriesByStableKey[entry.stableKey] = entry
+                normalizedByID[entry.id] = folded
             }
         }
     }

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
@@ -890,17 +890,15 @@ final class CommandBarService: ObservableObject {
     /// calling `indexEntries()`, so one opening indexes seven to ten times.
     private var foldedSections: [PoolSection: [(title: String, keywords: String)]] = [:]
 
-    private func indexEntries() {
-        index()
-    }
-
     private func clearIndex() {
         entriesByID = [:]
         normalizedByID = [:]
         entriesByStableKey = [:]
+        // Nothing folded outlives the panel.
+        foldedSections = [:]
     }
 
-    private func index() {
+    private func indexEntries() {
         // Folding a thousand titles on every keystroke is the one thing that
         // could make typing feel heavy. It happens here instead, once per list
         // per rebuild: a list nobody assigned again keeps the copy it has.

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
@@ -102,7 +102,7 @@ final class CommandBarService: ObservableObject {
     private var flagsMonitor: Any?
     private var activationObserver: NSObjectProtocol?
 
-    private var catalog: [CommandBarEntry] = []
+    private var catalog: [CommandBarEntry] = [] { didSet { foldedSections[.catalog] = nil } }
     let scriptRunner = CommandBarScriptRunner()
     let fileSearch = CommandBarFileSearch()
     /// Which row answered which few letters, for as long as the app runs. Not
@@ -115,30 +115,30 @@ final class CommandBarService: ObservableObject {
     private var entriesByStableKey: [String: CommandBarEntry] = [:]
     private var presentationLifecycle = CommandBarPresentationLifecycle()
     private var deferredRowShortcut = CommandBarDeferredRowShortcut()
-    private var appEntries: [CommandBarEntry] = []
-    private var windowEntries: [CommandBarEntry] = []
-    private var quitEntries: [CommandBarEntry] = []
+    private var appEntries: [CommandBarEntry] = [] { didSet { foldedSections[.apps] = nil } }
+    private var windowEntries: [CommandBarEntry] = [] { didSet { foldedSections[.windows] = nil } }
+    private var quitEntries: [CommandBarEntry] = [] { didSet { foldedSections[.quit] = nil } }
     /// The raw scan is what gets cached; the rows are rebuilt on every open so
     /// the live dot and the running apps are never a stale picture.
     private var cachedApps: [InstalledApps.InstalledApp] = []
     private var appsLoading = false
     private var windowsLoading = false
     private var windowsLoadedAt: Date?
-    private var menuEntries: [CommandBarEntry] = []
-    private var emojiEntries: [CommandBarEntry] = []
+    private var menuEntries: [CommandBarEntry] = [] { didSet { foldedSections[.menus] = nil } }
+    private var emojiEntries: [CommandBarEntry] = [] { didSet { foldedSections[.emoji] = nil } }
     /// The Mac's own Settings panes, scanned once per launch. The language
     /// they were built in comes with them, because the words they answer to
     /// are translated and a change of language has to reread them.
-    private var macSettingsEntries: [CommandBarEntry] = []
+    private var macSettingsEntries: [CommandBarEntry] = [] { didSet { foldedSections[.macSettings] = nil } }
     private var macSettingsLanguage: AppLanguage?
     private var macSettingsLoading = false
     /// Rows that act on what was selected when the bar opened. Read once per
     /// opening and thrown away on close: a selection is a moment, not a state.
-    private var selectionEntries: [CommandBarEntry] = []
+    private var selectionEntries: [CommandBarEntry] = [] { didSet { foldedSections[.selection] = nil } }
     private var selectionLoading = false
     /// One row per running process. Read once per opening through
     /// `KillProcessService`'s own cache, same lifetime as `selectionEntries`.
-    private var killProcessEntries: [CommandBarEntry] = []
+    private var killProcessEntries: [CommandBarEntry] = [] { didSet { foldedSections[.killProcess] = nil } }
     private var killProcessEntriesLoading = false
     /// True while the bar is closing, so nothing is rebuilt on the way out.
     private var isTearingDown = false
@@ -674,7 +674,9 @@ final class CommandBarService: ObservableObject {
     /// The rest of what the person decided, cached for the same reason and
     /// with the same lifetime: read once when the bar opens, asked for by
     /// every row on every keystroke after that.
-    private var aliasCache: [String: String] = [:]
+    private var aliasCache: [String: String] = [:] {
+        didSet { if aliasCache != oldValue { foldedSections = [:] } }
+    }
     private var hiddenCache: Set<String> = []
     private var disabledCache: Set<CommandBarSource> = []
     private var usageCache: [String: CommandBarUse] = [:]
@@ -858,15 +860,39 @@ final class CommandBarService: ObservableObject {
         return indexableEntries.last { $0.stableKey == key }
     }
 
-    /// Every row the bar can rank right now, in the order the pool builds
-    /// them: what the Mac holds first, what is borrowed after.
-    private var indexableEntries: [CommandBarEntry] {
-        selectionEntries + killProcessEntries + catalog + appEntries + macSettingsEntries + windowEntries
-            + quitEntries + menuEntries + emojiEntries
+    /// The nine lists the pool is made of, in the order it builds them: what
+    /// the Mac holds first, what is borrowed after.
+    private enum PoolSection: CaseIterable {
+        case selection, killProcess, catalog, apps, macSettings, windows, quit, menus, emoji
     }
 
+    private func entries(in section: PoolSection) -> [CommandBarEntry] {
+        switch section {
+        case .selection: return selectionEntries
+        case .killProcess: return killProcessEntries
+        case .catalog: return catalog
+        case .apps: return appEntries
+        case .macSettings: return macSettingsEntries
+        case .windows: return windowEntries
+        case .quit: return quitEntries
+        case .menus: return menuEntries
+        case .emoji: return emojiEntries
+        }
+    }
+
+    /// Every row the bar can rank right now.
+    private var indexableEntries: [CommandBarEntry] {
+        PoolSection.allCases.flatMap { entries(in: $0) }
+    }
+
+    /// Each list's folded copy, dropped by the `didSet` when that list is
+    /// assigned again. The lists land from separate background passes, each
+    /// calling `indexEntries()`, so one opening indexes seven to ten times.
+    private var foldedSections: [PoolSection: [(entry: CommandBarEntry,
+                                                folded: (title: String, keywords: String))]] = [:]
+
     private func indexEntries() {
-        index(indexableEntries)
+        index()
     }
 
     private func clearIndex() {
@@ -875,26 +901,34 @@ final class CommandBarService: ObservableObject {
         entriesByStableKey = [:]
     }
 
-    private func index(_ entries: [CommandBarEntry]) {
-        entriesByID = [:]
-        for entry in entries {
-            entriesByID[entry.id] = entry
-        }
+    private func index() {
         // Folding a thousand titles on every keystroke is the one thing that
-        // could make typing feel heavy. It happens here instead, once per
-        // rebuild.
+        // could make typing feel heavy. It happens here instead, once per list
+        // per rebuild: a list nobody assigned again keeps the copy it has.
+        let names = aliasCache
+        for section in PoolSection.allCases where foldedSections[section] == nil {
+            foldedSections[section] = entries(in: section).map { entry in
+                // A name the person gave is searchable text like any other, so
+                // the row surfaces even when its real title shares nothing with it.
+                let alias = names[entry.stableKey]
+                    .map { " " + CommandBarSearch.normalized($0) } ?? ""
+                return (entry,
+                        (CommandBarSearch.normalized(entry.matchTitle ?? entry.title),
+                         CommandBarSearch.normalized(entry.keywords) + alias))
+            }
+        }
+        // The three maps are built from nothing every time, so a row that left
+        // its list - the menus of the app that was in front a moment ago -
+        // cannot stay pressable.
+        entriesByID = [:]
         normalizedByID = [:]
         entriesByStableKey = [:]
-        let names = aliasCache
-        for entry in entries {
-            entriesByStableKey[entry.stableKey] = entry
-            // A name the person gave is searchable text like any other, so the
-            // row surfaces even when its real title shares nothing with it.
-            let alias = names[entry.stableKey]
-                .map { " " + CommandBarSearch.normalized($0) } ?? ""
-            normalizedByID[entry.id] = (
-                CommandBarSearch.normalized(entry.matchTitle ?? entry.title),
-                CommandBarSearch.normalized(entry.keywords) + alias)
+        for section in PoolSection.allCases {
+            for row in foldedSections[section] ?? [] {
+                entriesByID[row.entry.id] = row.entry
+                entriesByStableKey[row.entry.stableKey] = row.entry
+                normalizedByID[row.entry.id] = row.folded
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

One opening of the command bar folded every row's title and keywords seven to
ten times.

`index(_:)` folds each row once "per rebuild" so that typing never pays for it,
but it is handed the flat concatenation of nine lists, and those lists arrive at
different moments: the catalog and the running apps when the panel appears, then
the installed apps, the Mac's Settings panes, the open windows, the front app's
menus, the selection and the running processes each from their own background
pass, and each one calls `indexEntries()` on the way in. Every call refolded all
nine lists - 1000 to 1500 rows, two foldings each - in the few hundred
milliseconds while the panel was appearing and the person started typing.

Each list now keeps its own folded copy and only the list that was assigned
again is folded. The invalidation is the assignment itself: each of the nine
stored properties carries a `didSet` that drops its copy, so no write site has a
separate step to forget. `PoolSection` names the nine lists in the order the old
concatenation had, so `freshFullEntry`'s `.last` still picks the same row.

The three lookup maps are still built from nothing on every call, deliberately:
an id that is no longer in any list cannot reappear, so the menus of the app
that was in front a moment ago cannot stay pressable. `aliasCache` clears every
copy when it changes, since a name the person gave is folded in.

Considered and not done: #1245 also stopped `rebuildCatalog()` from rebuilding
the emoji rows unless the language or the Accessibility grant moved. The body
there put those rows at about fifteen hundred; `CommandBarEmoji.emojiCharacters`
on `main` is 204 characters, and `CommandBarEmoji.emoji` is a `static let`, so
the Unicode names are resolved once per launch and `emojiEntries(bar:)` is a map
over 204 structs. With the folding already down to once per list per opening,
skipping those 204 of 1000-1500 rows is worth at most about 1.2x, and it was
where every review finding on that PR landed (a stale permission warning after
a grant, the store left unpinned, the uninstall path leaning on `isEmpty`). Not
worth its guard, its extra field or its source-shape test.

A tenth `PoolSection` case whose array carries no `didSet` would keep its first
folded copy for the life of the service, and because the identity maps are built
inside the same `zip`, rows that list grew by would fall out of `entriesByID` and
`entriesByStableKey` too. Nine cases, nine `didSet`s today; the `didSet` is the
invariant, not a nicety.

`foldedSections` holds only the folded text per section; the rows themselves are read back through `entries(in:)` when the maps are built, zipped by position. The `didSet` that drops a section's fold whenever its list is assigned is what keeps the two the same length and order, so no second copy of the entries lives for the life of the service.

## Verification

Mac17,3, macOS 26.6.2 (25G83). `./build.sh` clean, no warnings;
`./build/Vorssaint --selftest` `SELFTEST OK`; `./build.sh --test` `TESTS OK (9608 checks)`.

`CommandBarService.swift` is outside the `--test` whitelist, so the test binary
does not compile it; the full build does. No test added: the change is in one
file the test target does not see, and there is no observable to pin by source
shape that the build itself does not already check.

Not tested: no run on real hardware. The count of index passes per opening is
read off the call graph, not measured. Opening the bar with menus, windows and a
selection all landing, and renaming a row while it is open, were not exercised
by hand.

## Anything else

No issue reports the cost this removes; it came out of reading the opening path.

Supersedes #1245.