### PR TITLE
fix(focus): suspend during extra-button drags (#1273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ Vorssaint adds quit and close protections, expands screen text recognition, capt
 - Smooth Scroll and Scroll Inverter now step aside during fast user switching and resume on return, preventing background scroll stalls. Thanks to @iltonandrew.
 - Turning features on and off repeatedly no longer leaves unused keyboard and mouse listeners registered with the system for the rest of the session. Thanks to @PathGao.
 - Mouse navigation, button shortcuts and middle click now step aside outside the active login session or after Accessibility access is removed, preventing input stalls.
-- Focus follows mouse now leaves chosen apps alone and tracks the final pointer position during drags before changing focus.
+- Focus follows mouse now leaves chosen apps alone, waits for every held mouse button to be released and tracks the final pointer position during drags before changing focus.
 - Cleaning Mode now ends when its login session leaves the screen, preventing its input lock from affecting another active user.
 - Window capture now includes attached sheets, alerts and modal dialogs stacked on a window, including when part of it is off-screen, while preserving full-window capture when it crosses displays. Thanks to @iltonandrew.
 - Accessibility messaging now uses a single, consistent process-wide timeout floor instead of allowing separate features to overwrite the shared limit. Thanks to @PathGao.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@ Vorssaint adds quit and close protections, expands screen text recognition, capt
 - Smooth Scroll and Scroll Inverter now step aside during fast user switching and resume on return, preventing background scroll stalls. Thanks to @iltonandrew.
 - Turning features on and off repeatedly no longer leaves unused keyboard and mouse listeners registered with the system for the rest of the session. Thanks to @PathGao.
 - Mouse navigation, button shortcuts and middle click now step aside outside the active login session or after Accessibility access is removed, preventing input stalls.
-- Focus follows mouse now leaves chosen apps alone, waits for every held mouse button to be released and tracks the final pointer position during drags before changing focus.
+- Focus follows mouse now leaves chosen apps alone, waits for every held mouse button to be released and tracks the final pointer position during drags before changing focus. Thanks to @khichinho.
 - Cleaning Mode now ends when its login session leaves the screen, preventing its input lock from affecting another active user.
 - Window capture now includes attached sheets, alerts and modal dialogs stacked on a window, including when part of it is off-screen, while preserving full-window capture when it crosses displays. Thanks to @iltonandrew.
 - Accessibility messaging now uses a single, consistent process-wide timeout floor instead of allowing separate features to overwrite the shared limit. Thanks to @PathGao.

--- a/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
+++ b/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
@@ -100,8 +100,12 @@ final class FocusFollowsMouseService {
     }
 
     private func evaluateIfSettled() {
-        guard AXIsProcessTrusted(), !buttonsArePressed,
-              NSEvent.modifierFlags.intersection([.command, .control, .option, .shift]).isEmpty,
+        guard AXIsProcessTrusted(),
+              FocusFollowsMouseSupport.canEvaluate(
+                  pressedMouseButtons: NSEvent.pressedMouseButtons,
+                  modifierKeysArePressed: !NSEvent.modifierFlags
+                      .intersection([.command, .control, .option, .shift]).isEmpty
+              ),
               let evaluation = state.nextEvaluation(
                   at: ProcessInfo.processInfo.systemUptime,
                   delayMilliseconds: delayMilliseconds),
@@ -124,12 +128,6 @@ final class FocusFollowsMouseService {
                                          retry: false)
             }
         }
-    }
-
-    private var buttonsArePressed: Bool {
-        CGEventSource.buttonState(.combinedSessionState, button: .left)
-            || CGEventSource.buttonState(.combinedSessionState, button: .right)
-            || CGEventSource.buttonState(.combinedSessionState, button: .center)
     }
 
     private func target(at point: CGPoint) -> Target? {

--- a/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
+++ b/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
@@ -101,11 +101,8 @@ final class FocusFollowsMouseService {
 
     private func evaluateIfSettled() {
         guard AXIsProcessTrusted(),
-              FocusFollowsMouseSupport.canEvaluate(
-                  pressedMouseButtons: NSEvent.pressedMouseButtons,
-                  modifierKeysArePressed: !NSEvent.modifierFlags
-                      .intersection([.command, .control, .option, .shift]).isEmpty
-              ),
+              NSEvent.pressedMouseButtons == 0,
+              NSEvent.modifierFlags.intersection([.command, .control, .option, .shift]).isEmpty,
               let evaluation = state.nextEvaluation(
                   at: ProcessInfo.processInfo.systemUptime,
                   delayMilliseconds: delayMilliseconds),

--- a/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseSupport.swift
+++ b/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseSupport.swift
@@ -11,6 +11,10 @@ enum FocusFollowsMouseSupport {
     static func sanitizedDelay(_ milliseconds: Int) -> Int {
         min(max(milliseconds, delayRange.lowerBound), delayRange.upperBound)
     }
+
+    static func canEvaluate(pressedMouseButtons: Int, modifierKeysArePressed: Bool) -> Bool {
+        pressedMouseButtons == 0 && !modifierKeysArePressed
+    }
 }
 
 struct FocusFollowsMouseEvaluation: Equatable {

--- a/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseSupport.swift
+++ b/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseSupport.swift
@@ -11,10 +11,6 @@ enum FocusFollowsMouseSupport {
     static func sanitizedDelay(_ milliseconds: Int) -> Int {
         min(max(milliseconds, delayRange.lowerBound), delayRange.upperBound)
     }
-
-    static func canEvaluate(pressedMouseButtons: Int, modifierKeysArePressed: Bool) -> Bool {
-        pressedMouseButtons == 0 && !modifierKeysArePressed
-    }
 }
 
 struct FocusFollowsMouseEvaluation: Equatable {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1513,6 +1513,14 @@ struct MetricsTests {
                 && FocusFollowsMouseSupport.sanitizedDelay(2_000)
                 == FocusFollowsMouseSupport.delayRange.upperBound,
                "focus follows mouse clamps a damaged delay preference")
+        let extraMouseButton = 1 << 3
+        expect(FocusFollowsMouseSupport.canEvaluate(pressedMouseButtons: 0,
+                                                    modifierKeysArePressed: false)
+                && !FocusFollowsMouseSupport.canEvaluate(pressedMouseButtons: extraMouseButton,
+                                                         modifierKeysArePressed: false)
+                && !FocusFollowsMouseSupport.canEvaluate(pressedMouseButtons: 0,
+                                                         modifierKeysArePressed: true),
+               "focus follows mouse waits for every mouse button and modifier to be released")
         var focusFollowsMouseState = FocusFollowsMouseState()
         focusFollowsMouseState.recordMovement(to: CGPoint(x: 40, y: 70), at: 10)
         expect(focusFollowsMouseState.nextEvaluation(at: 10.20, delayMilliseconds: 250) == nil,
@@ -1540,8 +1548,10 @@ struct MetricsTests {
             encoding: .utf8)) ?? ""
         expect(focusFollowsMouseServiceSource.contains(".leftMouseDragged")
                 && focusFollowsMouseServiceSource.contains(".rightMouseDragged")
-                && focusFollowsMouseServiceSource.contains(".otherMouseDragged"),
-               "focus follows mouse tracks the final pointer position while a button is held")
+                && focusFollowsMouseServiceSource.contains(".otherMouseDragged")
+                && focusFollowsMouseServiceSource.contains(
+                    "pressedMouseButtons: NSEvent.pressedMouseButtons"),
+               "focus follows mouse tracks drags and checks every held mouse button")
         expect(focusFollowsMouseServiceSource.contains("excludesPointerTarget(")
                 && focusFollowsMouseServiceSource.contains(
                     ".focusFollowsMouse, at: evaluation.point"),

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1513,14 +1513,6 @@ struct MetricsTests {
                 && FocusFollowsMouseSupport.sanitizedDelay(2_000)
                 == FocusFollowsMouseSupport.delayRange.upperBound,
                "focus follows mouse clamps a damaged delay preference")
-        let extraMouseButton = 1 << 3
-        expect(FocusFollowsMouseSupport.canEvaluate(pressedMouseButtons: 0,
-                                                    modifierKeysArePressed: false)
-                && !FocusFollowsMouseSupport.canEvaluate(pressedMouseButtons: extraMouseButton,
-                                                         modifierKeysArePressed: false)
-                && !FocusFollowsMouseSupport.canEvaluate(pressedMouseButtons: 0,
-                                                         modifierKeysArePressed: true),
-               "focus follows mouse waits for every mouse button and modifier to be released")
         var focusFollowsMouseState = FocusFollowsMouseState()
         focusFollowsMouseState.recordMovement(to: CGPoint(x: 40, y: 70), at: 10)
         expect(focusFollowsMouseState.nextEvaluation(at: 10.20, delayMilliseconds: 250) == nil,
@@ -1549,8 +1541,7 @@ struct MetricsTests {
         expect(focusFollowsMouseServiceSource.contains(".leftMouseDragged")
                 && focusFollowsMouseServiceSource.contains(".rightMouseDragged")
                 && focusFollowsMouseServiceSource.contains(".otherMouseDragged")
-                && focusFollowsMouseServiceSource.contains(
-                    "pressedMouseButtons: NSEvent.pressedMouseButtons"),
+                && focusFollowsMouseServiceSource.contains("NSEvent.pressedMouseButtons == 0"),
                "focus follows mouse tracks drags and checks every held mouse button")
         expect(focusFollowsMouseServiceSource.contains("excludesPointerTarget(")
                 && focusFollowsMouseServiceSource.contains(


### PR DESCRIPTION
## Summary

- suspend Focus follows mouse while any mouse button is held, including extra buttons
- keep the modifier-key guard inline and cover the complete button bitmask with a focused regression
- update the current release notes and credit the reporter

## Testing

- ./build.sh --test: TESTS OK (9705 checks)
- ./build.sh --dev --install
- installed Developer selftest: SELFTEST OK
- installed Developer signature verified with Developer ID
- ./build.sh
- ./build/Vorssaint --selftest: SELFTEST OK

Refs #1273