### PR TITLE
fix(brightness): check the display fingerprint before restoring gamma

### DIFF
--- a/Sources/Vorssaint/Services/Display/BrightnessService.swift
+++ b/Sources/Vorssaint/Services/Display/BrightnessService.swift
@@ -433,8 +433,10 @@ final class BrightnessService: ObservableObject {
                     return
                 }
                 // A software-dimmed screen should return with its clean gamma
-                // before the saved dim level is reapplied by the rebuild.
-                if let baseline = self.gammaBaselines[display.id] {
+                // before the saved dim level is reapplied by the rebuild. The
+                // number may already belong to another monitor (see `GammaTable`).
+                if let baseline = self.gammaBaselines[display.id],
+                   baseline.fingerprint == Self.displayFingerprint(display.id) {
                     CGSetDisplayTransferByTable(display.id, baseline.count, baseline.red,
                                                 baseline.green, baseline.blue)
                 }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -14143,6 +14143,10 @@ struct MetricsTests {
             .joined(separator: "\n")
         expect(!brightnessWorkQueueHalf.isEmpty && !brightnessWorkQueueCode.contains("NSScreen"),
                "the brightness work queue resolves display names without touching NSScreen")
+        // Display numbers are reissued after a reconnection, so the gamma
+        // restore before a switch-off must check the monitor like the others.
+        expect(brightnessSource.contains("baseline.fingerprint == Self.displayFingerprint(display.id)"),
+               "the pre-switch-off gamma restore checks the display fingerprint")
 
         let ddcWrite = BrightnessSupport.writePacket(code: 0x10, value: 0x1234)
         let expectedDDCWrite: [UInt8] = [0x84, 0x03, 0x10, 0x12, 0x34, 0x8E]


### PR DESCRIPTION
## Summary

`GammaTable` carries a `fingerprint` because display numbers are handed out again after a reconnection, and the remembered curves are deliberately kept across a disconnection. So "this number now belongs to a different monitor" is a state the code expects. Four places in `BrightnessService` write a curve. Three checked the fingerprint first. The fourth, the restore that runs just before a display is switched off, took the table by display number and wrote it, so a dimmed baseline could land on whichever monitor now holds that number.

The fix is the missing condition at that site: the restore now runs only when `baseline.fingerprint == Self.displayFingerprint(display.id)`, the same test the other three writers make. A source-shape check pins it.

Considered and not done: funnelling all four writers through one `writeGammaBaseline` helper with a call-count test (what #1231 did). Three sites already agree, one had drifted, and the sites are all in this file. A helper is a refactor of working code for one missing line. Dropping a curve whose monitor changed was also not done, because the "kept across the gap" comment on `gammaBaselines` exists to prevent that.

## Verification

Mac17,3, macOS 26.6.2 (25G83). On `main` at `f7378a8d`.

`./build.sh` exit 0, no warnings. `./build/Vorssaint --selftest` OK. `./build.sh --test` `TESTS OK (9609 checks)`.

The new assertion was run against `main` first: `main` has no `baseline.fingerprint == Self.displayFingerprint(display.id)`, so it is red there and green here.

**Not tested.** No second monitor here, so the gamma path was not exercised against real hardware: a software-dimmed display, switched off and back on with a different monitor taking its display number, is the case the fix is about and it has not been reproduced. `BrightnessService.swift` is not in the `--test` file list, so the full `./build.sh` is the only thing compiling this change.

## Anything else

#301 reports an external display blacking out, sometimes while the brightness slider is moving, recoverable only by unplugging the hub. This is one way that can happen: a display number handed out again after a reconnection let the pre-switch-off restore write a dimmed baseline to whichever monitor now holds the number. #836 attributes #301 to DDC renegotiation, which this branch does not touch, so this is an additional candidate path and not the fix that issue is waiting for.

Refs #301

Supersedes #1231.
