### PR TITLE
fix(mouse): keep acceleration disabled after reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project are documented here. The format follows
 ## [Unreleased]
 
 ### Summary
-Vorssaint adds edge snap controls and a shortcut for recent captures, refines the radial menu, and improves color picking, app icons, readability, localization and input behavior.
+Vorssaint adds edge snap controls and a shortcut for recent captures, refines the radial menu, and improves color picking, app icons, readability, localization and mouse reconnection behavior.
 
 ### Added
 - Switching Spaces by dragging a button can follow your hand, the way a trackpad swipe does, in Mouse settings.
@@ -20,6 +20,7 @@ Vorssaint adds edge snap controls and a shortcut for recent captures, refines th
 - Panel outlines answer the system's Increase Contrast, which they were ignoring while already following reduced motion and transparency.
 
 ### Fixed
+- Mouse acceleration stays disabled after disconnecting and reconnecting a mouse.
 - The App Switcher shows supported alternate app icons without flickering during navigation. Thanks to @EugeneCarldotme and @hash00.
 - Color picking copies the sampled pixel's correct color and shows matching values in the magnifier. Thanks to @MaksimEgorov.
 - Installing a build you compiled yourself keeps its system permissions across rebuilds, where only the Developer variant was protected. Thanks to @hash00 and @PathGao.

--- a/Sources/Vorssaint/Services/MouseAcceleration/MouseAccelerationRecovery.swift
+++ b/Sources/Vorssaint/Services/MouseAcceleration/MouseAccelerationRecovery.swift
@@ -15,7 +15,8 @@ enum MouseAccelerationRecovery {
         return restorePending(using: client)
     }
 
-    static func restorePending(using client: IOHIDEventSystemClient) -> Bool {
+    static func restorePending(using client: IOHIDEventSystemClient,
+                               preservingConnectedEntries: Bool = false) -> Bool {
         guard var journal = loadJournal(),
               let services = services(using: client) else { return false }
 
@@ -25,8 +26,9 @@ enum MouseAccelerationRecovery {
             servicesByID[id] = service
         }
         let reservedRegistryIDs = Set(journal.entries.map(\.registryID))
+        let connectedDevices = preservingConnectedEntries ? servicesByID.compactMapValues(identity(of:)) : [:]
 
-        for entry in journal.entries {
+        for entry in journal.entriesToRestore(preserving: connectedDevices) {
             guard let service = service(for: entry,
                                         in: services,
                                         servicesByID: servicesByID,

--- a/Sources/Vorssaint/Services/MouseAcceleration/MouseAccelerationService.swift
+++ b/Sources/Vorssaint/Services/MouseAcceleration/MouseAccelerationService.swift
@@ -13,6 +13,8 @@ final class MouseAccelerationService {
     private let defaults = UserDefaults.standard
     private var client: IOHIDEventSystemClient?
     private var hidManager: IOHIDManager?
+    private var reapplySchedule = MouseAccelerationReapplySchedule()
+    private var reapplyWork: DispatchWorkItem?
     private var recoveryGuard: MouseAccelerationGuard.Handle?
     private var lifecycleObservers: [NSObjectProtocol] = []
     private var sessionIsActive = false
@@ -64,6 +66,7 @@ final class MouseAccelerationService {
         self.client = client
         startDeviceObservation()
         applyLinearMode()
+        scheduleDeviceReapplication()
     }
 
     @discardableResult
@@ -146,14 +149,33 @@ final class MouseAccelerationService {
     private static let deviceChanged: IOHIDDeviceCallback = { context, _, _, _ in
         guard let context else { return }
         let service = Unmanaged<MouseAccelerationService>.fromOpaque(context).takeUnretainedValue()
-        // Let the event-system service settle after the physical-device callback.
-        DispatchQueue.main.async { [weak service] in service?.recoverAndApplyLinearMode() }
+        service.scheduleDeviceReapplication()
     }
 
-    private func recoverAndApplyLinearMode() {
-        guard let client else { return }
-        _ = MouseAccelerationRecovery.restorePending(using: client)
-        applyLinearMode()
+    private func scheduleDeviceReapplication() {
+        guard client != nil, featureWanted, sessionIsActive, systemIsAwake else { return }
+        reapplyWork?.cancel()
+        scheduleDeviceReapplication(for: reapplySchedule.restart())
+    }
+
+    private func scheduleDeviceReapplication(for token: UUID) {
+        guard let delay = reapplySchedule.nextDelay(for: token) else { return }
+        let work = DispatchWorkItem { [weak self] in
+            guard let self, self.reapplySchedule.isCurrent(token) else { return }
+            self.reapplyWork = nil
+            guard self.client != nil, self.featureWanted,
+                  self.sessionIsActive, self.systemIsAwake else { return }
+            // Physical-device callbacks can precede the event-system service, and
+            // its initial settings can arrive later still. Read a fresh service list.
+            let client = IOHIDEventSystemClientCreateSimpleClient(kCFAllocatorDefault)
+            self.client = client
+            _ = MouseAccelerationRecovery.restorePending(using: client,
+                                                          preservingConnectedEntries: true)
+            self.applyLinearMode()
+            self.scheduleDeviceReapplication(for: token)
+        }
+        reapplyWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
     }
 
     private func startDeviceObservation() {
@@ -180,6 +202,9 @@ final class MouseAccelerationService {
     }
 
     private func stopDeviceObservation() {
+        reapplyWork?.cancel()
+        reapplyWork = nil
+        reapplySchedule.cancel()
         guard let manager = hidManager else { return }
         IOHIDManagerUnscheduleFromRunLoop(manager,
                                           CFRunLoopGetMain(),

--- a/Sources/Vorssaint/Services/MouseAcceleration/MouseAccelerationSupport.swift
+++ b/Sources/Vorssaint/Services/MouseAcceleration/MouseAccelerationSupport.swift
@@ -52,6 +52,14 @@ struct MouseAccelerationRecoveryJournal: Codable, Equatable {
         entries.first { $0.registryID == registryID && $0.identity.matches(identity) }
     }
 
+    func entriesToRestore(preserving connectedDevices: [UInt64: MouseAccelerationDeviceIdentity])
+        -> [MouseAccelerationRecoveryEntry] {
+        entries.filter { entry in
+            guard let identity = connectedDevices[entry.registryID] else { return true }
+            return !entry.identity.matches(identity)
+        }
+    }
+
     mutating func upsert(_ entry: MouseAccelerationRecoveryEntry) {
         entries.removeAll { $0.registryID == entry.registryID }
         entries.append(entry)
@@ -60,6 +68,37 @@ struct MouseAccelerationRecoveryJournal: Codable, Equatable {
 
     mutating func remove(registryID: UInt64) {
         entries.removeAll { $0.registryID == registryID }
+    }
+}
+
+/// A short settling window after hotplug, never a repeating idle timer.
+struct MouseAccelerationReapplySchedule {
+    private var generation: UUID?
+    private var delays: ArraySlice<TimeInterval> = []
+
+    mutating func restart() -> UUID {
+        let token = UUID()
+        generation = token
+        delays = [0, 0.25, 0.75, 1.5, 2.5]
+        return token
+    }
+
+    func isCurrent(_ token: UUID) -> Bool {
+        generation == token
+    }
+
+    mutating func nextDelay(for token: UUID) -> TimeInterval? {
+        guard isCurrent(token) else { return nil }
+        guard let delay = delays.popFirst() else {
+            cancel()
+            return nil
+        }
+        return delay
+    }
+
+    mutating func cancel() {
+        generation = nil
+        delays = []
     }
 }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -13631,6 +13631,63 @@ struct MetricsTests {
         )
         expect(mouseJournal.entry(registryID: 42, identity: reusedRegistryIdentity) == nil,
                "a reused registry id can never receive another mouse's saved value")
+        expect(mouseJournal.entriesToRestore(preserving: [42: mouseIdentity]).isEmpty
+                && mouseJournal.entry(registryID: 42, identity: mouseIdentity) == mouseRecovery,
+               "hotplug retries preserve a connected mouse's original value without restoring acceleration between attempts")
+        expect(mouseJournal.entriesToRestore(preserving: [43: mouseIdentity]) == [mouseRecovery],
+               "a reconnected mouse with a new registry id still needs recovery before recapture")
+        expect(mouseJournal.entriesToRestore(preserving: [42: reusedRegistryIdentity]) == [mouseRecovery],
+               "an unrelated mouse reusing a registry id cannot hide a pending recovery")
+        expect(mouseJournal.entriesToRestore(preserving: [:]) == [mouseRecovery],
+               "stopping acceleration control still restores every saved entry")
+
+        var mouseReapplication = MouseAccelerationReapplySchedule()
+        let initialMouseConnection = mouseReapplication.restart()
+        expect(mouseReapplication.nextDelay(for: initialMouseConnection) == 0,
+               "hotplug requests the first acceleration refresh without blocking the device callback")
+        let reconnectedMouse = mouseReapplication.restart()
+        expect(!mouseReapplication.isCurrent(initialMouseConnection)
+                && mouseReapplication.nextDelay(for: initialMouseConnection) == nil,
+               "a newer hotplug event invalidates the previous retry window")
+
+        var mouseReapplyTime: TimeInterval = 0
+        var mouseReapplyAttempts = 0
+        var lateMouseValue: MouseAccelerationStoredValue?
+        var lateMouseReset = false
+        for _ in 0..<20 {
+            guard let delay = mouseReapplication.nextDelay(for: reconnectedMouse) else { break }
+            mouseReapplyTime += delay
+            mouseReapplyAttempts += 1
+            // The event-system service appears after the physical callback, then
+            // receives the system's initial acceleration setting later still.
+            if mouseReapplyTime >= 0.75, lateMouseValue == nil {
+                lateMouseValue = mouseRecovery.original
+            }
+            if mouseReapplyTime >= 2, !lateMouseReset {
+                lateMouseValue = mouseRecovery.original
+                lateMouseReset = true
+            }
+            if lateMouseValue != nil {
+                lateMouseValue = MouseAccelerationSupport.targetValue(
+                    for: mouseRecovery.key, originalIsBoolean: mouseRecovery.original.isBoolean)
+            }
+        }
+        expect(lateMouseReset && lateMouseValue?.rawValue == -1,
+               "acceleration is reapplied when a mouse service and its settings arrive after the physical callback")
+        expect(mouseReapplyAttempts > 1 && mouseReapplyAttempts < 20
+                && mouseReapplyTime > 2 && mouseReapplyTime <= 5
+                && !mouseReapplication.isCurrent(reconnectedMouse),
+               "hotplug reapplication finishes within five seconds and leaves no idle retry")
+        let cancelledMouseConnection = mouseReapplication.restart()
+        _ = mouseReapplication.nextDelay(for: cancelledMouseConnection)
+        mouseReapplication.cancel()
+        expect(!mouseReapplication.isCurrent(cancelledMouseConnection)
+                && mouseReapplication.nextDelay(for: cancelledMouseConnection) == nil,
+               "turning the feature off or pausing the session invalidates queued acceleration writes")
+        let resumedMouseConnection = mouseReapplication.restart()
+        expect(mouseReapplication.nextDelay(for: resumedMouseConnection) == 0
+                && !mouseReapplication.isCurrent(cancelledMouseConnection),
+               "resuming creates a fresh retry window without reviving cancelled callbacks")
         expect(mouseIdentity.canMatchAcrossRegistryIDs,
                "a stable physical identity can recover after a device receives a new registry id")
         let anonymousMouseIdentity = MouseAccelerationDeviceIdentity(


### PR DESCRIPTION
## Summary

Reconnecting a mouse could leave acceleration enabled while the option remained on: the physical-device callback made only one attempt, before the event-system service or its initial settings were ready. Reapply the setting with fresh device queries over a bounded five-second window, cancelling pending work when the feature stops or the session pauses.

Keep saved original values for connected mice during retries, and recover a reconnected device before capturing its new registry entry. This preserves restoration on disable or exit without temporarily restoring acceleration on other connected mice. Adds regression coverage and an Unreleased changelog entry.

## Verification

Validated locally on Mac16,12, macOS 27.0 (26A5425a), using the Developer debug build and macOS 26 SDK:

- `./build.sh --test`: 9,978 checks passed.
- `./build.sh --dev --install`: passed.
- Installed executable `--selftest`: `SELFTEST OK`.
- Installed bundle: strict signature verification passed.
- Additional isolated harness, separate from the committed suite: compiled the production service, recovery and support files unchanged against simulated hardware boundaries. All 43 lifecycle checks passed with live device lists and again with client snapshots, for 86 checks total. The previous implementation failed four assertions in the same late-reconnection scenario.

The isolated checks cover delayed service/settings arrival, original-value restoration, trackpad exclusion, cancellation, sleep and session changes, write failures, journal protection and repeated hotplug notifications. Physical mouse reconnection and device initialization beyond the five-second window were not exercised.

Refs #1372
