### PR TITLE
feat(fan-control): manual speed duration and named profiles

### DIFF
--- a/Sources/FanControlHelper/main.swift
+++ b/Sources/FanControlHelper/main.swift
@@ -143,9 +143,11 @@ private final class FanControlController {
                                                     snapshot: self.currentSnapshot())))
                 return
             }
-            let response = self.applyConfiguration(session: id,
-                                                   configuration: configuration,
-                                                   duration: nil)
+            let response = self.applyConfiguration(
+                session: id,
+                configuration: configuration,
+                duration: FanControlPolicy.sessionDuration(for: configuration)
+            )
             reply(FanControlIPC.encode(response))
         }
     }

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -355,6 +355,15 @@ enum DefaultsKey {
     // Apply step, so it can no longer be trusted to describe what the
     // hardware was actually running by the time the override expires.
     static let fanControlManualPreviousCurves = "fanControlManualPreviousCurves"
+    // Named fan profiles (an encoded [FanProfile], see FanControlSupport.swift),
+    // seeded once with the three built-ins by migrateFanControlProfiles.
+    static let fanControlProfiles = "fanControlProfiles"
+    // Which stored profile the panel last applied ("" means none). The panel
+    // recomputes its highlighted chip from matching the live controls against
+    // fanControlProfiles rather than trusting this blindly (hand-edited
+    // controls should deselect immediately), so this key is only a
+    // convenience cache of the last explicit selection.
+    static let fanControlActiveProfileID = "fanControlActiveProfileID"
     // Previous panel visibility key, read once by the migration below.
     static let monitorShowFanControlBeta = "monitorShowFanControlBeta"
     // Machine-only recovery state. A true value means the helper must confirm
@@ -1132,6 +1141,10 @@ enum Defaults {
         DefaultsKey.fanControlManualDuration: FanControlManualDuration.untilChanged.rawValue,
         DefaultsKey.fanControlRecoveryNeeded: false,
         DefaultsKey.fanControlHelperVersion: "",
+        // The real seeding happens in migrateFanControlProfiles (it needs the
+        // user's language); this is only the fallback if that somehow never ran.
+        DefaultsKey.fanControlProfiles: "[]",
+        DefaultsKey.fanControlActiveProfileID: "",
         DefaultsKey.panelNavigationEnabled: true,
         DefaultsKey.monitorGraphCPU: true,
         DefaultsKey.monitorGraphGPU: true,
@@ -1385,6 +1398,24 @@ enum Defaults {
         migrateOrphanedCaptureShortcut(in: defaults)
         migrateSilentHeadphonesDisconnectVolume(in: defaults)
         migrateSwitcherWindowlessFinder(in: defaults)
+        migrateFanControlProfiles(in: defaults)
+    }
+
+    /// Seeds `fanControlProfiles` with the three built-in presets the first
+    /// time this runs (nothing stored yet, so `object(forKey:)` is still
+    /// nil — this must run before `register(defaults:)` below establishes
+    /// the "[]" fallback, or that fallback would already answer this check).
+    /// Uses whatever language is already selected (or the system default, if
+    /// none was chosen yet) so the presets read naturally from first launch.
+    static func migrateFanControlProfiles(in defaults: UserDefaults) {
+        guard defaults.object(forKey: DefaultsKey.fanControlProfiles) == nil else { return }
+        let language = defaults.string(forKey: DefaultsKey.language)
+            .flatMap(AppLanguage.init(rawValue:)) ?? .systemDefault
+        let strings = FeatureStrings.fanControl(language)
+        let profiles = FanProfile.migratedProfiles(storedValue: nil, strings: strings)
+        if let encoded = FanProfile.encodeArray(profiles) {
+            defaults.set(encoded, forKey: DefaultsKey.fanControlProfiles)
+        }
     }
 
     /// When the user installs or runs a beta pre-release, activate the beta

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -333,6 +333,20 @@ enum DefaultsKey {
     static let fanControlMode = "fanControlMode"
     static let fanControlCoolingLevel = "fanControlCoolingLevel"
     static let fanControlCurves = "fanControlCurves"
+    // The user's currently selected manual-session length (a
+    // FanControlManualDuration raw value), independent of whether that
+    // session is actually running.
+    static let fanControlManualDuration = "fanControlManualDuration"
+    // Machine-only. The absolute deadline (seconds since 1970) of the manual
+    // session in progress, or absent when none is running. Persisted so the
+    // panel can show a remaining-time label before the first XPC round trip
+    // completes and across an app restart; the helper enforces the deadline
+    // on its own regardless of whether this key exists.
+    static let fanControlManualUntil = "fanControlManualUntil"
+    // Machine-only. Which mode (system or curve) a timed manual override
+    // should hand control back to once it expires; set once when the
+    // override begins, cleared together with fanControlManualUntil.
+    static let fanControlModeBeforeManual = "fanControlModeBeforeManual"
     // Previous panel visibility key, read once by the migration below.
     static let monitorShowFanControlBeta = "monitorShowFanControlBeta"
     // Machine-only recovery state. A true value means the helper must confirm
@@ -1105,6 +1119,9 @@ enum Defaults {
         DefaultsKey.fanControlMode: FanControlMode.system.rawValue,
         DefaultsKey.fanControlCoolingLevel: FanControlPolicy.defaultCoolingLevel,
         DefaultsKey.fanControlCurves: FanControlConfiguration.defaultCurvesStorage,
+        // Untouched manual sessions never expire, matching manual mode's
+        // behavior before this preference existed.
+        DefaultsKey.fanControlManualDuration: FanControlManualDuration.untilChanged.rawValue,
         DefaultsKey.fanControlRecoveryNeeded: false,
         DefaultsKey.fanControlHelperVersion: "",
         DefaultsKey.panelNavigationEnabled: true,

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -338,15 +338,23 @@ enum DefaultsKey {
     // session is actually running.
     static let fanControlManualDuration = "fanControlManualDuration"
     // Machine-only. The absolute deadline (seconds since 1970) of the manual
-    // session in progress, or absent when none is running. Persisted so the
-    // panel can show a remaining-time label before the first XPC round trip
-    // completes and across an app restart; the helper enforces the deadline
-    // on its own regardless of whether this key exists.
+    // session in progress, or absent when none is running. The helper enforces
+    // the deadline on its own; this key only lets the app notice, on launch,
+    // a deadline that already elapsed while it was not running, and gate
+    // resumePreviousCurveAfterManualExpiry so it only reaches for the other
+    // two keys below during a real, live-tracked expiry.
     static let fanControlManualUntil = "fanControlManualUntil"
     // Machine-only. Which mode (system or curve) a timed manual override
     // should hand control back to once it expires; set once when the
-    // override begins, cleared together with fanControlManualUntil.
+    // override is confirmed active, cleared together with fanControlManualUntil.
     static let fanControlModeBeforeManual = "fanControlModeBeforeManual"
+    // Machine-only. The curve configuration that was actually applied and
+    // running right before a timed manual override began, encoded the same
+    // way as fanControlCurves. Captured separately because the curve editor
+    // writes fanControlCurves live as the user drags points, without an
+    // Apply step, so it can no longer be trusted to describe what the
+    // hardware was actually running by the time the override expires.
+    static let fanControlManualPreviousCurves = "fanControlManualPreviousCurves"
     // Previous panel visibility key, read once by the migration below.
     static let monitorShowFanControlBeta = "monitorShowFanControlBeta"
     // Machine-only recovery state. A true value means the helper must confirm

--- a/Sources/Vorssaint/Core/FanControlStrings.swift
+++ b/Sources/Vorssaint/Core/FanControlStrings.swift
@@ -46,6 +46,27 @@ struct FanControlFeatureStrings {
     let hottestCPU: String
     let hottestGPU: String
     let helperUnavailable: String
+    let duration: String
+    let duration15Min: String
+    let duration30Min: String
+    let duration1Hour: String
+    let duration2Hours: String
+    let duration4Hours: String
+    let durationUntilChanged: String
+    let minutesRemainingFormat: String
+}
+
+extension FanControlFeatureStrings {
+    func durationLabel(for duration: FanControlManualDuration) -> String {
+        switch duration {
+        case .fifteenMinutes: return duration15Min
+        case .thirtyMinutes: return duration30Min
+        case .oneHour: return duration1Hour
+        case .twoHours: return duration2Hours
+        case .fourHours: return duration4Hours
+        case .untilChanged: return durationUntilChanged
+        }
+    }
 }
 
 extension FeatureStrings {
@@ -111,7 +132,15 @@ extension FanControlFeatureStrings {
         averageCPU: "Average CPU",
         hottestCPU: "Hottest CPU",
         hottestGPU: "Hottest GPU",
-        helperUnavailable: "The protected fan controller is unavailable. Allow Vorssaint in Login Items, then try again."
+        helperUnavailable: "The protected fan controller is unavailable. Allow Vorssaint in Login Items, then try again.",
+        duration: "Duration",
+        duration15Min: "15 minutes",
+        duration30Min: "30 minutes",
+        duration1Hour: "1 hour",
+        duration2Hours: "2 hours",
+        duration4Hours: "4 hours",
+        durationUntilChanged: "Until I change it",
+        minutesRemainingFormat: "%d min left"
     )
 
     static let ptBR = FanControlFeatureStrings(
@@ -156,7 +185,15 @@ extension FanControlFeatureStrings {
         averageCPU: "Média da CPU",
         hottestCPU: "CPU mais quente",
         hottestGPU: "GPU mais quente",
-        helperUnavailable: "O controlador protegido das ventoinhas não está disponível. Permita o Vorssaint nos Itens de Início e tente novamente."
+        helperUnavailable: "O controlador protegido das ventoinhas não está disponível. Permita o Vorssaint nos Itens de Início e tente novamente.",
+        duration: "Duração",
+        duration15Min: "15 minutos",
+        duration30Min: "30 minutos",
+        duration1Hour: "1 hora",
+        duration2Hours: "2 horas",
+        duration4Hours: "4 horas",
+        durationUntilChanged: "Até eu mudar",
+        minutesRemainingFormat: "%d min restantes"
     )
 
     static let tr = FanControlFeatureStrings(
@@ -201,7 +238,15 @@ extension FanControlFeatureStrings {
         averageCPU: "Ortalama CPU",
         hottestCPU: "En sıcak CPU",
         hottestGPU: "En sıcak GPU",
-        helperUnavailable: "Korumalı fan denetleyicisi kullanılamıyor. Giriş Öğeleri’nde Vorssaint’e izin verip yeniden deneyin."
+        helperUnavailable: "Korumalı fan denetleyicisi kullanılamıyor. Giriş Öğeleri’nde Vorssaint’e izin verip yeniden deneyin.",
+        duration: "Süre",
+        duration15Min: "15 dakika",
+        duration30Min: "30 dakika",
+        duration1Hour: "1 saat",
+        duration2Hours: "2 saat",
+        duration4Hours: "4 saat",
+        durationUntilChanged: "Değiştirene kadar",
+        minutesRemainingFormat: "%d dk kaldı"
     )
 
     static let ru = FanControlFeatureStrings(
@@ -246,7 +291,15 @@ extension FanControlFeatureStrings {
         averageCPU: "Средняя CPU",
         hottestCPU: "Самая горячая CPU",
         hottestGPU: "Самая горячая GPU",
-        helperUnavailable: "Защищённый контроллер вентиляторов недоступен. Разрешите Vorssaint в Объектах входа и повторите попытку."
+        helperUnavailable: "Защищённый контроллер вентиляторов недоступен. Разрешите Vorssaint в Объектах входа и повторите попытку.",
+        duration: "Длительность",
+        duration15Min: "15 минут",
+        duration30Min: "30 минут",
+        duration1Hour: "1 час",
+        duration2Hours: "2 часа",
+        duration4Hours: "4 часа",
+        durationUntilChanged: "Пока не изменю",
+        minutesRemainingFormat: "Осталось %d мин"
     )
 
     static let es = FanControlFeatureStrings(
@@ -291,7 +344,15 @@ extension FanControlFeatureStrings {
         averageCPU: "Promedio de CPU",
         hottestCPU: "CPU más caliente",
         hottestGPU: "GPU más caliente",
-        helperUnavailable: "El controlador protegido de los ventiladores no está disponible. Permite Vorssaint en Ítems de inicio e inténtalo de nuevo."
+        helperUnavailable: "El controlador protegido de los ventiladores no está disponible. Permite Vorssaint en Ítems de inicio e inténtalo de nuevo.",
+        duration: "Duración",
+        duration15Min: "15 minutos",
+        duration30Min: "30 minutos",
+        duration1Hour: "1 hora",
+        duration2Hours: "2 horas",
+        duration4Hours: "4 horas",
+        durationUntilChanged: "Hasta que lo cambie",
+        minutesRemainingFormat: "%d min restantes"
     )
 
     static let de = FanControlFeatureStrings(
@@ -336,7 +397,15 @@ extension FanControlFeatureStrings {
         averageCPU: "CPU-Durchschnitt",
         hottestCPU: "Heißeste CPU",
         hottestGPU: "Heißeste GPU",
-        helperUnavailable: "Die geschützte Lüftersteuerung ist nicht verfügbar. Erlaube Vorssaint unter Anmeldeobjekte und versuche es erneut."
+        helperUnavailable: "Die geschützte Lüftersteuerung ist nicht verfügbar. Erlaube Vorssaint unter Anmeldeobjekte und versuche es erneut.",
+        duration: "Dauer",
+        duration15Min: "15 Minuten",
+        duration30Min: "30 Minuten",
+        duration1Hour: "1 Stunde",
+        duration2Hours: "2 Stunden",
+        duration4Hours: "4 Stunden",
+        durationUntilChanged: "Bis ich es ändere",
+        minutesRemainingFormat: "Noch %d Min."
     )
 
     static let fr = FanControlFeatureStrings(
@@ -381,7 +450,15 @@ extension FanControlFeatureStrings {
         averageCPU: "Moyenne du CPU",
         hottestCPU: "CPU le plus chaud",
         hottestGPU: "GPU le plus chaud",
-        helperUnavailable: "Le contrôleur protégé des ventilateurs est indisponible. Autorisez Vorssaint dans Ouverture, puis réessayez."
+        helperUnavailable: "Le contrôleur protégé des ventilateurs est indisponible. Autorisez Vorssaint dans Ouverture, puis réessayez.",
+        duration: "Durée",
+        duration15Min: "15 minutes",
+        duration30Min: "30 minutes",
+        duration1Hour: "1 heure",
+        duration2Hours: "2 heures",
+        duration4Hours: "4 heures",
+        durationUntilChanged: "Jusqu’à ce que je le change",
+        minutesRemainingFormat: "%d min restantes"
     )
 
     static let it = FanControlFeatureStrings(
@@ -426,7 +503,15 @@ extension FanControlFeatureStrings {
         averageCPU: "Media CPU",
         hottestCPU: "CPU più calda",
         hottestGPU: "GPU più calda",
-        helperUnavailable: "Il controller protetto delle ventole non è disponibile. Consenti Vorssaint negli elementi di login e riprova."
+        helperUnavailable: "Il controller protetto delle ventole non è disponibile. Consenti Vorssaint negli elementi di login e riprova.",
+        duration: "Durata",
+        duration15Min: "15 minuti",
+        duration30Min: "30 minuti",
+        duration1Hour: "1 ora",
+        duration2Hours: "2 ore",
+        duration4Hours: "4 ore",
+        durationUntilChanged: "Finché non lo cambio",
+        minutesRemainingFormat: "%d min rimanenti"
     )
 
     static let ja = FanControlFeatureStrings(
@@ -471,7 +556,15 @@ extension FanControlFeatureStrings {
         averageCPU: "CPU平均",
         hottestCPU: "最高CPU",
         hottestGPU: "最高GPU",
-        helperUnavailable: "保護されたファンコントローラを利用できません。ログイン項目でVorssaintを許可してから、もう一度お試しください。"
+        helperUnavailable: "保護されたファンコントローラを利用できません。ログイン項目でVorssaintを許可してから、もう一度お試しください。",
+        duration: "期間",
+        duration15Min: "15分",
+        duration30Min: "30分",
+        duration1Hour: "1時間",
+        duration2Hours: "2時間",
+        duration4Hours: "4時間",
+        durationUntilChanged: "変更するまで",
+        minutesRemainingFormat: "残り%d分"
     )
 
     static let ko = FanControlFeatureStrings(
@@ -516,7 +609,15 @@ extension FanControlFeatureStrings {
         averageCPU: "평균 CPU",
         hottestCPU: "가장 뜨거운 CPU",
         hottestGPU: "가장 뜨거운 GPU",
-        helperUnavailable: "보호된 팬 컨트롤러를 사용할 수 없습니다. 로그인 항목에서 Vorssaint를 허용한 다음 다시 시도하세요."
+        helperUnavailable: "보호된 팬 컨트롤러를 사용할 수 없습니다. 로그인 항목에서 Vorssaint를 허용한 다음 다시 시도하세요.",
+        duration: "지속 시간",
+        duration15Min: "15분",
+        duration30Min: "30분",
+        duration1Hour: "1시간",
+        duration2Hours: "2시간",
+        duration4Hours: "4시간",
+        durationUntilChanged: "변경할 때까지",
+        minutesRemainingFormat: "%d분 남음"
     )
 
     static let zhHans = FanControlFeatureStrings(
@@ -561,7 +662,15 @@ extension FanControlFeatureStrings {
         averageCPU: "CPU平均温度",
         hottestCPU: "CPU最高温度",
         hottestGPU: "GPU最高温度",
-        helperUnavailable: "受保护的风扇控制器不可用。请在登录项中允许 Vorssaint，然后重试。"
+        helperUnavailable: "受保护的风扇控制器不可用。请在登录项中允许 Vorssaint，然后重试。",
+        duration: "持续时间",
+        duration15Min: "15分钟",
+        duration30Min: "30分钟",
+        duration1Hour: "1小时",
+        duration2Hours: "2小时",
+        duration4Hours: "4小时",
+        durationUntilChanged: "直到我更改",
+        minutesRemainingFormat: "剩余%d分钟"
     )
 
     static let zhTW = FanControlFeatureStrings(
@@ -606,7 +715,15 @@ extension FanControlFeatureStrings {
         averageCPU: "CPU平均溫度",
         hottestCPU: "CPU最高溫度",
         hottestGPU: "GPU最高溫度",
-        helperUnavailable: "受保護的風扇控制器無法使用。請在登入項目中允許 Vorssaint，然後再試一次。"
+        helperUnavailable: "受保護的風扇控制器無法使用。請在登入項目中允許 Vorssaint，然後再試一次。",
+        duration: "持續時間",
+        duration15Min: "15分鐘",
+        duration30Min: "30分鐘",
+        duration1Hour: "1小時",
+        duration2Hours: "2小時",
+        duration4Hours: "4小時",
+        durationUntilChanged: "直到我變更",
+        minutesRemainingFormat: "剩餘%d分鐘"
     )
 
     static let zhHK = FanControlFeatureStrings(
@@ -651,6 +768,14 @@ extension FanControlFeatureStrings {
         averageCPU: "CPU平均溫度",
         hottestCPU: "CPU最高溫度",
         hottestGPU: "GPU最高溫度",
-        helperUnavailable: "受保護的風扇控制器無法使用。請在登入項目允許 Vorssaint，然後再試一次。"
+        helperUnavailable: "受保護的風扇控制器無法使用。請在登入項目允許 Vorssaint，然後再試一次。",
+        duration: "持續時間",
+        duration15Min: "15分鐘",
+        duration30Min: "30分鐘",
+        duration1Hour: "1小時",
+        duration2Hours: "2小時",
+        duration4Hours: "4小時",
+        durationUntilChanged: "直到我變更",
+        minutesRemainingFormat: "剩餘%d分鐘"
     )
 }

--- a/Sources/Vorssaint/Core/FanControlStrings.swift
+++ b/Sources/Vorssaint/Core/FanControlStrings.swift
@@ -54,6 +54,66 @@ struct FanControlFeatureStrings {
     let duration4Hours: String
     let durationUntilChanged: String
     let minutesRemainingFormat: String
+    let profilesLabel: String
+    let profileSilent: String
+    let profileBalanced: String
+    let profilePerformance: String
+    let saveAsProfile: String
+    let profileNamePrompt: String
+    let profileNamePlaceholder: String
+    let saveProfileButton: String
+    let cancelButton: String
+    let renameProfile: String
+    let deleteProfile: String
+    let duplicateProfile: String
+    let profileRenamePrompt: String
+    let profileCopySuffixFormat: String
+}
+
+extension FanProfileBuiltIn {
+    /// The translated preset name. `FanControlSupport.swift` (which also
+    /// compiles into the privileged helper) knows only this case's `id` and
+    /// `kind`; the display name lives here instead, alongside the other
+    /// per-language fan control strings.
+    func name(_ strings: FanControlFeatureStrings) -> String {
+        switch self {
+        case .silent: return strings.profileSilent
+        case .balanced: return strings.profileBalanced
+        case .performance: return strings.profilePerformance
+        }
+    }
+
+    /// `name` here only seeds the stored value for the (rare) reader that
+    /// looks at it directly; every display path calls
+    /// `FanProfile.displayName(_:)` instead, which re-translates on read.
+    func makeProfile(_ strings: FanControlFeatureStrings) -> FanProfile {
+        FanProfile(id: id, name: name(strings), kind: kind)
+    }
+
+    static func defaultProfiles(_ strings: FanControlFeatureStrings) -> [FanProfile] {
+        allCases.map { $0.makeProfile(strings) }
+    }
+}
+
+extension FanProfile {
+    /// The label to show in the UI: a built-in always resolves its current
+    /// translation, ignoring whatever name happened to be stored for it;
+    /// everything else uses the name the user gave it.
+    func displayName(_ strings: FanControlFeatureStrings) -> String {
+        builtIn?.name(strings) ?? name
+    }
+
+    /// What `fanControlProfiles` should hold given whatever was previously
+    /// stored: the stored profiles as-is if there are any (even if the user
+    /// deleted every custom one down to nothing but kept editing — no,
+    /// built-ins can't be deleted, so "stored but empty" only happens before
+    /// first seeding), or the three built-ins on a genuinely first run.
+    static func migratedProfiles(storedValue: String?,
+                                 strings: FanControlFeatureStrings) -> [FanProfile] {
+        guard let storedValue else { return FanProfileBuiltIn.defaultProfiles(strings) }
+        let decoded = decodeArray(storedValue)
+        return decoded.isEmpty ? FanProfileBuiltIn.defaultProfiles(strings) : decoded
+    }
 }
 
 extension FanControlFeatureStrings {
@@ -140,7 +200,21 @@ extension FanControlFeatureStrings {
         duration2Hours: "2 hours",
         duration4Hours: "4 hours",
         durationUntilChanged: "Until I change it",
-        minutesRemainingFormat: "%d min left"
+        minutesRemainingFormat: "%d min left",
+        profilesLabel: "Profiles",
+        profileSilent: "Silent",
+        profileBalanced: "Balanced",
+        profilePerformance: "Performance",
+        saveAsProfile: "Save as profile…",
+        profileNamePrompt: "Name this profile",
+        profileNamePlaceholder: "Profile name",
+        saveProfileButton: "Save",
+        cancelButton: "Cancel",
+        renameProfile: "Rename",
+        deleteProfile: "Delete",
+        duplicateProfile: "Duplicate",
+        profileRenamePrompt: "Rename profile",
+        profileCopySuffixFormat: "%@ copy"
     )
 
     static let ptBR = FanControlFeatureStrings(
@@ -193,7 +267,21 @@ extension FanControlFeatureStrings {
         duration2Hours: "2 horas",
         duration4Hours: "4 horas",
         durationUntilChanged: "Até eu mudar",
-        minutesRemainingFormat: "%d min restantes"
+        minutesRemainingFormat: "%d min restantes",
+        profilesLabel: "Perfis",
+        profileSilent: "Silencioso",
+        profileBalanced: "Equilibrado",
+        profilePerformance: "Desempenho",
+        saveAsProfile: "Salvar como perfil…",
+        profileNamePrompt: "Nomeie este perfil",
+        profileNamePlaceholder: "Nome do perfil",
+        saveProfileButton: "Salvar",
+        cancelButton: "Cancelar",
+        renameProfile: "Renomear",
+        deleteProfile: "Excluir",
+        duplicateProfile: "Duplicar",
+        profileRenamePrompt: "Renomear perfil",
+        profileCopySuffixFormat: "Cópia de %@"
     )
 
     static let tr = FanControlFeatureStrings(
@@ -246,7 +334,21 @@ extension FanControlFeatureStrings {
         duration2Hours: "2 saat",
         duration4Hours: "4 saat",
         durationUntilChanged: "Değiştirene kadar",
-        minutesRemainingFormat: "%d dk kaldı"
+        minutesRemainingFormat: "%d dk kaldı",
+        profilesLabel: "Profiller",
+        profileSilent: "Sessiz",
+        profileBalanced: "Dengeli",
+        profilePerformance: "Performans",
+        saveAsProfile: "Profil olarak kaydet…",
+        profileNamePrompt: "Bu profili adlandırın",
+        profileNamePlaceholder: "Profil adı",
+        saveProfileButton: "Kaydet",
+        cancelButton: "İptal",
+        renameProfile: "Yeniden adlandır",
+        deleteProfile: "Sil",
+        duplicateProfile: "Çoğalt",
+        profileRenamePrompt: "Profili yeniden adlandır",
+        profileCopySuffixFormat: "%@ kopyası"
     )
 
     static let ru = FanControlFeatureStrings(
@@ -299,7 +401,21 @@ extension FanControlFeatureStrings {
         duration2Hours: "2 часа",
         duration4Hours: "4 часа",
         durationUntilChanged: "Пока не изменю",
-        minutesRemainingFormat: "Осталось %d мин"
+        minutesRemainingFormat: "Осталось %d мин",
+        profilesLabel: "Профили",
+        profileSilent: "Тихий",
+        profileBalanced: "Сбалансированный",
+        profilePerformance: "Производительность",
+        saveAsProfile: "Сохранить как профиль…",
+        profileNamePrompt: "Назовите этот профиль",
+        profileNamePlaceholder: "Название профиля",
+        saveProfileButton: "Сохранить",
+        cancelButton: "Отмена",
+        renameProfile: "Переименовать",
+        deleteProfile: "Удалить",
+        duplicateProfile: "Дублировать",
+        profileRenamePrompt: "Переименовать профиль",
+        profileCopySuffixFormat: "Копия %@"
     )
 
     static let es = FanControlFeatureStrings(
@@ -352,7 +468,21 @@ extension FanControlFeatureStrings {
         duration2Hours: "2 horas",
         duration4Hours: "4 horas",
         durationUntilChanged: "Hasta que lo cambie",
-        minutesRemainingFormat: "%d min restantes"
+        minutesRemainingFormat: "%d min restantes",
+        profilesLabel: "Perfiles",
+        profileSilent: "Silencioso",
+        profileBalanced: "Equilibrado",
+        profilePerformance: "Rendimiento",
+        saveAsProfile: "Guardar como perfil…",
+        profileNamePrompt: "Nombra este perfil",
+        profileNamePlaceholder: "Nombre del perfil",
+        saveProfileButton: "Guardar",
+        cancelButton: "Cancelar",
+        renameProfile: "Cambiar nombre",
+        deleteProfile: "Eliminar",
+        duplicateProfile: "Duplicar",
+        profileRenamePrompt: "Cambiar nombre del perfil",
+        profileCopySuffixFormat: "Copia de %@"
     )
 
     static let de = FanControlFeatureStrings(
@@ -405,7 +535,21 @@ extension FanControlFeatureStrings {
         duration2Hours: "2 Stunden",
         duration4Hours: "4 Stunden",
         durationUntilChanged: "Bis ich es ändere",
-        minutesRemainingFormat: "Noch %d Min."
+        minutesRemainingFormat: "Noch %d Min.",
+        profilesLabel: "Profile",
+        profileSilent: "Leise",
+        profileBalanced: "Ausgewogen",
+        profilePerformance: "Leistung",
+        saveAsProfile: "Als Profil speichern…",
+        profileNamePrompt: "Profil benennen",
+        profileNamePlaceholder: "Profilname",
+        saveProfileButton: "Speichern",
+        cancelButton: "Abbrechen",
+        renameProfile: "Umbenennen",
+        deleteProfile: "Löschen",
+        duplicateProfile: "Duplizieren",
+        profileRenamePrompt: "Profil umbenennen",
+        profileCopySuffixFormat: "%@ Kopie"
     )
 
     static let fr = FanControlFeatureStrings(
@@ -458,7 +602,21 @@ extension FanControlFeatureStrings {
         duration2Hours: "2 heures",
         duration4Hours: "4 heures",
         durationUntilChanged: "Jusqu’à ce que je le change",
-        minutesRemainingFormat: "%d min restantes"
+        minutesRemainingFormat: "%d min restantes",
+        profilesLabel: "Profils",
+        profileSilent: "Silencieux",
+        profileBalanced: "Équilibré",
+        profilePerformance: "Performance",
+        saveAsProfile: "Enregistrer comme profil…",
+        profileNamePrompt: "Nommez ce profil",
+        profileNamePlaceholder: "Nom du profil",
+        saveProfileButton: "Enregistrer",
+        cancelButton: "Annuler",
+        renameProfile: "Renommer",
+        deleteProfile: "Supprimer",
+        duplicateProfile: "Dupliquer",
+        profileRenamePrompt: "Renommer le profil",
+        profileCopySuffixFormat: "Copie de %@"
     )
 
     static let it = FanControlFeatureStrings(
@@ -511,7 +669,21 @@ extension FanControlFeatureStrings {
         duration2Hours: "2 ore",
         duration4Hours: "4 ore",
         durationUntilChanged: "Finché non lo cambio",
-        minutesRemainingFormat: "%d min rimanenti"
+        minutesRemainingFormat: "%d min rimanenti",
+        profilesLabel: "Profili",
+        profileSilent: "Silenzioso",
+        profileBalanced: "Bilanciato",
+        profilePerformance: "Prestazioni",
+        saveAsProfile: "Salva come profilo…",
+        profileNamePrompt: "Assegna un nome al profilo",
+        profileNamePlaceholder: "Nome del profilo",
+        saveProfileButton: "Salva",
+        cancelButton: "Annulla",
+        renameProfile: "Rinomina",
+        deleteProfile: "Elimina",
+        duplicateProfile: "Duplica",
+        profileRenamePrompt: "Rinomina profilo",
+        profileCopySuffixFormat: "Copia di %@"
     )
 
     static let ja = FanControlFeatureStrings(
@@ -564,7 +736,21 @@ extension FanControlFeatureStrings {
         duration2Hours: "2時間",
         duration4Hours: "4時間",
         durationUntilChanged: "変更するまで",
-        minutesRemainingFormat: "残り%d分"
+        minutesRemainingFormat: "残り%d分",
+        profilesLabel: "プロファイル",
+        profileSilent: "静音",
+        profileBalanced: "バランス",
+        profilePerformance: "パフォーマンス",
+        saveAsProfile: "プロファイルとして保存…",
+        profileNamePrompt: "このプロファイルに名前を付ける",
+        profileNamePlaceholder: "プロファイル名",
+        saveProfileButton: "保存",
+        cancelButton: "キャンセル",
+        renameProfile: "名前を変更",
+        deleteProfile: "削除",
+        duplicateProfile: "複製",
+        profileRenamePrompt: "プロファイル名を変更",
+        profileCopySuffixFormat: "%@のコピー"
     )
 
     static let ko = FanControlFeatureStrings(
@@ -617,7 +803,21 @@ extension FanControlFeatureStrings {
         duration2Hours: "2시간",
         duration4Hours: "4시간",
         durationUntilChanged: "변경할 때까지",
-        minutesRemainingFormat: "%d분 남음"
+        minutesRemainingFormat: "%d분 남음",
+        profilesLabel: "프로필",
+        profileSilent: "저소음",
+        profileBalanced: "균형",
+        profilePerformance: "성능",
+        saveAsProfile: "프로필로 저장…",
+        profileNamePrompt: "이 프로필의 이름 지정",
+        profileNamePlaceholder: "프로필 이름",
+        saveProfileButton: "저장",
+        cancelButton: "취소",
+        renameProfile: "이름 변경",
+        deleteProfile: "삭제",
+        duplicateProfile: "복제",
+        profileRenamePrompt: "프로필 이름 변경",
+        profileCopySuffixFormat: "%@ 사본"
     )
 
     static let zhHans = FanControlFeatureStrings(
@@ -670,7 +870,21 @@ extension FanControlFeatureStrings {
         duration2Hours: "2小时",
         duration4Hours: "4小时",
         durationUntilChanged: "直到我更改",
-        minutesRemainingFormat: "剩余%d分钟"
+        minutesRemainingFormat: "剩余%d分钟",
+        profilesLabel: "配置文件",
+        profileSilent: "静音",
+        profileBalanced: "均衡",
+        profilePerformance: "性能",
+        saveAsProfile: "存为配置文件…",
+        profileNamePrompt: "为此配置文件命名",
+        profileNamePlaceholder: "配置文件名称",
+        saveProfileButton: "存储",
+        cancelButton: "取消",
+        renameProfile: "重命名",
+        deleteProfile: "删除",
+        duplicateProfile: "复制",
+        profileRenamePrompt: "重命名配置文件",
+        profileCopySuffixFormat: "%@副本"
     )
 
     static let zhTW = FanControlFeatureStrings(
@@ -723,7 +937,21 @@ extension FanControlFeatureStrings {
         duration2Hours: "2小時",
         duration4Hours: "4小時",
         durationUntilChanged: "直到我變更",
-        minutesRemainingFormat: "剩餘%d分鐘"
+        minutesRemainingFormat: "剩餘%d分鐘",
+        profilesLabel: "設定檔",
+        profileSilent: "靜音",
+        profileBalanced: "均衡",
+        profilePerformance: "效能",
+        saveAsProfile: "另存為設定檔…",
+        profileNamePrompt: "為此設定檔命名",
+        profileNamePlaceholder: "設定檔名稱",
+        saveProfileButton: "儲存",
+        cancelButton: "取消",
+        renameProfile: "重新命名",
+        deleteProfile: "刪除",
+        duplicateProfile: "複製",
+        profileRenamePrompt: "重新命名設定檔",
+        profileCopySuffixFormat: "%@副本"
     )
 
     static let zhHK = FanControlFeatureStrings(
@@ -776,6 +1004,20 @@ extension FanControlFeatureStrings {
         duration2Hours: "2小時",
         duration4Hours: "4小時",
         durationUntilChanged: "直到我變更",
-        minutesRemainingFormat: "剩餘%d分鐘"
+        minutesRemainingFormat: "剩餘%d分鐘",
+        profilesLabel: "設定檔",
+        profileSilent: "靜音",
+        profileBalanced: "均衡",
+        profilePerformance: "效能",
+        saveAsProfile: "另存為設定檔…",
+        profileNamePrompt: "為此設定檔命名",
+        profileNamePlaceholder: "設定檔名稱",
+        saveProfileButton: "儲存",
+        cancelButton: "取消",
+        renameProfile: "重新命名",
+        deleteProfile: "刪除",
+        duplicateProfile: "複製",
+        profileRenamePrompt: "重新命名設定檔",
+        profileCopySuffixFormat: "%@副本"
     )
 }

--- a/Sources/Vorssaint/Services/FanControl/FanControlService.swift
+++ b/Sources/Vorssaint/Services/FanControl/FanControlService.swift
@@ -141,9 +141,7 @@ final class FanControlService: ObservableObject {
             return
         }
         error = nil
-        if configuration.mode == .manual {
-            recordManualTimerState(for: configuration)
-        } else {
+        if configuration.mode != .manual {
             clearManualTimerState()
         }
         let retrySnapshot = snapshot
@@ -158,13 +156,24 @@ final class FanControlService: ObservableObject {
             self.isWorking = false
             guard let response else {
                 self.error = .helperUnavailable
+                // No confirmation either way: do not let a half-applied
+                // request leave a later override reading a stale "previous
+                // mode" or deadline.
+                self.clearManualTimerState()
                 self.restoreAutomatic()
                 return
             }
             self.apply(response)
             if response.succeeded, response.snapshot.isCooling {
+                // Only recorded once the helper has actually confirmed the
+                // override is running, using the state from just before this
+                // apply (retrySnapshot), not the just-applied response.
+                if configuration.mode == .manual {
+                    self.recordManualTimerState(for: configuration, previousSnapshot: retrySnapshot)
+                }
                 self.startTimerIfNeeded()
             } else {
+                self.clearManualTimerState()
                 self.restoreAutomatic(supersedingCurrentRequest: false,
                                       preserving: response.error ?? .controlFailed,
                                       retrySnapshot: retrySnapshot)
@@ -190,6 +199,10 @@ final class FanControlService: ObservableObject {
             self.isWorking = false
             guard let response else {
                 self.error = .helperUnavailable
+                // Same reasoning as applyConfiguration's no-response branch:
+                // an unconfirmed restore must not leave stale bookkeeping for
+                // a later override to inherit.
+                self.clearManualTimerState()
                 return
             }
             self.apply(response)
@@ -412,10 +425,17 @@ final class FanControlService: ObservableObject {
 
     /// The deadline itself is enforced by the helper (see
     /// `FanControlPolicy.sessionDuration`), reusing the `endsAt`/watchdog
-    /// mechanism it already had. These UserDefaults keys exist only so the
-    /// panel can show a remaining-time label immediately, including right
-    /// after launch before the first XPC round trip completes.
-    private func recordManualTimerState(for configuration: FanControlConfiguration) {
+    /// mechanism it already had; the panel's remaining-time label reads that
+    /// live value from `snapshot.endsAt`, not from these UserDefaults keys.
+    /// What these keys are actually for: letting `reconcileManualTimerOnLaunch`
+    /// notice a deadline that elapsed while the app was not running, and
+    /// letting `resumePreviousCurveAfterManualExpiry` know what to hand
+    /// control back to once a real, observed expiry happens. Called only
+    /// after the helper has confirmed the override is actually running, so a
+    /// failed apply can never leave a later override inheriting a wrong
+    /// "previous mode".
+    private func recordManualTimerState(for configuration: FanControlConfiguration,
+                                        previousSnapshot: FanControlSnapshot) {
         let defaults = UserDefaults.standard
         guard let seconds = configuration.manualDuration.seconds else {
             clearManualTimerState()
@@ -423,13 +443,23 @@ final class FanControlService: ObservableObject {
         }
         if defaults.object(forKey: DefaultsKey.fanControlManualUntil) == nil {
             // A fresh override: remember what to hand control back to once it
-            // expires. Later tweaks (level, duration) while still in manual
-            // fall into the branch above and must not overwrite this.
+            // expires, using the state from right before this apply. Later
+            // tweaks (level, duration) while still in manual go through this
+            // same function but land here with the key already set, so they
+            // fall into the branch below and must not overwrite this.
             let previous = FanControlPolicy.manualOverridePreviousMode(
-                isCooling: snapshot.isCooling,
-                activeMode: snapshot.configuration?.mode
+                isCooling: previousSnapshot.isCooling,
+                activeMode: previousSnapshot.configuration?.mode
             )
             defaults.set(previous.rawValue, forKey: DefaultsKey.fanControlModeBeforeManual)
+            // The curve editor writes fanControlCurves live as the user drags
+            // points, with no Apply step, so by the time the override expires
+            // that key may no longer match what is actually running. Freeze
+            // the curve that was actually confirmed active instead.
+            if previous == .curve, let curves = previousSnapshot.configuration?.curves,
+               let encoded = FanControlConfiguration.encodeCurves(curves) {
+                defaults.set(encoded, forKey: DefaultsKey.fanControlManualPreviousCurves)
+            }
         }
         defaults.set(Date().addingTimeInterval(seconds).timeIntervalSince1970,
                      forKey: DefaultsKey.fanControlManualUntil)
@@ -439,6 +469,7 @@ final class FanControlService: ObservableObject {
         let defaults = UserDefaults.standard
         defaults.removeObject(forKey: DefaultsKey.fanControlManualUntil)
         defaults.removeObject(forKey: DefaultsKey.fanControlModeBeforeManual)
+        defaults.removeObject(forKey: DefaultsKey.fanControlManualPreviousCurves)
     }
 
     /// Called once a response reports the manual session ended on its own
@@ -450,9 +481,15 @@ final class FanControlService: ObservableObject {
         let defaults = UserDefaults.standard
         let previousMode = (defaults.string(forKey: DefaultsKey.fanControlModeBeforeManual))
             .flatMap(FanControlMode.init(rawValue:))
-        guard FanControlPolicy.modeAfterManualExpiry(previousMode: previousMode) == .curve,
-              let curvesStorage = defaults.string(forKey: DefaultsKey.fanControlCurves),
-              let curves = FanControlConfiguration.decodeCurves(curvesStorage) else {
+        guard FanControlPolicy.modeAfterManualExpiry(previousMode: previousMode) == .curve else {
+            return false
+        }
+        // Prefer the curve frozen when the override began, since the editor
+        // may have since changed fanControlCurves without an Apply; fall back
+        // to the current stored curves only if that snapshot is missing.
+        let storage = defaults.string(forKey: DefaultsKey.fanControlManualPreviousCurves)
+            ?? defaults.string(forKey: DefaultsKey.fanControlCurves)
+        guard let storage, let curves = FanControlConfiguration.decodeCurves(storage) else {
             return false
         }
         clearManualTimerState()

--- a/Sources/Vorssaint/Services/FanControl/FanControlService.swift
+++ b/Sources/Vorssaint/Services/FanControl/FanControlService.swift
@@ -43,6 +43,7 @@ final class FanControlService: ObservableObject {
     }
 
     private init() {
+        reconcileManualTimerOnLaunch()
         refreshAccessState()
     }
 
@@ -130,6 +131,7 @@ final class FanControlService: ObservableObject {
             return
         }
         if configuration.mode == .system {
+            clearManualTimerState()
             restoreAutomatic()
             return
         }
@@ -139,6 +141,11 @@ final class FanControlService: ObservableObject {
             return
         }
         error = nil
+        if configuration.mode == .manual {
+            recordManualTimerState(for: configuration)
+        } else {
+            clearManualTimerState()
+        }
         let retrySnapshot = snapshot
         startObservingSystemState()
         let generation = beginRequest()
@@ -191,6 +198,7 @@ final class FanControlService: ObservableObject {
                     self.snapshot = retrySnapshot
                 }
                 if let failure { self.error = failure }
+                self.clearManualTimerState()
                 UserDefaults.standard.removeObject(forKey: DefaultsKey.fanControlRecoveryNeeded)
                 if !AppFeature.fanControl.isAvailable {
                     do {
@@ -215,6 +223,7 @@ final class FanControlService: ObservableObject {
         send { proxy, reply in proxy.restoreAutomatic(withReply: reply) } completion: { response in
             if let response, response.succeeded, !response.snapshot.isCooling {
                 UserDefaults.standard.removeObject(forKey: DefaultsKey.fanControlRecoveryNeeded)
+                self.clearManualTimerState()
             }
         }
         // Losing the authenticated client connection is itself a restore
@@ -296,6 +305,11 @@ final class FanControlService: ObservableObject {
                                       forKey: DefaultsKey.fanControlHelperVersion)
             if response.succeeded, !response.snapshot.isCooling {
                 UserDefaults.standard.removeObject(forKey: DefaultsKey.fanControlRecoveryNeeded)
+                if response.snapshot.stopReason == .timeLimit, self.resumePreviousCurveAfterManualExpiry() {
+                    // Reapplying the interrupted curve is in flight.
+                } else {
+                    self.clearManualTimerState()
+                }
             }
         }
     }
@@ -366,7 +380,13 @@ final class FanControlService: ObservableObject {
             self.apply(response)
             if response.succeeded, !response.snapshot.isCooling {
                 UserDefaults.standard.removeObject(forKey: DefaultsKey.fanControlRecoveryNeeded)
-                self.stopIdleWorkIfPossible()
+                if response.snapshot.stopReason == .timeLimit, self.resumePreviousCurveAfterManualExpiry() {
+                    // A curve was running before the timed manual override;
+                    // reapplying it is already in flight, so idle work stays up.
+                } else {
+                    self.clearManualTimerState()
+                    self.stopIdleWorkIfPossible()
+                }
             }
         }
     }
@@ -386,6 +406,72 @@ final class FanControlService: ObservableObject {
         guard generation == requestGeneration else { return false }
         requestInFlight = false
         return true
+    }
+
+    // MARK: - Manual session timer
+
+    /// The deadline itself is enforced by the helper (see
+    /// `FanControlPolicy.sessionDuration`), reusing the `endsAt`/watchdog
+    /// mechanism it already had. These UserDefaults keys exist only so the
+    /// panel can show a remaining-time label immediately, including right
+    /// after launch before the first XPC round trip completes.
+    private func recordManualTimerState(for configuration: FanControlConfiguration) {
+        let defaults = UserDefaults.standard
+        guard let seconds = configuration.manualDuration.seconds else {
+            clearManualTimerState()
+            return
+        }
+        if defaults.object(forKey: DefaultsKey.fanControlManualUntil) == nil {
+            // A fresh override: remember what to hand control back to once it
+            // expires. Later tweaks (level, duration) while still in manual
+            // fall into the branch above and must not overwrite this.
+            let previous = FanControlPolicy.manualOverridePreviousMode(
+                isCooling: snapshot.isCooling,
+                activeMode: snapshot.configuration?.mode
+            )
+            defaults.set(previous.rawValue, forKey: DefaultsKey.fanControlModeBeforeManual)
+        }
+        defaults.set(Date().addingTimeInterval(seconds).timeIntervalSince1970,
+                     forKey: DefaultsKey.fanControlManualUntil)
+    }
+
+    private func clearManualTimerState() {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: DefaultsKey.fanControlManualUntil)
+        defaults.removeObject(forKey: DefaultsKey.fanControlModeBeforeManual)
+    }
+
+    /// Called once a response reports the manual session ended on its own
+    /// deadline. Returns whether a curve was interrupted and is being
+    /// reapplied; the caller leaves idle work running in that case instead of
+    /// treating the fans as settled on system control.
+    @discardableResult
+    private func resumePreviousCurveAfterManualExpiry() -> Bool {
+        let defaults = UserDefaults.standard
+        let previousMode = (defaults.string(forKey: DefaultsKey.fanControlModeBeforeManual))
+            .flatMap(FanControlMode.init(rawValue:))
+        guard FanControlPolicy.modeAfterManualExpiry(previousMode: previousMode) == .curve,
+              let curvesStorage = defaults.string(forKey: DefaultsKey.fanControlCurves),
+              let curves = FanControlConfiguration.decodeCurves(curvesStorage) else {
+            return false
+        }
+        clearManualTimerState()
+        applyConfiguration(.curve(curves))
+        return true
+    }
+
+    /// Reverting the hardware, if a session is somehow still running, is
+    /// already handled unconditionally by `recoverIfNeeded()` whenever the
+    /// app was not shut down cleanly, and by the helper's own watchdog
+    /// regardless of this app process. This only clears a stale label so the
+    /// panel does not show a countdown for a session that already ended.
+    private func reconcileManualTimerOnLaunch() {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: DefaultsKey.fanControlManualUntil) != nil else { return }
+        let until = Date(timeIntervalSince1970: defaults.double(forKey: DefaultsKey.fanControlManualUntil))
+        if FanControlPolicy.manualDurationElapsed(until: until, now: Date()) {
+            clearManualTimerState()
+        }
     }
 
     // MARK: - Registration and local reads
@@ -514,6 +600,7 @@ final class FanControlService: ObservableObject {
             self.isWorking = false
             guard let response, response.succeeded, !response.snapshot.isCooling else { return }
             UserDefaults.standard.removeObject(forKey: DefaultsKey.fanControlRecoveryNeeded)
+            self.clearManualTimerState()
             guard !AppFeature.fanControl.isAvailable else {
                 self.stopIdleWorkIfPossible()
                 return

--- a/Sources/Vorssaint/Services/FanControl/FanControlSupport.swift
+++ b/Sources/Vorssaint/Services/FanControl/FanControlSupport.swift
@@ -120,6 +120,156 @@ struct FanControlConfiguration: Codable, Equatable, Sendable {
     }
 }
 
+/// A named shortcut to a fan control configuration, selectable from the panel
+/// with one click instead of walking through mode/level/duration/curve by
+/// hand each time. `id` is stable storage identity (a built-in's is the fixed
+/// `FanProfileBuiltIn.id`, a custom profile's is a UUID string minted once at
+/// "Save as profile…" time); `name` is what the user sees for a custom
+/// profile, but a built-in's displayed name always comes fresh from
+/// `FanProfile.displayName(_:)` (in FanControlStrings.swift) so it
+/// re-translates if the interface language changes after the profile was
+/// seeded. This type stays free of `FanControlFeatureStrings` so it can keep
+/// compiling into the privileged helper target, which links this file for
+/// `FanControlConfiguration` but never needs UI strings.
+struct FanProfile: Codable, Equatable, Identifiable, Sendable {
+    /// Only one curve per profile: the panel and the built-in presets only
+    /// ever need to snapshot the single curve that was actually running, so
+    /// keeping a profile to one curve keeps switching and the settings list
+    /// simple. (Fan control itself still supports several simultaneous
+    /// curves; that combination just isn't something a one-click profile
+    /// captures.)
+    enum Kind: Codable, Equatable, Sendable {
+        case system
+        case manual(level: Int, duration: FanControlManualDuration)
+        case curve(points: [FanControlCurvePoint], temperatureSource: FanControlTemperatureSource)
+    }
+
+    let id: String
+    var name: String
+    var kind: Kind
+}
+
+extension FanProfile {
+    /// Which built-in this profile is, derived from `id` rather than a
+    /// stored flag — so there is no separate bit that could ever disagree
+    /// with the id about whether a profile is a built-in.
+    var builtIn: FanProfileBuiltIn? {
+        FanProfileBuiltIn.allCases.first { $0.id == id }
+    }
+
+    /// Built-ins are not renamable or deletable, only duplicable into an
+    /// editable copy.
+    var isBuiltIn: Bool { builtIn != nil }
+
+    /// The configuration this profile applies — exactly as if the user had
+    /// set mode/level/duration/curve to these values by hand.
+    var configuration: FanControlConfiguration {
+        switch kind {
+        case .system:
+            return FanControlConfiguration(mode: .system,
+                                           manualLevel: FanControlPolicy.defaultCoolingLevel,
+                                           curves: [], manualDuration: .untilChanged)
+        case let .manual(level, duration):
+            return .manual(level: level, duration: duration)
+        case let .curve(points, temperatureSource):
+            return .curve([FanControlCurve(sensor: temperatureSource, points: points)])
+        }
+    }
+
+    /// Whether `configuration` is exactly what this profile would apply.
+    /// Drives both the "apply" path (nothing to do if already active) and
+    /// the panel's highlight (hand-edited controls that happen to match a
+    /// profile again re-select it, without the app having to track that
+    /// specially).
+    func matches(_ configuration: FanControlConfiguration) -> Bool {
+        self.configuration == configuration
+    }
+
+    /// A new custom profile that captures `configuration` under `name`, for
+    /// the panel's "Save as profile…" action.
+    static func makeCustom(id: String = UUID().uuidString,
+                           name: String,
+                           from configuration: FanControlConfiguration) -> FanProfile {
+        let kind: Kind
+        switch configuration.mode {
+        case .system:
+            kind = .system
+        case .manual:
+            kind = .manual(level: configuration.manualLevel, duration: configuration.manualDuration)
+        case .curve:
+            let curve = configuration.curves.first ?? FanControlConfiguration.defaultCurve
+            kind = .curve(points: curve.points, temperatureSource: curve.sensor)
+        }
+        return FanProfile(id: id, name: name, kind: kind)
+    }
+
+    /// A duplicate of this profile as an editable custom copy, named with a
+    /// caller-supplied label (typically the original's displayed name plus a
+    /// "copy" suffix) — the only way to start editing a built-in.
+    func duplicated(named name: String) -> FanProfile {
+        FanProfile(id: UUID().uuidString, name: name, kind: kind)
+    }
+
+    /// The first stored profile whose configuration matches `configuration`,
+    /// if any — what the panel highlights as active. Recomputed from the
+    /// live controls rather than a separately tracked selection, so editing
+    /// mode/level/duration/curve by hand deselects automatically unless the
+    /// result happens to match a (possibly different) profile again.
+    static func activeProfile(matching configuration: FanControlConfiguration,
+                              in profiles: [FanProfile]) -> FanProfile? {
+        profiles.first { $0.matches(configuration) }
+    }
+
+    static func encodeArray(_ profiles: [FanProfile]) -> String? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(profiles) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Decodes a stored profile array, silently dropping any entry whose
+    /// `kind` this build does not recognize (e.g. one written by a future
+    /// version and read by an older one) instead of losing every other
+    /// profile because one entry failed to decode.
+    static func decodeArray(_ value: String) -> [FanProfile] {
+        guard let data = value.data(using: .utf8),
+              let attempts = try? JSONDecoder().decode([FanProfileDecodeAttempt].self, from: data)
+        else { return [] }
+        return attempts.compactMap(\.profile)
+    }
+}
+
+/// Decodes one profile in isolation so a single unrecognized `kind` cannot
+/// fail the decode of the whole stored array the way a plain `[FanProfile]`
+/// decode would.
+private struct FanProfileDecodeAttempt: Decodable {
+    let profile: FanProfile?
+    init(from decoder: Decoder) throws {
+        profile = try? FanProfile(from: decoder)
+    }
+}
+
+/// The three presets every install ships with. Not editable or deletable —
+/// `FanProfile.duplicated(named:)` is the only way to get an editable copy of
+/// one — so they always exist as a safe, known-good baseline.
+enum FanProfileBuiltIn: String, CaseIterable, Sendable {
+    case silent
+    case balanced
+    case performance
+
+    /// Stable storage identity; `FanProfile.builtIn` recognizes a profile as
+    /// this built-in only by matching this exact id.
+    var id: String { "builtin.\(rawValue)" }
+
+    var kind: FanProfile.Kind {
+        switch self {
+        case .silent: return .manual(level: 25, duration: .untilChanged)
+        case .balanced: return .system
+        case .performance: return .manual(level: 75, duration: .untilChanged)
+        }
+    }
+}
+
 struct FanControlSnapshot: Codable, Equatable, Sendable {
     var fans: [FanControlFanReading]
     var isCooling: Bool

--- a/Sources/Vorssaint/Services/FanControl/FanControlSupport.swift
+++ b/Sources/Vorssaint/Services/FanControl/FanControlSupport.swift
@@ -20,6 +20,35 @@ enum FanControlMode: String, Codable, Sendable {
     case curve
 }
 
+/// How long a manual-mode session runs before it reverts on its own.
+/// `untilChanged` means no automatic expiry, matching the behavior manual
+/// mode already had before this type existed. The helper is the only thing
+/// that enforces this (see `FanControlPolicy.sessionDuration` and the
+/// `endsAt`/watchdog mechanism it already had for the legacy fixed session),
+/// so picking a case here never needs a second, app-side timer.
+enum FanControlManualDuration: String, Codable, CaseIterable, Identifiable, Sendable {
+    case fifteenMinutes
+    case thirtyMinutes
+    case oneHour
+    case twoHours
+    case fourHours
+    case untilChanged
+
+    var id: String { rawValue }
+
+    /// `nil` means no automatic expiry.
+    var seconds: TimeInterval? {
+        switch self {
+        case .fifteenMinutes: return 15 * 60
+        case .thirtyMinutes: return 30 * 60
+        case .oneHour: return 60 * 60
+        case .twoHours: return 2 * 60 * 60
+        case .fourHours: return 4 * 60 * 60
+        case .untilChanged: return nil
+        }
+    }
+}
+
 enum FanControlTemperatureSource: String, Codable, CaseIterable, Identifiable, Sendable {
     case averageSoC
     case hottestSoC
@@ -49,6 +78,8 @@ struct FanControlConfiguration: Codable, Equatable, Sendable {
     var mode: FanControlMode
     var manualLevel: Int
     var curves: [FanControlCurve]
+    /// Only meaningful in `.manual` mode; ignored otherwise.
+    var manualDuration: FanControlManualDuration
 
     static let defaultCurve = FanControlCurve(
         sensor: .hottestSoC,
@@ -58,15 +89,16 @@ struct FanControlConfiguration: Codable, Equatable, Sendable {
         ]
     )
 
-    static func manual(level: Int) -> FanControlConfiguration {
+    static func manual(level: Int,
+                       duration: FanControlManualDuration = .untilChanged) -> FanControlConfiguration {
         FanControlConfiguration(mode: .manual, manualLevel: level,
-                                curves: [])
+                                curves: [], manualDuration: duration)
     }
 
     static func curve(_ curves: [FanControlCurve]) -> FanControlConfiguration {
         FanControlConfiguration(mode: .curve,
                                 manualLevel: FanControlPolicy.defaultCoolingLevel,
-                                curves: curves)
+                                curves: curves, manualDuration: .untilChanged)
     }
 
     static func encodeCurves(_ curves: [FanControlCurve]) -> String? {
@@ -193,6 +225,43 @@ enum FanControlPolicy {
         guard validBounds(minimum: minimum, maximum: maximum),
               validCoolingLevel(level) else { return nil }
         return minimum + (maximum - minimum) * Double(level) / 100
+    }
+
+    /// The deadline the helper should enforce for a session started with this
+    /// configuration. Only manual mode ever expires on its own; a curve keeps
+    /// running until temperatures or the app say otherwise. Centralizing this
+    /// keeps the app and the helper from independently answering the same
+    /// question and disagreeing.
+    static func sessionDuration(for configuration: FanControlConfiguration) -> TimeInterval? {
+        guard configuration.mode == .manual else { return nil }
+        return configuration.manualDuration.seconds
+    }
+
+    static func manualDurationElapsed(until: Date, now: Date) -> Bool {
+        now >= until
+    }
+
+    /// Minutes left before a manual session's deadline, rounded up so the
+    /// label never reads "0 min left" while control is still active, and
+    /// `nil` once (or before) the deadline to signal there is nothing to show.
+    static func remainingManualMinutes(until: Date?, now: Date) -> Int? {
+        guard let until, until > now else { return nil }
+        return max(1, Int((until.timeIntervalSince(now) / 60).rounded(.up)))
+    }
+
+    /// What a manual override should hand control back to once its timer
+    /// expires: the curve it interrupted, or the system if nothing was
+    /// actively running (or the interrupted mode was already system control).
+    static func modeAfterManualExpiry(previousMode: FanControlMode?) -> FanControlMode {
+        previousMode == .curve ? .curve : .system
+    }
+
+    /// What "previous mode" a timed manual override should remember, captured
+    /// once when the override begins so later tweaks (level, duration) while
+    /// still in manual do not overwrite what it should return to.
+    static func manualOverridePreviousMode(isCooling: Bool,
+                                           activeMode: FanControlMode?) -> FanControlMode {
+        (isCooling && activeMode == .curve) ? .curve : .system
     }
 
     static func validConfiguration(_ configuration: FanControlConfiguration) -> Bool {

--- a/Sources/Vorssaint/UI/MenuPanel/FanControlSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/FanControlSection.swift
@@ -11,6 +11,8 @@ struct FanControlSection: View {
         FanControlPolicy.defaultCoolingLevel
     @AppStorage(DefaultsKey.fanControlCurves) private var curvesStorage =
         FanControlConfiguration.defaultCurvesStorage
+    @AppStorage(DefaultsKey.fanControlManualDuration) private var manualDurationRaw =
+        FanControlManualDuration.untilChanged.rawValue
     @AppStorage(DefaultsKey.temperatureUnit) private var temperatureUnit =
         TemperatureUnit.celsius.rawValue
     var collapsible = true
@@ -29,6 +31,7 @@ struct FanControlSection: View {
                                   isWorking: service.isWorking,
                                   mode: modeBinding,
                                   coolingLevel: $coolingLevel,
+                                  manualDuration: manualDurationBinding,
                                   curves: curvesBinding,
                                   temperatureUnit: displayTemperatureUnit,
                                   authorize: service.authorize,
@@ -44,6 +47,13 @@ struct FanControlSection: View {
         Binding(
             get: { FanControlMode(rawValue: modeRaw) ?? .system },
             set: { modeRaw = $0.rawValue }
+        )
+    }
+
+    private var manualDurationBinding: Binding<FanControlManualDuration> {
+        Binding(
+            get: { FanControlManualDuration(rawValue: manualDurationRaw) ?? .untilChanged },
+            set: { manualDurationRaw = $0.rawValue }
         )
     }
 
@@ -75,6 +85,7 @@ struct FanControlCardContent: View {
     let isWorking: Bool
     @Binding var mode: FanControlMode
     @Binding var coolingLevel: Int
+    @Binding var manualDuration: FanControlManualDuration
     @Binding var curves: [FanControlCurve]
     let temperatureUnit: TemperatureUnit
     let authorize: () -> Void
@@ -153,7 +164,52 @@ struct FanControlCardContent: View {
                    step: Double(FanControlPolicy.coolingLevelStep))
                 .controlSize(.small)
                 .disabled(isWorking)
+
+            HStack {
+                Text(strings.duration)
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Picker(strings.duration, selection: $manualDuration) {
+                    ForEach(FanControlManualDuration.allCases) { option in
+                        Text(strings.durationLabel(for: option)).tag(option)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .controlSize(.small)
+                .disabled(isWorking)
+                .fixedSize()
+            }
+
+            if isManualSessionActive {
+                HStack {
+                    if let remainingMinutes {
+                        Text(String(format: strings.minutesRemainingFormat, remainingMinutes))
+                            .font(.system(size: 9.5).monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Button(strings.returnToSystem, action: stopCooling)
+                        .buttonStyle(.plain)
+                        .font(.system(size: 9.5, weight: .semibold))
+                        .foregroundStyle(Color.accentColor)
+                        .disabled(isWorking)
+                }
+            }
         }
+    }
+
+    /// A manual session considered "active" for the quick return-to-automatic
+    /// control, independent of whichever mode the picker currently shows —
+    /// flipping the segmented control back to System should not be the only
+    /// way to cancel a running manual override.
+    private var isManualSessionActive: Bool {
+        snapshot.isCooling && snapshot.configuration?.mode == .manual
+    }
+
+    private var remainingMinutes: Int? {
+        FanControlPolicy.remainingManualMinutes(until: snapshot.endsAt, now: Date())
     }
 
     private var statusHeader: some View {
@@ -238,7 +294,7 @@ struct FanControlCardContent: View {
             case .manual:
                 Button(strings.applyManual) {
                     coolingLevel = selectedCoolingLevel
-                    applyConfiguration(.manual(level: selectedCoolingLevel))
+                    applyConfiguration(.manual(level: selectedCoolingLevel, duration: manualDuration))
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)
@@ -263,7 +319,9 @@ struct FanControlCardContent: View {
         case .system:
             return strings.systemControl
         case .manual:
-            return "\(strings.manualControl) · \(level)%"
+            let base = "\(strings.manualControl) · \(level)%"
+            guard let remainingMinutes else { return base }
+            return "\(base) · \(String(format: strings.minutesRemainingFormat, remainingMinutes))"
         case .curve:
             let activeCurves = snapshot.configuration?.curves ?? []
             let temperature = activeCurves.count == 1

--- a/Sources/Vorssaint/UI/MenuPanel/FanControlSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/FanControlSection.swift
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Vorssaint
 
+import AppKit
 import SwiftUI
 
 struct FanControlSection: View {
@@ -13,6 +14,8 @@ struct FanControlSection: View {
         FanControlConfiguration.defaultCurvesStorage
     @AppStorage(DefaultsKey.fanControlManualDuration) private var manualDurationRaw =
         FanControlManualDuration.untilChanged.rawValue
+    @AppStorage(DefaultsKey.fanControlProfiles) private var profilesStorage = "[]"
+    @AppStorage(DefaultsKey.fanControlActiveProfileID) private var activeProfileID = ""
     @AppStorage(DefaultsKey.temperatureUnit) private var temperatureUnit =
         TemperatureUnit.celsius.rawValue
     var collapsible = true
@@ -33,10 +36,13 @@ struct FanControlSection: View {
                                   coolingLevel: $coolingLevel,
                                   manualDuration: manualDurationBinding,
                                   curves: curvesBinding,
+                                  profiles: profiles,
                                   temperatureUnit: displayTemperatureUnit,
                                   authorize: service.authorize,
                                   applyConfiguration: service.applyConfiguration,
-                                  stopCooling: service.restoreAutomatic)
+                                  stopCooling: service.restoreAutomatic,
+                                  applyProfile: apply(_:),
+                                  saveCurrentAsProfile: saveCurrentAsProfile)
                 .panelCard()
                 .onAppear { service.panelDidAppear() }
                 .onDisappear { service.panelDidDisappear() }
@@ -74,6 +80,58 @@ struct FanControlSection: View {
     private var displayTemperatureUnit: TemperatureUnit {
         TemperatureUnit(rawValue: temperatureUnit) ?? .celsius
     }
+
+    private var profiles: [FanProfile] {
+        FanProfile.decodeArray(profilesStorage)
+    }
+
+    /// Applies a profile exactly through the same path a hand-set mode/level/
+    /// duration/curve would take: fill the pending controls with what the
+    /// profile represents, remember it as the last explicit selection, then
+    /// hand the resulting configuration to `applyConfiguration` — the panel's
+    /// one-click switch.
+    private func apply(_ profile: FanProfile) {
+        let configuration = profile.configuration
+        modeRaw = configuration.mode.rawValue
+        coolingLevel = configuration.manualLevel
+        manualDurationRaw = configuration.manualDuration.rawValue
+        if configuration.mode == .curve, let encoded = FanControlConfiguration.encodeCurves(configuration.curves) {
+            curvesStorage = encoded
+        }
+        activeProfileID = profile.id
+        service.applyConfiguration(configuration)
+    }
+
+    /// "Save as profile…": prompts for a name with a native text-field alert,
+    /// then stores the currently pending mode/level/duration/curve as a new
+    /// custom profile. No window is required — this panel is a popover, not
+    /// a sheet-owning window — so a modal `runModal()` alert matches how the
+    /// rest of the app already asks quick yes/no questions from the menu bar.
+    private func saveCurrentAsProfile() {
+        let field = NSTextField(string: "")
+        field.placeholderString = strings.profileNamePlaceholder
+        field.frame = NSRect(x: 0, y: 0, width: 240, height: 24)
+        let alert = NSAlert()
+        alert.messageText = strings.profileNamePrompt
+        alert.accessoryView = field
+        alert.addButton(withTitle: strings.saveProfileButton)
+        alert.addButton(withTitle: strings.cancelButton)
+        NSApp.activate(ignoringOtherApps: true)
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let name = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return }
+        let configuration = FanControlConfiguration(mode: modeBinding.wrappedValue,
+                                                    manualLevel: coolingLevel,
+                                                    curves: curvesBinding.wrappedValue,
+                                                    manualDuration: manualDurationBinding.wrappedValue)
+        let profile = FanProfile.makeCustom(name: name, from: configuration)
+        var updated = profiles
+        updated.append(profile)
+        if let encoded = FanProfile.encodeArray(updated) {
+            profilesStorage = encoded
+        }
+        activeProfileID = profile.id
+    }
 }
 
 struct FanControlCardContent: View {
@@ -87,10 +145,13 @@ struct FanControlCardContent: View {
     @Binding var coolingLevel: Int
     @Binding var manualDuration: FanControlManualDuration
     @Binding var curves: [FanControlCurve]
+    let profiles: [FanProfile]
     let temperatureUnit: TemperatureUnit
     let authorize: () -> Void
     let applyConfiguration: (FanControlConfiguration) -> Void
     let stopCooling: () -> Void
+    let applyProfile: (FanProfile) -> Void
+    let saveCurrentAsProfile: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -106,6 +167,7 @@ struct FanControlCardContent: View {
             }
 
             if canConfigure {
+                profilesRow
                 modePicker
                 switch mode {
                 case .system:
@@ -134,6 +196,78 @@ struct FanControlCardContent: View {
                     .font(.system(size: 9.5))
                     .foregroundStyle(Color.secondary.opacity(0.84))
                     .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    /// What the pending (not-yet-applied) controls currently represent, used
+    /// to highlight the matching profile chip. Built the same way the
+    /// `applyConfiguration` calls below build it — `.manual`/system-shaped
+    /// configurations always carry an empty `curves`, matching what
+    /// `FanProfile.configuration` produces for those kinds — so a profile in
+    /// manual or system mode can match regardless of whatever curve was last
+    /// edited, instead of comparing against a `curves` array that mode never
+    /// actually sends.
+    private var pendingConfiguration: FanControlConfiguration {
+        switch mode {
+        case .system:
+            return FanControlConfiguration(mode: .system,
+                                           manualLevel: FanControlPolicy.defaultCoolingLevel,
+                                           curves: [], manualDuration: .untilChanged)
+        case .manual:
+            return .manual(level: coolingLevel, duration: manualDuration)
+        case .curve:
+            return .curve(curves)
+        }
+    }
+
+    /// A one-click row of saved profiles above the mode picker. A compact
+    /// menu picker is used once there are more than four profiles — a
+    /// segmented control stops reading well as a single row past that count —
+    /// but either way this is a native `Picker`, never a custom dropdown.
+    @ViewBuilder
+    private var profilesRow: some View {
+        if !profiles.isEmpty {
+            let selection = Binding<String?>(
+                get: { FanProfile.activeProfile(matching: pendingConfiguration, in: profiles)?.id },
+                set: { newID in
+                    guard let newID, let profile = profiles.first(where: { $0.id == newID }) else { return }
+                    applyProfile(profile)
+                }
+            )
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(strings.profilesLabel)
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button(action: saveCurrentAsProfile) {
+                        Image(systemName: "plus.circle")
+                    }
+                    .buttonStyle(.plain)
+                    .help(strings.saveAsProfile)
+                    .disabled(isWorking)
+                }
+                Group {
+                    if profiles.count > 4 {
+                        Picker(strings.profilesLabel, selection: selection) {
+                            ForEach(profiles) { profile in
+                                Text(profile.displayName(strings)).tag(Optional(profile.id))
+                            }
+                        }
+                        .pickerStyle(.menu)
+                    } else {
+                        Picker(strings.profilesLabel, selection: selection) {
+                            ForEach(profiles) { profile in
+                                Text(profile.displayName(strings)).tag(Optional(profile.id))
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                    }
+                }
+                .labelsHidden()
+                .controlSize(.small)
+                .disabled(isWorking)
             }
         }
     }

--- a/Sources/Vorssaint/UI/Settings/MonitorSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/MonitorSettings.swift
@@ -124,6 +124,9 @@ struct MonitorSettings: View {
                     }
                 }
                 .settingsSectionAnchor(.fanControl)
+                Section(fanStrings.profilesLabel) {
+                    FanProfilesSettingsList(strings: fanStrings)
+                }
             }
             Section(l10n.s.monitorGraphsSection) {
                 if AppFeature.monitorCPU.isAvailable {
@@ -589,5 +592,93 @@ private struct PanelOrderDropDelegate: DropDelegate {
         dragging = nil
         PanelLayout.setOrder(order)
         return true
+    }
+}
+
+/// A minimal management list for named fan profiles: rename and delete for
+/// custom profiles, duplicate for any profile (the only way to start editing
+/// a built-in), reorder by drag. Built-ins show no rename/delete controls —
+/// `FanProfile.isBuiltIn` is what the panel and this list both key off of, so
+/// the two surfaces can never disagree about which profiles are protected.
+private struct FanProfilesSettingsList: View {
+    let strings: FanControlFeatureStrings
+    @AppStorage(DefaultsKey.fanControlProfiles) private var profilesStorage = "[]"
+    @State private var renaming: FanProfile?
+    @State private var renameText = ""
+
+    private var profiles: [FanProfile] {
+        FanProfile.decodeArray(profilesStorage)
+    }
+
+    var body: some View {
+        ForEach(profiles) { profile in
+            HStack {
+                Text(profile.displayName(strings))
+                Spacer()
+                if !profile.isBuiltIn {
+                    Button(strings.renameProfile) {
+                        renaming = profile
+                        renameText = profile.displayName(strings)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(Color.accentColor)
+                }
+                Button(strings.duplicateProfile) { duplicate(profile) }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(Color.accentColor)
+                if !profile.isBuiltIn {
+                    Button {
+                        delete(profile)
+                    } label: {
+                        Image(systemName: "trash")
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .onMove(perform: move)
+        .alert(strings.profileRenamePrompt, isPresented: Binding(
+            get: { renaming != nil },
+            set: { if !$0 { renaming = nil } }
+        )) {
+            TextField(strings.profileNamePlaceholder, text: $renameText)
+            Button(strings.saveProfileButton) {
+                if let renaming { rename(renaming, to: renameText) }
+                self.renaming = nil
+            }
+            Button(strings.cancelButton, role: .cancel) { renaming = nil }
+        }
+    }
+
+    private func write(_ profiles: [FanProfile]) {
+        if let encoded = FanProfile.encodeArray(profiles) {
+            profilesStorage = encoded
+        }
+    }
+
+    private func rename(_ profile: FanProfile, to name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !profile.isBuiltIn else { return }
+        var updated = profiles
+        guard let index = updated.firstIndex(where: { $0.id == profile.id }) else { return }
+        updated[index].name = trimmed
+        write(updated)
+    }
+
+    private func duplicate(_ profile: FanProfile) {
+        let name = String(format: strings.profileCopySuffixFormat, profile.displayName(strings))
+        write(profiles + [profile.duplicated(named: name)])
+    }
+
+    private func delete(_ profile: FanProfile) {
+        guard !profile.isBuiltIn else { return }
+        write(profiles.filter { $0.id != profile.id })
+    }
+
+    private func move(from source: IndexSet, to destination: Int) {
+        var updated = profiles
+        updated.move(fromOffsets: source, toOffset: destination)
+        write(updated)
     }
 }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -14168,6 +14168,49 @@ struct MetricsTests {
                 && FanControlPolicy.interpolatedCoolingLevel(points: defaultCurve.points,
                                                              temperature: 80) == 100,
                "the default curve starts at 50 degrees, reaches maximum at 70 and rounds safely up")
+
+        expect(FanControlPolicy.sessionDuration(for: .manual(level: 60)) == nil
+                && FanControlPolicy.sessionDuration(for: .manual(level: 60, duration: .untilChanged)) == nil
+                && FanControlPolicy.sessionDuration(for: .manual(level: 60, duration: .fifteenMinutes)) == 15 * 60
+                && FanControlPolicy.sessionDuration(for: .manual(level: 60, duration: .thirtyMinutes)) == 30 * 60
+                && FanControlPolicy.sessionDuration(for: .manual(level: 60, duration: .oneHour)) == 60 * 60
+                && FanControlPolicy.sessionDuration(for: .manual(level: 60, duration: .twoHours)) == 2 * 60 * 60
+                && FanControlPolicy.sessionDuration(for: .manual(level: 60, duration: .fourHours)) == 4 * 60 * 60
+                && FanControlPolicy.sessionDuration(for: .curve([defaultCurve])) == nil,
+               "only a finite manual duration produces a session deadline; curve mode never expires on its own")
+        expect(FanControlPolicy.validConfiguration(.manual(level: 50, duration: .fifteenMinutes))
+                && FanControlPolicy.validConfiguration(.manual(level: 50, duration: .untilChanged)),
+               "a manual duration choice never affects whether the configuration is valid")
+
+        let manualDeadline = Date(timeIntervalSince1970: 10_000)
+        expect(FanControlPolicy.manualDurationElapsed(until: manualDeadline,
+                                                       now: manualDeadline) == true
+                && FanControlPolicy.manualDurationElapsed(until: manualDeadline,
+                                                          now: manualDeadline.addingTimeInterval(1)) == true
+                && FanControlPolicy.manualDurationElapsed(until: manualDeadline,
+                                                          now: manualDeadline.addingTimeInterval(-1)) == false,
+               "a manual session is considered elapsed exactly at, and after, its deadline")
+        expect(FanControlPolicy.remainingManualMinutes(until: nil, now: manualDeadline) == nil
+                && FanControlPolicy.remainingManualMinutes(until: manualDeadline, now: manualDeadline) == nil
+                && FanControlPolicy.remainingManualMinutes(
+                    until: manualDeadline.addingTimeInterval(1), now: manualDeadline) == 1
+                && FanControlPolicy.remainingManualMinutes(
+                    until: manualDeadline.addingTimeInterval(90), now: manualDeadline) == 2
+                && FanControlPolicy.remainingManualMinutes(
+                    until: manualDeadline.addingTimeInterval(600), now: manualDeadline) == 10,
+               "remaining minutes rounds up so the label never claims zero minutes while control is still active")
+
+        expect(FanControlPolicy.modeAfterManualExpiry(previousMode: .curve) == .curve
+                && FanControlPolicy.modeAfterManualExpiry(previousMode: .system) == .system
+                && FanControlPolicy.modeAfterManualExpiry(previousMode: .manual) == .system
+                && FanControlPolicy.modeAfterManualExpiry(previousMode: nil) == .system,
+               "a timed manual override resumes the curve it interrupted, or otherwise system control")
+        expect(FanControlPolicy.manualOverridePreviousMode(isCooling: true, activeMode: .curve) == .curve
+                && FanControlPolicy.manualOverridePreviousMode(isCooling: true, activeMode: .system) == .system
+                && FanControlPolicy.manualOverridePreviousMode(isCooling: false, activeMode: .curve) == .system
+                && FanControlPolicy.manualOverridePreviousMode(isCooling: true, activeMode: nil) == .system,
+               "a manual override only remembers curve as its previous mode when a curve was actually running")
+
         let coolingTemperature = [
             FanControlTemperatureReading(source: .hottestSoC, celsius: 59),
         ]
@@ -14346,7 +14389,7 @@ struct MetricsTests {
         for language in AppLanguage.allCases {
             let strings = FeatureStrings.fanControl(language)
             let values = Mirror(reflecting: strings).children.compactMap { $0.value as? String }
-            expect(values.count == 42 && values.allSatisfy { !$0.isEmpty },
+            expect(values.count == 50 && values.allSatisfy { !$0.isEmpty },
                    "fan control has every localized field for \(language.rawValue)")
             expect(values.allSatisfy { !$0.contains("—") },
                    "fan control text uses human punctuation for \(language.rawValue)")
@@ -14358,6 +14401,12 @@ struct MetricsTests {
                          "current fan speed format stays valid for \(language.rawValue)")
             expectFormat(strings.targetRPMFormat, ["d"],
                          "target fan speed format stays valid for \(language.rawValue)")
+            expectFormat(strings.minutesRemainingFormat, ["d"],
+                         "manual duration remaining format stays valid for \(language.rawValue)")
+            for option in FanControlManualDuration.allCases {
+                expect(!strings.durationLabel(for: option).isEmpty,
+                       "manual duration \(option.rawValue) has a label for \(language.rawValue)")
+            }
         }
         expect(FanControlFeatureStrings.ru.rpmFormat == "%d об/мин"
                 && FanControlFeatureStrings.de.rpmFormat == "%d U/min"

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -14320,6 +14320,87 @@ struct MetricsTests {
                 && FanControlPolicy.menuBarWidthUnits(fanCount: 0) == 0,
                "fan RPM menu bar width reserves one or several five-digit readings")
 
+        // MARK: - Fan profiles
+
+        let fanStrings = FanControlFeatureStrings.enUS
+        let systemProfile = FanProfile(id: "custom-system", name: "My System", kind: .system)
+        let manualProfile = FanProfile(id: "custom-manual", name: "My Manual",
+                                       kind: .manual(level: 40, duration: .oneHour))
+        let curveProfile = FanProfile(id: "custom-curve", name: "My Curve",
+                                      kind: .curve(points: defaultCurve.points, temperatureSource: .hottestSoC))
+        expect(systemProfile.configuration == FanControlConfiguration(mode: .system,
+                                                                       manualLevel: FanControlPolicy.defaultCoolingLevel,
+                                                                       curves: [], manualDuration: .untilChanged)
+                && manualProfile.configuration == .manual(level: 40, duration: .oneHour)
+                && curveProfile.configuration == .curve([FanControlCurve(sensor: .hottestSoC,
+                                                                         points: defaultCurve.points)]),
+               "a profile's kind maps to the exact configuration it should apply")
+
+        expect(FanProfile.makeCustom(name: "n", from: .manual(level: 60)).kind
+                == .manual(level: 60, duration: .untilChanged)
+                && FanProfile.makeCustom(name: "n", from: .curve([defaultCurve, cpuCurve])).kind
+                == .curve(points: defaultCurve.points, temperatureSource: defaultCurve.sensor)
+                && FanProfile.makeCustom(name: "n",
+                                        from: FanControlConfiguration(mode: .system, manualLevel: 55,
+                                                                      curves: [defaultCurve],
+                                                                      manualDuration: .thirtyMinutes)).kind == .system,
+               "capturing the current configuration into a profile maps the other direction too, keeping only the first curve")
+
+        expect(manualProfile.matches(.manual(level: 40, duration: .oneHour))
+                && !manualProfile.matches(.manual(level: 41, duration: .oneHour))
+                && !manualProfile.matches(.manual(level: 40, duration: .twoHours))
+                && !manualProfile.matches(.curve([defaultCurve])),
+               "a profile matches only the exact configuration it applies")
+
+        let builtIns = FanProfileBuiltIn.defaultProfiles(fanStrings)
+        expect(builtIns.map(\.id) == ["builtin.silent", "builtin.balanced", "builtin.performance"]
+                && builtIns.allSatisfy(\.isBuiltIn)
+                && builtIns[0].kind == .manual(level: 25, duration: .untilChanged)
+                && builtIns[1].kind == .system
+                && builtIns[2].kind == .manual(level: 75, duration: .untilChanged)
+                && builtIns.map { $0.displayName(fanStrings) } == [fanStrings.profileSilent,
+                                                                    fanStrings.profileBalanced,
+                                                                    fanStrings.profilePerformance]
+                && !manualProfile.isBuiltIn,
+               "the three built-in presets exist with the documented levels and translated names, and customs are not built-in")
+
+        // A built-in's displayed name always re-resolves from `strings`,
+        // ignoring whatever was stored — simulating a stale name from before
+        // a language change.
+        let staleBuiltIn = FanProfile(id: FanProfileBuiltIn.silent.id, name: "(stale)", kind: .manual(level: 25, duration: .untilChanged))
+        expect(staleBuiltIn.displayName(fanStrings) == fanStrings.profileSilent,
+               "a built-in's display name ignores its stored name and always re-translates")
+
+        expect(FanProfile.activeProfile(matching: .manual(level: 25, duration: .untilChanged), in: builtIns)?.id
+                == FanProfileBuiltIn.silent.id
+                && FanProfile.activeProfile(matching: .manual(level: 26, duration: .untilChanged), in: builtIns) == nil
+                && FanProfile.activeProfile(
+                    matching: FanControlConfiguration(mode: .system, manualLevel: FanControlPolicy.defaultCoolingLevel,
+                                                      curves: [], manualDuration: .untilChanged),
+                    in: builtIns)?.id == FanProfileBuiltIn.balanced.id,
+               "the active profile is whichever stored profile's configuration matches the live controls, or none")
+
+        // Decoding an array with one entry of an unrecognized `kind` (as a
+        // newer app version might have written) must not lose the rest.
+        let keepProfile = FanProfile(id: "keep", name: "Keep", kind: .system)
+        let futureProfile = FanProfile(id: "future", name: "Future",
+                                       kind: .manual(level: 50, duration: .untilChanged))
+        if let encodedPair = FanProfile.encodeArray([keepProfile, futureProfile]) {
+            let corrupted = encodedPair.replacingOccurrences(of: "\"manual\"", with: "\"mysteryKind\"")
+            expect(FanProfile.decodeArray(corrupted) == [keepProfile],
+                   "a stored profile with an unrecognized kind is skipped, not fatal to the rest of the array")
+        } else {
+            expect(false, "fan profiles failed to encode")
+        }
+        expect(FanProfile.decodeArray("not json").isEmpty,
+               "malformed profile storage decodes to no profiles rather than crashing")
+
+        expect(FanProfile.migratedProfiles(storedValue: nil, strings: fanStrings) == builtIns
+                && FanProfile.migratedProfiles(storedValue: "[]", strings: fanStrings) == builtIns
+                && FanProfile.migratedProfiles(storedValue: FanProfile.encodeArray([keepProfile]) ?? "",
+                                               strings: fanStrings) == [keepProfile],
+               "migration seeds the three built-ins only when nothing (or nothing usable) was stored yet")
+
         let floatRPM = SMCValueCodec.encode(4_850, type: "flt ", size: 4)
         expect(floatRPM.flatMap { SMCValueCodec.decode($0, type: "flt ") } == 4_850,
                "native fan RPM floats round-trip exactly")
@@ -14389,7 +14470,7 @@ struct MetricsTests {
         for language in AppLanguage.allCases {
             let strings = FeatureStrings.fanControl(language)
             let values = Mirror(reflecting: strings).children.compactMap { $0.value as? String }
-            expect(values.count == 50 && values.allSatisfy { !$0.isEmpty },
+            expect(values.count == 64 && values.allSatisfy { !$0.isEmpty },
                    "fan control has every localized field for \(language.rawValue)")
             expect(values.allSatisfy { !$0.contains("—") },
                    "fan control text uses human punctuation for \(language.rawValue)")


### PR DESCRIPTION
## Summary
- A manual fan speed can now expire after a chosen duration — 15 min, 30 min, 1 h, 2 h, 4 h, or until changed (the default) — riding on the helper's existing `endsAt` watchdog rather than a new timer. When the deadline fires, the service resumes whatever curve/mode was running before the manual override instead of always dropping to system control.
- Named fan profiles (Silent / Balanced / Performance, plus custom ones saved from the current settings) let you switch configurations with one click from the panel, with management (rename/duplicate/delete/reorder) in Settings.

## Safety
- The privileged helper's protocol is unchanged; crash recovery, sleep/wake and quit paths are untouched.
- Manual-timer bookkeeping (`fanControlManualUntil`, `fanControlModeBeforeManual`, `fanControlManualPreviousCurves`) is only recorded after a confirmed successful apply, so a failed or unanswered XPC call can't leave stale state for a later override to inherit.
- The helper still enforces the deadline itself — the app is not what's making the override end on time.

## Changes
- `feat(fan-control): let a manual speed expire after a chosen duration` — adds the duration picker and remaining-time label next to the manual slider, wired to the helper's `endsAt` watchdog; expiry resumes the previously running curve/mode instead of always falling back to system control.
- `fix(fan-control): keep manual timer bookkeeping honest` — corrects a stale doc comment, freezes the curve configuration actually confirmed active into `fanControlManualPreviousCurves` at override start (instead of re-reading the live, possibly-unapplied curve editor state at expiry), and only records timer bookkeeping after a confirmed successful apply, clearing it explicitly on the no-response guard paths.
- `feat(fan-control): named fan profiles with one-click switching` — adds `FanProfile` (system/manual/curve) stored under `fanControlProfiles`/`fanControlActiveProfileID`, three non-deletable built-ins seeded on first run, a profile chip row in the panel (segmented, or a compact menu past four profiles) that applies through the same `applyConfiguration` path as a hand-set mode, a "Save as profile…" action, and a minimal Profiles list in Settings; pure mapping/matching/migration logic stays in `FanControlSupport.swift` so it keeps compiling into the privileged helper target.

## Testing
- Pure-logic unit tests added/updated for: duration mapping and expiry behavior, manual-timer bookkeeping honesty (stale-state clearing on failed apply), and profile configuration mapping both ways, match/mismatch against live controls, the three built-ins and their translated names (all 13 locales), decoding an array with one unrecognized-`kind` entry, and first-run migration.
- `./build.sh --dev`, `./build.sh --test`, and `--selftest` all pass (the one failing test, "App Switcher icon-row hints describe default app and window shortcuts", reproduces identically on `origin/main` and is unrelated to fan control).
- Manual: picked 60% manual speed for 15 min, watched the countdown in the panel, confirmed it reverted to the prior curve/mode at expiry; tapped Silent and Performance chips and confirmed the helper applied each correctly.

## Notes
Refs #796 (the request to let the manual duration be chosen). This PR is the fan-control-related part of the fork described in #1367 — the manual-timer and profiles work only, independent of the window-management work in that discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011p5VL4cwCmCZzWXya6owDa
