### PR TITLE
Post the Super Key Escape with no modifier flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project are documented here. The format follows
 - The zoom panel's button says what it does instead of borrowing the timeline's hint to click somewhere else.
 - Slider labels shrink instead of being cut where Turkish and Spanish run past the column, in the backdrop and recording panels.
 - Clicks and scrolling no longer lag in full-screen apps and games while the three-finger middle click or the reversed scroll direction is on.
+- Tapping Super key for Escape no longer carries a modifier still reported by the keyboard. Thanks to @gatzifratzi, @PathGao and @hash00.
 
 ## [3.3.3-beta.4] - 2026-09-03
 

--- a/Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift
+++ b/Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift
@@ -798,6 +798,15 @@ final class SuperKeyService: ObservableObject {
         guard let down = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true),
               let up = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
         else { return false }
+        // An event built from the HID source starts with whatever modifier
+        // state that source reports, so a modifier still registered as down
+        // rides along and the Escape lands as Control-Escape. Most apps
+        // ignore the difference; Zed's vim mode does not. This Escape is
+        // meant to be unmodified, so say so: every other synthesized
+        // keystroke in the app assigns flags explicitly, whether that is a
+        // real shortcut's modifiers or none at all.
+        down.flags = []
+        up.flags = []
         down.post(tap: .cgSessionEventTap)
         up.post(tap: .cgSessionEventTap)
         return true

--- a/Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift
+++ b/Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift
@@ -798,13 +798,7 @@ final class SuperKeyService: ObservableObject {
         guard let down = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true),
               let up = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false)
         else { return false }
-        // An event built from the HID source starts with whatever modifier
-        // state that source reports, so a modifier still registered as down
-        // rides along and the Escape lands as Control-Escape. Most apps
-        // ignore the difference; Zed's vim mode does not. This Escape is
-        // meant to be unmodified, so say so: every other synthesized
-        // keystroke in the app assigns flags explicitly, whether that is a
-        // real shortcut's modifiers or none at all.
+        // The HID source can inherit a still-held physical modifier.
         down.flags = []
         up.flags = []
         down.post(tap: .cgSessionEventTap)


### PR DESCRIPTION
**Refs #1348** — Super key press function also inputs control

`SuperKeyService.postKey` is the only site in the app that builds a `CGEvent(keyboardEventSource:)` and posts it without ever assigning `flags`. An event created from a `.hidSystemState` source starts with the modifier state that source reports, so a modifier still registered as down rides along and the solo-tap Escape arrives as Control-Escape. Most apps ignore the difference; Zed's vim mode does not, which is how the reporter found it.

The other synthesized-keystroke sites — `TextSnippetService`, `FinderCutPaste`, `DockClickService`, `MouseButtonShortcutService`, `MouseNavigationService` — all set `flags` explicitly, including to `[]`. This makes the Super Key path match.

One thing I can't answer: why the stray flag is Control specifically. The Escape is posted from `performSoloAction`, which runs after `.triggerUp`, so the trigger's own modifier should already be clear by then. I couldn't reproduce on my hardware, so clearing the flags is the fix I'm confident in, not a confirmed account of where the Control comes from. The reporter is best placed to confirm.

## Validation

- `./build.sh --test` — TESTS OK (9924 checks)
- `./build.sh` — exit 0, 0 warnings
- `--selftest` — SELFTEST OK

Not verified on hardware: I don't have a setup that reproduces the stray Control.
