### PR TITLE
Point previous window at symbolic hotkey 220, not 28

### DIFF
--- a/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
+++ b/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
@@ -50,7 +50,13 @@ enum SwitcherNativeSymbolicHotKey: Int32, CaseIterable, Hashable {
     case commandTab = 1
     case commandShiftTab = 2
     case nextWindow = 27
-    case previousWindow = 28
+    // Previous window is 220, not 28. 28 is "Save picture of screen as a
+    // file", the ⌘⇧3 screenshot key, which sits on the 3 key rather than the
+    // grave key. Because the take-over matches each id's live combination
+    // against the switcher shortcuts and allows an extra Shift for the
+    // reverse direction, the wrong id both handed ⌘⇧3 to a switcher shortcut
+    // on the 3 key and left the real ⌘⇧` with macOS.
+    case previousWindow = 220
 }
 
 struct SwitcherNativeHotkeyTransition: Equatable {


### PR DESCRIPTION
**Refs #1355** — App Switcher take-over switches off macOS ⌘⇧3 and leaves ⌘⇧` with macOS

`SwitcherNativeSymbolicHotKey.previousWindow` was 28. 28 is "Save picture of screen as a file"; the previous-window key is 220. Since the take-over matches each id's live combination against the switcher shortcuts and allows an extra Shift for the reverse direction, the wrong id both let a switcher shortcut on the 3 key claim ⌘⇧3, and left the real ⌘⇧` with macOS so the reverse direction was only half taken over.

The reporter diagnosed this precisely; I only confirmed it and changed the constant.

## Confirmation

Read back from the live WindowServer table on macOS 27.0 via `CGSGetSymbolicHotKeyValue`:

```
id=27   keyCode=50 (`)  mods=0x100000 (⌘)    → ⌘`   next window
id=28   keyCode=20 (3)  mods=0x120000 (⌘⇧)   → ⌘⇧3  screenshot to file
id=220  keyCode=50 (`)  mods=0x120000 (⌘⇧)   → ⌘⇧`  previous window
```

The existing coverage in `MetricsTests.swift` already models `.previousWindow` as ⌘⇧` on the grave key, so the tests were describing the intended semantics while the raw value disagreed. They pass unchanged.

## Validation

- `./build.sh --test` — TESTS OK (9944 checks)
- `./build.sh` — exit 0, 0 warnings
- `--selftest` — SELFTEST OK

Not verified end to end: I did not exercise the take-over against a live WindowServer with the option enabled, so the id mapping above is read-back evidence rather than a behavioural test. Worth a confirmation from the reporter, who can reproduce both halves.
