### PR TITLE
fix(recorder): scrub the filmstrip by dragging and pick cuts with Shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Vorssaint adds quit and close protections, expands screen text recognition, capt
 - Cleaning now checks which apps are still installed once per run instead of once per leftover, and skips that check entirely when no leftover is selected, so a clean starts without scanning the application folders. Thanks to @PathGao.
 - GPU usage sampling no longer leaves a system resource behind on Macs with more than one graphics processor, and extra brightness now does less work on each refresh. Thanks to @PathGao.
 - The radial menu now checks only which extra mouse button opens a wheel when a side button is pressed, instead of loading every wheel and its icons on each event, so holding a side button and moving the mouse no longer risks dropped clicks. Thanks to @PathGao.
+- The recording editor's filmstrip now scrubs through the video when you drag across it, showing the frame under the pointer as you go. Hold Shift while dragging to pick a stretch to cut out, and each cut-out stretch now goes dark on the filmstrip. Thanks to @saminton.
 
 ### Fixed
 - Automatic cleaning now leaves protected items in place instead of requesting an administrator password while unattended, and reports that they could not be moved to the Trash. Thanks to @PathGao.

--- a/Sources/Vorssaint/UI/Recorder/RecorderEditorView.swift
+++ b/Sources/Vorssaint/UI/Recorder/RecorderEditorView.swift
@@ -773,6 +773,10 @@ private struct Filmstrip: View {
 
     private let handleWidth: CGFloat = 12
     private let coordinateSpace = "recorderFilmstrip"
+    /// Whether the drag in progress is picking a stretch to cut rather than
+    /// scrubbing. Decided on its first movement and kept, so letting go of
+    /// Shift halfway through does not turn the pick into a scrub.
+    @State private var dragPicksCut: Bool?
 
     var body: some View {
         GeometryReader { proxy in
@@ -786,34 +790,49 @@ private struct Filmstrip: View {
                 // The strip itself is what scrubbing listens to. The handles
                 // sit above it with their own gestures, so a drag that starts
                 // on a handle trims and never moves the playhead too.
-                // Dragging across the film picks a stretch to remove; a plain
-                // click clears it. Scrubbing lives on the ruler above, so the
-                // two never fight over the same drag.
+                // Dragging across the film scrubs, the way every simple
+                // editor does; holding Shift while dragging picks a stretch
+                // to remove instead. The picture follows the pointer either
+                // way, so a cut can land on the exact moment.
                 thumbnails
                     .frame(width: width, height: height)
                     .contentShape(Rectangle())
                     .gesture(
                         DragGesture(minimumDistance: 2)
                             .onChanged { value in
-                                let from = seconds(at: value.startLocation.x, width: width)
+                                let picksCut = dragPicksCut
+                                    ?? NSEvent.modifierFlags.contains(.shift)
+                                dragPicksCut = picksCut
                                 let to = seconds(at: value.location.x, width: width)
-                                model.setCutSelection(min(from, to)...max(from, to))
+                                if picksCut {
+                                    let from = seconds(at: value.startLocation.x, width: width)
+                                    model.setCutSelection(min(from, to)...max(from, to))
+                                }
+                                model.seek(to: to)
                             }
+                            .onEnded { _ in dragPicksCut = nil }
                     )
                     .onTapGesture { location in
-                        if model.cutSelection != nil {
-                            model.setCutSelection(nil)
-                        } else {
-                            model.seek(to: seconds(at: location.x, width: width))
-                        }
+                        // A click goes to that moment and puts down any
+                        // selection, the way clicking away works everywhere.
+                        model.setCutSelection(nil)
+                        model.seek(to: seconds(at: location.x, width: width))
                     }
 
-                // What was already cut out, as a seam you can click to undo.
+                // What was already cut out goes dark like the trimmed ends,
+                // with a seam at its start you can click to put it back.
                 ForEach(Array(model.document.cuts.enumerated()), id: \.offset) { _, cut in
                     let seam = position(cut.start, width: width)
+                    let from = max(startX, seam)
+                    let to = min(endX, position(cut.end, width: width))
+                    Color.black.opacity(0.62)
+                        .frame(width: max(0, to - from), height: height)
+                        .offset(x: from)
+                        .allowsHitTesting(false)
                     Rectangle()
                         .fill(Color.orange.opacity(0.9))
                         .frame(width: 3, height: height)
+                        .contentShape(Rectangle().inset(by: -4))
                         .offset(x: max(0, seam - 1.5))
                         .onTapGesture { model.restoreCut(at: cut.start) }
                 }


### PR DESCRIPTION
## Summary

Dragging across the recording editor's filmstrip now scrubs, with the frame under the pointer shown as you go. Holding Shift while dragging picks a stretch to cut out instead, and a plain click goes to that moment and clears any pending selection. Each cut-out stretch now goes dark on the filmstrip like the trimmed ends, and the seam that restores it is easier to hit.

What was wrong: dragging on the filmstrip created a cut selection, scrubbing only lived on the thin ruler above the zoom lane, and after a cut the filmstrip looked untouched apart from a three-point seam. The trim handles the report also mentions could not be dragged on 3.3.2; that part was fixed by a3703b63 and is already on main.

## Verification

MacBook Air (M4), macOS 27.0 beta (26A5425a), Developer build from this branch: `./build.sh --test` (9700 checks), `./build.sh --dev --install`, `--selftest` OK, Developer ID signature verified. Not tested: the gestures in the running editor, which were validated by code review, build and selftest only.

## Anything else

Refs #1309
