### PR TITLE
fix(tests): ramp the pool starvation check until the pool starves

### DIFF
--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -13223,27 +13223,33 @@ struct MetricsTests {
         // one more worker doing it. Waiting on the child itself is immune, so
         // the pool the runner starved can no longer starve the runner.
         let poolGate = DispatchSemaphore(value: 0)
-        let poolOccupied = DispatchSemaphore(value: 0)
-        // The dispatch pool's soft limit is 64 threads blocked in synchronous
-        // work; one block per thread takes every one of them.
-        for _ in 0..<64 {
-            DispatchQueue.global(qos: .utility).async {
-                poolOccupied.signal()
-                poolGate.wait()
+        // How many threads the pool lets block in synchronous work before it
+        // stops serving anything follows the machine rather than a documented
+        // number, so the blocks ramp until a probe submitted to the pool times
+        // out. A fixed count leaves this check passing without ever reaching
+        // the starvation it needs on a Mac whose ceiling is higher.
+        var blockedWorkers = 0
+        var poolIsStarved = false
+        var starvedProbe: DispatchSemaphore?
+        while !poolIsStarved && blockedWorkers < 256 {
+            for _ in 0..<32 {
+                blockedWorkers += 1
+                DispatchQueue.global(qos: .utility).async { poolGate.wait() }
             }
+            let probe = DispatchSemaphore(value: 0)
+            DispatchQueue.global(qos: .utility).async { probe.signal() }
+            starvedProbe = probe
+            poolIsStarved = probe.wait(timeout: .now() + 0.5) == .timedOut
         }
-        var occupiedWorkers = 0
-        for _ in 0..<64 where poolOccupied.wait(timeout: .now() + 5) == .success { occupiedWorkers += 1 }
-        let starvedProbe = DispatchSemaphore(value: 0)
-        DispatchQueue.global(qos: .utility).async { starvedProbe.signal() }
-        let poolIsStarved = starvedProbe.wait(timeout: .now() + 0.5) == .timedOut
         let starvedStarted = Date()
         let starvedPoolProcess = BoundedProcessRunner.run(
             "/bin/echo", ["ready"], timeout: 1, maxOutputBytes: 1_024)
         let starvedPoolElapsed = Date().timeIntervalSince(starvedStarted)
-        for _ in 0..<64 { poolGate.signal() }
-        _ = starvedProbe.wait(timeout: .now() + 5)
-        expect(occupiedWorkers == 64 && poolIsStarved,
+        // One signal per block submitted, running or still queued, so the rest
+        // of this file never runs against workers parked on the gate.
+        for _ in 0..<blockedWorkers { poolGate.signal() }
+        _ = starvedProbe?.wait(timeout: .now() + 5)
+        expect(poolIsStarved,
                "the dispatch pool starvation this check needs was actually reached")
         expect(!starvedPoolProcess.timedOut && starvedPoolProcess.status == 0
                 && String(decoding: starvedPoolProcess.output, as: UTF8.self) == "ready\n"


### PR DESCRIPTION
## Summary

The starvation check could not reach its own precondition on this Mac, so it
stopped proving anything: it submitted 64 blocking tasks, took that for the
pool's ceiling, and asserted `occupiedWorkers == 64 && poolIsStarved`. All 64
started, the pool served the probe well inside 0.5 s, `poolIsStarved` was false,
and the check failed while the runner it guards was fine. The ceiling here is 90
threads, not 64 — #1172 has the ramp table.

This is the shape you suggested. `poolOccupied` goes, since it counted a proxy
for what the probe measures directly, and the blocks ramp 32 at a time until a
probe submitted to the pool times out. Nothing is pinned to a machine: a Mac
that starves at 64 stops on the second round, and one that starves later keeps
going to the 256 cap, where the assertion still fails rather than passing
quietly.

On the trap you named: the count is one variable. `blockedWorkers` is
incremented at submit and is exactly what the release loop signals, so the two
cannot drift apart and leave workers parked on `poolGate` for the remaining
~9900 assertions. It counts submissions rather than starts on purpose — once
the pool is starved some blocks are still queued, and each of those needs its
signal too.

One thing your sketch does not show and the code needs: the probe is a fresh
`let` inside each round, with the last one kept in `starvedProbe`. A `var`
reassigned in the loop is captured by reference, so an earlier round's closure
would signal the newest semaphore instead of its own. The wait after the release
still drains the timed-out probe before the rest of the file runs.

The assertion this guards — a subprocess watched off the dispatch pool — is
unchanged.

## Verification

MacBook Pro, Apple M5 Max, 18 cores (6P + 12E), 48 GB, macOS 26.5.1 (25F80),
own build from source.

`./build.sh --test` on this branch: 1 of 9968 failed, and it is not this one.
`./build.sh --test` on clean `origin/main` at 7bb9c80, detached worktree, same
session: 2 of 9968 failed — this check, and `App Switcher icon-row hints
describe default app and window shortcuts`. So the branch removes exactly the
one it targets and introduces nothing.

The switcher-hints failure is unrelated to this change and also present before
it. It is the same class of problem in a different place: the test expects
``⌘ ` `` while `GlobalShortcut.keyLabel` resolves that key through the active
keyboard layout, and this Mac runs Turkish-QWERTY-PC, where that key is not a
backtick. Happy to open it separately rather than fold it in here.

Instrumented run of this branch, printing what it measured:

```
blockedWorkers=96 poolIsStarved=true starvedPoolElapsed=0.0069 activeProcessors=18
```

96 is the first round past the 90-thread ceiling #1172 measured, and the pool
serves normally again after the release.

`./build.sh`: no warnings, and `./build/Vorssaint --selftest` reports `SELFTEST OK`. Neither
exercises this file — the app build does not compile the tests — but both were
run on the branch.

What I could not test: a Mac whose ceiling is at or below 64, which is what CI
has been exercising all along — there the first or second round should trip the
probe, but I have no machine here that does it. Nor a Mac that never starves
within 256 blocks; that path only turns a silent pass into the same assertion
failure.

## Anything else

Refs #1172
