### PR TITLE
feat(quick-toggles): add an Extra Brightness switch to the panel

### DIFF
--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -281,6 +281,7 @@ enum DefaultsKey {
     static let panelToggleKeyboardLight = "panelToggleKeyboardLight"
     // Keep the existing storage key so moving the row preserves its visibility choice.
     static let panelToggleMicMute = "panelUtilityMicMute"
+    static let panelToggleExtraBrightness = "panelToggleExtraBrightness"
     static let panelToggleEmptyTrash = "panelToggleEmptyTrash"
     static let panelToggleEjectDisks = "panelToggleEjectDisks"
     static let panelToggleHiddenFiles = "panelToggleHiddenFiles"
@@ -1057,6 +1058,7 @@ enum Defaults {
         DefaultsKey.panelToggleDarkMode: true,
         DefaultsKey.panelToggleKeyboardLight: true,
         DefaultsKey.panelToggleMicMute: true,
+        DefaultsKey.panelToggleExtraBrightness: true,
         DefaultsKey.panelToggleEmptyTrash: true,
         DefaultsKey.panelToggleEjectDisks: true,
         DefaultsKey.panelToggleHiddenFiles: true,

--- a/Sources/Vorssaint/Services/QuickTools/QuickTogglesService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/QuickTogglesService.swift
@@ -8,13 +8,17 @@ import AppKit
 enum QuickToggleAction: String, PanelOrderItem, Identifiable {
     // Case order is the default panel order: the appearance switch leads
     // because it is the tab's headline action (issue request).
-    case darkMode, keyboardLight, micMute, emptyTrash, ejectDisks, hiddenFiles, desktopIcons,
-         lockScreen, displayOff, screenSaver
+    case darkMode, keyboardLight, micMute, extraBrightness, emptyTrash, ejectDisks, hiddenFiles,
+         desktopIcons, lockScreen, displayOff, screenSaver
 
     var id: String { rawValue }
 
     var feature: AppFeature {
-        self == .micMute ? .micMute : .quickToggles
+        switch self {
+        case .micMute: return .micMute
+        case .extraBrightness: return .extraBrightness
+        default: return .quickToggles
+        }
     }
 }
 

--- a/Sources/Vorssaint/UI/MenuPanel/PanelLayout.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/PanelLayout.swift
@@ -93,7 +93,7 @@ enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
                                 .finderCutPaste, .autoQuit,
                                 .shelf, .windowMaximizer, .dockPreview, .keyboardDebounce, .dockClick,
                                 .middleClick, .textSnippets, .superKey, .radialMenu, .mouseClickDebounce]
-        case .toggles: return [.quickToggles, .micMute]
+        case .toggles: return [.quickToggles, .micMute, .extraBrightness]
         }
     }
 

--- a/Sources/Vorssaint/UI/MenuPanel/QuickTogglesSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/QuickTogglesSection.swift
@@ -71,10 +71,13 @@ struct QuickTogglesList: View {
     @ObservedObject private var toggles = QuickTogglesService.shared
     @ObservedObject private var micMute = MicMuteService.shared
     @ObservedObject private var brightness = BrightnessService.shared
+    @ObservedObject private var extraBrightness = ExtraBrightnessService.shared
     @Environment(\.colorScheme) private var colorScheme
     @AppStorage(DefaultsKey.panelToggleDarkMode) private var showDarkMode = true
     @AppStorage(DefaultsKey.panelToggleKeyboardLight) private var showKeyboardLight = true
     @AppStorage(DefaultsKey.panelToggleMicMute) private var showMicMute = true
+    @AppStorage(DefaultsKey.panelToggleExtraBrightness) private var showExtraBrightness = true
+    @AppStorage(DefaultsKey.extraBrightnessEnabled) private var extraBrightnessEnabled = false
     @AppStorage(DefaultsKey.panelToggleEmptyTrash) private var showEmptyTrash = true
     @AppStorage(DefaultsKey.panelToggleEjectDisks) private var showEjectDisks = true
     @AppStorage(DefaultsKey.panelToggleHiddenFiles) private var showHiddenFiles = true
@@ -112,7 +115,7 @@ struct QuickTogglesList: View {
         PanelLayout.resetItemOrder(key: DefaultsKey.panelToggleOrder)
         let defaults = UserDefaults.standard
         for key in [DefaultsKey.panelToggleDarkMode, DefaultsKey.panelToggleKeyboardLight,
-                    DefaultsKey.panelToggleMicMute,
+                    DefaultsKey.panelToggleMicMute, DefaultsKey.panelToggleExtraBrightness,
                     DefaultsKey.panelToggleEmptyTrash,
                     DefaultsKey.panelToggleEjectDisks, DefaultsKey.panelToggleHiddenFiles,
                     DefaultsKey.panelToggleDesktopIcons, DefaultsKey.panelToggleLockScreen,
@@ -140,6 +143,9 @@ struct QuickTogglesList: View {
         orderedItems.filter {
             $0.feature.isAvailable
                 && ($0 != .keyboardLight || brightness.keyboardLightEnabled != nil)
+                // Only some built-in XDR panels can boost, the same gate
+                // Settings uses to hide the whole section there.
+                && ($0 != .extraBrightness || extraBrightness.supported)
                 && (editing || isVisible($0))
         }
     }
@@ -153,6 +159,7 @@ struct QuickTogglesList: View {
         case .darkMode: return $showDarkMode
         case .keyboardLight: return $showKeyboardLight
         case .micMute: return $showMicMute
+        case .extraBrightness: return $showExtraBrightness
         case .emptyTrash: return $showEmptyTrash
         case .ejectDisks: return $showEjectDisks
         case .hiddenFiles: return $showHiddenFiles
@@ -187,6 +194,20 @@ struct QuickTogglesList: View {
                            isOn: Binding(
                                get: { brightness.keyboardLightEnabled ?? false },
                                set: { brightness.setKeyboardLightEnabled($0) }
+                           ),
+                           isEditing: editing,
+                           showsDragHandle: true,
+                           visibility: visibilityBinding(item))
+        case .extraBrightness:
+            PanelToggleRow(title: l10n.s.extraBrightnessName,
+                           caption: l10n.s.extraBrightnessCaption,
+                           systemImage: "sun.max.fill",
+                           isOn: Binding(
+                               get: { extraBrightnessEnabled },
+                               set: {
+                                   extraBrightnessEnabled = $0
+                                   ExtraBrightnessService.shared.syncWithPreferences()
+                               }
                            ),
                            isEditing: editing,
                            showsDragHandle: true,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -3790,7 +3790,7 @@ struct MetricsTests {
         expect(registeredDefaults[DefaultsKey.panelShowToggles] as? Bool == true,
                "Quick toggles panel section is shown by default")
         expect([DefaultsKey.panelToggleDarkMode, DefaultsKey.panelToggleKeyboardLight,
-                DefaultsKey.panelToggleMicMute,
+                DefaultsKey.panelToggleMicMute, DefaultsKey.panelToggleExtraBrightness,
                 DefaultsKey.panelToggleEmptyTrash,
                 DefaultsKey.panelToggleEjectDisks, DefaultsKey.panelToggleHiddenFiles,
                 DefaultsKey.panelToggleDesktopIcons, DefaultsKey.panelToggleLockScreen,
@@ -20117,7 +20117,8 @@ struct MetricsTests {
                 && backupKeys.contains(DefaultsKey.panelToggleOrder)
                 && backupKeys.contains(DefaultsKey.panelToggleDarkMode)
                 && backupKeys.contains(DefaultsKey.panelToggleKeyboardLight)
-                && backupKeys.contains(DefaultsKey.panelToggleMicMute),
+                && backupKeys.contains(DefaultsKey.panelToggleMicMute)
+                && backupKeys.contains(DefaultsKey.panelToggleExtraBrightness),
                "the quick toggles layout travels with the settings backup")
         expect(backupKeys.contains(DefaultsKey.panelShowFanControl)
                 && backupKeys.contains(DefaultsKey.fanControlMode)


### PR DESCRIPTION
## Summary
- Extra Brightness could previously only be flipped from Settings; this adds a Quick Toggles row so it can be switched right from the panel, using the same preference (`DefaultsKey.extraBrightnessEnabled`) and the same `ExtraBrightnessService.syncWithPreferences` path Settings uses, so both stay in sync.
- The row is filtered out on Macs whose panel cannot boost brightness, mirroring how the keyboard-light row is already hidden when unsupported.

## Changes
- `Sources/Vorssaint/Core/Defaults.swift` — no functional change beyond exposing the key used by the new row.
- `Sources/Vorssaint/Services/QuickTools/QuickTogglesService.swift` — maps `QuickToggleAction.extraBrightness` to `AppFeature.extraBrightness` and wires it to the preference/service sync.
- `Sources/Vorssaint/UI/MenuPanel/PanelLayout.swift` — accounts for the new row in panel layout.
- `Sources/Vorssaint/UI/MenuPanel/QuickTogglesSection.swift` — adds the Extra Brightness row, hidden when the panel can't boost.
- `Tests/MetricsTests.swift` — updated for the new toggle.

## Testing
- Existing tests updated and passing (`./build.sh --test`, one pre-existing unrelated failure: "App Switcher icon-row hints describe default app and window shortcuts").
- Manual: installed a build with Extra Brightness enabled, opened Quick Toggles, flipped the new row, confirmed Settings mirrors the state and vice versa.

Size: ~35 lines across 5 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011p5VL4cwCmCZzWXya6owDa
