### PR TITLE
fix: hand the remaining event taps back across a user switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Vorssaint adds quit and close protections, expands screen text recognition, capt
 - The radial menu now checks only which extra mouse button opens a wheel when a side button is pressed, instead of loading every wheel and its icons on each event, so holding a side button and moving the mouse no longer risks dropped clicks. Thanks to @PathGao.
 
 ### Fixed
+- Features that handle keyboard, mouse and media keys now step aside during fast user switching, preventing input stalls in the active account. Thanks to @PathGao.
 - Restoring screen gamma before switching off a display now verifies the display's identity, preventing a dimmed curve from applying to another monitor after reconnections. Thanks to @PathGao.
 - The radial menu now releases its mouse button tap when switching macOS user accounts and closes any open wheel, preventing extra button clicks from stalling in the other account. Thanks to @PathGao.
 - Paste as plain text no longer freezes the app when the app you copied from is slow to hand over the copied content. Thanks to @PathGao.

--- a/Sources/Vorssaint/Services/Audio/PreciseVolumeRollerService.swift
+++ b/Sources/Vorssaint/Services/Audio/PreciseVolumeRollerService.swift
@@ -15,12 +15,20 @@ final class PreciseVolumeRollerService: ObservableObject {
     private var source: CFRunLoopSource?
     private var gate = PreciseVolumeRollerGate()
 
-    private init() {}
+    private init() {
+        SessionActivity.shared.onChange { [weak self] _ in self?.syncWithPreferences() }
+    }
 
     func syncWithPreferences() {
         let wanted = AppFeature.mixer.isAvailable
             && UserDefaults.standard.bool(forKey: DefaultsKey.preciseVolumeRollerEnabled)
-        wanted ? start() : stop()
+        if SessionActivitySupport.tapShouldRun(featureWanted: wanted,
+                                               accessibilityGranted: AXIsProcessTrusted(),
+                                               sessionIsActive: SessionActivity.shared.isActive) {
+            start()
+        } else {
+            stop()
+        }
     }
 
     func suspend() {
@@ -85,8 +93,10 @@ final class PreciseVolumeRollerService: ObservableObject {
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if AXIsProcessTrusted(), let tap {
+            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let tap {
                 CGEvent.tapEnable(tap: tap, enable: true)
+            } else {
+                DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
             }
             return Unmanaged.passUnretained(event)
         }

--- a/Sources/Vorssaint/Services/Display/BrightnessService.swift
+++ b/Sources/Vorssaint/Services/Display/BrightnessService.swift
@@ -217,7 +217,9 @@ final class BrightnessService: ObservableObject {
     /// panel must not put the same slow monitor probe behind itself again.
     private var rebuildingTopology: BrightnessSupport.DisplayTopology?
 
-    private init() {}
+    private init() {
+        SessionActivity.shared.onChange { [weak self] _ in self?.syncKeyTap() }
+    }
 
     func setKeyboardLightEnabled(_ enabled: Bool) {
         guard keyboardLightEnabled != nil, let keyboardLightBridge else { return }
@@ -645,9 +647,10 @@ final class BrightnessService: ObservableObject {
         let wantsBrightnessOSD = defaults.bool(
             forKey: DefaultsKey.brightnessOSDEnabled
         ) && brightnessOSDSupported
-        let wanted = running
-            && (wantsKeyRouting || wantsBrightnessOSD)
-            && Permissions.shared.accessibility
+        let wanted = SessionActivitySupport.tapShouldRun(
+            featureWanted: running && (wantsKeyRouting || wantsBrightnessOSD),
+            accessibilityGranted: AXIsProcessTrusted(),
+            sessionIsActive: SessionActivity.shared.isActive)
         if wanted { installKeyTap() } else { removeKeyTap() }
         // The plain key press path only earns its keystroke tap when the
         // pointer actually decides the target.
@@ -804,7 +807,11 @@ final class BrightnessService: ObservableObject {
     private func routeFunctionKey(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             let tap = keyThreadLock.withLock { shouldStopFunctionKeyThread ? nil : functionKeyTap }
-            if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
+            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let tap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            } else {
+                DispatchQueue.main.async { [weak self] in self?.syncKeyTap() }
+            }
             return Unmanaged.passUnretained(event)
         }
         guard type == .keyDown || type == .keyUp else {
@@ -968,7 +975,11 @@ final class BrightnessService: ObservableObject {
     /// Both halves are swallowed so the system never performs the same step.
     private func handleKeyEvent(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let keyTap { CGEvent.tapEnable(tap: keyTap, enable: true) }
+            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let keyTap {
+                CGEvent.tapEnable(tap: keyTap, enable: true)
+            } else {
+                DispatchQueue.main.async { [weak self] in self?.syncKeyTap() }
+            }
             return Unmanaged.passUnretained(event)
         }
         guard type.rawValue == CleaningSystemKeyEvent.systemDefinedEventTypeRawValue,

--- a/Sources/Vorssaint/Services/DockClick/DockClickService.swift
+++ b/Sources/Vorssaint/Services/DockClick/DockClickService.swift
@@ -60,15 +60,19 @@ final class DockClickService {
     private static let syntheticEventMarker: Int64 = 0x564F5253
     private var pendingSweeps: [pid_t: DispatchWorkItem] = [:]
 
-    private init() {}
+    private init() {
+        SessionActivity.shared.onChange { [weak self] _ in self?.syncWithPreferences() }
+    }
 
     func syncWithPreferences() {
         let minimizeEnabled = UserDefaults.standard.bool(forKey: DefaultsKey.dockClickMinimize)
         let hideEnabled = UserDefaults.standard.bool(forKey: DefaultsKey.dockClickHide)
         let cycleEnabled = UserDefaults.standard.bool(forKey: DefaultsKey.dockClickCycleWindows)
-        if AppFeature.dockClick.isAvailable,
-           (minimizeEnabled || hideEnabled || cycleEnabled),
-           Permissions.shared.accessibility {
+        if SessionActivitySupport.tapShouldRun(
+            featureWanted: AppFeature.dockClick.isAvailable
+                && (minimizeEnabled || hideEnabled || cycleEnabled),
+            accessibilityGranted: AXIsProcessTrusted(),
+            sessionIsActive: SessionActivity.shared.isActive) {
             start()
         } else {
             stop()
@@ -123,7 +127,11 @@ final class DockClickService {
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
+            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let tap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            } else {
+                DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
+            }
             return Unmanaged.passUnretained(event)
         }
         // The replayed down of a press that became a drag: the Dock must

--- a/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
@@ -89,7 +89,9 @@ final class FinderCutPaste: ObservableObject {
         static let v: Int64 = 9
     }
 
-    private init() {}
+    private init() {
+        SessionActivity.shared.onChange { [weak self] _ in self?.syncWithPreferences() }
+    }
 
     var isRunning: Bool { tapLifecycleLock.withLock { tap != nil } }
 
@@ -105,7 +107,9 @@ final class FinderCutPaste: ObservableObject {
         showHUD = UserDefaults.standard.object(forKey: DefaultsKey.finderCutPasteShowHUD) as? Bool ?? true
         pasteImageAsFileEnabled = available
             && UserDefaults.standard.bool(forKey: DefaultsKey.finderPasteImageAsFile)
-        if (cutPasteEnabled || pasteImageAsFileEnabled), Permissions.shared.accessibility {
+        if SessionActivitySupport.tapShouldRun(featureWanted: cutPasteEnabled || pasteImageAsFileEnabled,
+                                               accessibilityGranted: AXIsProcessTrusted(),
+                                               sessionIsActive: SessionActivity.shared.isActive) {
             installTap()
         } else {
             removeTap()
@@ -253,7 +257,11 @@ final class FinderCutPaste: ObservableObject {
     private func route(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             let currentTap = tapLifecycleLock.withLock { shouldStopTapThread ? nil : tap }
-            if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
+            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let currentTap {
+                CGEvent.tapEnable(tap: currentTap, enable: true)
+            } else {
+                DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
+            }
             return Unmanaged.passUnretained(event)
         }
         guard type == .keyDown,

--- a/Sources/Vorssaint/Services/Finder/FinderRenameService.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderRenameService.swift
@@ -26,7 +26,9 @@ final class FinderRenameService {
     private var shouldStopTapThread = false
     private var pendingStartAfterStop = false
 
-    private init() {}
+    private init() {
+        SessionActivity.shared.onChange { [weak self] _ in self?.syncWithPreferences() }
+    }
 
     func syncWithPreferences() {
         let shortcut = GlobalShortcut.saved(for: DefaultsKey.finderRenameShortcut,
@@ -34,7 +36,9 @@ final class FinderRenameService {
         routeLock.withLock { routeShortcut = shortcut }
         let enabled = AppFeature.finderRename.isAvailable
             && UserDefaults.standard.bool(forKey: DefaultsKey.finderRenameEnabled)
-        if enabled, Permissions.shared.accessibility {
+        if SessionActivitySupport.tapShouldRun(featureWanted: enabled,
+                                               accessibilityGranted: AXIsProcessTrusted(),
+                                               sessionIsActive: SessionActivity.shared.isActive) {
             installTap()
         } else {
             removeTap()
@@ -155,7 +159,11 @@ final class FinderRenameService {
     private func route(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             let currentTap = lifecycleLock.withLock { shouldStopTapThread ? nil : tap }
-            if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
+            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let currentTap {
+                CGEvent.tapEnable(tap: currentTap, enable: true)
+            } else {
+                DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
+            }
             return Unmanaged.passUnretained(event)
         }
         guard type == .keyDown else { return Unmanaged.passUnretained(event) }

--- a/Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift
+++ b/Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Vorssaint
 
+import ApplicationServices
 import Combine
 import CoreGraphics
 import Foundation
@@ -27,7 +28,9 @@ final class KeyboardDebounceService: ObservableObject {
                                                 globalWindowMs: Defaults.defaultKeyboardDebounceWindowMs,
                                                 keyWindows: [:])
 
-    private init() {}
+    private init() {
+        SessionActivity.shared.onChange { [weak self] _ in self?.syncWithPreferences() }
+    }
 
     func syncWithPreferences() {
         let nextConfig = KeyboardDebounceConfig(
@@ -44,7 +47,9 @@ final class KeyboardDebounceService: ObservableObject {
             config = nextConfig
         }
 
-        if nextConfig.enabled, Permissions.shared.accessibility {
+        if SessionActivitySupport.tapShouldRun(featureWanted: nextConfig.enabled,
+                                               accessibilityGranted: AXIsProcessTrusted(),
+                                               sessionIsActive: SessionActivity.shared.isActive) {
             start()
         } else {
             stop()
@@ -109,6 +114,7 @@ final class KeyboardDebounceService: ObservableObject {
 
         if let tap = snapshot.tap {
             CGEvent.tapEnable(tap: tap, enable: false)
+            CFMachPortInvalidate(tap)
         }
         if let runLoop = snapshot.runLoop {
             CFRunLoopPerformBlock(runLoop, CFRunLoopMode.commonModes.rawValue) {
@@ -231,10 +237,12 @@ final class KeyboardDebounceService: ObservableObject {
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            let currentTap = lifecycleLock.withLock {
-                tap
+            let currentTap = lifecycleLock.withLock { shouldStopTapThread ? nil : tap }
+            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let currentTap {
+                CGEvent.tapEnable(tap: currentTap, enable: true)
+            } else {
+                DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
             }
-            if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
             return Unmanaged.passUnretained(event)
         }
 

--- a/Sources/Vorssaint/Services/ShortcutRecordingTap.swift
+++ b/Sources/Vorssaint/Services/ShortcutRecordingTap.swift
@@ -123,7 +123,7 @@ enum ShortcutRecordingTap {
 
     private static func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if SessionActivity.shared.isActive, let tap {
+            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let tap {
                 CGEvent.tapEnable(tap: tap, enable: true)
             } else {
                 DispatchQueue.main.async { tearDown(); ShortcutCapture.end() }

--- a/Sources/Vorssaint/Services/ShortcutRecordingTap.swift
+++ b/Sources/Vorssaint/Services/ShortcutRecordingTap.swift
@@ -33,6 +33,7 @@ enum ShortcutRecordingTap {
     /// super key does lets a field record the combination the way it will be
     /// pressed later, instead of asking for the chosen modifiers by hand.
     private static var superState = SuperKeySupport.State()
+    private static var observingSession = false
 
     /// Starts swallowing key events and delivering each fresh press to the
     /// handler. Returns false when the tap cannot exist (no Accessibility),
@@ -44,6 +45,12 @@ enum ShortcutRecordingTap {
         drainingKeyCode = nil
         heldKeyCode = nil
         superState.reset()
+        // Registered before the Accessibility check: ShortcutCapture.begin() has
+        // already switched the global shortcuts off, and the resign must give them back.
+        if !observingSession {
+            observingSession = true
+            SessionActivity.shared.onChange { if !$0 { tearDown(); ShortcutCapture.end() } }
+        }
         // A tap the system disabled behind our back reads as dead; rebuild.
         if let tap, !CGEvent.tapIsEnabled(tap: tap) {
             tearDown()
@@ -116,7 +123,11 @@ enum ShortcutRecordingTap {
 
     private static func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
+            if SessionActivity.shared.isActive, let tap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            } else {
+                DispatchQueue.main.async { tearDown(); ShortcutCapture.end() }
+            }
             return Unmanaged.passUnretained(event)
         }
         let keyCode = event.getIntegerValueField(.keyboardEventKeycode)

--- a/Sources/Vorssaint/Services/Snippets/TextSnippetService.swift
+++ b/Sources/Vorssaint/Services/Snippets/TextSnippetService.swift
@@ -33,7 +33,9 @@ final class TextSnippetService {
     private var immediateSnippets: [TextSnippet] = []
     private var delimiterSnippets: [TextSnippet] = []
 
-    private init() {}
+    private init() {
+        SessionActivity.shared.onChange { [weak self] _ in self?.syncWithPreferences() }
+    }
 
     var isRunning: Bool { tapLifecycleLock.withLock { tap != nil } }
 
@@ -44,7 +46,9 @@ final class TextSnippetService {
         let hasWork = inputLock.withLock {
             !(immediateSnippets.isEmpty && delimiterSnippets.isEmpty)
         }
-        if enabled, hasWork, Permissions.shared.accessibility {
+        if SessionActivitySupport.tapShouldRun(featureWanted: enabled && hasWork,
+                                               accessibilityGranted: AXIsProcessTrusted(),
+                                               sessionIsActive: SessionActivity.shared.isActive) {
             let libraryIsVisible = SnippetLibraryService.shared.isVisible
             let commandBarIsVisible = AppFeature.commandBar.isAvailable
                 && CommandBarService.shared.isVisible
@@ -223,7 +227,11 @@ final class TextSnippetService {
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             let currentTap = tapLifecycleLock.withLock { shouldStopTapThread ? nil : tap }
-            if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
+            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let currentTap {
+                CGEvent.tapEnable(tap: currentTap, enable: true)
+            } else {
+                DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
+            }
             return Unmanaged.passUnretained(event)
         }
         // Clicks move the caret somewhere unknown; the half-typed trigger is

--- a/Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift
+++ b/Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift
@@ -109,7 +109,9 @@ final class SuperKeyService: ObservableObject {
         return min(30, max(3, firstRepeat * 2))
     }
 
-    private init() {}
+    private init() {
+        SessionActivity.shared.onChange { [weak self] _ in self?.syncWithPreferences() }
+    }
 
     func syncWithPreferences() {
         let defaults = UserDefaults.standard
@@ -132,6 +134,7 @@ final class SuperKeyService: ObservableObject {
         self.source = source
         let enabled = AppFeature.superKey.isAvailable
             && defaults.bool(forKey: DefaultsKey.superKeyEnabled)
+            && SessionActivity.shared.isActive
         guard enabled else {
             stop()
             return
@@ -593,8 +596,12 @@ final class SuperKeyService: ObservableObject {
             let currentTaps = lifecycleLock.withLock {
                 shouldStopTapThread ? (nil, nil) : (tap, mouseTap)
             }
-            if let currentTap = currentTaps.0 { CGEvent.tapEnable(tap: currentTap, enable: true) }
-            if let currentMouseTap = currentTaps.1 { CGEvent.tapEnable(tap: currentMouseTap, enable: true) }
+            if SessionActivity.shared.isActive, AXIsProcessTrusted() {
+                if let currentTap = currentTaps.0 { CGEvent.tapEnable(tap: currentTap, enable: true) }
+                if let currentMouseTap = currentTaps.1 { CGEvent.tapEnable(tap: currentMouseTap, enable: true) }
+            } else {
+                DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
+            }
             forgetHeldKey()
             return Unmanaged.passUnretained(event)
         }

--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -157,13 +157,23 @@ final class AppSwitcher: ObservableObject {
         static let upArrow: Int64 = 126
     }
 
-    private init() {}
+    private init() {
+        SessionActivity.shared.onChange { [weak self] _ in self?.syncWithPreferences() }
+    }
 
     private var isTapLive: Bool {
         lifecycleLock.withLock {
             guard let tap else { return false }
             return CFMachPortIsValid(tap) && CGEvent.tapIsEnabled(tap: tap)
         }
+    }
+
+    private var tapIsWanted: Bool {
+        SessionActivitySupport.tapShouldRun(
+            featureWanted: AppFeature.switcher.isAvailable
+                && UserDefaults.standard.bool(forKey: DefaultsKey.switcherEnabled),
+            accessibilityGranted: AXIsProcessTrusted(),
+            sessionIsActive: SessionActivity.shared.isActive)
     }
 
     /// Applies the persisted preference; safe to call repeatedly.
@@ -176,9 +186,7 @@ final class AppSwitcher: ObservableObject {
             routeShortcut = shortcut
             routeWindowShortcut = windowShortcut
         }
-        let enabled = AppFeature.switcher.isAvailable
-            && UserDefaults.standard.bool(forKey: DefaultsKey.switcherEnabled)
-        let canStartSession = enabled && Permissions.shared.accessibility
+        let canStartSession = tapIsWanted
         routeLock.withLock { routeCanStartSession = canStartSession }
         if canStartSession {
             startObservingKeyboardLayout()
@@ -283,9 +291,7 @@ final class AppSwitcher: ObservableObject {
     }
 
     private func reconcileTakeover() {
-        guard AppFeature.switcher.isAvailable,
-              UserDefaults.standard.bool(forKey: DefaultsKey.switcherEnabled),
-              Permissions.shared.accessibility else {
+        guard tapIsWanted else {
             restoreNativeHotkeys()
             return
         }
@@ -455,7 +461,11 @@ final class AppSwitcher: ObservableObject {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
             // Never resurrect a tap that removeTap is already tearing down.
             let currentTap = lifecycleLock.withLock { shouldStopTapThread ? nil : tap }
-            if let currentTap { CGEvent.tapEnable(tap: currentTap, enable: true) }
+            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let currentTap {
+                CGEvent.tapEnable(tap: currentTap, enable: true)
+            } else {
+                DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
+            }
             routeLock.withLock { routePendingSessionStart = nil }
             DispatchQueue.main.async { [weak self] in
                 guard let self, self.sessionActive else { return }

--- a/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift
@@ -80,11 +80,16 @@ final class WindowLayoutService: ObservableObject {
     private let resizeGestureUpdateInterval: TimeInterval = 1.0 / 60.0
     private let edgeSnapSampleInterval: TimeInterval = 1.0 / 30.0
 
-    private init() {}
+    private init() {
+        SessionActivity.shared.onChange { [weak self] _ in self?.syncWithPreferences() }
+    }
 
     func syncWithPreferences() {
         let available = AppFeature.windowLayout.isAvailable
-        let trusted = AXIsProcessTrusted()
+        let trusted = SessionActivitySupport.tapShouldRun(
+            featureWanted: available,
+            accessibilityGranted: AXIsProcessTrusted(),
+            sessionIsActive: SessionActivity.shared.isActive)
         let wantsShortcuts = available
             && UserDefaults.standard.bool(forKey: DefaultsKey.windowLayoutShortcutsEnabled)
             && trusted
@@ -1016,7 +1021,11 @@ final class WindowLayoutService: ObservableObject {
     private func observeEdgeSnapEvent(type: CGEventType,
                                       event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let edgeSnapTap { CGEvent.tapEnable(tap: edgeSnapTap, enable: true) }
+            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let edgeSnapTap {
+                CGEvent.tapEnable(tap: edgeSnapTap, enable: true)
+            } else {
+                DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
+            }
             DispatchQueue.main.async { [weak self] in self?.cancelEdgeSnapTracking() }
             return Unmanaged.passUnretained(event)
         }
@@ -1462,7 +1471,11 @@ final class WindowLayoutService: ObservableObject {
 
         let tapDisabled = type == .tapDisabledByTimeout || type == .tapDisabledByUserInput
         if tapDisabled, let gestureTap {
-            CGEvent.tapEnable(tap: gestureTap, enable: true)
+            if SessionActivity.shared.isActive, AXIsProcessTrusted() {
+                CGEvent.tapEnable(tap: gestureTap, enable: true)
+            } else {
+                DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
+            }
         }
 
         var chord: (button: WindowPointerGesture.Button, wantsResize: Bool)?

--- a/Sources/Vorssaint/Services/WindowMaximizer.swift
+++ b/Sources/Vorssaint/Services/WindowMaximizer.swift
@@ -25,12 +25,16 @@ final class WindowMaximizer: ObservableObject {
     private let frameTolerance: CGFloat = 4
     private let zoomAnimationDuration: TimeInterval = 0.22
 
-    private init() {}
+    private init() {
+        SessionActivity.shared.onChange { [weak self] _ in self?.syncWithPreferences() }
+    }
 
     func syncWithPreferences() {
         let wanted = AppFeature.windowMaximizer.isAvailable
             && UserDefaults.standard.bool(forKey: DefaultsKey.windowMaximizeEnabled)
-        if wanted, Permissions.shared.accessibility {
+        if SessionActivitySupport.tapShouldRun(featureWanted: wanted,
+                                               accessibilityGranted: AXIsProcessTrusted(),
+                                               sessionIsActive: SessionActivity.shared.isActive) {
             start()
         } else {
             stop()
@@ -88,7 +92,11 @@ final class WindowMaximizer: ObservableObject {
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if let tap { CGEvent.tapEnable(tap: tap, enable: true) }
+            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let tap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            } else {
+                DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
+            }
             return Unmanaged.passUnretained(event)
         }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21942,7 +21942,19 @@ struct MetricsTests {
                          "Sources/Vorssaint/Services/MouseNavigation/MouseNavigationService.swift",
                          "Sources/Vorssaint/Services/MouseButtons/MouseButtonShortcutService.swift",
                          "Sources/Vorssaint/Services/MiddleClick/MiddleClickService.swift",
-                         "Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift"] {
+                         "Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift",
+                         "Sources/Vorssaint/Services/WindowLayout/WindowLayoutService.swift",
+                         "Sources/Vorssaint/Services/WindowMaximizer.swift",
+                         "Sources/Vorssaint/Services/Finder/FinderCutPaste.swift",
+                         "Sources/Vorssaint/Services/Finder/FinderRenameService.swift",
+                         "Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift",
+                         "Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift",
+                         "Sources/Vorssaint/Services/ShortcutRecordingTap.swift",
+                         "Sources/Vorssaint/Services/Switcher/AppSwitcher.swift",
+                         "Sources/Vorssaint/Services/Snippets/TextSnippetService.swift",
+                         "Sources/Vorssaint/Services/Audio/PreciseVolumeRollerService.swift",
+                         "Sources/Vorssaint/Services/DockClick/DockClickService.swift",
+                         "Sources/Vorssaint/Services/Display/BrightnessService.swift"] {
             let source = (try? String(contentsOfFile: tapOwner, encoding: .utf8)) ?? ""
             expect(!source.isEmpty, "\(tapOwner) reads back for its session-switch check")
             let code = source.components(separatedBy: "\n")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -22246,8 +22246,9 @@ struct MetricsTests {
                 || tapOwner.contains("MouseButtonShortcut")
                 || tapOwner.contains("MiddleClick")
                 || tapOwner.contains("QuitProtection")
-                || tapOwner.contains("RadialMenu") {
-                expect(code.contains("AXIsProcessTrusted()"),
+                || tapOwner.contains("RadialMenu")
+                || tapOwner.contains("ShortcutRecordingTap") {
+                expect(rearm.contains("AXIsProcessTrusted()"),
                        "\(tapOwner) does not keep a modifying tap alive after Accessibility is lost")
             }
             // Switching a tap off leaves the process owning it, which is what


### PR DESCRIPTION
## Summary

After a fast user switch this process keeps running in the session that left
the screen, and a filter tap created there keeps its place in the event chain.
The window server still routes every matching event through a process that
cannot answer and waits out the tap timeout on each one, so the account
actually in use pays it (#1153, #1075). #1145 wired nine tap owners to
`SessionActivity` for this. Twelve more owners still ran their taps without
looking at the session:

- `WindowLayout/WindowLayoutService.swift` (gesture, edge snap, directional; the layout hotkeys share the same `trusted` gate, so they are unregistered on resign and re-registered on activate)
- `WindowMaximizer.swift`
- `Finder/FinderCutPaste.swift`
- `Finder/FinderRenameService.swift`
- `KeyboardDebounce/KeyboardDebounceService.swift`
- `SuperKey/SuperKeyService.swift` (keyboard and mouse taps)
- `ShortcutRecordingTap.swift`
- `Switcher/AppSwitcher.swift`
- `Snippets/TextSnippetService.swift`
- `Audio/PreciseVolumeRollerService.swift`
- `DockClick/DockClickService.swift`
- `Display/BrightnessService.swift` (brightness key tap and function-key tap)

Each now follows the shape `SmoothScrollService` and
`MouseClickDebounceService` already use on `main`: `init` subscribes to
`SessionActivity.shared.onChange`, the preference sync asks
`SessionActivitySupport.tapShouldRun` with `AXIsProcessTrusted()` instead of
the polled `Permissions.shared.accessibility`, and the timeout re-arm re-enables
the tap only while the session is active and Accessibility is granted, otherwise
it hands the decision to the sync on the main queue. Taps that run on their own
thread read the two flags in place, the way `MouseClickDebounceService.handle`
does.

Three things the earlier review rounds found are kept:

- `ShortcutRecordingTap` ends the recording, not only the tap, when the session
  resigns: `ShortcutCapture.begin()` had switched every global shortcut off, so
  dropping the tap alone came back with all of them dead. `ShortcutCapture.end()`
  is idempotent, and the observer registers before the Accessibility check
  because the capture is already on by then.
- `KeyboardDebounceService.stop()` invalidates the port as well as disabling
  it, matching its twin `MouseClickDebounceService`.
- `AppSwitcher.reconcileTakeover()` (#882) rebuilt the tap from its own
  predicate with no session term; it now shares the sync's gate.

Not done, on purpose: the `restartTapOnMain` / `rearmDisabledTap` helpers and
the rewrite of the tap-thread restart tails (a stop and a start crossing at the
handover was read from the lifecycle code, never observed); the directional tap's timeout handling and the Escape deferral in
`WindowLayoutService` (nothing was seen to fail there); the
`publishRunning(false)` move in the debounce (its generation is always stale by
then, so it never landed); the restart-tail and gate-argument shape tests. The
radial menu's side-button tap is #1270 and is not in here. The gamma fingerprint
half of #1231 is a separate change.

Super Key does more than hand its tap back. Its `onChange` handler and its re-arm else branch both go through `syncWithPreferences()`, which on resign reaches `stop()` and `clearLeftoverMapping()`: three `hidutil` calls and two defaults writes per switch, on the serial `mappingQueue`. That is the intended behaviour, not a side effect: the Caps Lock mapping is system-wide, so leaving it in place would hand the other account a dead Caps Lock. On activate the sync re-applies it.

## Verification

Mac17,3, macOS 26.6.2 (25G83), branched from `main` at `f7378a8d`.

```
./build.sh                     exit 0, no warnings
./build/Vorssaint --selftest   SELFTEST OK
./build.sh --test              TESTS OK (9656 checks)
```

The twelve service files are outside the `--test` compile whitelist; the full
`./build.sh` is what compiled them. The added assertions are the twelve roster
entries in the existing session-switch sweep, each of which is red on `main`
(none of the twelve files contains `SessionActivity.shared.onChange` there).

**Not tested.** There is one login session on this machine, so the fast user
switching behaviour is reasoned from the mechanism #1153 describes, not
measured, the same caveat the issue carries. None of the twelve features was
exercised interactively after the change; the tap lifecycle is what moved, so
the ordinary paths should be unaffected, but that is an argument, not a run. The
revoke race (a tap disabled inside the polling interval after a revoked grant)
is not reproduced either.

## Anything else

Refs #1153
Refs #1075

Supersedes #1233.
Supersedes #1234.
Supersedes #1235.
Supersedes #1236.
Supersedes the tap half of #1231.