### PR TITLE
fix(color-picker): preserve sampled color profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Summary
+Vorssaint adds edge snap controls and a shortcut for recent captures, refines the radial menu, and improves color picking, readability, localization and input behavior.
+
 ### Added
 - Switching Spaces by dragging a button can follow your hand, the way a trackpad swipe does, in Mouse settings.
 - Recent captures can open from their own assignable shortcut without returning to the menu bar panel.
@@ -17,6 +20,7 @@ All notable changes to this project are documented here. The format follows
 - Panel outlines answer the system's Increase Contrast, which they were ignoring while already following reduced motion and transparency.
 
 ### Fixed
+- Color picking copies the sampled pixel's correct color and shows matching values in the magnifier. Thanks to @MaksimEgorov.
 - Installing a build you compiled yourself keeps its system permissions across rebuilds, where only the Developer variant was protected. Thanks to @hash00 and @PathGao.
 - The Keep Awake option for no icon shows the crossed-out circle it promised, where the bar across it was never drawn.
 - Saving the scratchpad to a file says so when it cannot be written, where a full disk or a read-only volume ended in silence.

--- a/Sources/Vorssaint/Services/QuickTools/QuickToolsSupport.swift
+++ b/Sources/Vorssaint/Services/QuickTools/QuickToolsSupport.swift
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Vorssaint
 
-import Foundation
+import AppKit
 
 /// How a sampled color lands on the clipboard.
 enum ColorCopyFormat: String, CaseIterable, Identifiable {
@@ -28,6 +28,22 @@ enum ColorCopyFormat: String, CaseIterable, Identifiable {
 }
 
 enum QuickToolsSupport {
+    static func sampledColor(in image: CGImage, x: Int, y: Int) -> NSColor? {
+        guard let pixel = image.cropping(to: CGRect(x: x, y: y, width: 1, height: 1))
+        else { return nil }
+        let bitmap = NSBitmapImageRep(cgImage: pixel)
+        guard let color = bitmap.colorAt(x: 0, y: 0) else { return nil }
+        // colorAt returns the pixel's components tagged as a generic color
+        // space. Preserve the bitmap's profile before converting to sRGB.
+        var components = [CGFloat](repeating: 0, count: color.numberOfComponents)
+        color.getComponents(&components)
+        guard components.count == bitmap.colorSpace.numberOfColorComponents + 1
+        else { return nil }
+        return NSColor(colorSpace: bitmap.colorSpace,
+                       components: components,
+                       count: components.count)
+    }
+
     /// Formats sRGB components (0...1) in the chosen copy format. Components
     /// out of range are clamped so extended-gamut samples never produce
     /// invalid strings. `bareHex` drops the leading # (issue #168: some design

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotSelectionController.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotSelectionController.swift
@@ -628,8 +628,7 @@ final class ScreenshotSelectionController {
             imageSize: CGSize(width: image.width, height: image.height))
         let x = min(max(Int(point.x.rounded(.down)), 0), image.width - 1)
         let y = min(max(Int(point.y.rounded(.down)), 0), image.height - 1)
-        guard let pixel = image.cropping(to: CGRect(x: x, y: y, width: 1, height: 1)),
-              let color = NSBitmapImageRep(cgImage: pixel).colorAt(x: 0, y: 0)
+        guard let color = QuickToolsSupport.sampledColor(in: image, x: x, y: y)
         else {
             finish(.failed)
             return
@@ -1327,9 +1326,7 @@ private final class ScreenshotOverlayView: NSView {
         let x = min(max(Int(pixelPoint.x.rounded(.down)), 0), image.width - 1)
         let y = min(max(Int(pixelPoint.y.rounded(.down)), 0), image.height - 1)
         let point = CGPoint(x: x, y: y)
-        guard let pixel = image.cropping(to: CGRect(x: x, y: y, width: 1, height: 1))
-        else { return (nil, point) }
-        return (NSBitmapImageRep(cgImage: pixel).colorAt(x: 0, y: 0), point)
+        return (QuickToolsSupport.sampledColor(in: image, x: x, y: y), point)
     }
 
     /// Readout bar under the magnifier: a swatch of the pixel under the

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -10528,6 +10528,36 @@ struct MetricsTests {
                     "rgb(51, 102, 153)",
                     "bare hex option leaves the other copy formats untouched")
 
+        // Sample known pixels, including an ICC profile, through the same
+        // path used by color confirmation and the magnifier's readout/copy.
+        for profile in [CGColorSpace.sRGB, CGColorSpace.displayP3] {
+            let space = CGColorSpace(name: profile)!
+            let bytes: [UInt8] = [0, 0, 255, 255, 153, 102, 51, 255]
+            let image = CGImage(width: 2, height: 1, bitsPerComponent: 8, bitsPerPixel: 32,
+                                bytesPerRow: 8, space: space,
+                                bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedFirst.rawValue)
+                                    .union(.byteOrder32Little),
+                                provider: CGDataProvider(data: Data(bytes) as CFData)!,
+                                decode: nil, shouldInterpolate: false, intent: .defaultIntent)!
+            let sampled = QuickToolsSupport.sampledColor(in: image, x: 1, y: 0)?.usingColorSpace(.sRGB)
+            let expected = NSColor(cgColor: CGColor(colorSpace: space,
+                                                   components: [0.2, 0.4, 0.6, 1])!)!
+                .usingColorSpace(.sRGB)!
+            expect(sampled != nil, "color picker reads the chosen pixel in \(profile)")
+            if let sampled {
+                expectClose(sampled.redComponent, expected.redComponent, "sampled red respects \(profile)")
+                expectClose(sampled.greenComponent, expected.greenComponent, "sampled green respects \(profile)")
+                expectClose(sampled.blueComponent, expected.blueComponent, "sampled blue respects \(profile)")
+                if profile == CGColorSpace.sRGB {
+                    expectEqual(QuickToolsSupport.colorString(red: sampled.redComponent,
+                                                             green: sampled.greenComponent,
+                                                             blue: sampled.blueComponent,
+                                                             format: .hex),
+                                "#336699", "color picker preserves a known sRGB hex")
+                }
+            }
+        }
+
         let ocrLines = [
             QuickToolsSupport.RecognizedLine(text: "world", x: 0.5, y: 0.8),
             QuickToolsSupport.RecognizedLine(text: "hello", x: 0.1, y: 0.81),


### PR DESCRIPTION
## Summary

The capture overlay could turn an sRGB `#336699` pixel into `#407AAA` because pixel sampling returned the components with a generic color profile. Preserve the bitmap's actual profile before converting to sRGB, using the same sampling path for click confirmation, the magnifier readout and copying with C.

## Verification

On Apple Silicon with macOS 27.0 (26A5425a), using the macOS 26 SDK:

- `./build.sh --test`: 9,953 checks, including known BGRA pixels in sRGB and Display P3.
- `./build.sh --dev --install`, the installed executable's `--selftest`, and strict Developer ID signature verification passed.
- The reporter's physical three-display setup was not exercised; the color mismatch was reproduced with pixels in memory.

Refs #1351
