### PR TITLE
fix(build): only count signing identities that can actually sign

### DIFF
--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21921,6 +21921,21 @@ struct MetricsTests {
         expect(!signingSetupCode.contains("-legacy"),
                "setup-signing.sh avoids the -legacy flag the stock LibreSSL openssl rejects")
 
+        // MARK: The stable identity is judged by whether codesign can sign with it
+        // A find-identity listing names certificates codesign then rejects, and
+        // -v excludes every self-signed one, so neither spelling may decide.
+        let buildScriptCode = buildScript.components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("#") }
+        for (script, code, identity) in [("build.sh", buildScriptCode, "$LEGACY_IDENTITY"),
+                                         ("Tools/setup-signing.sh", signingSetupCode.components(separatedBy: "\n"),
+                                          "$IDENTITY")] {
+            expect(!code.contains { $0.contains("find-identity") && $0.contains(identity) },
+                   "\(script) never decides the stable identity by a find-identity listing")
+            expect(code.contains { $0.contains("cp /bin/echo") }
+                    && code.contains { $0.contains("--sign \"\(identity)\" \"$probe\"") },
+                   "\(script) asks codesign to sign a throwaway copy of /bin/echo with the stable identity")
+        }
+
         // MARK: Modifying mouse taps are handed back across a session switch
         // The tap owners cannot be reached from this list (they need the event
         // chain), so the wiring is pinned as text: each service follows the

--- a/Tools/setup-signing.sh
+++ b/Tools/setup-signing.sh
@@ -29,6 +29,9 @@ KCPASS="vorssaint-signing"
 # excludes every self-signed one; ask codesign itself with a throwaway copy.
 identity_can_sign() {
     local probe signed=1
+    # Locked after every reboot; a locked keychain cannot sign, and a false
+    # answer here would delete it and reissue the identity.
+    security unlock-keychain -p "$KCPASS" "$KC" 2>/dev/null || true
     probe="$(mktemp)"
     cp /bin/echo "$probe"
     codesign --force --strip-disallowed-xattrs --sign "$IDENTITY" "$probe" >/dev/null 2>&1 && signed=0

--- a/Tools/setup-signing.sh
+++ b/Tools/setup-signing.sh
@@ -13,7 +13,7 @@
 # requirement and drop every user's granted permissions. The name lives only in
 # the keychain and codesign output, never in anything the app shows.
 #
-# Free, offline, and idempotent (re-running is a no-op once the identity exists).
+# Free, offline, and idempotent (re-running is a no-op once a working identity exists).
 # It does NOT replace Apple notarization: downloaded builds still show Gatekeeper's
 # "unverified developer" prompt on first launch. It only stabilizes the identity.
 #
@@ -25,7 +25,18 @@ IDENTITY="Vorssaint Utils Signing"
 KC="$HOME/Library/Keychains/vorssaint-signing.keychain-db"
 KCPASS="vorssaint-signing"
 
-if security find-identity -p codesigning 2>/dev/null | grep -q "$IDENTITY"; then
+# A find-identity listing also names certificates codesign then rejects, and -v
+# excludes every self-signed one; ask codesign itself with a throwaway copy.
+identity_can_sign() {
+    local probe signed=1
+    probe="$(mktemp)"
+    cp /bin/echo "$probe"
+    codesign --force --strip-disallowed-xattrs --sign "$IDENTITY" "$probe" >/dev/null 2>&1 && signed=0
+    rm -f "$probe"
+    return $signed
+}
+
+if identity_can_sign; then
     echo "✓ Signing identity already installed."
     exit 0
 fi
@@ -58,11 +69,11 @@ security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KCPASS" 
 EXISTING=$(security list-keychains -d user | sed 's/"//g' | xargs)
 security list-keychains -d user -s "$KC" ${=EXISTING}
 
-# Import succeeding is not evidence codesign can see it: read it back the same
-# way build.sh looks it up, so a broken search list fails here and not as a
-# silent ad-hoc fallback three builds later.
-security find-identity -p codesigning 2>/dev/null | grep -q "$IDENTITY" || {
-    echo "✗ Identity imported but codesign cannot find it; keychain search list may be off." >&2
+# Import succeeding is not evidence codesign can sign with it: read it back the
+# same way build.sh looks it up, so a broken search list fails here and not as
+# a silent ad-hoc fallback three builds later.
+identity_can_sign || {
+    echo "✗ Identity imported but codesign cannot sign with it; keychain search list may be off." >&2
     exit 1
 }
 echo "✓ Created signing identity '$IDENTITY'. Future ./build.sh runs use it automatically."

--- a/build.sh
+++ b/build.sh
@@ -70,6 +70,19 @@ developer_id_identity() {
         | sed -E 's/.*"(.*)".*/\1/' || true
 }
 
+# A find-identity listing also names certificates codesign then rejects (an
+# expired one fails the build with errSecInternalComponent), and -v excludes
+# every self-signed one; ask codesign itself with a throwaway copy of /bin/echo.
+legacy_identity_installed() {
+    local probe signed=1
+    probe="$(mktemp)"
+    cp /bin/echo "$probe"
+    /usr/bin/codesign --force --strip-disallowed-xattrs --sign "$LEGACY_IDENTITY" "$probe" \
+        >/dev/null 2>&1 && signed=0
+    rm -f "$probe"
+    return $signed
+}
+
 # The Developer build exists for iterative local work, where an ad-hoc
 # signature is a trap: macOS ties Accessibility and Screen Recording grants to
 # the exact binary hash, so every rebuild orphans them while System Settings
@@ -77,7 +90,7 @@ developer_id_identity() {
 # identity is installed, create the stable local one up front instead of
 # falling through to ad-hoc — setup-signing.sh is free, offline and idempotent.
 if (( DEV )) && [[ -z "$(developer_id_identity)" ]] \
-    && ! security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"; then
+    && ! legacy_identity_installed; then
     echo "▸ No signing identity installed; creating the stable local one…"
     if ! ./Tools/setup-signing.sh; then
         echo "  ⚠ Tools/setup-signing.sh failed; signing ad-hoc instead." >&2
@@ -142,7 +155,7 @@ finalize_installed_bundle_after_child() {
             --options runtime --timestamp --identifier "$NOW_PLAYING_ADAPTER_ID" --sign "$devid" "$adapter"
         codesign_with_timestamp_retry --force --strip-disallowed-xattrs --options runtime --timestamp \
             --entitlements "$ENTITLEMENTS" --sign "$devid" "$bundle"
-    elif security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"; then
+    elif legacy_identity_installed; then
         [[ -f "$helper" ]] && /usr/bin/codesign --force --strip-disallowed-xattrs \
             --identifier "$FAN_HELPER_ID" --sign "$LEGACY_IDENTITY" "$helper"
         [[ -f "$adapter" ]] && /usr/bin/codesign --force --strip-disallowed-xattrs \
@@ -543,7 +556,7 @@ codesign_app() {
     if [[ -n "$DEVID" ]]; then
         codesign_with_timestamp_retry --force --strip-disallowed-xattrs --options runtime --timestamp \
             --entitlements "$ENTITLEMENTS" --sign "$DEVID" "$target"
-    elif security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"; then
+    elif legacy_identity_installed; then
         codesign --force --strip-disallowed-xattrs --sign "$LEGACY_IDENTITY" "$target"
     else
         codesign --force --strip-disallowed-xattrs --sign - "$target"
@@ -555,7 +568,7 @@ codesign_fan_helper() {
     if [[ -n "$DEVID" ]]; then
         codesign_with_timestamp_retry --force --strip-disallowed-xattrs --options runtime --timestamp \
             --identifier "$FAN_HELPER_ID" --sign "$DEVID" "$target"
-    elif security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"; then
+    elif legacy_identity_installed; then
         codesign --force --strip-disallowed-xattrs --identifier "$FAN_HELPER_ID" \
             --sign "$LEGACY_IDENTITY" "$target"
     else
@@ -568,7 +581,7 @@ codesign_now_playing_adapter() {
     if [[ -n "$DEVID" ]]; then
         codesign_with_timestamp_retry --force --strip-disallowed-xattrs --options runtime --timestamp \
             --identifier "$NOW_PLAYING_ADAPTER_ID" --sign "$DEVID" "$target"
-    elif security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"; then
+    elif legacy_identity_installed; then
         codesign --force --strip-disallowed-xattrs --identifier "$NOW_PLAYING_ADAPTER_ID" \
             --sign "$LEGACY_IDENTITY" "$target"
     else
@@ -584,7 +597,7 @@ sign_bundle() {
 
     if [[ -n "$DEVID" ]]; then
         echo "  signing with Developer ID (hardened runtime): $DEVID"
-    elif security find-identity -p codesigning 2>/dev/null | grep -q "$LEGACY_IDENTITY"; then
+    elif legacy_identity_installed; then
         echo "  signing with legacy self-signed identity: $LEGACY_IDENTITY"
     else
         echo "  signing ad-hoc (no identity installed — run Tools/setup-signing.sh)"

--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,10 @@ developer_id_identity() {
 # every self-signed one; ask codesign itself with a throwaway copy of /bin/echo.
 legacy_identity_installed() {
     local probe signed=1
+    # A locked keychain still lists its identities but cannot sign with them,
+    # and this one is locked after every reboot; unlock it before asking.
+    security unlock-keychain -p vorssaint-signing \
+        "$HOME/Library/Keychains/vorssaint-signing.keychain-db" 2>/dev/null || true
     probe="$(mktemp)"
     cp /bin/echo "$probe"
     /usr/bin/codesign --force --strip-disallowed-xattrs --sign "$LEGACY_IDENTITY" "$probe" \


### PR DESCRIPTION
## Summary

`build.sh` and `Tools/setup-signing.sh` decided whether the stable
self-signed identity `Vorssaint Utils Signing` was usable by reading a
`security find-identity` listing. Neither spelling answers that question.
Without `-v` the listing includes certificates that cannot sign, so a stale
one is handed to `codesign`, which fails with `errSecInternalComponent` after
a clean release compile, while the ad-hoc fallback sits unreached in the
`else` arm; on `--dev` the same misreading skips `Tools/setup-signing.sh`,
whose own front door then prints `✓ Signing identity already installed.` over
the dead certificate. With `-v` the listing reports only trusted certificates,
which a self-signed one never is, so every local build would go ad-hoc and
`setup-signing.sh` would delete and reissue a working identity on every run.

Both scripts now ask `codesign` itself: sign a throwaway copy of `/bin/echo`
with the identity and believe the result. `build.sh` gets
`legacy_identity_installed`, replacing all six `find-identity | grep`
guards (the `NOW_PLAYING_ADAPTER_ID` one added since #1232 included);
`Tools/setup-signing.sh` gets `identity_can_sign` at the front door and as
the post-import read-back. The probe passes `--strip-disallowed-xattrs` like
every other signing call, since a copy into `$TMPDIR` carries
`com.apple.provenance`. The Developer ID lookup keeps `-v`: that certificate
is Apple-issued and trust is the right question there.

Both probes unlock `vorssaint-signing.keychain-db` first. A locked keychain still lists its identities but cannot sign with them, and this one is locked after every reboot; without the unlock the probe answers "no" and `--dev` hands off to `setup-signing.sh`, whose next step deletes the keychain and reissues the identity, orphaning every Accessibility grant. Reproduced with `security lock-keychain`: the probe fails before the unlock line and passes after it, and `setup-signing.sh` on a locked keychain now reports the identity as already installed instead of replacing it. The keychain password literal is therefore in `build.sh` as well as `setup-signing.sh`; that is the cost of not sharing state between the two scripts.

Considered and not done, relative to #1232: no result cache for the probe (four extra codesign calls on a copy of `/bin/echo` per build are milliseconds, and the cache carried a staleness bug), no cleanup sweep for the probe file (a plain `rm -f` in the function covers it), and none of the source-shape tests that pinned those parts.

## Verification

Mac17,3, macOS 26.6.2 (25G83). Release build without a Developer ID; the
stable self-signed identity is installed on this machine.

`./build.sh` exit 0, 0 warnings, log says `signing with legacy self-signed
identity: Vorssaint Utils Signing`, so the probe took the real path here;
`./build/Vorssaint --selftest` OK; `./build.sh --test` 9612 checks, 0 failed.

Not tested: a machine with a valid Developer ID identity (that branch is
untouched), a keychain holding an expired stable certificate (the failure
this fixes, seen on the machine behind #1232), and
`./build.sh --dev` / `Tools/setup-signing.sh` from an identity-less state.

## Anything else

Refs #1123
Supersedes #1232.