### PR TITLE
fix(mouse): serve the click and wheel taps on their own thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project are documented here. The format follows
 - The recording editor's look presets carry one name each instead of repeating it, and sizes use a proper multiplication sign.
 - The zoom panel's button says what it does instead of borrowing the timeline's hint to click somewhere else.
 - Slider labels shrink instead of being cut where Turkish and Spanish run past the column, in the backdrop and recording panels.
+- Clicking and scrolling no longer wait on the app's own work while the three-finger middle click or the reversed scroll direction is on, which was felt as lag in full-screen apps and games.
 
 ## [3.3.3-beta.4] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ All notable changes to this project are documented here. The format follows
 - The recording editor's look presets carry one name each instead of repeating it, and sizes use a proper multiplication sign.
 - The zoom panel's button says what it does instead of borrowing the timeline's hint to click somewhere else.
 - Slider labels shrink instead of being cut where Turkish and Spanish run past the column, in the backdrop and recording panels.
-- Clicking and scrolling no longer wait on the app's own work while the three-finger middle click or the reversed scroll direction is on, which was felt as lag in full-screen apps and games.
+- Clicks and scrolling no longer lag in full-screen apps and games while the three-finger middle click or the reversed scroll direction is on.
 
 ## [3.3.3-beta.4] - 2026-09-03
 

--- a/Sources/Vorssaint/Services/MiddleClick/MiddleClickService.swift
+++ b/Sources/Vorssaint/Services/MiddleClick/MiddleClickService.swift
@@ -26,6 +26,14 @@ final class MiddleClickService: ObservableObject {
 
     private var tap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
+    /// Guards the tap port above and the press state below: the callback runs
+    /// on the pointer thread while the main thread arms and tears the feature
+    /// down.
+    private let tapStateLock = NSLock()
+    /// Guards the cached system gesture setting, read on the tap callback and
+    /// written on the main thread.
+    private let dragLock = NSLock()
+    private var dragGestureRefreshScheduled = false
     /// Retains the MTDeviceRefs while listening; the framework hands out
     /// CF objects owned by this array.
     private var deviceList: CFArray?
@@ -47,7 +55,8 @@ final class MiddleClickService: ObservableObject {
     private var middleButtonHeldSince: TimeInterval = 0
     /// When the last transformed click finished, for the bounce guard.
     private var lastTransformEnd: TimeInterval?
-    /// Cached three-finger drag system setting; re-read at most every 2 s.
+    /// Cached three-finger drag system setting; re-read at most every 2 s,
+    /// always on the main thread, never from the event path.
     private var dragGestureCache: (enabled: Bool, readAt: TimeInterval) = (false, -10)
 
     /// Contact state shared between the multitouch callback thread and the
@@ -104,20 +113,32 @@ final class MiddleClickService: ObservableObject {
     /// Re-reads the conflicting system gesture; Settings calls this when the
     /// Mouse tab appears so the warning reflects reality.
     func refreshDragGestureConflict() {
-        dragGestureCache = (Self.systemThreeFingerDragEnabled(), ProcessInfo.processInfo.systemUptime)
-        if systemDragGestureConflict != dragGestureCache.enabled {
-            systemDragGestureConflict = dragGestureCache.enabled
+        let enabled = Self.systemThreeFingerDragEnabled()
+        dragLock.lock()
+        dragGestureCache = (enabled, ProcessInfo.processInfo.systemUptime)
+        dragGestureRefreshScheduled = false
+        dragLock.unlock()
+        if systemDragGestureConflict != enabled {
+            systemDragGestureConflict = enabled
         }
         stateLock.lock()
-        tapDragConflict = dragGestureCache.enabled
+        tapDragConflict = enabled
         stateLock.unlock()
     }
 
+    /// Answers from the cache: reading a system preference and publishing the
+    /// conflict belong on the main thread, never in the path of a click. A
+    /// stale answer refreshes behind the press and applies to the next one.
     private func dragGestureEnabled(now: TimeInterval) -> Bool {
-        if now - dragGestureCache.readAt > 2 {
-            refreshDragGestureConflict()
+        dragLock.lock()
+        let cache = dragGestureCache
+        let needsRefresh = now - cache.readAt > 2 && !dragGestureRefreshScheduled
+        if needsRefresh { dragGestureRefreshScheduled = true }
+        dragLock.unlock()
+        if needsRefresh {
+            DispatchQueue.main.async { [weak self] in self?.refreshDragGestureConflict() }
         }
-        return dragGestureCache.enabled
+        return cache.enabled
     }
 
     private static func systemThreeFingerDragEnabled() -> Bool {
@@ -141,7 +162,7 @@ final class MiddleClickService: ObservableObject {
     // MARK: - Lifecycle
 
     private func start() {
-        guard tap == nil else { return }
+        guard tapStateLock.withLock({ tap }) == nil else { return }
         guard Multitouch.available else { return }
 
         guard let tap = CGEvent.tapCreate(
@@ -162,10 +183,14 @@ final class MiddleClickService: ObservableObject {
             userInfo: Unmanaged.passUnretained(self).toOpaque()
         ) else { return }
 
-        self.tap = tap
         let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
-        runLoopSource = source
-        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        tapStateLock.withLock {
+            self.tap = tap
+            runLoopSource = source
+        }
+        if let source {
+            PointerTapRunLoop.add(source)
+        }
         CGEvent.tapEnable(tap: tap, enable: true)
 
         startMultitouch()
@@ -177,20 +202,24 @@ final class MiddleClickService: ObservableObject {
         // Close a transformed press while this process and its event tap are
         // still alive, before tearing down either source.
         releaseHeldMiddleButton()
-        if let tap {
-            CGEvent.tapEnable(tap: tap, enable: false)
+        let (port, source) = tapStateLock.withLock { () -> (CFMachPort?, CFRunLoopSource?) in
+            let current = (tap, runLoopSource)
+            tap = nil
+            runLoopSource = nil
+            return current
         }
-        if let runLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+        if let port {
+            CGEvent.tapEnable(tap: port, enable: false)
         }
-        if let tap {
-            CFMachPortInvalidate(tap)
+        if let source {
+            PointerTapRunLoop.remove(source, invalidating: port)
         }
-        tap = nil
-        runLoopSource = nil
         stopMultitouch()
         removeObservers()
-        lastTransformEnd = nil
+        tapStateLock.withLock {
+            lastTransformEnd = nil
+            suppressedButtonSequence = false
+        }
         stateLock.lock()
         fingerCount = 0
         lastFrameUptime = 0
@@ -203,7 +232,7 @@ final class MiddleClickService: ObservableObject {
     /// Trackpads come and go across sleep and Bluetooth: drop every contact
     /// registration and rebuild from the current device list.
     private func restartMultitouch() {
-        guard tap != nil else { return }
+        guard tapStateLock.withLock({ tap }) != nil else { return }
         stopMultitouch()
         startMultitouch()
     }
@@ -384,11 +413,12 @@ final class MiddleClickService: ObservableObject {
     }
 
     /// A judged tap becomes a full middle click at the current pointer. Runs
-    /// on the main thread; also arms the bounce guard so a system-synthesized
-    /// click right behind the tap is not transformed into a second one.
+    /// on the main thread, away from the tap callback; also arms the bounce
+    /// guard so a system-synthesized click right behind the tap is not
+    /// transformed into a second one.
     private func postMiddleTap() {
         DispatchQueue.main.async { [weak self] in
-            guard let self, self.tap != nil else { return }
+            guard let self, self.tapStateLock.withLock({ self.tap }) != nil else { return }
             let position = CGEvent(source: nil)?.location ?? .zero
             // Nothing is synthesized over an app on the exception list.
             guard !MouseAppExceptions.shared.excludesPointerTarget(.middleClick, at: position) else { return }
@@ -405,11 +435,13 @@ final class MiddleClickService: ObservableObject {
             up.setIntegerValueField(.mouseEventClickState, value: 1)
             down.post(tap: .cghidEventTap)
             up.post(tap: .cghidEventTap)
-            self.lastTransformEnd = ProcessInfo.processInfo.systemUptime
+            self.tapStateLock.withLock {
+                self.lastTransformEnd = ProcessInfo.processInfo.systemUptime
+            }
         }
     }
 
-    // MARK: - Event tap (main thread)
+    // MARK: - Event tap (pointer thread)
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
@@ -421,8 +453,8 @@ final class MiddleClickService: ObservableObject {
                 accessibilityGranted: AXIsProcessTrusted(),
                 sessionIsActive: SessionActivity.shared.isActive
             )
-            if shouldRearm, let tap {
-                CGEvent.tapEnable(tap: tap, enable: true)
+            if shouldRearm, let port = tapStateLock.withLock({ tap }) {
+                CGEvent.tapEnable(tap: port, enable: true)
             } else {
                 // The matching middle-up was sent above. Tear the disabled tap
                 // down after its callback returns instead of resurrecting it.
@@ -440,19 +472,30 @@ final class MiddleClickService: ObservableObject {
             stateLock.lock()
             if tapStartUptime != nil { tapSawButton = true }
             stateLock.unlock()
-            if suppressedButtonSequence { return nil }
+            tapStateLock.lock()
+            if suppressedButtonSequence {
+                tapStateLock.unlock()
+                return nil
+            }
+            var releaseLostHold = false
             if middleButtonHeld {
                 // A lost release must not swallow the user's clicks forever.
                 if now - middleButtonHeldSince > 10 {
-                    releaseHeldMiddleButton()
+                    releaseLostHold = true
                 } else {
                     // Duplicate synthesized press while the middle button is
                     // already being relayed: drop its whole sequence without
                     // ending the real held click.
                     suppressedButtonSequence = true
+                    tapStateLock.unlock()
                     return nil
                 }
             }
+            tapStateLock.unlock()
+            // The release posts an event and waits for it, so it happens with
+            // no lock held. It also ends a transform, which the bounce guard
+            // below reads back afterwards, exactly as it did inline.
+            if releaseLostHold { releaseHeldMiddleButton() }
             // An app on the exception list keeps the plain native click, so a
             // three-finger click means to it what it always meant (issue #358).
             if MouseAppExceptions.shared.excludesPointerTarget(.middleClick, at: event.location) {
@@ -463,40 +506,52 @@ final class MiddleClickService: ObservableObject {
             let age = now - lastFrameUptime
             let settledFor = threeFingersSince.map { now - $0 } ?? 0
             stateLock.unlock()
+            let sinceLastTransformEnd = tapStateLock.withLock { lastTransformEnd }
             let action = MiddleClickSupport.actionForClick(
                 fingerCount: count,
                 frameAge: age,
                 settledFor: settledFor,
-                sinceLastTransformEnd: lastTransformEnd.map { now - $0 },
+                sinceLastTransformEnd: sinceLastTransformEnd.map { now - $0 },
                 systemDragGestureEnabled: dragGestureEnabled(now: now)
             )
             switch action {
             case .passThrough:
                 return Unmanaged.passUnretained(event)
             case .swallow:
-                suppressedButtonSequence = true
+                tapStateLock.withLock { suppressedButtonSequence = true }
                 return nil
             case .transform:
-                middleButtonHeld = true
-                middleButtonHeldSince = now
                 let targetPID = event.getIntegerValueField(.eventTargetUnixProcessID)
-                middleButtonTargetPID = targetPID > 0 ? pid_t(targetPID) : nil
+                tapStateLock.withLock {
+                    middleButtonHeld = true
+                    middleButtonHeldSince = now
+                    middleButtonTargetPID = targetPID > 0 ? pid_t(targetPID) : nil
+                }
                 return Unmanaged.passUnretained(asMiddle(event, type: .otherMouseDown))
             }
         case .leftMouseDragged, .rightMouseDragged:
-            if middleButtonHeld {
+            let (held, suppressed) = tapStateLock.withLock {
+                (middleButtonHeld, suppressedButtonSequence)
+            }
+            if held {
                 return Unmanaged.passUnretained(asMiddle(event, type: .otherMouseDragged))
             }
-            return suppressedButtonSequence ? nil : Unmanaged.passUnretained(event)
+            return suppressed ? nil : Unmanaged.passUnretained(event)
         case .leftMouseUp, .rightMouseUp:
+            tapStateLock.lock()
             if suppressedButtonSequence {
                 suppressedButtonSequence = false
+                tapStateLock.unlock()
                 return nil
             }
-            guard middleButtonHeld else { return Unmanaged.passUnretained(event) }
+            guard middleButtonHeld else {
+                tapStateLock.unlock()
+                return Unmanaged.passUnretained(event)
+            }
             middleButtonHeld = false
             middleButtonTargetPID = nil
             lastTransformEnd = now
+            tapStateLock.unlock()
             return Unmanaged.passUnretained(asMiddle(event, type: .otherMouseUp))
         default:
             return Unmanaged.passUnretained(event)
@@ -506,12 +561,17 @@ final class MiddleClickService: ObservableObject {
     /// A transformed down must always get its matching middle-button up, even
     /// when the native release was lost or the event tap is being torn down.
     private func releaseHeldMiddleButton() {
+        tapStateLock.lock()
         suppressedButtonSequence = false
-        guard middleButtonHeld else { return }
+        guard middleButtonHeld else {
+            tapStateLock.unlock()
+            return
+        }
         middleButtonHeld = false
-        let position = CGEvent(source: nil)?.location ?? .zero
         let targetPID = middleButtonTargetPID
         middleButtonTargetPID = nil
+        tapStateLock.unlock()
+        let position = CGEvent(source: nil)?.location ?? .zero
         let event = CGEvent(mouseEventSource: CGEventSource(stateID: .hidSystemState),
                             mouseType: .otherMouseUp,
                             mouseCursorPosition: position,
@@ -524,7 +584,7 @@ final class MiddleClickService: ObservableObject {
         // CGEvent posting is asynchronous. During app termination, keep this
         // process alive just long enough for WindowServer to deliver the up.
         Thread.sleep(forTimeInterval: 0.02)
-        lastTransformEnd = ProcessInfo.processInfo.systemUptime
+        tapStateLock.withLock { lastTransformEnd = ProcessInfo.processInfo.systemUptime }
     }
 
     /// Rewrites the event in place: same position, timestamp and modifiers,

--- a/Sources/Vorssaint/Services/MouseExceptions/MouseAppExceptions.swift
+++ b/Sources/Vorssaint/Services/MouseExceptions/MouseAppExceptions.swift
@@ -20,14 +20,20 @@ import CoreGraphics
 /// window; with every list empty, which is the normal case, nothing is
 /// resolved at all and the taps cost exactly what they always did.
 ///
-/// Main thread only, like the taps that ask.
+/// The lists are written on the main thread; the taps that ask run on the
+/// pointer thread (`PointerTapRunLoop`), so everything they read is guarded by
+/// `lock` and the AppKit half of resolving is asked on the main thread.
 final class MouseAppExceptions: ObservableObject {
     static let shared = MouseAppExceptions()
+
+    /// Guards the lookups, the source ids and the resolved-app cache: written
+    /// on the main thread, read from the tap callbacks.
+    private let lock = NSLock()
 
     /// The stored lists, as bundle identifiers per feature.
     @Published private(set) var lists: [MouseExceptionScope: [String]] = [:]
 
-    /// The same lists as sets, for the lookups the taps make.
+    /// The same lists as sets, for the lookups the taps make. Under `lock`.
     private var lookups: [MouseExceptionScope: Set<String>] = [:]
     /// True while every list is empty, the fast path out of every question.
     private var allEmpty = true
@@ -63,14 +69,25 @@ final class MouseAppExceptions: ObservableObject {
                 defaults.set(sanitized, forKey: scope.defaultsKey)
             }
             lists[scope] = sanitized
-            lookups[scope] = Set(sanitized)
+            lock.withLock { lookups[scope] = Set(sanitized) }
         }
-        allEmpty = lookups.values.allSatisfy(\.isEmpty)
+        lock.withLock { allEmpty = lookups.values.allSatisfy(\.isEmpty) }
         invalidateCache()
         refreshSourceTracking()
     }
 
     func list(_ scope: MouseExceptionScope) -> [String] { lists[scope] ?? [] }
+
+    /// The lists and source ids a tap needs, copied out under the lock.
+    private func lookup(_ scope: MouseExceptionScope) -> (exceptions: Set<String>, sources: Set<Int32>) {
+        lock.withLock { (lookups[scope] ?? [], sourceProcessIDs[scope] ?? []) }
+    }
+
+    /// AppKit answers on the main thread, since the taps that ask no longer
+    /// run there.
+    private static func onMain<T>(_ work: () -> T) -> T {
+        Thread.isMainThread ? work() : DispatchQueue.main.sync(execute: work)
+    }
 
     /// Sanitized here the same way `reload` sanitizes what it reads, so an
     /// entry cannot be stored in one spelling and looked for in another.
@@ -95,9 +112,10 @@ final class MouseAppExceptions: ObservableObject {
     func excludesPointerTarget(_ scope: MouseExceptionScope,
                                at point: CGPoint,
                                sourceProcessID: Int64 = 0) -> Bool {
-        guard let exceptions = lookups[scope], !exceptions.isEmpty else { return false }
+        let (exceptions, sources) = lookup(scope)
+        guard !exceptions.isEmpty else { return false }
         if let pid = MouseAppExceptionSupport.sourceProcessID(sourceProcessID),
-           sourceProcessIDs[scope]?.contains(pid) == true {
+           sources.contains(pid) {
             return true
         }
         return MouseAppExceptionSupport.isExcepted(pointerIdentity(at: point), exceptions: exceptions)
@@ -111,33 +129,36 @@ final class MouseAppExceptions: ObservableObject {
     func excludesActionTarget(_ scope: MouseExceptionScope,
                               at point: CGPoint,
                               sourceProcessID: Int64 = 0) -> Bool {
-        guard let exceptions = lookups[scope], !exceptions.isEmpty else { return false }
+        let (exceptions, sources) = lookup(scope)
+        guard !exceptions.isEmpty else { return false }
         if let pid = MouseAppExceptionSupport.sourceProcessID(sourceProcessID),
-           sourceProcessIDs[scope]?.contains(pid) == true {
+           sources.contains(pid) {
             return true
         }
         if MouseAppExceptionSupport.isExcepted(pointerIdentity(at: point), exceptions: exceptions) {
             return true
         }
-        return MouseAppExceptionSupport.isExcepted(Self.identity(for: NSWorkspace.shared.frontmostApplication),
-                                                   exceptions: exceptions)
+        let frontmost = Self.onMain { Self.identity(for: NSWorkspace.shared.frontmostApplication) }
+        return MouseAppExceptionSupport.isExcepted(frontmost, exceptions: exceptions)
     }
 
     /// Services that intercept wheel events call this with their tap lifecycle.
     /// With every such feature off, unavailable or carrying an empty list, no
     /// workspace observer or source cache remains alive.
     func setSourceTracking(_ active: Bool, for scope: MouseExceptionScope) {
-        if active {
-            trackedSourceScopes.insert(scope)
-        } else {
-            trackedSourceScopes.remove(scope)
+        lock.withLock {
+            if active {
+                trackedSourceScopes.insert(scope)
+            } else {
+                trackedSourceScopes.remove(scope)
+            }
         }
         refreshSourceTracking()
     }
 
     private func refreshSourceTracking() {
-        let shouldTrack = trackedSourceScopes.contains {
-            lookups[$0]?.isEmpty == false
+        let shouldTrack = lock.withLock {
+            trackedSourceScopes.contains { lookups[$0]?.isEmpty == false }
         }
         guard shouldTrack else {
             stopSourceTracking()
@@ -157,21 +178,23 @@ final class MouseAppExceptions: ObservableObject {
     private func stopSourceTracking() {
         runningApplicationsObservation?.invalidate()
         runningApplicationsObservation = nil
-        sourceProcessIDs.removeAll(keepingCapacity: false)
+        lock.withLock { sourceProcessIDs.removeAll(keepingCapacity: false) }
     }
 
     private func rebuildSourceProcesses(_ applications: [NSRunningApplication]) {
-        sourceProcessIDs.removeAll(keepingCapacity: true)
+        var rebuilt: [MouseExceptionScope: Set<Int32>] = [:]
+        let (scopes, exceptionsByScope) = lock.withLock { (trackedSourceScopes, lookups) }
         for app in applications {
             let bundleIDs = sourceBundleIdentifiers(for: app)
             guard !bundleIDs.isEmpty else { continue }
-            for scope in trackedSourceScopes {
-                guard let exceptions = lookups[scope],
+            for scope in scopes {
+                guard let exceptions = exceptionsByScope[scope],
                       MouseAppExceptionSupport.isExcepted(bundleIDs,
                                                           exceptions: exceptions) else { continue }
-                sourceProcessIDs[scope, default: []].insert(app.processIdentifier)
+                rebuilt[scope, default: []].insert(app.processIdentifier)
             }
         }
+        lock.withLock { sourceProcessIDs = rebuilt }
     }
 
     /// Helpers bundled inside a selected app inherit its exception. This uses
@@ -202,26 +225,34 @@ final class MouseAppExceptions: ObservableObject {
     /// What the app that owns the window under the pointer answers to, falling
     /// back to the app in front when the pointer is over none.
     private func pointerIdentity(at point: CGPoint) -> String? {
-        guard !allEmpty else { return nil }
         let now = ProcessInfo.processInfo.systemUptime
-        if MouseAppExceptionSupport.cacheHolds(region: cachedRegion,
-                                               resolvedPoint: cachedPoint,
-                                               resolvedAt: cachedAt,
-                                               point: point,
-                                               now: now) {
-            return cachedIdentity
+        // The cache answers under the lock; resolving happens outside it,
+        // since it ends up on the main thread.
+        let answer = lock.withLock { () -> (settled: Bool, identity: String?) in
+            guard !allEmpty else { return (true, nil) }
+            guard MouseAppExceptionSupport.cacheHolds(region: cachedRegion,
+                                                      resolvedPoint: cachedPoint,
+                                                      resolvedAt: cachedAt,
+                                                      point: point,
+                                                      now: now) else { return (false, nil) }
+            return (true, cachedIdentity)
         }
+        if answer.settled { return answer.identity }
 
         let window = MouseAppExceptionSupport.pointerWindow(in: WindowServerSupport.onScreenWindows(),
                                                             at: point,
                                                             ownProcessID: Self.ownProcessID)
-        let app = window.map { NSRunningApplication(processIdentifier: $0.processID) }
-            ?? NSWorkspace.shared.frontmostApplication
-        let identity = Self.identity(for: app)
-        cachedIdentity = identity
-        cachedRegion = window?.frame
-        cachedPoint = point
-        cachedAt = now
+        let identity = Self.onMain { () -> String? in
+            let app = window.map { NSRunningApplication(processIdentifier: $0.processID) }
+                ?? NSWorkspace.shared.frontmostApplication
+            return Self.identity(for: app)
+        }
+        lock.withLock {
+            cachedIdentity = identity
+            cachedRegion = window?.frame
+            cachedPoint = point
+            cachedAt = now
+        }
         return identity
     }
 
@@ -235,8 +266,10 @@ final class MouseAppExceptions: ObservableObject {
     }
 
     private func invalidateCache() {
-        cachedIdentity = nil
-        cachedRegion = nil
-        cachedAt = -1
+        lock.withLock {
+            cachedIdentity = nil
+            cachedRegion = nil
+            cachedAt = -1
+        }
     }
 }

--- a/Sources/Vorssaint/Services/PointerTapRunLoop.swift
+++ b/Sources/Vorssaint/Services/PointerTapRunLoop.swift
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import CoreGraphics
+import Foundation
+
+/// The run loop that serves the event taps standing in the path of ordinary
+/// clicks and wheel events.
+///
+/// An active tap holds each event it asked for until its callback returns, so a
+/// tap served by the main run loop makes every click in every app wait for
+/// whatever this app happens to be drawing, reading or asking Accessibility at
+/// that moment. Under a full-screen game that shows up as clicks arriving late
+/// and, when the wait crosses the system's limit, as events the window server
+/// drops on its way to disabling the tap.
+///
+/// This thread does nothing else: no UI, no timers, no Accessibility. A tap
+/// served here answers as soon as the event arrives, whatever the rest of the
+/// app is doing.
+enum PointerTapRunLoop {
+    /// Serves `source` on the pointer thread. The tap callback runs there, so
+    /// everything it touches has to be safe away from the main thread.
+    static func add(_ source: CFRunLoopSource) {
+        CFRunLoopAddSource(runLoop, source, .commonModes)
+    }
+
+    /// Gives the source and its port back on the thread that owns them, once
+    /// the callback that may be running there has returned.
+    ///
+    /// Never waits for that thread: a callback in flight may be asking the main
+    /// thread for the app under the pointer, and the caller is usually the main
+    /// thread itself. The port is only invalidated after the tap has been
+    /// switched off, so nothing arrives once the block has run.
+    static func remove(_ source: CFRunLoopSource, invalidating port: CFMachPort?) {
+        CFRunLoopPerformBlock(runLoop, CFRunLoopMode.commonModes.rawValue) {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+            if let port {
+                CFMachPortInvalidate(port)
+            }
+        }
+        CFRunLoopWakeUp(runLoop)
+    }
+
+    /// Built on first use: a feature that never runs never starts the thread.
+    private static let runLoop: CFRunLoop = {
+        var started: CFRunLoop?
+        let ready = DispatchSemaphore(value: 0)
+        let thread = Thread {
+            started = CFRunLoopGetCurrent()
+            // A run loop with no source of its own returns immediately; this
+            // port is never signalled and exists only to keep it alive.
+            RunLoop.current.add(NSMachPort(), forMode: .common)
+            ready.signal()
+            while true {
+                CFRunLoopRunInMode(.defaultMode, .greatestFiniteMagnitude, false)
+            }
+        }
+        thread.name = "Vorssaint Pointer Input"
+        thread.qualityOfService = .userInteractive
+        thread.start()
+        // The wait orders the write above against the read below.
+        ready.wait()
+        return started!
+    }()
+}

--- a/Sources/Vorssaint/Services/ScrollInverter.swift
+++ b/Sources/Vorssaint/Services/ScrollInverter.swift
@@ -30,8 +30,12 @@ final class ScrollInverter: ObservableObject {
 
     private var tap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
+    /// Guards the two above: the callback runs on the pointer thread while the
+    /// main thread arms and tears the tap down.
+    private let tapStateLock = NSLock()
     /// Timestamp (ns, event clock) of the last event carrying a gesture phase —
-    /// only touch devices emit those. Read/written solely on the tap callback.
+    /// only touch devices emit those. Read/written solely on the tap callback,
+    /// which is the pointer thread and nothing else.
     private var lastGesturePhaseTimestamp: UInt64?
     private var tapCreationRetryUsed = false
     private var tapCreationRetryWork: DispatchWorkItem?
@@ -65,10 +69,8 @@ final class ScrollInverter: ObservableObject {
     func suspend() { stop() }
 
     private func start() {
-        guard tap == nil else {
-            if let tap {
-                CGEvent.tapEnable(tap: tap, enable: true)
-            }
+        if let port = tapStateLock.withLock({ tap }) {
+            CGEvent.tapEnable(tap: port, enable: true)
             MouseAppExceptions.shared.setSourceTracking(true, for: .scrollDirection)
             isRunning = true
             return
@@ -104,10 +106,14 @@ final class ScrollInverter: ObservableObject {
         tapCreationRetryUsed = false
         tapCreationRetryWork?.cancel()
         tapCreationRetryWork = nil
-        self.tap = tap
         let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
-        runLoopSource = source
-        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        tapStateLock.withLock {
+            self.tap = tap
+            runLoopSource = source
+        }
+        if let source {
+            PointerTapRunLoop.add(source)
+        }
         CGEvent.tapEnable(tap: tap, enable: true)
         isRunning = true
     }
@@ -117,20 +123,21 @@ final class ScrollInverter: ObservableObject {
         tapCreationRetryWork = nil
         tapCreationRetryUsed = false
         MouseAppExceptions.shared.setSourceTracking(false, for: .scrollDirection)
-        if let tap {
-            CGEvent.tapEnable(tap: tap, enable: false)
+        let (port, source) = tapStateLock.withLock { () -> (CFMachPort?, CFRunLoopSource?) in
+            let current = (tap, runLoopSource)
+            tap = nil
+            runLoopSource = nil
+            return current
         }
-        if let runLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+        if let port {
+            CGEvent.tapEnable(tap: port, enable: false)
         }
         // Hand the tap back rather than only switching it off: a disabled tap
         // keeps its place in the chain, and a session that is switched away
         // has to stop being an event tap owner outright (issue #1075).
-        if let tap {
-            CFMachPortInvalidate(tap)
+        if let source {
+            PointerTapRunLoop.remove(source, invalidating: port)
         }
-        tap = nil
-        runLoopSource = nil
         isRunning = false
     }
 
@@ -139,8 +146,8 @@ final class ScrollInverter: ObservableObject {
         // unless this session is the one that was switched away from, where
         // the stall is the reason the tap was disabled and re-arming feeds it.
         if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
-            if SessionActivity.shared.isActive, let tap {
-                CGEvent.tapEnable(tap: tap, enable: true)
+            if SessionActivity.shared.isActive, let port = tapStateLock.withLock({ tap }) {
+                CGEvent.tapEnable(tap: port, enable: true)
             }
             return Unmanaged.passUnretained(event)
         }

--- a/Sources/Vorssaint/Services/SessionActivity.swift
+++ b/Sources/Vorssaint/Services/SessionActivity.swift
@@ -18,8 +18,13 @@ import CoreGraphics
 final class SessionActivity {
     static let shared = SessionActivity()
 
-    /// True while this session is the one on screen.
-    private(set) var isActive = false
+    /// True while this session is the one on screen. Written on the main
+    /// thread and read from the tap callbacks the pointer thread serves, so
+    /// it answers under `lock`.
+    var isActive: Bool { lock.withLock { active } }
+
+    private let lock = NSLock()
+    private var active = false
 
     private let center: NotificationCenter
     private var observers: [NSObjectProtocol] = []
@@ -45,7 +50,7 @@ final class SessionActivity {
                 self?.update(isActive: true)
             },
         ]
-        isActive = initialIsActive()
+        active = initialIsActive()
     }
 
     deinit {
@@ -58,9 +63,15 @@ final class SessionActivity {
         handlers.append(handler)
     }
 
+    /// The handlers hand taps back and build them again, so they run with the
+    /// lock released.
     private func update(isActive: Bool) {
-        guard isActive != self.isActive else { return }
-        self.isActive = isActive
+        let changed = lock.withLock { () -> Bool in
+            guard isActive != active else { return false }
+            active = isActive
+            return true
+        }
+        guard changed else { return }
         for handler in handlers { handler(isActive) }
     }
 }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -23130,9 +23130,34 @@ struct MetricsTests {
                        "\(tapOwner) does not keep a modifying tap alive after Accessibility is lost")
             }
             // Switching a tap off leaves the process owning it, which is what
-            // the window server waits on; teardown must invalidate the port.
-            expect(code.contains("CFMachPortInvalidate"),
+            // the window server waits on; teardown must invalidate the port,
+            // either here or through the pointer thread that owns the source.
+            expect(code.contains("CFMachPortInvalidate")
+                    || code.contains("PointerTapRunLoop.remove("),
                    "\(tapOwner) hands its tap back rather than only disabling it")
+        }
+
+        // The taps that filter ordinary clicks and wheel events are served by
+        // a thread of their own. On the main run loop each of those events
+        // waits for whatever this app is drawing or asking Accessibility,
+        // which is felt as click lag in whatever app is in front.
+        let pointerTapSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/PointerTapRunLoop.swift",
+            encoding: .utf8)) ?? ""
+        expect(pointerTapSource.contains("CFMachPortInvalidate"),
+               "the pointer thread hands back the port of every tap it gives up")
+        expect(pointerTapSource.contains("qualityOfService = .userInteractive"),
+               "the pointer thread is scheduled as input work")
+        for pointerTapOwner in ["Sources/Vorssaint/Services/ScrollInverter.swift",
+                                "Sources/Vorssaint/Services/MiddleClick/MiddleClickService.swift"] {
+            let source = (try? String(contentsOfFile: pointerTapOwner, encoding: .utf8)) ?? ""
+            let code = source.components(separatedBy: "\n")
+                .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+                .joined(separator: "\n")
+            expect(code.contains("PointerTapRunLoop.add("),
+                   "\(pointerTapOwner) serves its tap on the pointer thread")
+            expect(!code.contains("CFRunLoopGetMain()"),
+                   "\(pointerTapOwner) keeps its tap off the main run loop")
         }
 
         // Disabling a tap and dropping the last Swift reference does not hand
@@ -23162,7 +23187,11 @@ struct MetricsTests {
             let taps = code.components(separatedBy: "CGEvent.tapCreate").count - 1
             guard taps > 0 else { continue }
             tapOwners += 1
+            // A tap served by the pointer thread is handed back there, which
+            // is the same promise: `PointerTapRunLoop.remove` invalidates the
+            // port it is given, and the sweep above pins that it does.
             let invalidations = code.components(separatedBy: "CFMachPortInvalidate").count - 1
+                + (code.components(separatedBy: "PointerTapRunLoop.remove(").count - 1)
             if invalidations < taps {
                 tapOwnersWithoutInvalidate.append("\(file) (\(taps) taps, \(invalidations) invalidated)")
             }


### PR DESCRIPTION
An active event tap holds every event it asked for until its callback returns. The three-finger middle click and the reversed scroll direction were both served by the main run loop, so each click and each wheel tick in every app waited for whatever this app happened to be drawing, reading or asking Accessibility at that moment. A user playing a full-screen game reported exactly that: clicks arriving late across the screen, and events going missing.

Both taps now live on a thread that does nothing else. Alongside that:

- the state the main thread shares with those taps is under a lock, and the port is handed back on the thread that owns it;
- the app under the pointer is resolved on the main thread only while a list of exceptions is in play;
- reading the system's three-finger drag setting left the click path: it refreshes behind the press.

Still on the main run loop, and left for a separate change: window snapping and the window gesture, the Dock actions, smooth scrolling, the extra buttons and side-button navigation. Each of those shares state with the interface, and moving them without untangling that first would risk a stuck button, which is worse than the lag.

## Validation

- `./build.sh --test`: 9930 checks, including a new one pinning these taps off the main run loop.
- `./build.sh --dev --install`, `--selftest` and signature verification: clean.
- Thread sanitizer on the new thread host: 1200 attach/detach cycles across 4 threads, no races, every port handed back.
- Installed build, observed: the pointer thread is alive and serving its ports, both taps are registered and enabled at the same tap point as before, and three quit/relaunch cycles leave no tap behind.