### PR TITLE
fix(snippets): clear an inline completion before deleting a trigger

### DIFF
--- a/Sources/Vorssaint/Services/Snippets/TextSnippetService.swift
+++ b/Sources/Vorssaint/Services/Snippets/TextSnippetService.swift
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Vorssaint
 
 import AppKit
+import ApplicationServices
 import Carbon.HIToolbox
 import CoreGraphics
 
@@ -14,6 +15,36 @@ final class TextSnippetService {
 
     /// Marks our own synthetic events so the tap never re-processes them.
     private static let syntheticMarker: Int64 = 0x564F5253 // "VORS"
+
+    /// Whether the field in front is holding a selection the deletes would
+    /// eat. Browsers inline-autocomplete what you type and leave the added
+    /// part selected: typing `gitgra` offers `gitgra[ph]`. A backspace then
+    /// removes that selection instead of a character, so the counted deletes
+    /// clear one character too few and the trigger's first character is left
+    /// stranded in front of the replacement. A selection of the user's own
+    /// cannot be confused with it — typing into one replaces it, so anything
+    /// still standing when a trigger completes was added by the app in front.
+    private static func hasSelection() -> Bool {
+        let system = AXUIElementCreateSystemWide()
+        // A hung AX query must never stall the tap thread: an app that does
+        // not answer is treated as having no selection, which is what the
+        // deletes already assume today.
+        AXUIElementSetMessagingTimeout(system, 0.2)
+        var focused: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(system,
+                                            kAXFocusedUIElementAttribute as CFString,
+                                            &focused) == .success,
+              let candidate = focused,
+              CFGetTypeID(candidate) == AXUIElementGetTypeID() else { return false }
+        let field = candidate as! AXUIElement
+        AXUIElementSetMessagingTimeout(field, 0.2)
+        var selected: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(field,
+                                            kAXSelectedTextAttribute as CFString,
+                                            &selected) == .success,
+              let text = selected as? String else { return false }
+        return !text.isEmpty
+    }
 
     // The tap callback and its mutable text state live off the main thread so
     // demanding foreground apps cannot turn a main-thread stall into queued
@@ -395,13 +426,20 @@ final class TextSnippetService {
                 post(event)
             }
         }
+        // One extra delete consumes an inline completion the app in front
+        // added, so the counted deletes each clear a character the user typed.
+        func postDeletes(_ count: Int) {
+            guard count > 0 else { return }
+            if hasSelection() { postKey(CGKeyCode(kVK_Delete)) }
+            for _ in 0..<count { postKey(CGKeyCode(kVK_Delete)) }
+        }
 
         if TextSnippetSupport.requiresPaste(text) {
             let payload = TextSnippetSupport.pastePayload(text: text, trailingText: trailingText)
             return TransientPaste.shared.paste(
                 payload,
                 willPostShortcut: {
-                    for _ in 0..<deleteCount { postKey(CGKeyCode(kVK_Delete)) }
+                    postDeletes(deleteCount)
                 },
                 didFail: {
                     if let failureKeyCode { postKey(failureKeyCode, flags: failureFlags) }
@@ -409,7 +447,7 @@ final class TextSnippetService {
             )
         }
 
-        for _ in 0..<deleteCount { postKey(CGKeyCode(kVK_Delete)) }
+        postDeletes(deleteCount)
 
         // Typed injection instead of pasting: the clipboard stays untouched.
         // Keystroke events carry at most ~20 UTF-16 units reliably.

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15467,6 +15467,23 @@ struct MetricsTests {
                 == "first\nsecond ",
                "multi-line snippets keep their delimiter in the same ordered paste")
 
+        // An inline completion the app in front added is selected text, and a
+        // backspace eats the selection instead of a character, so the counted
+        // deletes clear one short and strand the trigger's first character.
+        let snippetServiceSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Snippets/TextSnippetService.swift",
+            encoding: .utf8)) ?? ""
+        let snippetServiceCode = snippetServiceSource
+            .replacingOccurrences(of: "(?m)^\\s*//.*$", with: "", options: .regularExpression)
+        expect(snippetServiceCode.contains("kAXSelectedTextAttribute"),
+               "the deletes ask the focused field whether a selection would absorb one")
+        expect(snippetServiceCode.contains("AXUIElementSetMessagingTimeout"),
+               "an app that never answers the selection query cannot stall the tap")
+        expect(!snippetServiceCode.contains("for _ in 0..<deleteCount"),
+               "no delete loop bypasses the selection-aware helper")
+        expect(snippetServiceCode.components(separatedBy: "postDeletes(deleteCount)").count - 1 == 2,
+               "the typed and pasted expansions both clear the trigger the same way")
+
         // Custom date patterns after a colon (issue #348)
         let enUS = Locale(identifier: "en_US")
         expect(TextSnippetSupport.expand("{{date:yyyy-MM-dd}}", date: fixedDate, clipboard: nil,


### PR DESCRIPTION
Refs #1377

**Before.** A snippet expanded in a browser address bar leaves the trigger's first character in front of the replacement, when the prefix has an inline completion. `gitgrav` produces `ghttps://github.com/getgrav/grav/`; `gittril` is fine, because `gittri` has no completion.

**After.** The trigger is cleared completely and the replacement stands alone.

**Why.** Browsers append their completion as *selected* text, so the first backspace consumes the selection instead of a character and the counted deletes come up one short. The fix asks the focused element for `kAXSelectedText` before deleting and posts one extra delete when it is non-empty. A user-made selection cannot be mistaken for it: typing into a selection replaces it, so anything still selected when a trigger completes was added by the app in front.

The AX query is capped with `AXUIElementSetMessagingTimeout` and a non-answer is treated as no selection — the assumption the code already makes — so an app that does not respond cannot stall the event tap. #1110 is a bug about exactly that kind of hang in Chrome.

**Other callers.** `postExpansion` had two delete loops, the typed path and the multi-line paste path added in #917. Both now go through one `postDeletes` helper, so this is fixed for multi-line snippets too rather than only for the reported case. No other synthetic-key call site in #937's census posts deletes.

**Test.** Four assertions in `MetricsTests`. The AX path cannot be unit-tested, so this is a source-shape test pinning the contract: that the selection is queried, that the query is bounded, and that neither delete site bypasses the helper. Verified in both directions — green with the fix, all four red with the source reverted.

**Verified on** Mac16,6, macOS 26.6.2 (25G83), en-US, self-signed local `--dev` build, against Chrome 152.0.7977.76 and Safari 26.6.2. Watched the old and new behaviour directly: reproduced the stranded character, applied the fix, confirmed it cleared.

`./build.sh` finishes with no warnings, `--selftest` passes, and `./build.sh --test` reports 1 failure of 9972 — "the dispatch pool starvation this check needs was actually reached", which fails identically on unmodified `main` (1 of 9968).

**Not tested:** Intel, older macOS, other browsers (Arc, Firefox, Edge), non-Latin input methods, and whether an app that re-offers a completion *after* the first delete would cascade — neither browser does, since both suppress inline autocompletion once you start deleting.
