### PR TITLE
feat(capture): add recent captures shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. The format follows
 
 ### Added
 - Switching Spaces by dragging a button can follow your hand, the way a trackpad swipe does, in Mouse settings.
+- Recent captures can open from their own assignable shortcut without returning to the menu bar panel.
 
 ### Changed
 - The radial menu throws its actions out of the center one after another when it opens and gathers them back in when it closes.

--- a/Sources/Vorssaint/App/FeatureRuntime.swift
+++ b/Sources/Vorssaint/App/FeatureRuntime.swift
@@ -224,10 +224,12 @@ final class FeatureRuntime: ObservableObject {
         .screenshot: {
             ScreenCaptureService.shared.syncWithPreferences()
             ScreenshotService.shared.syncWithPreferences()
+            RecentCaptureService.shared.syncWithPreferences()
         },
         .screenRecorder: {
             ScreenCaptureService.shared.syncWithPreferences()
             ScreenRecorderService.shared.syncWithPreferences()
+            RecentCaptureService.shared.syncWithPreferences()
         },
         .cameraPreview: { CameraPreviewService.shared.syncWithPreferences() },
         .radialMenu: { RadialMenuService.shared.syncWithPreferences() },

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -525,6 +525,8 @@ enum DefaultsKey {
     static let screenshotFullScreenShortcut = "screenshotFullScreenShortcut"
     static let screenshotLastCaptureShortcutEnabled = "screenshotLastCaptureShortcutEnabled"
     static let screenshotLastCaptureShortcut = "screenshotLastCaptureShortcut"
+    static let recentCapturesShortcutEnabled = "recentCapturesShortcutEnabled"
+    static let recentCapturesShortcut = "recentCapturesShortcut"
     static let screenshotClipboardShortcutEnabled = "screenshotClipboardShortcutEnabled"
     static let screenshotClipboardShortcut = "screenshotClipboardShortcut"
     static let screenshotFreeze = "screenshotFreeze"
@@ -1265,6 +1267,8 @@ enum Defaults {
         DefaultsKey.screenshotFullScreenShortcut: GlobalShortcut.screenshotFullScreenDefault.storageValue,
         DefaultsKey.screenshotLastCaptureShortcutEnabled: false,
         DefaultsKey.screenshotLastCaptureShortcut: GlobalShortcut.screenshotLastCaptureDefault.storageValue,
+        DefaultsKey.recentCapturesShortcutEnabled: false,
+        DefaultsKey.recentCapturesShortcut: GlobalShortcut.recentCapturesDefault.storageValue,
         DefaultsKey.screenshotClipboardShortcutEnabled: false,
         DefaultsKey.screenshotClipboardShortcut: GlobalShortcut.screenshotClipboardDefault.storageValue,
         DefaultsKey.screenshotFreeze: true,

--- a/Sources/Vorssaint/Core/GlobalShortcut.swift
+++ b/Sources/Vorssaint/Core/GlobalShortcut.swift
@@ -190,6 +190,9 @@ struct GlobalShortcut: Equatable, Hashable {
     // E opens the latest capture in the editor, beside the capture shortcut.
     static let screenshotLastCaptureDefault = GlobalShortcut(keyCode: Int64(kVK_ANSI_E),
                                                              modifiers: [.control, .option, .command])
+    // H opens capture history, on the same free control-option-command layer.
+    static let recentCapturesDefault = GlobalShortcut(keyCode: Int64(kVK_ANSI_H),
+                                                      modifiers: [.control, .option, .command])
     // P opens a copied image in the editor, beside the other screenshot tools.
     static let screenshotClipboardDefault = GlobalShortcut(keyCode: Int64(kVK_ANSI_P),
                                                            modifiers: [.control, .option, .command])
@@ -657,6 +660,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
     case screenshot
     case screenshotFullScreen
     case screenshotLastCapture
+    case recentCaptures
     case screenshotClipboard
     case cameraPreview
     case radialMenu
@@ -684,6 +688,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .screenshot: return DefaultsKey.screenshotShortcut
         case .screenshotFullScreen: return DefaultsKey.screenshotFullScreenShortcut
         case .screenshotLastCapture: return DefaultsKey.screenshotLastCaptureShortcut
+        case .recentCaptures: return DefaultsKey.recentCapturesShortcut
         case .screenshotClipboard: return DefaultsKey.screenshotClipboardShortcut
         case .cameraPreview: return DefaultsKey.cameraPreviewShortcut
         case .radialMenu: return DefaultsKey.radialMenuShortcut
@@ -711,6 +716,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .screenshot: return .screenshotDefault
         case .screenshotFullScreen: return .screenshotFullScreenDefault
         case .screenshotLastCapture: return .screenshotLastCaptureDefault
+        case .recentCaptures: return .recentCapturesDefault
         case .screenshotClipboard: return .screenshotClipboardDefault
         case .cameraPreview: return .cameraPreviewDefault
         case .radialMenu: return .radialMenuDefault
@@ -745,6 +751,8 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
             return FeatureStrings.screenshot(L10n.shared.language).fullScreenShortcutTitle
         case .screenshotLastCapture:
             return FeatureStrings.screenshot(L10n.shared.language).editLastCapture
+        case .recentCaptures:
+            return FeatureStrings.recentCaptures(L10n.shared.language).title
         case .screenshotClipboard:
             return FeatureStrings.screenshot(L10n.shared.language).editClipboardImage
         case .cameraPreview: return FeatureStrings.cameraPreview(L10n.shared.language).pageTitle
@@ -790,6 +798,7 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .screenshot: return [DefaultsKey.screenshotShortcutEnabled]
         case .screenshotFullScreen: return [DefaultsKey.screenshotFullScreenShortcutEnabled]
         case .screenshotLastCapture: return [DefaultsKey.screenshotLastCaptureShortcutEnabled]
+        case .recentCaptures: return [DefaultsKey.recentCapturesShortcutEnabled]
         case .screenshotClipboard: return [DefaultsKey.screenshotClipboardShortcutEnabled]
         case .cameraPreview: return [DefaultsKey.cameraPreviewShortcutEnabled]
         case .radialMenu: return [DefaultsKey.radialMenuEnabled]
@@ -816,7 +825,8 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         case .screenOCR: return .screenOCR
         case .micMute: return .micMute
         case .quickLauncher: return .quickLauncher
-        case .screenshot, .screenshotFullScreen, .screenshotLastCapture, .screenshotClipboard:
+        case .screenshot, .screenshotFullScreen, .screenshotLastCapture, .recentCaptures,
+             .screenshotClipboard:
             return .screenshot
         case .cameraPreview: return .cameraPreview
         case .radialMenu: return .radialMenu
@@ -827,10 +837,13 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
         }
     }
 
-    /// Every capture role follows its own tool: the shortcut opens the shared
-    /// chooser on that mode, so it lives and dies with the mode itself.
+    /// Capture roles normally follow their own tool. Shared capture history
+    /// stays available while either kind of capture that fills it is installed.
     var availabilityFeatures: [AppFeature] {
-        [feature]
+        switch self {
+        case .recentCaptures: return [.screenshot, .screenRecorder]
+        default: return [feature]
+        }
     }
 
     func isAvailable(using isAvailable: (AppFeature) -> Bool) -> Bool {
@@ -874,10 +887,10 @@ enum GlobalShortcutRole: CaseIterable, Identifiable {
     static let captureFeatures: [AppFeature] =
         [.screenshot, .screenRecorder, .screenOCR, .colorPicker]
 
-    /// Chooser tools first, in chooser order, then the screenshot extras.
+    /// Chooser tools first, in chooser order, then shared history and screenshot extras.
     static let captureDisplayOrder: [GlobalShortcutRole] = [
         .screenshot, .screenRecorder, .screenOCR, .colorPicker,
-        .screenshotFullScreen, .screenshotLastCapture, .screenshotClipboard,
+        .recentCaptures, .screenshotFullScreen, .screenshotLastCapture, .screenshotClipboard,
     ]
 
     /// The given roles narrowed to the capture group, in display order. The

--- a/Sources/Vorssaint/Services/QuickTools/RecentCaptureService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/RecentCaptureService.swift
@@ -41,7 +41,7 @@ final class RecentCaptureService: ObservableObject {
     @Published private(set) var shortcutRegistrationFailed = false
 
     private let manager = FileManager.default
-    private let hotkey = QuickToolHotkey(id: 25)
+    private let hotkey = QuickToolHotkey(id: 21)
     private let queue = DispatchQueue(label: "com.vorssaint.utils.recent-captures",
                                       qos: .utility)
     private let generationLock = NSLock()

--- a/Sources/Vorssaint/Services/QuickTools/RecentCaptureService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/RecentCaptureService.swift
@@ -38,8 +38,10 @@ final class RecentCaptureService: ObservableObject {
     static let shared = RecentCaptureService()
 
     @Published private(set) var entries: [RecentCaptureEntry] = []
+    @Published private(set) var shortcutRegistrationFailed = false
 
     private let manager = FileManager.default
+    private let hotkey = QuickToolHotkey(id: 25)
     private let queue = DispatchQueue(label: "com.vorssaint.utils.recent-captures",
                                       qos: .utility)
     private let generationLock = NSLock()
@@ -54,7 +56,23 @@ final class RecentCaptureService: ObservableObject {
     private var panelDeactivateObserver: NSObjectProtocol?
 
     private init() {
+        hotkey.onPress = { [weak self] in self?.showHistoryWindow() }
         reload()
+    }
+
+    func syncWithPreferences() {
+        let available = AppFeature.screenshot.isAvailable || AppFeature.screenRecorder.isAvailable
+        let enabled = available
+            && UserDefaults.standard.bool(forKey: DefaultsKey.recentCapturesShortcutEnabled)
+        let shortcut = GlobalShortcut.saved(for: DefaultsKey.recentCapturesShortcut,
+                                            fallback: .recentCapturesDefault)
+        shortcutRegistrationFailed = !hotkey.sync(enabled: enabled, shortcut: shortcut)
+        if !available { hideHistoryWindow() }
+    }
+
+    func suspend() {
+        hotkey.unregister()
+        hideHistoryWindow()
     }
 
     // MARK: - History palette
@@ -62,6 +80,9 @@ final class RecentCaptureService: ObservableObject {
     func showHistoryWindow() {
         guard Thread.isMainThread else {
             DispatchQueue.main.async { [weak self] in self?.showHistoryWindow() }
+            return
+        }
+        guard AppFeature.screenshot.isAvailable || AppFeature.screenRecorder.isAvailable else {
             return
         }
         let anchor = NSApp.keyWindow?.isVisible == true ? NSApp.keyWindow : nil

--- a/Sources/Vorssaint/Services/SelfUninstall.swift
+++ b/Sources/Vorssaint/Services/SelfUninstall.swift
@@ -96,6 +96,7 @@ enum SelfUninstall {
         PastePlainService.shared.suspend()
         SnippetLibraryService.shared.suspend()
         ScreenCaptureService.shared.suspend()
+        RecentCaptureService.shared.suspend()
         QuickLauncherService.shared.suspend()
         ScreenTextService.shared.suspend()
         CameraPreviewService.shared.suspend()

--- a/Sources/Vorssaint/UI/Settings/ScreenCaptureSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/ScreenCaptureSettings.swift
@@ -43,6 +43,9 @@ struct ScreenCaptureSettings: View {
                     }
                     ToolShortcutRows(tool: currentTool, keys: currentTool.dedicatedShortcut)
                         .id(currentTool)
+                    if AppFeature.screenshot.isAvailable || AppFeature.screenRecorder.isAvailable {
+                        RecentCapturesShortcutRows()
+                    }
                 } header: {
                     Text(strings.screenCaptureTitle)
                 }
@@ -92,6 +95,30 @@ struct ScreenCaptureSettings: View {
         }
         if !availableTools.contains(selectedTool), let first = availableTools.first {
             selectedTool = first
+        }
+    }
+}
+
+/// Capture history belongs to screenshots and recordings together, so its
+/// shortcut stays visible whichever of those tools is selected.
+private struct RecentCapturesShortcutRows: View {
+    @ObservedObject private var l10n = L10n.shared
+    @ObservedObject private var service = RecentCaptureService.shared
+    @AppStorage(DefaultsKey.recentCapturesShortcutEnabled) private var enabled = false
+
+    var body: some View {
+        let role = GlobalShortcutRole.recentCaptures
+        Toggle(role.title(l10n.s), isOn: $enabled)
+            .onChange(of: enabled) { _, _ in
+                service.syncWithPreferences()
+            }
+        ShortcutPreferenceRow(role: role, isEnabled: enabled) {
+            service.syncWithPreferences()
+        }
+        if enabled, service.shortcutRegistrationFailed {
+            Text(l10n.s.shortcutUnavailable)
+                .font(.caption)
+                .foregroundStyle(.orange)
         }
     }
 }

--- a/Sources/Vorssaint/UI/Settings/ShortcutsSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/ShortcutsSettings.swift
@@ -167,7 +167,7 @@ struct ShortcutsSettings: View {
                 return WindowLayoutService.shared.shortcutConflictTitle(shortcut, excluding: nil)
             },
             onChange: {
-                FeatureRuntime.shared.sync([role.feature])
+                FeatureRuntime.shared.sync(role.availabilityFeatures)
             }
         )
     }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -16858,7 +16858,7 @@ struct MetricsTests {
         let recentCaptureServiceSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/Services/QuickTools/RecentCaptureService.swift",
             encoding: .utf8)) ?? ""
-        expect(recentCaptureServiceSource.contains("QuickToolHotkey(id: 25)")
+        expect(recentCaptureServiceSource.contains("QuickToolHotkey(id: 21)")
                 && recentCaptureServiceSource.contains(
                     "hotkey.onPress = { [weak self] in self?.showHistoryWindow() }")
                 && featureRuntimeSource.components(separatedBy:

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -16852,8 +16852,18 @@ struct MetricsTests {
             encoding: .utf8)) ?? ""
         expect(captureSettingsSource.contains("selectedTool")
                 && captureSettingsSource.contains(".pickerStyle(.segmented)")
-                && captureSettingsSource.contains("ToolShortcutRows(tool: currentTool"),
-               "the capture page uses a segmented picker with tool-specific shortcuts in the top section")
+                && captureSettingsSource.contains("ToolShortcutRows(tool: currentTool")
+                && captureSettingsSource.contains("RecentCapturesShortcutRows()"),
+               "the capture page keeps tool and shared-history shortcuts in the top section")
+        let recentCaptureServiceSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/QuickTools/RecentCaptureService.swift",
+            encoding: .utf8)) ?? ""
+        expect(recentCaptureServiceSource.contains("QuickToolHotkey(id: 25)")
+                && recentCaptureServiceSource.contains(
+                    "hotkey.onPress = { [weak self] in self?.showHistoryWindow() }")
+                && featureRuntimeSource.components(separatedBy:
+                    "RecentCaptureService.shared.syncWithPreferences()").count == 3,
+               "the history shortcut opens its window and follows both capture producers")
         expect(!ScreenshotSupport.captureAvailabilityChanged(
                     activeTools: [.screenshot, .recording],
                     availableTools: [.screenshot, .recording])
@@ -17705,6 +17715,12 @@ struct MetricsTests {
         expect(Defaults.registeredDefaults[DefaultsKey.screenshotLastCaptureShortcut] as? String
                 == "control+option+command:14",
                "the latest screenshot editor shortcut defaults to control option command E")
+        expect(Defaults.registeredDefaults[DefaultsKey.recentCapturesShortcutEnabled]
+                as? Bool == false,
+               "the recent captures shortcut ships off")
+        expect(Defaults.registeredDefaults[DefaultsKey.recentCapturesShortcut] as? String
+                == "control+option+command:4",
+               "the recent captures shortcut defaults to control option command H")
         expect(ScreenshotShareDuration.allCases.map(\.rawValue) == [3_600, 21_600, 86_400],
                "temporary links allow only one, six or twenty-four hours")
         let testShareEndpoint = ScreenshotSharingSupport.endpoint(
@@ -17765,8 +17781,10 @@ struct MetricsTests {
         expect(!GlobalShortcutRole.availableRoles(isAvailable: recordingOnly.contains)
                 .contains(.screenshot)
                 && GlobalShortcutRole.availableRoles(isAvailable: recordingOnly.contains)
-                    .contains(.screenRecorder),
-               "a recording-only install shows only the recorder's own shortcut")
+                    .contains(.screenRecorder)
+                && GlobalShortcutRole.availableRoles(isAvailable: recordingOnly.contains)
+                    .contains(.recentCaptures),
+               "a recording-only install keeps the recorder and shared capture history shortcuts")
         expect(GlobalShortcutRole.screenshotFullScreen.requiredEnableKeys
                 == [DefaultsKey.screenshotFullScreenShortcutEnabled]
                 && GlobalShortcutRole.screenshotFullScreen.feature == .screenshot,
@@ -17775,6 +17793,11 @@ struct MetricsTests {
                 == [DefaultsKey.screenshotLastCaptureShortcutEnabled]
                 && GlobalShortcutRole.screenshotLastCapture.feature == .screenshot,
                "the latest screenshot shortcut gates on its own toggle and the screenshot feature")
+        expect(GlobalShortcutRole.recentCaptures.requiredEnableKeys
+                == [DefaultsKey.recentCapturesShortcutEnabled]
+                && GlobalShortcutRole.recentCaptures.availabilityFeatures
+                    == [.screenshot, .screenRecorder],
+               "the recent captures shortcut follows either feature that fills its history")
         expect(Defaults.registeredDefaults[DefaultsKey.screenshotClipboardShortcutEnabled]
                 as? Bool == false
                 && Defaults.registeredDefaults[DefaultsKey.screenshotClipboardShortcut] as? String
@@ -19579,6 +19602,8 @@ struct MetricsTests {
                 && backupKeys.contains(DefaultsKey.screenshotToolShortcutsEnabled)
                 && backupKeys.contains(DefaultsKey.screenshotLastCaptureShortcutEnabled)
                 && backupKeys.contains(DefaultsKey.screenshotLastCaptureShortcut)
+                && backupKeys.contains(DefaultsKey.recentCapturesShortcutEnabled)
+                && backupKeys.contains(DefaultsKey.recentCapturesShortcut)
                 && backupKeys.contains(DefaultsKey.screenshotClipboardShortcutEnabled)
                 && backupKeys.contains(DefaultsKey.screenshotClipboardShortcut)
                 && backupKeys.contains(DefaultsKey.screenshotPreviewPosition)


### PR DESCRIPTION
## Summary

- add an opt-in global shortcut that opens Recent Captures
- keep it available while screenshots or screen recording is installed
- expose it in Screen Capture and the central shortcut editor, with backup coverage

## Testing

- ./build.sh --test (TESTS OK, 9934 checks)
- ./build.sh --dev --install
- installed Developer executable: SELFTEST OK
- installed Developer signature verified with Team ID 3D485NHW29