### PR TITLE
fix(paste-plain): read the clipboard on the shared lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Vorssaint adds quit and close protections, expands screen text recognition, capt
 - The radial menu now checks only which extra mouse button opens a wheel when a side button is pressed, instead of loading every wheel and its icons on each event, so holding a side button and moving the mouse no longer risks dropped clicks. Thanks to @PathGao.
 
 ### Fixed
+- Paste as plain text no longer freezes the app when the app you copied from is slow to hand over the copied content. Thanks to @PathGao.
 - The App Switcher, a Dock icon restore and the process list now bring the chosen app to the front instead of raising its windows behind the app you were using. Thanks to @pboucher and @PathGao.
 - The Homebrew panel now refreshes installed packages after a run that only partly finished, so one skipped package no longer leaves the versions and pending updates showing the state from before it. Thanks to @PathGao.
 - The radial menu's Now Playing action now finds the playing track again on macOS 15.4 and later, where it had quietly shown nothing. Thanks to @PathGao.

--- a/Sources/Vorssaint/Services/QuickTools/PastePlainService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/PastePlainService.swift
@@ -48,9 +48,15 @@ final class PastePlainService: ObservableObject {
             }
             return
         }
-        let pasteboard = NSPasteboard.general
-        guard let plain = Self.plainText(from: pasteboard), !plain.isEmpty else { return }
+        // Promised content renders when read, so a busy source app would hold
+        // the main thread here; the lane answers back on main when it can.
+        GeneralPasteboardAccess.shared.async({ Self.plainText(from: .general) }) { [weak self] plain in
+            guard let self, let plain, !plain.isEmpty else { return }
+            self.pastePlain(plain)
+        }
+    }
 
+    private func pastePlain(_ plain: String) {
         // An app that ships its own matching-style paste does this better
         // than any synthesized ⌘V: the destination decides the typing
         // attributes (a stripped string pasted normally can leave the

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -752,6 +752,12 @@ struct MetricsTests {
         }
         expect(laneAnswer == 887, "the queued work runs once the lane comes free")
         expect(laneAnsweredOnMain, "the pasteboard lane answers on the main queue")
+        let pastePlainSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/QuickTools/PastePlainService.swift",
+            encoding: .utf8)) ?? ""
+        expect(pastePlainSource.contains("GeneralPasteboardAccess.shared.async")
+                && !pastePlainSource.contains("NSPasteboard.general"),
+               "paste as plain text reads the clipboard on the lane, not on the main thread")
 
         let maxCapacityStringJSON = Data(#"{"SPPowerDataType":[{"sppower_battery_health_info":{"sppower_battery_health_maximum_capacity":"93%"}}]}"#.utf8)
         expect(MaxCapacityProbe.percent(fromSystemProfilerJSON: maxCapacityStringJSON) == 93,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -755,8 +755,7 @@ struct MetricsTests {
         let pastePlainSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/Services/QuickTools/PastePlainService.swift",
             encoding: .utf8)) ?? ""
-        expect(pastePlainSource.contains("GeneralPasteboardAccess.shared.async")
-                && !pastePlainSource.contains("NSPasteboard.general"),
+        expect(pastePlainSource.contains("GeneralPasteboardAccess.shared.async"),
                "paste as plain text reads the clipboard on the lane, not on the main thread")
 
         let maxCapacityStringJSON = Data(#"{"SPPowerDataType":[{"sppower_battery_health_info":{"sppower_battery_health_maximum_capacity":"93%"}}]}"#.utf8)


### PR DESCRIPTION
## Summary

`PastePlainService.performPastePlain()` read `NSPasteboard.general` on the main thread. A pasteboard read has no time limit: content can be promised and rendered only when asked for, so a busy source app (Word, Excel, Illustrator all promise) holds the reader as long as it likes, and one press of ⌥⇧⌘V against it froze the app. `GeneralPasteboardAccess` exists for exactly this and says so in its header (issue #887); `ScreenshotService.openClipboardImage()` one file over already reads through it.

The read now goes through the lane's two-argument overload. The rest of the function moved unchanged into `pastePlain(_:)` and runs in the completion, which the lane already delivers on the main queue, so the frontmost app is still resolved at the moment of the paste. One source-shape assertion pins the read to the lane.

Considered and not done: a deadline plus frontmost-pid check on the completion, a `stillWanted` predicate threaded through `TransientPaste`, and named constants for its poll timings (all in #1238). The late-paste scenario they guard was never observed or reproduced, and `TransientPaste`'s own snapshot read already runs on the lane without a bound for both of its callers, so nothing here introduces that exposure. A beep on `didFail` is a separate defect (every failure on this path is silent today) and is left for its own change. `SnippetLibraryService.insert` and `TextSnippetService.expand` still read the general pasteboard on main (the latter via `DispatchQueue.main.sync` from the event-tap callback); also separate changes.

## Verification

Mac17,3, macOS 26.6.2 (25G83). `./build.sh` exit 0, no warnings; `./build/Vorssaint --selftest` `SELFTEST OK`; `./build.sh --test` `TESTS OK (9609 checks)`.

The new assertion is red on `main` (`PastePlainService.swift` there has no `GeneralPasteboardAccess`). It pins only the lane call, not the absence of the `NSPasteboard.general` spelling, since every other lane user names the type inside the closure.

Not tested: I did not run the app. The freeze was reasoned from the code and from the rule `GeneralPasteboardAccess` states, not reproduced against a stalled provider. `pressNativeMatchStyleItem` still walks the front app's menu bar on the main thread (600 elements × 0.35 s, cached per pid); pre-existing and untouched.

## Anything else

Refs #887
Refs #893

Supersedes #1238.