### PR TITLE
test: enumerate event-tap owners instead of listing six by hand

### DIFF
--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -22212,49 +22212,44 @@ struct MetricsTests {
             encoding: .utf8)) ?? ""
         expect(mouseAccelerationSource.contains("SessionActivitySupport.isOnConsole("),
                "mouse acceleration shares the safe initial session-state fallback")
-        for tapOwner in ["Sources/Vorssaint/Services/ScrollInverter.swift",
-                         "Sources/Vorssaint/Services/SmoothScrollService.swift",
-                         "Sources/Vorssaint/Services/MouseNavigation/MouseNavigationService.swift",
-                         "Sources/Vorssaint/Services/MouseButtons/MouseButtonShortcutService.swift",
-                         "Sources/Vorssaint/Services/MiddleClick/MiddleClickService.swift",
-                         "Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift",
-                         "Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift",
-                         "Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift",
-                         "Sources/Vorssaint/Services/WindowMaximizer.swift",
-                         "Sources/Vorssaint/Services/Finder/FinderCutPaste.swift",
-                         "Sources/Vorssaint/Services/Finder/FinderRenameService.swift",
-                         "Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift",
-                         "Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift",
-                         "Sources/Vorssaint/Services/ShortcutRecordingTap.swift",
-                         "Sources/Vorssaint/Services/Switcher/AppSwitcher.swift",
-                         "Sources/Vorssaint/Services/Snippets/TextSnippetService.swift",
-                         "Sources/Vorssaint/Services/Audio/PreciseVolumeRollerService.swift",
-                         "Sources/Vorssaint/Services/DockClick/DockClickService.swift",
-                         "Sources/Vorssaint/Services/Display/BrightnessService.swift"] {
-            let source = (try? String(contentsOfFile: tapOwner, encoding: .utf8)) ?? ""
-            expect(!source.isEmpty, "\(tapOwner) reads back for its session-switch check")
-            let code = source.components(separatedBy: "\n")
-                .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
-                .joined(separator: "\n")
+        // The owners are read out of the tree, not listed by hand, so a new
+        // CGEvent.tapCreate has nothing to register. One enumeration feeds
+        // both sweeps below, rooted at Sources so every target is asked.
+        let tapOwnerFiles: [(path: String, code: String)] = (FileManager.default
+            .enumerator(atPath: "Sources")?.compactMap { $0 as? String } ?? [])
+            .filter { $0.hasSuffix(".swift") && !$0.contains(" 2") }
+            .sorted()
+            .compactMap { entry in
+                let path = "Sources/\(entry)"
+                guard let source = try? String(contentsOfFile: path, encoding: .utf8) else { return nil }
+                let code = source.components(separatedBy: "\n")
+                    .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+                    .joined(separator: "\n")
+                return code.contains("CGEvent.tapCreate") ? (path, code) : nil
+            }
+        // An empty sweep would pass every check below in silence.
+        expect(tapOwnerFiles.count >= 20,
+               "the CGEvent.tapCreate sweep reaches the sources from the test's working directory")
+        for (tapOwner, code) in tapOwnerFiles {
+            // A listen-only tap hands every event back unchanged, so a session
+            // that is off screen cannot swallow the on-screen account's input.
+            if code.contains(".listenOnly") && !code.contains(".defaultTap") { continue }
             expect(code.contains("SessionActivity.shared.onChange"),
                    "\(tapOwner) rebuilds its tap when the session comes back")
-            let rearm = code.components(separatedBy: "tapDisabledByTimeout")
-                .dropFirst().first?.components(separatedBy: "return").first ?? ""
-            expect(rearm.contains("SessionActivity.shared.isActive"),
-                   "\(tapOwner) does not re-arm a disabled tap into a switched-away session")
-            if tapOwner.contains("MouseNavigation")
-                || tapOwner.contains("MouseButtonShortcut")
-                || tapOwner.contains("MiddleClick")
-                || tapOwner.contains("QuitProtection")
-                || tapOwner.contains("RadialMenu")
-                || tapOwner.contains("ShortcutRecordingTap") {
-                expect(rearm.contains("AXIsProcessTrusted()"),
-                       "\(tapOwner) does not keep a modifying tap alive after Accessibility is lost")
+            // Every site, not the first: two owners re-arm in two callbacks.
+            // And at least one, or the walk below passes on nothing.
+            let rearmSlices = code.components(separatedBy: "tapDisabledByTimeout").dropFirst()
+            expect(!rearmSlices.isEmpty, "\(tapOwner) handles its tap being disabled")
+            for slice in rearmSlices {
+                let rearm = slice.components(separatedBy: "return").first ?? ""
+                expect(rearm.contains("SessionActivity.shared.isActive"),
+                       "\(tapOwner) does not re-arm a disabled tap into a switched-away session")
             }
-            // Switching a tap off leaves the process owning it, which is what
-            // the window server waits on; teardown must invalidate the port.
-            expect(code.contains("CFMachPortInvalidate"),
-                   "\(tapOwner) hands its tap back rather than only disabling it")
+            // Either spelling of the permission half: the shared helper takes
+            // it as an argument, older services ask the API directly.
+            expect(code.contains("SessionActivitySupport.tapShouldRun(")
+                    || code.contains("AXIsProcessTrusted()"),
+                   "\(tapOwner) does not keep a modifying tap alive after Accessibility is lost")
         }
 
         // Disabling a tap and dropping the last Swift reference does not hand
@@ -22266,32 +22261,19 @@ struct MetricsTests {
         // as in the per-service check above, so prose naming the API cannot
         // answer for a missing call. A margin does not cover a tap added later:
         // MouseClickDebounceService's two invalidations are both on its one
-        // tap. The owners reached are counted too, because a file with no
-        // literal CGEvent.tapCreate is skipped, so moving the call behind a
-        // helper would otherwise leave a sweep that passes having read nothing.
+        // tap. No exemption list here: the session gate is a different
+        // question, and the port is owed whether or not the tap is gated.
         var tapOwnersWithoutInvalidate: [String] = []
-        var tapOwners = 0
-        let tapOwnerSources = FileManager.default
-            .enumerator(atPath: "Sources/Vorssaint")?
-            .compactMap { $0 as? String }
-            .filter { $0.hasSuffix(".swift") && !$0.contains(" 2") } ?? []
-        for file in tapOwnerSources.sorted() {
-            guard let source = try? String(contentsOfFile: "Sources/Vorssaint/\(file)",
-                                           encoding: .utf8) else { continue }
-            let code = source.components(separatedBy: "\n")
-                .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
-                .joined(separator: "\n")
+        for (path, code) in tapOwnerFiles {
             let taps = code.components(separatedBy: "CGEvent.tapCreate").count - 1
-            guard taps > 0 else { continue }
-            tapOwners += 1
             let invalidations = code.components(separatedBy: "CFMachPortInvalidate").count - 1
             if invalidations < taps {
-                tapOwnersWithoutInvalidate.append("\(file) (\(taps) taps, \(invalidations) invalidated)")
+                tapOwnersWithoutInvalidate.append("\(path) (\(taps) taps, \(invalidations) invalidated)")
             }
         }
-        expect(tapOwners > 0 && tapOwnersWithoutInvalidate.isEmpty,
+        expect(tapOwnersWithoutInvalidate.isEmpty,
                "every event tap owner invalidates its port on teardown, across "
-               + "\(tapOwners) scanned owners: \(tapOwnersWithoutInvalidate)")
+               + "\(tapOwnerFiles.count) scanned owners: \(tapOwnersWithoutInvalidate)")
 
         let mouseTapAppDelegateSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/App/AppDelegate.swift",


### PR DESCRIPTION
## Summary

The session-switch guard in `Tests/MetricsTests.swift` walked a hand-written list of files: six when this was opened, nineteen on `main` today. `main` has 24 files that call `CGEvent.tapCreate`, and a service adding a tap tomorrow inherits nothing from the list. The taps that never joined the session gate were exactly the ones missing from it.

The loop now reads its subjects out of `Sources/`: every `.swift` file whose comment-stripped source contains `CGEvent.tapCreate` is asked the three session questions the guard already asked (`SessionActivity.shared.onChange`, `SessionActivity.shared.isActive` between every `tapDisabledByTimeout` and its `return`, and an Accessibility check). There is nothing to register any more, and no exemption set: with #1304 and #1270 on `main`, every modifying tap owner passes, so there is nothing to exempt and no list to go stale. The enumeration is the same one the port sweep from #1225 already did, so that sweep now walks the shared list instead of its own; both sweeps are rooted at `Sources` rather than `Sources/Vorssaint`, so a tap landing in `HIDEventSystem` or `VMStatisticsCompat` gets the same questions. A `>= 20` floor keeps an empty walk from passing in silence, and each owner must have at least one `tapDisabledByTimeout` block, or the per-site walk would pass on nothing.

Two things follow from enumerating:

- Listen-only taps (`.listenOnly` and never `.defaultTap`) skip the session checks. They hand every event back unchanged, so a switched-away session cannot swallow the on-screen account's input. Flip one to `.defaultTap` and it is checked on the next run. They are still asked for the port by the invalidate sweep.
- The Accessibility assertion accepts either `SessionActivitySupport.tapShouldRun(` or `AXIsProcessTrusted()` anywhere in the file, on all 21 modifying owners. `main` asks six owners by name for `AXIsProcessTrusted()` inside the re-arm slice and the other fifteen nothing. Measured on `main`: 22 of the 23 re-arm sites already carry `AXIsProcessTrusted()`; the one that does not is `ScrollInverter`, which re-enables on `SessionActivity.shared.isActive` alone and asks `tapShouldRun` only on start. A slice-level check for every owner is one `Sources` line away, in `ScrollInverter`, and is not this change.

Considered and not done: the earlier version of this change (#1230) carried a harm description next to each ungated path, and the version reviewed here kept an exemption set with a staleness check. Both existed for owners that were outside the gate; none are left, so the set is deleted rather than kept empty. A future ungated tap fails the sweep directly, which is the rule the set was stating. The invalidate sweep keeps a per-tap count rather than the per-file `CFMachPortInvalidate` check the roster had, since three owners hold more than one tap.

## Verification

Mac17,3, macOS 26.6.2 (25G83), own build from this branch on `main` (`4dd067de`).

`./build.sh --test`: TESTS OK (9699 checks) on this branch, against 9694 on `main`, zero failures either side.

Falsified rather than only run. A throwaway `Sources/Vorssaint/Services/ZZProbeTapService.swift` holding nothing but a bare `.defaultTap` `CGEvent.tapCreate` and no teardown turns four checks red naming that file (the three session questions plus the port sweep reporting `1 taps, 0 invalidated` across 25 owners). Deleting the `SessionActivity.shared.onChange` subscription from `RadialMenuService`, the owner that joined on this rebase, gives one red from this sweep naming the file, beside the one #1270's own test raises on the same subscription. Replacing `SessionActivity.shared.isActive` with `true` in `BrightnessService`'s second `tapDisabledByTimeout` block (`handleKeyEvent`, the one a first-slice read never sees) gives exactly one red naming the file. Renaming every `tapDisabledByTimeout` in `KeyboardDebounceService` gives exactly one red saying it no longer handles its tap being disabled. All restored, back to green.

Census on `main`: 24 owners, all under `Sources/Vorssaint`; 3 listen-only (`MusicLaunchBlocker`, `AutoQuitService`, `DockPreviewService`); the remaining 21 pass every check across 23 re-arm sites, including `CleaningModeManager` and `MouseClickDebounceService`, which the hand-written list never reached.

Not tested: nothing here runs a tap. A tap handed back across a fast user switch needs a second logged-in account and was not exercised. The full `./build.sh` and `--selftest` were not run; only the test file changes, so nothing outside the `--test` compile is affected.

## Anything else

Refs #1153

Supersedes #1230.
