### PR TITLE
fix(switcher): centre a grid card's name over the app name under it

### DIFF
--- a/Sources/Vorssaint/UI/Switcher/DockPreviewPanelView.swift
+++ b/Sources/Vorssaint/UI/Switcher/DockPreviewPanelView.swift
@@ -522,6 +522,7 @@ private struct DockPreviewCard: View {
                 ScrollingTitle(text: window.displayTitle,
                                weight: isSelected ? .semibold : .regular,
                                width: DockPreviewSupport.cardTitleTextWidth,
+                               alignment: .leading,
                                scrolls: isHovering)
                     .foregroundStyle(.primary)
                 if let subtitle = window.displaySubtitle {

--- a/Sources/Vorssaint/UI/Switcher/ScrollingTitle.swift
+++ b/Sources/Vorssaint/UI/Switcher/ScrollingTitle.swift
@@ -12,6 +12,12 @@ struct ScrollingTitle: View {
     let text: String
     let weight: Font.Weight
     let width: CGFloat
+    /// Where a name short enough to fit sits in its band: centred under a grid
+    /// thumbnail, like every other label in the switcher, and on the leading
+    /// edge in a column that carries controls beside it. A name too long to fit
+    /// fills the band either way, and a scrolling one always starts from the
+    /// leading edge.
+    let alignment: Alignment
     let scrolls: Bool
 
     @State private var began: Date?
@@ -41,7 +47,7 @@ struct ScrollingTitle: View {
             }
         }
         .font(.system(size: Self.size, weight: weight))
-        .frame(width: width, alignment: .leading)
+        .frame(width: width, alignment: alignment)
     }
 
     /// Two copies a gap apart, slid left and wrapped, so the name reads

--- a/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
+++ b/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
@@ -974,6 +974,7 @@ private struct WindowCard: View {
                 ScrollingTitle(text: window.displayTitle,
                                weight: isSelected ? .semibold : .regular,
                                width: SwitcherGridCard.titleWidth,
+                               alignment: .center,
                                scrolls: isHovering)
                     .foregroundStyle(isSelected ? .primary : .secondary)
                 if let subtitle = window.displaySubtitle {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -9677,6 +9677,17 @@ struct MetricsTests {
         expect(switcherCardSource.contains("ScrollingTitle(")
                && dockPreviewCardSource.contains("ScrollingTitle("),
                "the App Switcher and the Dock preview both draw their name through it")
+        // One view, hung differently by each panel. Pinning it to the leading
+        // edge in both left a grid card's name and the app name under it on two
+        // different axes, which reads as a broken card rather than a choice.
+        expect(scrollingTitleSource.contains(".frame(width: width, alignment: alignment)"),
+               "the shared name view is told where to sit instead of always taking the leading edge")
+        expect(sourceBody(of: switcherCardSource, from: "ScrollingTitle(", to: "scrolls:")
+                .contains("alignment: .center"),
+               "a grid card centres the window's name over the app name under it")
+        expect(sourceBody(of: dockPreviewCardSource, from: "ScrollingTitle(", to: "scrolls:")
+                .contains("alignment: .leading"),
+               "a Dock preview card keeps the name on the leading edge, beside its two buttons")
         expect(!DockPreviewSupport.showsPanelHeader(isPinned: false),
                "a hovered panel draws no header, whatever it is showing")
         expect(DockPreviewSupport.showsPanelHeader(isPinned: true),


### PR DESCRIPTION
## Summary

In an App Switcher grid card the window's name and the app name under it sat on
two different axes: the shared scrolling title pinned itself to the leading edge
while the app name below stayed centred, so a short name read as a broken card.
3.3.2 drew the name centred; it moved to the leading edge when both panels
started sharing one title view.

The alignment now comes from the caller. The grid centres it, where every other
label in the switcher already sits centred under its picture, and the Dock
preview keeps the leading edge, because its column carries the close and
minimize buttons beside it. A name too long to fit fills the band either way,
and a scrolling one still starts from the leading edge.

No changelog entry: the mismatch only ever shipped in 3.3.3-beta.3 and beta.4,
never in an official version.

## Verification

MacBook (M4), macOS 27 beta, Command Line Tools only, local Developer build.

```sh
./build.sh --test              # TESTS OK (9947 checks)
./build.sh --dev --install     # clean, Developer ID + hardened runtime
./build/VorssaintDeveloper --selftest   # SELFTEST OK
codesign --verify --strict --deep "/Applications/Vorssaint (Developer).app"
```

The three new checks are regression checks, not description: flipping the grid
card back to the leading edge fails the run (`TESTS FAILED (1 of 9947)`).

Not verified: nothing was checked by eye or driven through the live switcher.
