### PR TITLE
feat(screenshot): add arrow style selection

### DIFF
--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -542,6 +542,7 @@ enum DefaultsKey {
     static let screenshotLastTool = "screenshotLastTool"
     static let screenshotLastColor = "screenshotLastColor"
     static let screenshotLastStroke = "screenshotLastStroke"
+    static let screenshotLastArrowStyle = "screenshotLastArrowStyle"
     static let screenshotLastSticker = "screenshotLastSticker"
     static let screenshotAnnotationShadows = "screenshotAnnotationShadows"
     static let screenshotToolOrder = "screenshotToolOrder"
@@ -1281,6 +1282,7 @@ enum Defaults {
         DefaultsKey.screenshotLastTool: "arrow",
         DefaultsKey.screenshotLastColor: "red",
         DefaultsKey.screenshotLastStroke: "medium",
+        DefaultsKey.screenshotLastArrowStyle: "filled",
         DefaultsKey.screenshotLastSticker: "check",
         DefaultsKey.screenshotAnnotationShadows: false,
         DefaultsKey.screenshotToolOrder: ScreenshotSupport.Tool.defaultOrderStorage,

--- a/Sources/Vorssaint/Core/ScreenshotStrings.swift
+++ b/Sources/Vorssaint/Core/ScreenshotStrings.swift
@@ -38,6 +38,12 @@ struct ScreenshotFeatureStrings {
     let toolShortcutsCaption: String
     let toolSelect: String
     let toolArrow: String
+    let arrowStyleLabel: String
+    let arrowStyleFilled: String
+    let arrowStyleOutline: String
+    let arrowStyleOpen: String
+    let arrowStyleDoubleEnded: String
+    let arrowStyleScribbly: String
     let toolLine: String
     let toolRect: String
     let toolEllipse: String
@@ -200,6 +206,12 @@ extension ScreenshotFeatureStrings {
         toolShortcutsCaption: "Use the arrows or choose a number. The first nine tools use 1 to 9. The others have no shortcut.",
         toolSelect: "Select",
         toolArrow: "Arrow",
+        arrowStyleLabel: "Arrow style",
+        arrowStyleFilled: "Solid",
+        arrowStyleOutline: "Outline",
+        arrowStyleOpen: "Open",
+        arrowStyleDoubleEnded: "Double-ended",
+        arrowStyleScribbly: "Scribbly",
         toolLine: "Line",
         toolRect: "Rectangle",
         toolEllipse: "Ellipse",
@@ -341,6 +353,12 @@ extension ScreenshotFeatureStrings {
         toolShortcutsCaption: "Use as setas ou escolha um número. As nove primeiras ferramentas usam 1 a 9. As demais ficam sem atalho.",
         toolSelect: "Selecionar",
         toolArrow: "Seta",
+        arrowStyleLabel: "Estilo da seta",
+        arrowStyleFilled: "Sólida",
+        arrowStyleOutline: "Contorno",
+        arrowStyleOpen: "Aberta",
+        arrowStyleDoubleEnded: "Duas pontas",
+        arrowStyleScribbly: "Rabiscada",
         toolLine: "Linha",
         toolRect: "Retângulo",
         toolEllipse: "Elipse",
@@ -482,6 +500,12 @@ extension ScreenshotFeatureStrings {
         toolShortcutsCaption: "Okları kullanın veya bir sayı seçin. İlk dokuz araç 1 ile 9'u kullanır. Diğerlerinin kısayolu yoktur.",
         toolSelect: "Seç",
         toolArrow: "Ok",
+        arrowStyleLabel: "Ok stili",
+        arrowStyleFilled: "Dolu",
+        arrowStyleOutline: "Kontur",
+        arrowStyleOpen: "Açık",
+        arrowStyleDoubleEnded: "Çift uçlu",
+        arrowStyleScribbly: "Karalama",
         toolLine: "Çizgi",
         toolRect: "Dikdörtgen",
         toolEllipse: "Elips",
@@ -623,6 +647,12 @@ extension ScreenshotFeatureStrings {
         toolShortcutsCaption: "Используйте стрелки или выберите цифру. Первые девять инструментов используют цифры от 1 до 9. У остальных нет сочетания.",
         toolSelect: "Выбор",
         toolArrow: "Стрелка",
+        arrowStyleLabel: "Стиль стрелки",
+        arrowStyleFilled: "Сплошная",
+        arrowStyleOutline: "Контурная",
+        arrowStyleOpen: "Открытая",
+        arrowStyleDoubleEnded: "Двунаправленная",
+        arrowStyleScribbly: "Набросок",
         toolLine: "Линия",
         toolRect: "Прямоугольник",
         toolEllipse: "Эллипс",
@@ -764,6 +794,12 @@ extension ScreenshotFeatureStrings {
         toolShortcutsCaption: "Usa las flechas o elige un número. Las primeras nueve herramientas usan del 1 al 9. Las demás no tienen atajo.",
         toolSelect: "Seleccionar",
         toolArrow: "Flecha",
+        arrowStyleLabel: "Estilo de flecha",
+        arrowStyleFilled: "Sólida",
+        arrowStyleOutline: "Contorno",
+        arrowStyleOpen: "Abierta",
+        arrowStyleDoubleEnded: "De doble punta",
+        arrowStyleScribbly: "Garabato",
         toolLine: "Línea",
         toolRect: "Rectángulo",
         toolEllipse: "Elipse",
@@ -905,6 +941,12 @@ extension ScreenshotFeatureStrings {
         toolShortcutsCaption: "Mit den Pfeilen verschieben oder eine Ziffer wählen. Die ersten neun Werkzeuge verwenden 1 bis 9. Die übrigen haben keinen Kurzbefehl.",
         toolSelect: "Auswählen",
         toolArrow: "Pfeil",
+        arrowStyleLabel: "Pfeilstil",
+        arrowStyleFilled: "Voll",
+        arrowStyleOutline: "Umriss",
+        arrowStyleOpen: "Offen",
+        arrowStyleDoubleEnded: "Beidseitig",
+        arrowStyleScribbly: "Gekritzelt",
         toolLine: "Linie",
         toolRect: "Rechteck",
         toolEllipse: "Ellipse",
@@ -1046,6 +1088,12 @@ extension ScreenshotFeatureStrings {
         toolShortcutsCaption: "Utilisez les flèches ou choisissez un numéro. Les neuf premiers outils utilisent 1 à 9. Les autres n’ont pas de raccourci.",
         toolSelect: "Sélectionner",
         toolArrow: "Flèche",
+        arrowStyleLabel: "Style de flèche",
+        arrowStyleFilled: "Pleine",
+        arrowStyleOutline: "Contour",
+        arrowStyleOpen: "Ouverte",
+        arrowStyleDoubleEnded: "À deux pointes",
+        arrowStyleScribbly: "Gribouillée",
         toolLine: "Ligne",
         toolRect: "Rectangle",
         toolEllipse: "Ellipse",
@@ -1187,6 +1235,12 @@ extension ScreenshotFeatureStrings {
         toolShortcutsCaption: "Usa le frecce o scegli un numero. I primi nove strumenti usano i tasti da 1 a 9. Gli altri non hanno una scorciatoia.",
         toolSelect: "Seleziona",
         toolArrow: "Freccia",
+        arrowStyleLabel: "Stile freccia",
+        arrowStyleFilled: "Piena",
+        arrowStyleOutline: "Contorno",
+        arrowStyleOpen: "Aperta",
+        arrowStyleDoubleEnded: "A doppia punta",
+        arrowStyleScribbly: "Scarabocchio",
         toolLine: "Linea",
         toolRect: "Rettangolo",
         toolEllipse: "Ellisse",
@@ -1328,6 +1382,12 @@ extension ScreenshotFeatureStrings {
         toolShortcutsCaption: "矢印を使うか数字を選びます。最初の9個は1から9を使い、それ以降にはショートカットがありません。",
         toolSelect: "選択",
         toolArrow: "矢印",
+        arrowStyleLabel: "矢印のスタイル",
+        arrowStyleFilled: "塗りつぶし",
+        arrowStyleOutline: "アウトライン",
+        arrowStyleOpen: "開いた矢印",
+        arrowStyleDoubleEnded: "両矢印",
+        arrowStyleScribbly: "手描き",
         toolLine: "直線",
         toolRect: "長方形",
         toolEllipse: "楕円",
@@ -1469,6 +1529,12 @@ extension ScreenshotFeatureStrings {
         toolShortcutsCaption: "화살표를 사용하거나 숫자를 선택합니다. 처음 9개 도구는 1부터 9를 사용하고 나머지는 단축키가 없습니다.",
         toolSelect: "선택",
         toolArrow: "화살표",
+        arrowStyleLabel: "화살표 스타일",
+        arrowStyleFilled: "채움",
+        arrowStyleOutline: "윤곽선",
+        arrowStyleOpen: "열린 화살표",
+        arrowStyleDoubleEnded: "양방향",
+        arrowStyleScribbly: "낙서풍",
         toolLine: "직선",
         toolRect: "사각형",
         toolEllipse: "타원",
@@ -1610,6 +1676,12 @@ extension ScreenshotFeatureStrings {
         toolShortcutsCaption: "使用箭头或选择数字。前九个工具使用 1 到 9，其余工具没有快捷键。",
         toolSelect: "选择",
         toolArrow: "箭头",
+        arrowStyleLabel: "箭头样式",
+        arrowStyleFilled: "实心",
+        arrowStyleOutline: "轮廓",
+        arrowStyleOpen: "开口",
+        arrowStyleDoubleEnded: "双向",
+        arrowStyleScribbly: "涂鸦",
         toolLine: "直线",
         toolRect: "矩形",
         toolEllipse: "椭圆",
@@ -1751,6 +1823,12 @@ extension ScreenshotFeatureStrings {
         toolShortcutsCaption: "使用箭頭或選擇數字。前九個工具使用 1 到 9，其餘工具沒有快速鍵。",
         toolSelect: "選取",
         toolArrow: "箭頭",
+        arrowStyleLabel: "箭頭樣式",
+        arrowStyleFilled: "實心",
+        arrowStyleOutline: "輪廓",
+        arrowStyleOpen: "開口",
+        arrowStyleDoubleEnded: "雙向",
+        arrowStyleScribbly: "塗鴉",
         toolLine: "直線",
         toolRect: "矩形",
         toolEllipse: "橢圓",
@@ -1892,6 +1970,12 @@ extension ScreenshotFeatureStrings {
         toolShortcutsCaption: "使用箭嘴或選擇數字。前九個工具使用 1 到 9，其餘工具沒有快速鍵。",
         toolSelect: "選取",
         toolArrow: "箭嘴",
+        arrowStyleLabel: "箭嘴樣式",
+        arrowStyleFilled: "實心",
+        arrowStyleOutline: "輪廓",
+        arrowStyleOpen: "開口",
+        arrowStyleDoubleEnded: "雙向",
+        arrowStyleScribbly: "塗鴉",
         toolLine: "直線",
         toolRect: "矩形",
         toolEllipse: "橢圓",
@@ -1998,4 +2082,16 @@ extension ScreenshotFeatureStrings {
         dragOutHandleLabel: "拖放",
         loupeStartsOnToggle: "開始選取時啟用放大鏡"
     )
+}
+
+extension ScreenshotFeatureStrings {
+    func arrowStyleTitle(_ style: ScreenshotSupport.ArrowStyleID) -> String {
+        switch style {
+        case .filled: return arrowStyleFilled
+        case .outline: return arrowStyleOutline
+        case .open: return arrowStyleOpen
+        case .doubleEnded: return arrowStyleDoubleEnded
+        case .scribbly: return arrowStyleScribbly
+        }
+    }
 }

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift
@@ -49,6 +49,13 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
             applyStyleToSelection()
         }
     }
+    @Published var arrowStyle: ScreenshotSupport.ArrowStyleID {
+        didSet {
+            UserDefaults.standard.set(arrowStyle.rawValue,
+                                      forKey: DefaultsKey.screenshotLastArrowStyle)
+            applyStyleToSelection()
+        }
+    }
     @Published var sticker: ScreenshotSupport.StickerID {
         didSet {
             UserDefaults.standard.set(sticker.rawValue,
@@ -144,6 +151,8 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
             defaults.string(forKey: DefaultsKey.screenshotLastColor))
         stroke = ScreenshotSupport.StrokeID.sanitized(
             defaults.string(forKey: DefaultsKey.screenshotLastStroke))
+        arrowStyle = ScreenshotSupport.ArrowStyleID.sanitized(
+            defaults.string(forKey: DefaultsKey.screenshotLastArrowStyle))
         sticker = ScreenshotSupport.StickerID.sanitized(
             defaults.string(forKey: DefaultsKey.screenshotLastSticker))
         annotationShadowsEnabled = defaults.bool(
@@ -436,15 +445,26 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
 
     // MARK: - Selection styling
 
-    /// Applies color or thickness changes to the selected annotation.
+    /// Applies color, thickness, or arrow style changes to the selected annotation.
     private func applyStyleToSelection() {
         guard let selectedID,
               let index = annotations.firstIndex(where: { $0.id == selectedID })
         else { return }
-        guard annotations[index].color != color || annotations[index].stroke != stroke else { return }
+        let arrowStyleChanged = annotations[index].tool == .arrow
+            && annotations[index].arrowStyle != arrowStyle
+        guard annotations[index].color != color
+                || annotations[index].stroke != stroke
+                || arrowStyleChanged
+        else { return }
         registerUndo()
         annotations[index].color = color
         annotations[index].stroke = stroke
+        if annotations[index].tool == .arrow {
+            if arrowStyleChanged, arrowStyle == .scribbly {
+                annotations[index].scribbleSeed = ScreenshotSupport.randomScribbleSeed()
+            }
+            annotations[index].arrowStyle = arrowStyle
+        }
         if annotations[index].tool == .text {
             annotations[index].rect = ScreenshotRenderer.textBounds(
                 annotations[index].text,
@@ -475,6 +495,11 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
             beginSelectDrag(at: point)
             return
         }
+        if tool != .select, tool != .crop {
+            selectedID = ScreenshotSupport.selectionAtStartOfAnnotationDrag(
+                current: selectedID,
+                editingSelectedAnnotation: false)
+        }
         switch tool {
         case .select:
             beginSelectDrag(at: point)
@@ -497,7 +522,8 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
             registerUndo()
             dragRegistered = true
             let annotation = ScreenshotSupport.Annotation(
-                tool: tool, points: [point, point], color: color, stroke: stroke)
+                tool: tool, points: [point, point], color: color, stroke: stroke,
+                arrowStyle: arrowStyle)
             annotations.append(annotation)
             draftID = annotation.id
         case .freehand:
@@ -547,11 +573,15 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
         }
         selectedID = hitTest(point)
         if let selectedID, let hit = annotations.first(where: { $0.id == selectedID }) {
+            let selectionStyle = ScreenshotSupport.selectionStyle(for: hit)
+            self.selectedID = nil
+            color = selectionStyle.color
+            stroke = selectionStyle.stroke
+            arrowStyle = selectionStyle.arrowStyle
             if hit.tool == .sticker {
-                self.selectedID = nil
                 sticker = ScreenshotSupport.StickerID.sanitized(hit.text)
-                self.selectedID = selectedID
             }
+            self.selectedID = selectedID
             moveOrigin = hit.rect
             movePoints = hit.points
             clearTextSelection()

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift
@@ -496,9 +496,7 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
             return
         }
         if tool != .select, tool != .crop {
-            selectedID = ScreenshotSupport.selectionAtStartOfAnnotationDrag(
-                current: selectedID,
-                editingSelectedAnnotation: false)
+            selectedID = nil
         }
         switch tool {
         case .select:
@@ -787,8 +785,12 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
             selectedID = nil
             return false
         }
+        let style = ScreenshotSupport.selectionStyle(for: hit)
+        self.selectedID = nil
+        color = style.color
+        stroke = style.stroke
+        arrowStyle = style.arrowStyle
         if hit.tool == .sticker {
-            selectedID = nil
             sticker = ScreenshotSupport.StickerID.sanitized(hit.text)
         }
         selectedID = hitID

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift
@@ -523,6 +523,7 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
                 tool: tool, points: [point, point], color: color, stroke: stroke,
                 arrowStyle: arrowStyle)
             annotations.append(annotation)
+            selectedID = annotation.id
             draftID = annotation.id
         case .freehand:
             registerUndo()
@@ -530,6 +531,7 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
             let annotation = ScreenshotSupport.Annotation(
                 tool: tool, points: [point], color: color, stroke: stroke)
             annotations.append(annotation)
+            selectedID = annotation.id
             draftID = annotation.id
         case .rect, .ellipse, .highlight, .pixelate, .redact:
             if tool == .pixelate { ensurePixelated() }
@@ -539,6 +541,7 @@ final class ScreenshotEditorModel: ObservableObject, BackdropEditing {
                 tool: tool, rect: CGRect(origin: point, size: .zero),
                 color: color, stroke: stroke)
             annotations.append(annotation)
+            selectedID = annotation.id
             draftID = annotation.id
         case .text, .sticker, .counter:
             break

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotRenderer.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotRenderer.swift
@@ -79,11 +79,11 @@ enum ScreenshotRenderer {
                     context.strokeEllipse(in: annotation.rect)
                 }
             case .line:
-                drawLine(annotation, in: context, scale: scale, arrow: false,
+                drawLine(annotation, in: context, scale: scale,
                          shadowsEnabled: annotationShadowsEnabled)
             case .arrow:
-                drawLine(annotation, in: context, scale: scale, arrow: true,
-                         shadowsEnabled: annotationShadowsEnabled)
+                drawArrow(annotation, in: context, scale: scale,
+                          shadowsEnabled: annotationShadowsEnabled)
             case .freehand:
                 drawFreehand(annotation, in: context, scale: scale,
                              shadowsEnabled: annotationShadowsEnabled)
@@ -122,7 +122,6 @@ enum ScreenshotRenderer {
     private static func drawLine(_ annotation: ScreenshotSupport.Annotation,
                                  in context: CGContext,
                                  scale: CGFloat,
-                                 arrow: Bool,
                                  shadowsEnabled: Bool) {
         guard annotation.points.count >= 2 else { return }
         let start = annotation.points[0]
@@ -130,25 +129,104 @@ enum ScreenshotRenderer {
         let width = annotation.stroke.width * scale
         context.saveGState()
         applyShadow(context, scale: scale, enabled: shadowsEnabled)
-
-        guard arrow else {
-            context.setStrokeColor(color(annotation.color))
-            context.setLineWidth(width)
-            context.setLineCap(.round)
-            context.beginPath()
-            context.move(to: start)
-            context.addLine(to: end)
-            context.strokePath()
-            context.restoreGState()
-            return
-        }
-
-        context.setFillColor(color(annotation.color))
-        context.addPath(ScreenshotSupport.arrowSilhouette(from: start,
-                                                          to: end,
-                                                          strokeWidth: width))
-        context.fillPath()
+        context.setStrokeColor(color(annotation.color))
+        context.setLineWidth(width)
+        context.setLineCap(.round)
+        context.beginPath()
+        context.move(to: start)
+        context.addLine(to: end)
+        context.strokePath()
         context.restoreGState()
+    }
+
+    private static func drawArrow(_ annotation: ScreenshotSupport.Annotation,
+                                  in context: CGContext,
+                                  scale: CGFloat,
+                                  shadowsEnabled: Bool) {
+        guard annotation.points.count >= 2 else { return }
+        let start = annotation.points[0]
+        let end = annotation.points[1]
+        let width = annotation.stroke.width * scale
+        let head = ScreenshotSupport.arrowHead(from: start, to: end, strokeWidth: width)
+
+        context.saveGState()
+        applyShadow(context, scale: scale, enabled: shadowsEnabled)
+        context.setStrokeColor(color(annotation.color))
+        context.setFillColor(color(annotation.color))
+        context.setLineWidth(width)
+        context.setLineJoin(.round)
+        context.setLineCap(.round)
+
+        switch annotation.arrowStyle {
+        case .filled:
+            context.addPath(ScreenshotSupport.arrowSilhouette(from: start,
+                                                              to: end,
+                                                              strokeWidth: width))
+            context.fillPath()
+        case .outline:
+            drawArrowShaft(context, from: start, to: end, base: arrowBase(head))
+            context.beginPath()
+            context.move(to: head.left)
+            context.addLine(to: end)
+            context.addLine(to: head.right)
+            context.closePath()
+            context.strokePath()
+        case .open:
+            drawArrowShaft(context, from: start, to: end, base: end)
+            drawOpenArrowHead(context, tip: end, head: head)
+        case .doubleEnded:
+            let tailHead = ScreenshotSupport.arrowHead(from: end,
+                                                       to: start,
+                                                       strokeWidth: width)
+            drawArrowShaft(context, from: start, to: end, base: end)
+            drawOpenArrowHead(context, tip: end, head: head)
+            drawOpenArrowHead(context, tip: start, head: tailHead)
+        case .scribbly:
+            let geometry = ScreenshotSupport.scribblyArrowGeometry(
+                from: start,
+                to: end,
+                strokeWidth: width,
+                seed: annotation.scribbleSeed)
+            drawPolyline(context, points: geometry.shaft)
+            drawPolyline(context, points: geometry.leftWing)
+            drawPolyline(context, points: geometry.rightWing)
+        }
+        context.restoreGState()
+    }
+
+    private static func arrowBase(_ head: (left: CGPoint, right: CGPoint)) -> CGPoint {
+        CGPoint(x: (head.left.x + head.right.x) / 2,
+                y: (head.left.y + head.right.y) / 2)
+    }
+
+    private static func drawArrowShaft(_ context: CGContext,
+                                       from start: CGPoint,
+                                       to end: CGPoint,
+                                       base: CGPoint) {
+        context.beginPath()
+        context.move(to: start)
+        context.addLine(to: base)
+        context.strokePath()
+    }
+
+    private static func drawOpenArrowHead(_ context: CGContext,
+                                          tip: CGPoint,
+                                          head: (left: CGPoint, right: CGPoint)) {
+        context.beginPath()
+        context.move(to: head.left)
+        context.addLine(to: tip)
+        context.addLine(to: head.right)
+        context.strokePath()
+    }
+
+    private static func drawPolyline(_ context: CGContext, points: [CGPoint]) {
+        guard let first = points.first else { return }
+        context.beginPath()
+        context.move(to: first)
+        for point in points.dropFirst() {
+            context.addLine(to: point)
+        }
+        context.strokePath()
     }
 
     private static func drawFreehand(_ annotation: ScreenshotSupport.Annotation,

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
@@ -1244,6 +1244,18 @@ enum ScreenshotSupport {
         }
     }
 
+    enum ArrowStyleID: String, CaseIterable {
+        case filled, outline, open, doubleEnded, scribbly
+
+        static func sanitized(_ raw: String?) -> ArrowStyleID {
+            ArrowStyleID(rawValue: raw ?? "") ?? .filled
+        }
+    }
+
+    static func randomScribbleSeed() -> UInt64 {
+        UInt64.random(in: UInt64.min...UInt64.max)
+    }
+
     enum StickerID: String, CaseIterable {
         case check, cross, star, heart, thumbsUp, thumbsDown,
              smile, laugh, party, fire, warning, eyes
@@ -1298,6 +1310,8 @@ enum ScreenshotSupport {
         var text: String
         var color: ColorID
         var stroke: StrokeID
+        var arrowStyle: ArrowStyleID
+        var scribbleSeed: UInt64
         var number: Int
 
         init(id: UUID = UUID(),
@@ -1307,6 +1321,8 @@ enum ScreenshotSupport {
              text: String = "",
              color: ColorID = .red,
              stroke: StrokeID = .medium,
+             arrowStyle: ArrowStyleID = .filled,
+             scribbleSeed: UInt64? = nil,
              number: Int = 0) {
             self.id = id
             self.tool = tool
@@ -1315,13 +1331,39 @@ enum ScreenshotSupport {
             self.text = text
             self.color = color
             self.stroke = stroke
+            self.arrowStyle = arrowStyle
+            self.scribbleSeed = scribbleSeed
+                ?? (arrowStyle == .scribbly
+                    ? ScreenshotSupport.randomScribbleSeed()
+                    : 0)
             self.number = number
         }
+    }
+
+    /// The style values the editor controls should show for a picked mark.
+    struct SelectionStyle: Equatable {
+        let color: ColorID
+        let stroke: StrokeID
+        let arrowStyle: ArrowStyleID
+    }
+
+    static func selectionStyle(for annotation: Annotation) -> SelectionStyle {
+        SelectionStyle(color: annotation.color,
+                       stroke: annotation.stroke,
+                       arrowStyle: annotation.arrowStyle)
     }
 
     /// Which way a selected annotation moves through the drawing order.
     enum LayerMove {
         case forward, backward
+    }
+
+    /// A new annotation should not inherit the previous selection while its
+    /// drag is in progress. Existing annotations remain selected only when a
+    /// creation-tool gesture is actually editing one of their handles.
+    static func selectionAtStartOfAnnotationDrag(current: UUID?,
+                                                 editingSelectedAnnotation: Bool) -> UUID? {
+        editingSelectedAnnotation ? current : nil
     }
 
     /// Whether the annotation has somewhere to go: false at the end it is
@@ -1594,6 +1636,101 @@ enum ScreenshotSupport {
                     clockwise: true)
         path.closeSubpath()
         return path
+    }
+
+    /// A lightly hand-drawn arrow made from stable, seeded wobble. The seed
+    /// belongs to the annotation so a redraw or export keeps the same sketch,
+    /// while each newly created scribbly arrow gets its own variation.
+    struct ScribblyArrowGeometry: Equatable {
+        let shaft: [CGPoint]
+        let leftWing: [CGPoint]
+        let rightWing: [CGPoint]
+    }
+
+    static func scribblyArrowGeometry(from tail: CGPoint,
+                                      to tip: CGPoint,
+                                      strokeWidth: CGFloat,
+                                      seed: UInt64) -> ScribblyArrowGeometry {
+        let dx = tip.x - tail.x
+        let dy = tip.y - tail.y
+        let distance = hypot(dx, dy)
+        let angle = atan2(dy, dx)
+        let direction = CGPoint(x: cos(angle), y: sin(angle))
+        let perpendicular = CGPoint(x: -direction.y, y: direction.x)
+        let head = arrowHead(from: tail, to: tip, strokeWidth: strokeWidth)
+        let base = CGPoint(x: (head.left.x + head.right.x) / 2,
+                           y: (head.left.y + head.right.y) / 2)
+        var randomizer = ScribbleRandomizer(seed: seed)
+        let shaftSegments = max(4, min(24, Int(ceil(distance / max(10, strokeWidth * 3)))))
+        let shaftWobble = min(max(1, strokeWidth * 0.35), distance * 0.025)
+        let shaft = roughPath(from: tail,
+                              to: base,
+                              segments: shaftSegments,
+                              direction: direction,
+                              perpendicular: perpendicular,
+                              wobble: shaftWobble,
+                              randomizer: &randomizer)
+        let wingWobble = min(max(0.8, strokeWidth * 0.22), distance * 0.035)
+        let leftWing = roughPath(from: head.left,
+                                 to: tip,
+                                 segments: 3,
+                                 wobble: wingWobble,
+                                 randomizer: &randomizer)
+        let rightWing = roughPath(from: head.right,
+                                  to: tip,
+                                  segments: 3,
+                                  wobble: wingWobble,
+                                  randomizer: &randomizer)
+        return ScribblyArrowGeometry(shaft: shaft,
+                                     leftWing: leftWing,
+                                     rightWing: rightWing)
+    }
+
+    private struct ScribbleRandomizer {
+        private var state: UInt64
+
+        init(seed: UInt64) {
+            state = seed == 0 ? 0x9E3779B97F4A7C15 : seed
+        }
+
+        mutating func signedUnit() -> CGFloat {
+            state = state &* 2862933555777941757 &+ 3037000493
+            let normalized = Double(state) / Double(UInt64.max)
+            return CGFloat(normalized * 2 - 1)
+        }
+    }
+
+    private static func roughPath(from start: CGPoint,
+                                  to end: CGPoint,
+                                  segments: Int,
+                                  direction: CGPoint? = nil,
+                                  perpendicular: CGPoint? = nil,
+                                  wobble: CGFloat,
+                                  randomizer: inout ScribbleRandomizer) -> [CGPoint] {
+        let lineX = end.x - start.x
+        let lineY = end.y - start.y
+        let length = hypot(lineX, lineY)
+        let pathDirection = direction
+            ?? CGPoint(x: lineX / max(length, 0.001), y: lineY / max(length, 0.001))
+        let pathPerpendicular = perpendicular
+            ?? CGPoint(x: -pathDirection.y, y: pathDirection.x)
+        let count = max(1, segments)
+        return (0...count).map { index in
+            let progress = CGFloat(index) / CGFloat(count)
+            guard index != 0, index != count else {
+                return CGPoint(x: start.x + lineX * progress,
+                               y: start.y + lineY * progress)
+            }
+            let envelope = CGFloat(sin(Double.pi * Double(progress)))
+            let sideOffset = randomizer.signedUnit() * wobble * envelope
+            let forwardOffset = randomizer.signedUnit() * wobble * 0.28 * envelope
+            return CGPoint(x: start.x + lineX * progress
+                                + pathPerpendicular.x * sideOffset
+                                + pathDirection.x * forwardOffset,
+                           y: start.y + lineY * progress
+                                + pathPerpendicular.y * sideOffset
+                                + pathDirection.y * forwardOffset)
+        }
     }
 
     /// Distance from a point to a segment, for hit-testing lines and arrows.

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
@@ -1358,14 +1358,6 @@ enum ScreenshotSupport {
         case forward, backward
     }
 
-    /// A new annotation should not inherit the previous selection while its
-    /// drag is in progress. Existing annotations remain selected only when a
-    /// creation-tool gesture is actually editing one of their handles.
-    static func selectionAtStartOfAnnotationDrag(current: UUID?,
-                                                 editingSelectedAnnotation: Bool) -> UUID? {
-        editingSelectedAnnotation ? current : nil
-    }
-
     /// Whether the annotation has somewhere to go: false at the end it is
     /// already heading for, and for an id that is not in the array.
     static func canReorder(_ annotations: [Annotation],

--- a/Sources/Vorssaint/UI/Screenshot/ScreenshotEditorView.swift
+++ b/Sources/Vorssaint/UI/Screenshot/ScreenshotEditorView.swift
@@ -19,6 +19,7 @@ struct ScreenshotEditorView: View {
     @State private var backdropPopoverShown = false
     @State private var hoveredTool: ScreenshotSupport.Tool?
     @State private var toolOptionsShown = false
+    @State private var arrowStylePopoverShown = false
     @State private var sharing = false
     @State private var sharedRecord: ScreenshotShareRecord?
     @AppStorage(DefaultsKey.screenshotToolOrder) private var toolOrderRaw =
@@ -824,6 +825,15 @@ struct ScreenshotEditorView: View {
         }
     }
 
+    private var showsArrowStyleControls: Bool {
+        if model.tool == .arrow { return true }
+        guard model.tool == .select,
+              let selectedID = model.selectedID,
+              let selected = model.annotations.first(where: { $0.id == selectedID })
+        else { return false }
+        return selected.tool == .arrow
+    }
+
     /// Depth only means something once a shape is picked, and only when there
     /// is something else for it to pass.
     private var showsLayerControls: Bool {
@@ -880,6 +890,10 @@ struct ScreenshotEditorView: View {
 
     private var styleBar: some View {
         HStack(spacing: 10) {
+            if showsArrowStyleControls {
+                arrowStyleMenu
+                Divider().frame(height: 16)
+            }
             if showsStickerControls {
                 stickerMenu
                 Divider().frame(height: 16)
@@ -917,6 +931,52 @@ struct ScreenshotEditorView: View {
                 .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
         )
         .shadow(color: .black.opacity(0.16), radius: 12, y: 3)
+    }
+
+    private var arrowStyleMenu: some View {
+        Button {
+            arrowStylePopoverShown.toggle()
+        } label: {
+            HStack(spacing: 4) {
+                ScreenshotArrowStylePreview(style: model.arrowStyle)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 6)
+            .frame(height: 24)
+        }
+        .buttonStyle(.borderless)
+        .fixedSize()
+        .screenshotSafeHelp(strings.arrowStyleLabel)
+        .accessibilityLabel(strings.arrowStyleLabel)
+        .popover(isPresented: $arrowStylePopoverShown, arrowEdge: .bottom) {
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(ScreenshotSupport.ArrowStyleID.allCases, id: \.self) { style in
+                    Button {
+                        model.arrowStyle = style
+                        arrowStylePopoverShown = false
+                    } label: {
+                        HStack(spacing: 10) {
+                            ScreenshotArrowStylePreview(style: style)
+                            Text(strings.arrowStyleTitle(style))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            if model.arrowStyle == style {
+                                Image(systemName: "checkmark")
+                                    .foregroundStyle(Color.accentColor)
+                            }
+                        }
+                        .padding(.horizontal, 8)
+                        .frame(height: 34)
+                        .contentShape(RoundedRectangle(cornerRadius: 7,
+                                                       style: .continuous))
+                    }
+                    .buttonStyle(.borderless)
+                }
+            }
+            .padding(8)
+            .frame(width: 190)
+        }
     }
 
     private var stickerMenu: some View {
@@ -1320,6 +1380,119 @@ extension ScreenshotSupport.Tool {
         case .pixelate: return strings.toolPixelate
         case .redact: return strings.toolRedact
         case .crop: return strings.toolCrop
+        }
+    }
+}
+
+private struct ScreenshotArrowStylePreview: View {
+    let style: ScreenshotSupport.ArrowStyleID
+
+    private static let size = CGSize(width: 48, height: 28)
+    private static let start = CGPoint(x: 5, y: size.height / 2)
+    private static let end = CGPoint(x: 43, y: size.height / 2)
+    // Keep the selector sample lighter than the full-size annotation.
+    private static let strokeWidth: CGFloat = 2
+
+    private var head: (left: CGPoint, right: CGPoint) {
+        ScreenshotSupport.arrowHead(from: Self.start,
+                                    to: Self.end,
+                                    strokeWidth: Self.strokeWidth)
+    }
+
+    private var tailHead: (left: CGPoint, right: CGPoint) {
+        ScreenshotSupport.arrowHead(from: Self.end,
+                                    to: Self.start,
+                                    strokeWidth: Self.strokeWidth)
+    }
+
+    private var scribblyGeometry: ScreenshotSupport.ScribblyArrowGeometry {
+        ScreenshotSupport.scribblyArrowGeometry(from: Self.start,
+                                                to: Self.end,
+                                                strokeWidth: Self.strokeWidth,
+                                                seed: 0x5343524942424C59)
+    }
+
+    private var arrowColor: Color { .primary }
+
+    var body: some View {
+        ZStack {
+            switch style {
+            case .filled:
+                Path(ScreenshotSupport.arrowSilhouette(from: Self.start,
+                                                       to: Self.end,
+                                                       strokeWidth: Self.strokeWidth))
+                    .fill(arrowColor)
+            case .outline:
+                shaftPath(to: arrowBase(head))
+                    .stroke(arrowColor, style: strokeStyle)
+                outlineHeadPath(head)
+                    .stroke(arrowColor, style: strokeStyle)
+            case .open:
+                shaftPath(to: Self.end)
+                    .stroke(arrowColor, style: strokeStyle)
+                openHeadPath(tip: Self.end, head: head)
+                    .stroke(arrowColor, style: strokeStyle)
+            case .doubleEnded:
+                shaftPath(to: Self.end)
+                    .stroke(arrowColor, style: strokeStyle)
+                openHeadPath(tip: Self.end, head: head)
+                    .stroke(arrowColor, style: strokeStyle)
+                openHeadPath(tip: Self.start, head: tailHead)
+                    .stroke(arrowColor, style: strokeStyle)
+            case .scribbly:
+                polylinePath(scribblyGeometry.shaft)
+                    .stroke(arrowColor, style: strokeStyle)
+                polylinePath(scribblyGeometry.leftWing)
+                    .stroke(arrowColor, style: strokeStyle)
+                polylinePath(scribblyGeometry.rightWing)
+                    .stroke(arrowColor, style: strokeStyle)
+            }
+        }
+        .frame(width: Self.size.width, height: Self.size.height)
+        .accessibilityHidden(true)
+    }
+
+    private var strokeStyle: StrokeStyle {
+        StrokeStyle(lineWidth: Self.strokeWidth, lineCap: .round, lineJoin: .round)
+    }
+
+    private func arrowBase(_ head: (left: CGPoint, right: CGPoint)) -> CGPoint {
+        CGPoint(x: (head.left.x + head.right.x) / 2,
+                y: (head.left.y + head.right.y) / 2)
+    }
+
+    private func shaftPath(to endpoint: CGPoint) -> Path {
+        Path { path in
+            path.move(to: Self.start)
+            path.addLine(to: endpoint)
+        }
+    }
+
+    private func outlineHeadPath(_ head: (left: CGPoint, right: CGPoint)) -> Path {
+        Path { path in
+            path.move(to: head.left)
+            path.addLine(to: Self.end)
+            path.addLine(to: head.right)
+            path.closeSubpath()
+        }
+    }
+
+    private func openHeadPath(tip: CGPoint,
+                              head: (left: CGPoint, right: CGPoint)) -> Path {
+        Path { path in
+            path.move(to: head.left)
+            path.addLine(to: tip)
+            path.addLine(to: head.right)
+        }
+    }
+
+    private func polylinePath(_ points: [CGPoint]) -> Path {
+        Path { path in
+            guard let first = points.first else { return }
+            path.move(to: first)
+            for point in points.dropFirst() {
+                path.addLine(to: point)
+            }
         }
     }
 }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -16711,21 +16711,13 @@ struct MetricsTests {
         expect(!ScreenshotSupport.canReorder(layered, moving: UUID(), .forward)
                 && !ScreenshotSupport.canReorder([], moving: layered[0].id, .backward),
                "an annotation that is not there can never be reordered")
-        let previousSelection = UUID()
-        expect(ScreenshotSupport.selectionAtStartOfAnnotationDrag(
-                    current: previousSelection,
-                    editingSelectedAnnotation: false) == nil
-                && ScreenshotSupport.selectionAtStartOfAnnotationDrag(
-                    current: previousSelection,
-                    editingSelectedAnnotation: true) == previousSelection,
-               "a new annotation drag cannot expose the previous layer selection")
         let screenshotEditorSource = ((try? String(
             contentsOfFile: "Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift",
             encoding: .utf8)) ?? "")
             .split(separator: "\n", omittingEmptySubsequences: false)
             .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
             .joined(separator: "\n")
-        expect(screenshotEditorSource.contains("selectionAtStartOfAnnotationDrag"),
+        expect(screenshotEditorSource.contains("if tool != .select, tool != .crop {\n            selectedID = nil\n        }"),
                "the editor clears stale selection before creating a new annotation")
 
         let resized = ScreenshotSupport.resizedRect(CGRect(x: 10, y: 10, width: 100, height: 100),
@@ -16806,6 +16798,18 @@ struct MetricsTests {
                "selecting a thin arrow exposes its own stroke in the editor controls")
         expect(screenshotEditorSource.contains("selectionStyle(for: hit)"),
                "the editor synchronizes controls from the selected annotation")
+        let existingSelectionSource: String
+        if let start = screenshotEditorSource.range(of: "private func selectExistingAnnotation"),
+           let end = screenshotEditorSource.range(of: "private func updateDraft") {
+            existingSelectionSource = String(screenshotEditorSource[start.lowerBound..<end.lowerBound])
+        } else {
+            existingSelectionSource = ""
+        }
+        let existingStyleSync = "self.selectedID = nil\n        color = style.color\n"
+            + "        stroke = style.stroke\n        arrowStyle = style.arrowStyle"
+        expect(existingSelectionSource.contains("let style = ScreenshotSupport.selectionStyle(for: hit)")
+                && existingSelectionSource.contains(existingStyleSync),
+               "creation-tool taps synchronize controls before selecting the annotation")
         expect(abs(ScreenshotSupport.distance(from: CGPoint(x: 50, y: 10),
                                               toSegment: CGPoint(x: 0, y: 0),
                                               CGPoint(x: 100, y: 0)) - 10) < 0.001,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -16711,6 +16711,22 @@ struct MetricsTests {
         expect(!ScreenshotSupport.canReorder(layered, moving: UUID(), .forward)
                 && !ScreenshotSupport.canReorder([], moving: layered[0].id, .backward),
                "an annotation that is not there can never be reordered")
+        let previousSelection = UUID()
+        expect(ScreenshotSupport.selectionAtStartOfAnnotationDrag(
+                    current: previousSelection,
+                    editingSelectedAnnotation: false) == nil
+                && ScreenshotSupport.selectionAtStartOfAnnotationDrag(
+                    current: previousSelection,
+                    editingSelectedAnnotation: true) == previousSelection,
+               "a new annotation drag cannot expose the previous layer selection")
+        let screenshotEditorSource = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/QuickTools/ScreenshotEditorController.swift",
+            encoding: .utf8)) ?? "")
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(screenshotEditorSource.contains("selectionAtStartOfAnnotationDrag"),
+               "the editor clears stale selection before creating a new annotation")
 
         let resized = ScreenshotSupport.resizedRect(CGRect(x: 10, y: 10, width: 100, height: 100),
                                                     dragging: .bottomRight,
@@ -16754,6 +16770,42 @@ struct MetricsTests {
                                   using: .winding,
                                   transform: .identity),
                "the arrow stays filled where its shaft meets the head")
+        let arrowStyles = ScreenshotSupport.ArrowStyleID.allCases
+        expect(arrowStyles == [.filled, .outline, .open, .doubleEnded, .scribbly]
+                && ScreenshotSupport.ArrowStyleID.sanitized("unknown") == .filled,
+               "the screenshot editor offers five arrow styles and safely falls back to solid")
+        let openArrow = ScreenshotSupport.Annotation(tool: .arrow,
+                                                     points: [.zero, CGPoint(x: 100, y: 100)],
+                                                     arrowStyle: .open)
+        expect(openArrow.arrowStyle == .open,
+               "arrow annotations retain the chosen style independently of color and thickness")
+        let stableScribble = ScreenshotSupport.scribblyArrowGeometry(
+            from: .zero,
+            to: CGPoint(x: 160, y: 80),
+            strokeWidth: 4,
+            seed: 17)
+        let sameScribble = ScreenshotSupport.scribblyArrowGeometry(
+            from: .zero,
+            to: CGPoint(x: 160, y: 80),
+            strokeWidth: 4,
+            seed: 17)
+        let differentScribble = ScreenshotSupport.scribblyArrowGeometry(
+            from: .zero,
+            to: CGPoint(x: 160, y: 80),
+            strokeWidth: 4,
+            seed: 18)
+        expect(stableScribble == sameScribble
+                && stableScribble != differentScribble
+                && stableScribble.shaft.count > 2,
+               "scribbly arrows vary by seed but keep one stable design when redrawn")
+        let thickArrow = ScreenshotSupport.Annotation(tool: .arrow, stroke: .large)
+        let thinArrow = ScreenshotSupport.Annotation(tool: .arrow, stroke: .small)
+        expect(ScreenshotSupport.selectionStyle(for: thinArrow).stroke == .small
+                && ScreenshotSupport.selectionStyle(for: thinArrow)
+                    != ScreenshotSupport.selectionStyle(for: thickArrow),
+               "selecting a thin arrow exposes its own stroke in the editor controls")
+        expect(screenshotEditorSource.contains("selectionStyle(for: hit)"),
+               "the editor synchronizes controls from the selected annotation")
         expect(abs(ScreenshotSupport.distance(from: CGPoint(x: 50, y: 10),
                                               toSegment: CGPoint(x: 0, y: 0),
                                               CGPoint(x: 100, y: 0)) - 10) < 0.001,
@@ -17102,6 +17154,8 @@ struct MetricsTests {
                "the screenshot rail ships in its useful numbered order")
         expect(Defaults.registeredDefaults[DefaultsKey.screenshotLastSticker] as? String == "check",
                "the sticker tool starts with a safe built-in choice")
+        expect(Defaults.registeredDefaults[DefaultsKey.screenshotLastArrowStyle] as? String == "filled",
+               "the arrow tool starts with the existing solid style")
         expect(Defaults.registeredDefaults[DefaultsKey.screenshotShortcut] as? String
                 == "control+option+command:21",
                "the default screenshot shortcut is control option command 4")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -16719,6 +16719,8 @@ struct MetricsTests {
             .joined(separator: "\n")
         expect(screenshotEditorSource.contains("if tool != .select, tool != .crop {\n            selectedID = nil\n        }"),
                "the editor clears stale selection before creating a new annotation")
+        expect(screenshotEditorSource.contains("annotations.append(annotation)\n            selectedID = annotation.id\n            draftID = annotation.id"),
+               "a shape draft stays selected while it is being drawn")
 
         let resized = ScreenshotSupport.resizedRect(CGRect(x: 10, y: 10, width: 100, height: 100),
                                                     dragging: .bottomRight,


### PR DESCRIPTION
## Summary

Adds arrow style selection to the existing screenshot editor.

The arrow tool now offers filled, outline, open, double-ended and scribbly styles. Scribbly arrows receive a slightly different seeded design when created while remaining visually stable when the same annotation is redrawn.

This also fixes two selection-state problems in the existing editor:

- Finishing a new arrow no longer briefly activates the layer control and then leaves it gray.
- Selecting a thin arrow after a thick arrow updates the toolbar to show the selected arrow's actual thickness and style.

This belongs in Vorssaint because it extends the existing screenshot annotation tool without adding a new subsystem. It is built on the current annotation model, renderer, toolbar and defaults system.

The existing filled arrow remains the default. The additional behavior is only used by people who open the screenshot editor and use arrows.

There are no new dependencies, processes, network requests, permissions or third-party integrations. The permanent surface is limited to the arrow-style model, renderer paths, one saved preference, localized labels, toolbar previews and screenshot regression tests.

## Verification

Tested on an Apple Silicon Mac running macOS 27.0.

- Developer build created with `./build.sh --dev`
- Release build created with `./build.sh` without warnings
- `./build/Vorssaint --selftest` returned `SELFTEST OK`

Manually verified:

- Drawing a new arrow keeps the layer-selection state consistent after releasing the pointer.
- Selecting thin and thick arrows updates the toolbar controls.
- Filled, outline, open and double-ended arrows render correctly.
- Creating multiple scribbly arrows produces different designs.
- A scribbly arrow keeps the same design when redrawn.

`./build.sh --test` completed 9,747 checks but reported two pre-existing failures unrelated to this change:

- `App Switcher icon-row hints describe default app and window shortcuts`
- `the dispatch pool starvation this check needs was actually reached`

Not tested:

- Other Mac models or macOS versions
- Multi-display behavior
- Different Spaces layouts

All new user-facing labels compile in every supported language.

## Anything else

I could not find an existing issue specifically covering screenshot arrow-style selection. New issue creation is currently restricted for this repository, so there is no `Refs #N` line to include.