### PR TITLE
feat(mixer): software master for outputs macOS cannot set

### DIFF
--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -113,6 +113,7 @@ enum DefaultsKey {
     static let mixerShowFinder = "mixerShowFinder"
     static let mixerHideInactiveApps = "mixerHideInactiveApps"
     static let mixerHiddenApps = "mixerHiddenApps"        // [persistence id: display name] kept out of the mixer list (issue #300)
+    static let mixerSoftwareOutputVolumes = "mixerSoftwareOutputVolumes" // [audio device UID: 0...1] master for outputs macOS cannot set
     static let mixerLowerVolumeOnHeadphonesDisconnect = "mixerLowerVolumeOnHeadphonesDisconnect"
     static let mixerHeadphonesDisconnectVolumePercent = "mixerHeadphonesDisconnectVolumePercent"
     static let preciseVolumeRollerEnabled = "preciseVolumeRollerEnabled"
@@ -1820,6 +1821,15 @@ enum Defaults {
     static func sanitizedAppVolume(_ volume: Double) -> Double {
         guard volume.isFinite else { return 1 }
         return min(max(volume, 0), 2)
+    }
+
+    /// The software master of an output device runs 0...1. It stands in for a
+    /// hardware volume control, and standing in for one is not a reason to
+    /// send the device more than the app already produces: the boost above
+    /// 100% stays where it belongs, on the per app rows.
+    static func sanitizedSoftwareOutputVolume(_ volume: Double) -> Double {
+        guard volume.isFinite else { return 1 }
+        return min(max(volume, 0), 1)
     }
 
     /// The volume the speakers are set to when headphones disconnect. It is a

--- a/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
+++ b/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
@@ -133,6 +133,14 @@ final class AppVolumeMixer: ObservableObject {
     /// refresh and reconciliation verifies every engine is still rendering.
     private var wakeObserver: NSObjectProtocol?
     private var lastAutomaticLoweredOutputUID: String?
+    /// The output device whose volume macOS cannot set, so the master slider
+    /// standing in for it is carried by the taps instead of the hardware. Nil
+    /// whenever the current output has a real volume control of its own.
+    @Published private(set) var softwareMasterDeviceUID: String?
+    /// That device's master, held in memory because every engine decision
+    /// reads it: the gates run once per row on each HAL notification, and a
+    /// defaults read per row per notification is not what this is worth.
+    private var softwareMasterVolume: Double = 1
     /// The output volume as it was before the headphone disconnect protection
     /// lowered it, so the speakers can be handed back the way they were found.
     private var loweredOutput: LoweredOutput?
@@ -240,8 +248,7 @@ final class AppVolumeMixer: ObservableObject {
         if !outputDevices.isEmpty { outputDevices = [] }
         if currentOutputDeviceUID != nil { currentOutputDeviceUID = nil }
         if currentSystemSoundOutputDeviceUID != nil { currentSystemSoundOutputDeviceUID = nil }
-        if systemOutputVolume != nil { systemOutputVolume = nil }
-        if systemOutputMuted != nil { systemOutputMuted = nil }
+        publishSystemOutput(hardwareVolume: nil, muted: nil, deviceUID: nil)
         if outputSwitchError != nil { outputSwitchError = nil }
         if needsPermission { needsPermission = false }
     }
@@ -364,8 +371,9 @@ final class AppVolumeMixer: ObservableObject {
                           self.listenerInstalled,
                           self.outputControlListenerDevice == device,
                           self.outputControlRefreshGeneration == generation else { return }
-                    if self.systemOutputVolume != volume { self.systemOutputVolume = volume }
-                    if self.systemOutputMuted != muted { self.systemOutputMuted = muted }
+                    self.publishSystemOutput(hardwareVolume: volume,
+                                             muted: muted,
+                                             deviceUID: self.currentOutputDeviceUID)
                 }
             }
         }
@@ -430,12 +438,86 @@ final class AppVolumeMixer: ObservableObject {
 
     func setCurrentOutputVolume(_ volume: Double) {
         let clamped = min(max(volume, 0), 1)
+        if let deviceUID = softwareMasterDeviceUID {
+            softwareMasterVolume = clamped
+            persistSoftwareMasterVolume(clamped, for: deviceUID)
+            if systemOutputVolume != clamped { systemOutputVolume = clamped }
+            applySoftwareMasterToEveryRow()
+            return
+        }
         guard Self.setSystemOutputVolume(clamped) else {
             scheduleListenerRefresh()
             return
         }
         if systemOutputVolume != clamped { systemOutputVolume = clamped }
         if clamped > 0, systemOutputMuted == true { systemOutputMuted = false }
+    }
+
+    /// Whether the current output is one macOS cannot set the volume of, so
+    /// the volume keys have the software master to move instead of nothing.
+    var hasSoftwareMasterOutput: Bool { softwareMasterDeviceUID != nil }
+
+    /// What the current output calls itself, for the overlay that names the
+    /// device the level belongs to.
+    var currentOutputDeviceName: String? {
+        outputDevices.first { $0.uid == currentOutputDeviceUID }?.name
+    }
+
+    /// One press of a volume key on an output that has no volume control of
+    /// its own. False when the current output has one, so the caller leaves
+    /// the key to macOS.
+    func stepSoftwareMasterVolume(up: Bool, fine: Bool) -> Double? {
+        guard softwareMasterDeviceUID != nil else { return nil }
+        let stepped = MixerRoutingSupport.steppedMasterVolume(current: softwareMasterVolume,
+                                                             up: up,
+                                                             fine: fine)
+        setCurrentOutputVolume(stepped)
+        return stepped
+    }
+
+    /// Publishes what the panel's output slider shows. A device macOS cannot
+    /// set the volume of has no hardware value to read, and the software
+    /// master stands in for it there, so the row stays a live control instead
+    /// of disappearing.
+    private func publishSystemOutput(hardwareVolume: Double?, muted: Bool?, deviceUID: String?) {
+        let softwareUID = hardwareVolume == nil ? deviceUID : nil
+        if softwareMasterDeviceUID != softwareUID {
+            softwareMasterDeviceUID = softwareUID
+            softwareMasterVolume = softwareUID.map { storedSoftwareMasterVolume(for: $0) } ?? 1
+            // The volume keys are only worth taking over while there is a
+            // master to move, so the tap follows this state rather than
+            // staying armed for every output.
+            PreciseVolumeRollerService.shared.syncWithPreferences()
+        }
+        let volume = hardwareVolume ?? (softwareUID == nil ? nil : softwareMasterVolume)
+        if systemOutputVolume != volume { systemOutputVolume = volume }
+        if systemOutputMuted != muted { systemOutputMuted = muted }
+    }
+
+    /// A row already tapped only takes the new gain; a row that was passing
+    /// through gets an engine, and hands it back when the master returns to
+    /// 100%. Dragging the slider lands here per step, and the build tokens
+    /// swallow the duplicates exactly as they do for an app's own slider.
+    private func applySoftwareMasterToEveryRow() {
+        for app in apps { applyRouting(for: app) }
+        clearPermissionIfNoActiveAdjustments()
+    }
+
+    /// How far this row is turned down by the software master. The master
+    /// belongs to one device: a row routed elsewhere is left alone.
+    private func masterFactor(for app: MixerApp) -> Double {
+        MixerRoutingSupport.softwareMasterFactor(
+            masterVolume: softwareMasterVolume,
+            masterDeviceUID: softwareMasterDeviceUID,
+            targetOutputDeviceUID: app.effectiveOutputDeviceUID)
+    }
+
+    /// What the row's tap renders at. The row's own slider never moves with
+    /// the master; the product of the two is what reaches the device.
+    private func effectiveGain(for app: MixerApp) -> Double {
+        MixerRoutingSupport.effectiveGain(appVolume: app.volume,
+                                          masterFactor: masterFactor(for: app),
+                                          maximum: Self.maxVolume)
     }
 
     /// 100% means bit-perfect passthrough (no tap). A value the UI would round to
@@ -606,7 +688,7 @@ final class AppVolumeMixer: ObservableObject {
         if let engine = engines[app.id],
            engine.tappedObjects == app.audioObjects,
            engine.outputDeviceUID == targetOutputDeviceUID {
-            engine.gain = Float(app.volume)
+            engine.gain = Float(effectiveGain(for: app))
             return
         }
         // Nothing is ever tapped on behalf of an app the user never adjusted.
@@ -621,9 +703,12 @@ final class AppVolumeMixer: ObservableObject {
         guard engineRecovery.allowsBuild(app.id, configuration: configuration) else { return }
         guard #available(macOS 14.4, *), let token = builds.begin(app.id) else { return }
 
+        // Read off the main thread's state here: the build itself runs on
+        // another queue and the master belongs to this one.
+        let gain = Float(effectiveGain(for: app))
         buildQueue.async { [weak self] in
             let engine = TapGainEngine(objects: app.audioObjects,
-                                       gain: Float(app.volume),
+                                       gain: gain,
                                        outputDeviceUID: targetOutputDeviceUID)
             DispatchQueue.main.async {
                 guard let self else {
@@ -678,7 +763,7 @@ final class AppVolumeMixer: ObservableObject {
             applyRouting(for: latestApp)
             return
         }
-        engine.gain = Float(latestApp.volume)
+        engine.gain = Float(effectiveGain(for: latestApp))
         let previous = engines.updateValue(engine, forKey: id)
         engineChangeAt[id] = CFAbsoluteTimeGetCurrent()
         // The fresh engine starts its render count over.
@@ -704,12 +789,14 @@ final class AppVolumeMixer: ObservableObject {
         MixerRoutingSupport.rowMayBeTapped(
             savedVolume: storedVolume(for: app.identity, saved: savedVolumes()),
             savedRouteUID: storedRoute(for: app.identity, saved: savedOutputDeviceUIDs()),
+            masterFactor: masterFactor(for: app),
             defaultOutputDeviceUID: currentOutputDeviceUID)
     }
 
     private func appNeedsEngine(_ app: MixerApp) -> Bool {
         MixerRoutingSupport.requiresEngine(hasAudioObjects: !app.audioObjects.isEmpty,
                                            volume: app.volume,
+                                           masterFactor: masterFactor(for: app),
                                            selectedOutputDeviceUID: app.selectedOutputDeviceUID,
                                            targetOutputDeviceUID: app.effectiveOutputDeviceUID,
                                            defaultOutputDeviceUID: currentOutputDeviceUID)
@@ -851,12 +938,9 @@ final class AppVolumeMixer: ObservableObject {
             outputDevices = snapshot.outputDevices
         }
         subscribeToOutputControls(of: snapshot.defaultDeviceID)
-        if systemOutputVolume != snapshot.systemOutputVolume {
-            systemOutputVolume = snapshot.systemOutputVolume
-        }
-        if systemOutputMuted != snapshot.systemOutputMuted {
-            systemOutputMuted = snapshot.systemOutputMuted
-        }
+        publishSystemOutput(hardwareVolume: snapshot.systemOutputVolume,
+                            muted: snapshot.systemOutputMuted,
+                            deviceUID: snapshot.defaultUID)
 
         guard let next = snapshot.apps else {
             if !apps.isEmpty {
@@ -924,6 +1008,9 @@ final class AppVolumeMixer: ObservableObject {
         var playing: Set<pid_t> = []
         var bypassed: Set<pid_t> = []
         var bundleHints: [pid_t: String] = [:]
+        var systemSoundObjects: [AudioObjectID] = []
+        var systemSoundPid: pid_t = 0
+        var systemSoundPlaying = false
         let processObjects = audioProcessObjects()
         for object in processObjects {
             var pid: pid_t = -1
@@ -932,7 +1019,21 @@ final class AppVolumeMixer: ObservableObject {
             // Show every regular app that holds an audio connection, not only
             // the ones making sound this instant, so apps are adjustable before
             // they play and stay put between sounds.
-            guard let app = ResponsibleProcess.regularAppOwner(of: pid) else { continue }
+            guard let app = ResponsibleProcess.regularAppOwner(of: pid) else {
+                // The system sound server owns no application, so the lookup
+                // above drops it and the master never reached the sounds
+                // macOS itself plays. It gets no row — there is nothing for
+                // the user to adjust on it — but its audio is part of what
+                // the output carries, so the master has to reach it.
+                guard MixerRoutingSupport.isSystemSoundServer(
+                    Self.processBundleIdentifier(of: object)) else { continue }
+                systemSoundObjects.append(object)
+                systemSoundPid = pid
+                var running: UInt32 = 0
+                _ = Self.read(object, kAudioProcessPropertyIsRunningOutput, &running)
+                if running != 0 { systemSoundPlaying = true }
+                continue
+            }
             let owner = app.processIdentifier
             let name = ResponsibleProcess.displayName(pid: owner, fallback: app.localizedName ?? "pid \(owner)")
             // Bypassed apps (Zoom, DAWs) still get a row — hiding them read
@@ -1017,6 +1118,22 @@ final class AppVolumeMixer: ObservableObject {
                                     selectedUID: savedOutputs[id],
                                     availableUIDs: availableUIDs),
                                  volume: saved[id] ?? 1))
+        }
+        // Rendered to the device the system sounds actually play on, which
+        // the user picks apart from the main output: sending them to the
+        // default one instead would move sound the mixer was only meant to
+        // turn down.
+        if !systemSoundObjects.isEmpty, let systemSoundUID {
+            next.append(MixerApp(id: MixerRoutingSupport.systemSoundsRowID,
+                                 persistenceID: nil,
+                                 ownerPid: systemSoundPid,
+                                 name: MixerRoutingSupport.systemSoundsRowID,
+                                 audioObjects: systemSoundObjects.sorted(),
+                                 isPlaying: systemSoundPlaying,
+                                 selectedOutputDeviceUID: nil,
+                                 effectiveOutputDeviceUID: systemSoundUID,
+                                 outputDeviceUnavailable: false,
+                                 volume: 1))
         }
         next.sort {
             MixerRoutingSupport.displayOrderedBefore(name: $0.name, id: $0.id,
@@ -1302,6 +1419,34 @@ final class AppVolumeMixer: ObservableObject {
             sanitized[id] = Defaults.sanitizedAppVolume(number)
         }
         return sanitized
+    }
+
+    /// The software master of each output device that has one, by device UID:
+    /// plugging the monitor back in brings its level back with it.
+    private func softwareMasterVolumes() -> [String: Double] {
+        let raw = UserDefaults.standard.dictionary(forKey: DefaultsKey.mixerSoftwareOutputVolumes) ?? [:]
+        var sanitized: [String: Double] = [:]
+        for (uid, value) in raw {
+            guard let number = (value as? NSNumber)?.doubleValue else { continue }
+            sanitized[uid] = Defaults.sanitizedSoftwareOutputVolume(number)
+        }
+        return sanitized
+    }
+
+    /// 100% until the user moves it: an output that gains a slider must never
+    /// also become quieter on its own.
+    private func storedSoftwareMasterVolume(for uid: String) -> Double {
+        softwareMasterVolumes()[uid] ?? 1
+    }
+
+    private func persistSoftwareMasterVolume(_ volume: Double, for uid: String) {
+        var volumes = softwareMasterVolumes()
+        if isUnity(volume) {
+            volumes.removeValue(forKey: uid)
+        } else {
+            volumes[uid] = volume
+        }
+        UserDefaults.standard.set(volumes, forKey: DefaultsKey.mixerSoftwareOutputVolumes)
     }
 
     private func savedOutputDeviceUIDs() -> [String: String] {

--- a/Sources/Vorssaint/Services/Audio/MixerRoutingSupport.swift
+++ b/Sources/Vorssaint/Services/Audio/MixerRoutingSupport.swift
@@ -279,14 +279,57 @@ enum MixerRoutingSupport {
         return directTerms.contains { normalized.contains($0) }
     }
 
+    /// The software master's factor for one row. The master belongs to a single
+    /// output device, so a row playing somewhere else keeps its own volume: the
+    /// factor is 1 for every row that is not routed to that device.
+    static func softwareMasterFactor(masterVolume: Double?,
+                                     masterDeviceUID: String?,
+                                     targetOutputDeviceUID: String?) -> Double {
+        guard let masterVolume, masterVolume.isFinite,
+              let masterDeviceUID,
+              targetOutputDeviceUID == masterDeviceUID else { return 1 }
+        return min(max(masterVolume, 0), 1)
+    }
+
+    /// What a tap renders at. The row's slider and the software master are two
+    /// independent controls: neither moves the other, and what reaches the
+    /// device is their product.
+    static func effectiveGain(appVolume: Double,
+                              masterFactor: Double,
+                              maximum: Double) -> Double {
+        let product = appVolume * masterFactor
+        guard product.isFinite else { return 0 }
+        return min(max(product, 0), maximum)
+    }
+
+    /// macOS moves its own volume in sixteenths, and a quarter of that with
+    /// Option-Shift held. The software master follows the same steps, so the
+    /// keys feel the same on an output macOS can set and one it cannot.
+    static let masterVolumeStep: Double = 1.0 / 16
+    static let fineMasterVolumeStep: Double = 1.0 / 64
+
+    /// One press of a volume key. A level left off the step grid by the
+    /// slider snaps onto it in the direction of travel, so the first press
+    /// after a drag moves by one step rather than a fraction of one.
+    static func steppedMasterVolume(current: Double, up: Bool, fine: Bool) -> Double {
+        let step = fine ? fineMasterVolumeStep : masterVolumeStep
+        guard current.isFinite else { return up ? step : 0 }
+        let grid = (min(max(current, 0), 1) / step).rounded(up ? .down : .up)
+        return min(max((grid + (up ? 1 : -1)) * step, 0), 1)
+    }
+
     static func requiresEngine(hasAudioObjects: Bool = true,
                                volume: Double,
+                               masterFactor: Double = 1,
                                selectedOutputDeviceUID: String?,
                                targetOutputDeviceUID: String?,
                                defaultOutputDeviceUID: String?) -> Bool {
         guard hasAudioObjects else { return false }
         guard let targetOutputDeviceUID else { return false }
         if !isUnity(volume) { return true }
+        // A master below 100% has to be carried by the taps, so every row
+        // routed to that device needs an engine even at its own 100%.
+        if !isUnity(masterFactor) { return true }
         guard let selectedOutputDeviceUID else { return false }
         guard let defaultOutputDeviceUID else { return true }
         return selectedOutputDeviceUID != defaultOutputDeviceUID
@@ -295,12 +338,15 @@ enum MixerRoutingSupport {
 
     /// The last gate before a tap is built: a row is tapped only when the user
     /// actually adjusted it, either to a volume other than 100% or to an output
-    /// other than the system default. An app that is merely listed is never
-    /// part of any tap, so the mixer can neither mute it nor re-render its
-    /// sound.
+    /// other than the system default, or because the software master is
+    /// turned down and the row plays through it. An app that is merely listed
+    /// is never part of any tap, so the mixer can neither mute it nor
+    /// re-render its sound.
     static func rowMayBeTapped(savedVolume: Double?,
                                savedRouteUID: String?,
+                               masterFactor: Double = 1,
                                defaultOutputDeviceUID: String?) -> Bool {
+        if !isUnity(masterFactor) { return true }
         if let savedVolume, !isUnity(savedVolume) { return true }
         guard let savedRouteUID else { return false }
         guard let defaultOutputDeviceUID else { return true }
@@ -324,6 +370,18 @@ enum MixerRoutingSupport {
     }
 
     static let unidentifiedRowPrefix = "process:"
+
+    /// The row the system's alert and interface sounds play through. It owns
+    /// no application, so it never appears in the list the panel draws — it is
+    /// carried only so the software master reaches the sounds macOS itself
+    /// makes, which are part of what the output plays like anything else.
+    static let systemSoundsRowID = "__system_sounds__"
+
+    /// What the audio HAL reports for the process macOS plays those sounds
+    /// from. Not a bundle id, which is why the row lookup misses it.
+    static func isSystemSoundServer(_ bundleIdentifier: String?) -> Bool {
+        bundleIdentifier == "systemsoundserverd"
+    }
 
     /// Window used to fold a row's comings and goings into one decision.
     static let engineChurnCoalescingWindow: Double = 0.2

--- a/Sources/Vorssaint/Services/Audio/PreciseVolumeRollerService.swift
+++ b/Sources/Vorssaint/Services/Audio/PreciseVolumeRollerService.swift
@@ -4,8 +4,11 @@
 import AppKit
 import Combine
 
-/// Turns coarse hardware volume wheel bursts into macOS' fine volume step.
-/// Active only while enabled and Accessibility is granted.
+/// Owns the volume keys. It turns coarse hardware volume wheel bursts into
+/// macOS' fine volume step, and on an output macOS refuses to set the volume
+/// of, moves the mixer's software master instead — the keys are dead there
+/// otherwise. Active only while one of the two applies and Accessibility is
+/// granted.
 final class PreciseVolumeRollerService: ObservableObject {
     static let shared = PreciseVolumeRollerService()
 
@@ -14,14 +17,18 @@ final class PreciseVolumeRollerService: ObservableObject {
     private var tap: CFMachPort?
     private var source: CFRunLoopSource?
     private var gate = PreciseVolumeRollerGate()
+    /// The finer-steps preference, read where it is set rather than in the
+    /// tap: the callback runs on every press of a held key.
+    private var prefersFineSteps = false
 
     private init() {
         SessionActivity.shared.onChange { [weak self] _ in self?.syncWithPreferences() }
     }
 
     func syncWithPreferences() {
+        prefersFineSteps = UserDefaults.standard.bool(forKey: DefaultsKey.preciseVolumeRollerEnabled)
         let wanted = AppFeature.mixer.isAvailable
-            && UserDefaults.standard.bool(forKey: DefaultsKey.preciseVolumeRollerEnabled)
+            && (prefersFineSteps || AppVolumeMixer.shared.hasSoftwareMasterOutput)
         if SessionActivitySupport.tapShouldRun(featureWanted: wanted,
                                                accessibilityGranted: AXIsProcessTrusted(),
                                                sessionIsActive: SessionActivity.shared.isActive) {
@@ -107,7 +114,30 @@ final class PreciseVolumeRollerService: ObservableObject {
             return Unmanaged.passUnretained(event)
         }
 
-        if event.flags.contains(.maskAlternate), event.flags.contains(.maskShift) {
+        let fine = event.flags.contains(.maskAlternate) && event.flags.contains(.maskShift)
+
+        // Nothing in the system moves for these keys on an output with no
+        // volume control, so the press is spent here: the master the mixer
+        // renders takes the step, and macOS never gets to draw the overlay
+        // that says the key did nothing.
+        if AppVolumeMixer.shared.hasSoftwareMasterOutput {
+            guard volumePress.isDown else { return nil }
+            // The finer-steps option asks for the smaller step everywhere it
+            // can reach, and on this output it is the only thing that can
+            // honour it: re-posting the key with the modifier reaches a
+            // volume macOS still refuses to set.
+            let fineStep = fine || prefersFineSteps
+            if let level = AppVolumeMixer.shared.stepSoftwareMasterVolume(
+                up: volumePress.direction == .up,
+                fine: fineStep) {
+                LevelOSD.show(displayID: nil,
+                              level: level,
+                              style: .volume(deviceName: AppVolumeMixer.shared.currentOutputDeviceName))
+            }
+            return nil
+        }
+
+        if fine {
             return Unmanaged.passUnretained(event)
         }
 

--- a/Sources/Vorssaint/Services/Display/BrightnessService.swift
+++ b/Sources/Vorssaint/Services/Display/BrightnessService.swift
@@ -352,7 +352,7 @@ final class BrightnessService: ObservableObject {
         pendingDisplayIDs = []
         displayControlFailure = nil
         brightnessOSDSupported = false
-        BrightnessOSD.teardown()
+        LevelOSD.teardown()
         if !displays.isEmpty { displays = [] }
         if !drawableDisplays.isEmpty { drawableDisplays = [] }
         // Queue on the work queue first so this lands AFTER any operation
@@ -1624,8 +1624,9 @@ final class BrightnessService: ObservableObject {
                     self.stateLock.unlock()
                     guard current == writeGeneration,
                           latestWrite == pending.sequence else { return }
-                    BrightnessOSD.show(displayID: id,
-                                       brightness: osdLevel)
+                    LevelOSD.show(displayID: id,
+                                  level: osdLevel,
+                                  style: .glyph("sun.max.fill"))
                 }
             }
         }

--- a/Sources/Vorssaint/Services/Display/BrightnessSupport.swift
+++ b/Sources/Vorssaint/Services/Display/BrightnessSupport.swift
@@ -370,9 +370,11 @@ enum BrightnessSupport {
     /// leaves rather than from a height of its own, which differs between a
     /// notched display and every other one, and from that screen's own origin,
     /// so a second display does not pull it back to the first.
-    static func cornerOverlayFrame(size: CGSize, in visibleFrame: CGRect, inset: CGFloat) -> CGRect {
-        CGRect(x: visibleFrame.maxX - size.width - inset,
-               y: visibleFrame.maxY - size.height - inset,
+    static func cornerOverlayFrame(size: CGSize,
+                                   in visibleFrame: CGRect,
+                                   inset: CGSize) -> CGRect {
+        CGRect(x: visibleFrame.maxX - size.width - inset.width,
+               y: visibleFrame.maxY - size.height - inset.height,
                width: size.width,
                height: size.height)
     }

--- a/Sources/Vorssaint/Services/Display/BrightnessSupport.swift
+++ b/Sources/Vorssaint/Services/Display/BrightnessSupport.swift
@@ -356,6 +356,27 @@ enum BrightnessSupport {
         return min(Int((clamped * 16).rounded(.up)), 16)
     }
 
+    /// Where a level overlay sits: brightness in the middle of the display the
+    /// level belongs to, as it has always been drawn.
+    static func centeredOverlayFrame(size: CGSize, in screenFrame: CGRect) -> CGRect {
+        CGRect(x: screenFrame.midX - size.width / 2,
+               y: screenFrame.midY - size.height / 2,
+               width: size.width,
+               height: size.height)
+    }
+
+    /// The volume overlay's place since macOS 26 moved it: under the menu bar
+    /// at the right of the focused screen. Measured from the area the menu bar
+    /// leaves rather than from a height of its own, which differs between a
+    /// notched display and every other one, and from that screen's own origin,
+    /// so a second display does not pull it back to the first.
+    static func cornerOverlayFrame(size: CGSize, in visibleFrame: CGRect, inset: CGFloat) -> CGRect {
+        CGRect(x: visibleFrame.maxX - size.width - inset,
+               y: visibleFrame.maxY - size.height - inset,
+               width: size.width,
+               height: size.height)
+    }
+
     /// Whole percentage used by the brightness overlay.
     static func wholePercent(_ brightness: Double) -> Int {
         guard brightness.isFinite else { return 0 }

--- a/Sources/Vorssaint/Services/Display/LevelOSD.swift
+++ b/Sources/Vorssaint/Services/Display/LevelOSD.swift
@@ -92,17 +92,11 @@ enum LevelOSD {
     private static func frame(for style: Style, size: NSSize, on screen: NSScreen) -> NSRect {
         switch style {
         case .glyph:
-            return NSRect(x: screen.frame.midX - size.width / 2,
-                          y: screen.frame.midY - size.height / 2,
-                          width: size.width, height: size.height)
+            return BrightnessSupport.centeredOverlayFrame(size: size, in: screen.frame)
         case .volume:
-            // visibleFrame, so the panel clears the menu bar (and the notch's
-            // taller one) instead of a hardcoded height that is wrong on half
-            // the Macs.
-            let area = screen.visibleFrame
-            return NSRect(x: area.maxX - size.width - cornerInset,
-                          y: area.maxY - size.height - cornerInset,
-                          width: size.width, height: size.height)
+            return BrightnessSupport.cornerOverlayFrame(size: size,
+                                                        in: screen.visibleFrame,
+                                                        inset: cornerInset)
         }
     }
 
@@ -225,7 +219,7 @@ struct LevelOSDView: View {
         .background(HUDBackdrop(cornerRadius: 20))
         .environment(\.colorScheme, .dark)
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(deviceName ?? "")
+        .accessibilityLabel(deviceName ?? "\(percentage)%")
         .accessibilityValue("\(percentage)%")
     }
 

--- a/Sources/Vorssaint/Services/Display/LevelOSD.swift
+++ b/Sources/Vorssaint/Services/Display/LevelOSD.swift
@@ -4,45 +4,61 @@
 import AppKit
 import SwiftUI
 
-/// A brief percentage overlay for every brightness route. The disabled
-/// feature owns no window, observer or timer.
-enum BrightnessOSD {
+/// A brief percentage overlay for a level the app moved: every brightness
+/// route, and the software volume master, whose keys macOS draws nothing for.
+/// The disabled feature owns no window, observer or timer.
+enum LevelOSD {
+    /// What the overlay draws around the level, and the shape it takes. The
+    /// two follow their native counterparts rather than each other: macOS 26
+    /// draws volume as a named device over a track, and that is the one the
+    /// app takes over.
+    enum Style: Equatable {
+        /// One large glyph over the level, as the brightness overlay has
+        /// always drawn it.
+        case glyph(String)
+        /// The horizontal panel macOS draws for volume: the output device
+        /// named above a track between a quiet and a loud speaker.
+        case volume(deviceName: String?)
+    }
+
     private static var panel: NSPanel?
-    private static var host: NSHostingController<BrightnessOSDView>?
+    private static var host: NSHostingController<LevelOSDView>?
     private static var dismissWork: DispatchWorkItem?
     private static var generation = 0
 
-    static func show(displayID: CGDirectDisplayID, brightness: Double) {
+    /// `displayID` names the screen the level belongs to. Volume belongs to no
+    /// display, so it passes nil and lands on the focused screen, where macOS
+    /// draws its own volume overlay.
+    static func show(displayID: CGDirectDisplayID?, level: Double, style: Style) {
         guard Thread.isMainThread else {
             DispatchQueue.main.async {
-                show(displayID: displayID, brightness: brightness)
+                show(displayID: displayID, level: level, style: style)
             }
             return
         }
-        guard let screen = NSScreen.screens.first(where: {
-            ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?
-                .uint32Value == displayID
-        }) else { return }
+        guard let screen = displayID.flatMap({ id in
+            NSScreen.screens.first {
+                ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?
+                    .uint32Value == id
+            }
+        }) ?? NSScreen.main else { return }
 
         // One hosting controller for the panel's lifetime: a slider drag
         // shows dozens of updates a second, and rebuilding the SwiftUI host
         // for each would burn CPU for no visual difference.
         let panel = ensurePanel()
-        let host: NSHostingController<BrightnessOSDView>
+        let host: NSHostingController<LevelOSDView>
         if let existing = Self.host {
-            existing.rootView = BrightnessOSDView(brightness: brightness)
+            existing.rootView = LevelOSDView(level: level, style: style)
             host = existing
         } else {
-            host = NSHostingController(rootView: BrightnessOSDView(brightness: brightness))
+            host = NSHostingController(rootView: LevelOSDView(level: level, style: style))
             Self.host = host
             panel.contentViewController = host
         }
         host.view.layoutSubtreeIfNeeded()
         let size = host.view.fittingSize
-        panel.setFrame(NSRect(x: screen.frame.midX - size.width / 2,
-                              y: screen.frame.midY - size.height / 2,
-                              width: size.width, height: size.height),
-                       display: true)
+        panel.setFrame(Self.frame(for: style, size: size, on: screen), display: true)
 
         generation += 1
         if !panel.isVisible {
@@ -68,6 +84,29 @@ enum BrightnessOSD {
         dismissWork = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: work)
     }
+
+    /// Each overlay lands where its native counterpart does: brightness in the
+    /// middle of the display it belongs to, volume tucked under the menu bar
+    /// at the right, where macOS 26 moved it — beneath the Control Center icon
+    /// the level belongs to.
+    private static func frame(for style: Style, size: NSSize, on screen: NSScreen) -> NSRect {
+        switch style {
+        case .glyph:
+            return NSRect(x: screen.frame.midX - size.width / 2,
+                          y: screen.frame.midY - size.height / 2,
+                          width: size.width, height: size.height)
+        case .volume:
+            // visibleFrame, so the panel clears the menu bar (and the notch's
+            // taller one) instead of a hardcoded height that is wrong on half
+            // the Macs.
+            let area = screen.visibleFrame
+            return NSRect(x: area.maxX - size.width - cornerInset,
+                          y: area.maxY - size.height - cornerInset,
+                          width: size.width, height: size.height)
+        }
+    }
+
+    private static let cornerInset: CGFloat = 10
 
     /// Releases the window entirely; the disabled feature owns no panel.
     static func teardown() {
@@ -125,20 +164,74 @@ enum BrightnessOSD {
 
 /// Kept separate from the transient panel so the mandatory UI preview can
 /// host and inspect the exact shipped surface.
-struct BrightnessOSDView: View {
-    let brightness: Double
+struct LevelOSDView: View {
+    let level: Double
+    let style: LevelOSD.Style
 
     private var percentage: Int {
-        BrightnessSupport.wholePercent(brightness)
+        BrightnessSupport.wholePercent(level)
     }
 
     private var filledSegments: Int {
-        BrightnessSupport.filledBrightnessSegments(brightness)
+        BrightnessSupport.filledBrightnessSegments(level)
     }
 
     var body: some View {
+        switch style {
+        case .glyph(let symbol): glyphBody(symbol: symbol)
+        case .volume(let deviceName): volumeBody(deviceName: deviceName)
+        }
+    }
+
+    /// macOS 26's volume overlay: the output device named over a track, since
+    /// the level belongs to a device the user can change, and a percentage on
+    /// its own would not say which one moved.
+    private func volumeBody(deviceName: String?) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            if let deviceName, !deviceName.isEmpty {
+                Text(deviceName)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.85))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            HStack(spacing: 10) {
+                Image(systemName: "speaker.fill")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.75))
+
+                GeometryReader { geometry in
+                    let width = geometry.size.width
+                    Capsule(style: .continuous)
+                        .fill(.white.opacity(0.20))
+                        .overlay(alignment: .leading) {
+                            Capsule(style: .continuous)
+                                .fill(.white)
+                                .frame(width: max(width * min(max(level, 0), 1), 0))
+                        }
+                }
+                .frame(height: 24)
+
+                Image(systemName: "speaker.wave.3.fill")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.75))
+            }
+            .frame(height: 24)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .frame(width: 285)
+        .background(HUDBackdrop(cornerRadius: 20))
+        .environment(\.colorScheme, .dark)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(deviceName ?? "")
+        .accessibilityValue("\(percentage)%")
+    }
+
+    private func glyphBody(symbol: String) -> some View {
         VStack(spacing: 11) {
-            Image(systemName: "sun.max.fill")
+            Image(systemName: symbol)
                 .font(.system(size: 39, weight: .regular))
                 .symbolRenderingMode(.monochrome)
                 .foregroundStyle(.white.opacity(0.82))

--- a/Sources/Vorssaint/Services/Display/LevelOSD.swift
+++ b/Sources/Vorssaint/Services/Display/LevelOSD.swift
@@ -19,6 +19,14 @@ enum LevelOSD {
         /// The horizontal panel macOS draws for volume: the output device
         /// named above a track between a quiet and a loud speaker.
         case volume(deviceName: String?)
+
+        /// macOS' own volume overlay is part of a screenshot; the brightness
+        /// one this replaces has always been left out of capture, and stays
+        /// that way.
+        var appearsInCaptures: Bool {
+            if case .volume = self { return true }
+            return false
+        }
     }
 
     private static var panel: NSPanel?
@@ -47,6 +55,8 @@ enum LevelOSD {
         // shows dozens of updates a second, and rebuilding the SwiftUI host
         // for each would burn CPU for no visual difference.
         let panel = ensurePanel()
+        let sharing: NSWindow.SharingType = style.appearsInCaptures ? .readOnly : .none
+        if panel.sharingType != sharing { panel.sharingType = sharing }
         let host: NSHostingController<LevelOSDView>
         if let existing = Self.host {
             existing.rootView = LevelOSDView(level: level, style: style)
@@ -100,7 +110,9 @@ enum LevelOSD {
         }
     }
 
-    private static let cornerInset: CGFloat = 10
+    /// Measured off the system overlay: ten points in from the right edge and
+    /// thirteen below the menu bar.
+    private static let cornerInset = CGSize(width: 10, height: 13)
 
     /// Releases the window entirely; the disabled feature owns no panel.
     static func teardown() {
@@ -180,47 +192,89 @@ struct LevelOSDView: View {
     /// macOS 26's volume overlay: the output device named over a track, since
     /// the level belongs to a device the user can change, and a percentage on
     /// its own would not say which one moved.
+    /// Every number here was measured off the overlay macOS 26 draws for its
+    /// own volume keys, on a 1x display, in points: the panel, where the track
+    /// and the icons sit inside it, and the sixteen step marks under the
+    /// track. The point of this surface is to be the one the user already
+    /// knows, so the measurements are the specification.
+    enum VolumeMetrics {
+        static let panel = CGSize(width: 294, height: 58)
+        static let cornerRadius: CGFloat = 19
+        /// How much of the surface is the glass filter rather than the screen
+        /// behind it. Calibrated against the system overlay, which passes
+        /// noticeably more detail than the filter alone does.
+        /// How much of the surface is the blurred material rather than the
+        /// screen behind it. The material at full strength holds back nearly
+        /// all the contrast; fading it lets the screen through unfiltered,
+        /// which is what the system overlay reads as.
+        static let materialOpacity: Double = 0.55
+        static let labelOrigin = CGPoint(x: 21, y: 7)
+        static let labelSize: CGFloat = 12
+        static let trackOrigin = CGPoint(x: 33, y: 36)
+        static let trackWidth: CGFloat = 223
+        static let trackHeight: CGFloat = 4
+        /// The step marks sit this far under the track, and there is one at
+        /// each end of the sixteen steps a volume key moves through.
+        static let markGap: CGFloat = 3
+        static let markSize: CGFloat = 2
+        static let markCount = 17
+        static let iconSize: CGFloat = 11
+        static let quietIconCenter = CGPoint(x: 21, y: 38)
+        static let loudIconCenter = CGPoint(x: 268, y: 38)
+    }
+
     private func volumeBody(deviceName: String?) -> some View {
-        VStack(alignment: .leading, spacing: 7) {
+        let metrics = VolumeMetrics.self
+        let fraction = min(max(level, 0), 1)
+        return ZStack(alignment: .topLeading) {
             if let deviceName, !deviceName.isEmpty {
                 Text(deviceName)
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.85))
+                    .font(.system(size: metrics.labelSize, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.88))
                     .lineLimit(1)
                     .truncationMode(.middle)
+                    .frame(width: metrics.panel.width - metrics.labelOrigin.x * 2,
+                           alignment: .leading)
+                    .offset(x: metrics.labelOrigin.x, y: metrics.labelOrigin.y)
             }
 
-            HStack(spacing: 10) {
-                Image(systemName: "speaker.fill")
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.75))
+            volumeIcon("speaker.fill", at: metrics.quietIconCenter)
+            volumeIcon("speaker.wave.3.fill", at: metrics.loudIconCenter)
 
-                GeometryReader { geometry in
-                    let width = geometry.size.width
-                    Capsule(style: .continuous)
-                        .fill(.white.opacity(0.20))
-                        .overlay(alignment: .leading) {
-                            Capsule(style: .continuous)
-                                .fill(.white)
-                                .frame(width: max(width * min(max(level, 0), 1), 0))
-                        }
+            ZStack(alignment: .topLeading) {
+                Capsule(style: .continuous)
+                    .fill(.white.opacity(0.20))
+                    .frame(width: metrics.trackWidth, height: metrics.trackHeight)
+                Capsule(style: .continuous)
+                    .fill(.white)
+                    .frame(width: metrics.trackWidth * fraction, height: metrics.trackHeight)
+                HStack(spacing: 0) {
+                    ForEach(0..<metrics.markCount, id: \.self) { index in
+                        Capsule(style: .continuous)
+                            .fill(.white.opacity(0.30))
+                            .frame(width: metrics.markSize, height: metrics.markSize)
+                        if index < metrics.markCount - 1 { Spacer(minLength: 0) }
+                    }
                 }
-                .frame(height: 24)
-
-                Image(systemName: "speaker.wave.3.fill")
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.75))
+                .frame(width: metrics.trackWidth, height: metrics.markSize)
+                .offset(y: metrics.trackHeight + metrics.markGap)
             }
-            .frame(height: 24)
+            .offset(x: metrics.trackOrigin.x, y: metrics.trackOrigin.y)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
-        .frame(width: 285)
-        .background(HUDBackdrop(cornerRadius: 20))
+        .frame(width: metrics.panel.width, height: metrics.panel.height, alignment: .topLeading)
+        .background(VolumeOverlayBackdrop(cornerRadius: metrics.cornerRadius))
         .environment(\.colorScheme, .dark)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(deviceName ?? "\(percentage)%")
         .accessibilityValue("\(percentage)%")
+    }
+
+    private func volumeIcon(_ symbol: String, at center: CGPoint) -> some View {
+        Image(systemName: symbol)
+            .font(.system(size: VolumeMetrics.iconSize, weight: .medium))
+            .foregroundStyle(.white.opacity(0.9))
+            .frame(width: 20, height: 20)
+            .offset(x: center.x - 10, y: center.y - 10)
     }
 
     private func glyphBody(symbol: String) -> some View {
@@ -265,5 +319,33 @@ struct LevelOSDView: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(percentage)%")
         .accessibilityValue("\(percentage)%")
+    }
+}
+
+
+/// The volume overlay's surface, kept apart from the app's own panels because
+/// it stands in for a system overlay rather than matching the app.
+///
+/// A blurred material faded over the screen, not Liquid Glass: glass refracts
+/// what is behind it inside the window, a borderless panel has nothing there,
+/// and the effect flattens into frost. Measured against the system overlay,
+/// this passes the detail that reads as transparent without the effect's cost.
+private struct VolumeOverlayBackdrop: View {
+    var cornerRadius: CGFloat
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .fill(Color.clear)
+            .background(
+                HUDBackdropMaterial(
+                    cornerRadius: cornerRadius,
+                    opacity: reduceTransparency ? 1 : LevelOSDView.VolumeMetrics.materialOpacity)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(.white.opacity(0.12), lineWidth: 0.8)
+            )
     }
 }

--- a/Sources/Vorssaint/UI/MenuPanel/MixerSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/MixerSection.swift
@@ -190,6 +190,19 @@ struct MixerSection: View {
                 }
             }
 
+            // The volume keys reach this slider through an event tap, and
+            // without the permission they stay as dead as macOS leaves them
+            // on an output it cannot set. The slider works either way.
+            if mixer.hasSoftwareMasterOutput, !permissions.accessibility {
+                Button {
+                    permissions.requestAccessibility()
+                } label: {
+                    Label(l10n.s.permissionOpenSettings, systemImage: "hand.raised")
+                }
+                .buttonStyle(.link)
+                .font(.system(size: 10.5, weight: .medium))
+            }
+
             if universalOutputDevices.isEmpty {
                 inputMessage(l10n.s.mixerSystemOutputNoDevices, systemImage: "speaker.slash")
             }
@@ -601,10 +614,14 @@ struct MixerSection: View {
 
     private var visibleApps: [MixerApp] {
         mixer.apps.filter { app in
-            MixerRoutingSupport.shouldShowApp(isPlaying: app.isPlaying,
-                                              volume: app.volume,
-                                              selectedOutputDeviceUID: app.selectedOutputDeviceUID,
-                                              hideInactiveApps: hideInactiveApps)
+            // The system sounds row carries the master to macOS' own sounds
+            // and has nothing for the user to set, so it stays out of the list.
+            guard app.id != MixerRoutingSupport.systemSoundsRowID else { return false }
+            return MixerRoutingSupport.shouldShowApp(
+                isPlaying: app.isPlaying,
+                volume: app.volume,
+                selectedOutputDeviceUID: app.selectedOutputDeviceUID,
+                hideInactiveApps: hideInactiveApps)
         }
     }
 

--- a/Sources/Vorssaint/UI/SharedUI.swift
+++ b/Sources/Vorssaint/UI/SharedUI.swift
@@ -209,7 +209,10 @@ struct HUDBackdrop: View {
 /// outline just outside the rounded card, and whether it shows depends on what
 /// is behind the window, which is why it looks intermittent. Clipping the layer
 /// to the same radius as the card removes it. Pass the card's corner radius.
-private struct HUDBackdropMaterial: NSViewRepresentable {
+/// Shared with the level overlay, which lays Liquid Glass over this rather
+/// than over nothing: glass refracts what is behind it inside the window, and
+/// a borderless panel has nothing there until this material draws the screen.
+struct HUDBackdropMaterial: NSViewRepresentable {
     var cornerRadius: CGFloat = 0
     var opacity: Double = 1
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -6892,6 +6892,102 @@ struct MetricsTests {
         expectClose(Defaults.sanitizedAppVolume(3), 2, "high app volume clamps to boost maximum")
         expectClose(Defaults.sanitizedAppVolume(-1), 0, "negative app volume clamps to mute")
         expectClose(Defaults.sanitizedAppVolume(.infinity), 1, "non-finite app volume falls back to unity")
+        expectClose(Defaults.sanitizedSoftwareOutputVolume(0.5), 0.5,
+                    "valid software output volume is preserved")
+        expectClose(Defaults.sanitizedSoftwareOutputVolume(1.8), 1,
+                    "software output volume stops at unity instead of boosting the device")
+        expectClose(Defaults.sanitizedSoftwareOutputVolume(-1), 0,
+                    "negative software output volume clamps to silence")
+        expectClose(Defaults.sanitizedSoftwareOutputVolume(.nan), 1,
+                    "non-finite software output volume falls back to unity")
+        let hdmiUID = "AppleHDMIEngineOutputDP:0,1,0,0"
+        let speakersUID = "BuiltInSpeakerDevice"
+        expectClose(MixerRoutingSupport.softwareMasterFactor(masterVolume: 0.5,
+                                                             masterDeviceUID: hdmiUID,
+                                                             targetOutputDeviceUID: hdmiUID),
+                    0.5,
+                    "software master applies to a row playing through its device")
+        expectClose(MixerRoutingSupport.softwareMasterFactor(masterVolume: 0.5,
+                                                             masterDeviceUID: hdmiUID,
+                                                             targetOutputDeviceUID: speakersUID),
+                    1,
+                    "software master leaves a row routed to another device alone")
+        expectClose(MixerRoutingSupport.softwareMasterFactor(masterVolume: 0.5,
+                                                             masterDeviceUID: nil,
+                                                             targetOutputDeviceUID: hdmiUID),
+                    1,
+                    "no software master means no attenuation")
+        // The boost ceiling, taken from the clamp that stores it rather than
+        // written out again here.
+        let boostMaximum = Defaults.sanitizedAppVolume(.greatestFiniteMagnitude)
+        expectClose(MixerRoutingSupport.effectiveGain(appVolume: 0.5,
+                                                      masterFactor: 0.5,
+                                                      maximum: boostMaximum),
+                    0.25,
+                    "an app at 50% under a master at 50% renders at 25%")
+        expectClose(MixerRoutingSupport.effectiveGain(appVolume: 2,
+                                                      masterFactor: 0.5,
+                                                      maximum: boostMaximum),
+                    1,
+                    "the software master scales a boosted row like any other")
+        expectClose(MixerRoutingSupport.effectiveGain(appVolume: .infinity,
+                                                      masterFactor: 0.5,
+                                                      maximum: boostMaximum),
+                    0,
+                    "a non-finite gain never reaches the render thread")
+        expect(MixerRoutingSupport.requiresEngine(volume: 1,
+                                                  masterFactor: 0.5,
+                                                  selectedOutputDeviceUID: nil,
+                                                  targetOutputDeviceUID: hdmiUID,
+                                                  defaultOutputDeviceUID: hdmiUID),
+               "a row at 100% still needs a tap while the software master is down")
+        expect(!MixerRoutingSupport.requiresEngine(volume: 1,
+                                                   masterFactor: 1,
+                                                   selectedOutputDeviceUID: nil,
+                                                   targetOutputDeviceUID: hdmiUID,
+                                                   defaultOutputDeviceUID: hdmiUID),
+               "a master back at 100% returns the row to passthrough")
+        expect(MixerRoutingSupport.rowMayBeTapped(savedVolume: nil,
+                                                  savedRouteUID: nil,
+                                                  masterFactor: 0.5,
+                                                  defaultOutputDeviceUID: hdmiUID),
+               "the software master may tap a row the user never adjusted")
+        expect(!MixerRoutingSupport.rowMayBeTapped(savedVolume: nil,
+                                                   savedRouteUID: nil,
+                                                   masterFactor: 1,
+                                                   defaultOutputDeviceUID: hdmiUID),
+               "an untouched row stays untapped when no master is turned down")
+        expect(MixerRoutingSupport.isSystemSoundServer("systemsoundserverd"),
+               "the process macOS plays its own sounds from is recognised")
+        expect(!MixerRoutingSupport.isSystemSoundServer("com.apple.Music"),
+               "an ordinary app is not mistaken for the system sound server")
+        expect(!MixerRoutingSupport.isSystemSoundServer(nil),
+               "a process with no reported bundle is not the system sound server")
+        let masterStep = MixerRoutingSupport.masterVolumeStep
+        expectClose(MixerRoutingSupport.steppedMasterVolume(current: 0.5, up: true, fine: false),
+                    0.5 + masterStep,
+                    "a volume key raises the software master by one macOS step")
+        expectClose(MixerRoutingSupport.steppedMasterVolume(current: 0.5, up: false, fine: false),
+                    0.5 - masterStep,
+                    "a volume key lowers the software master by one macOS step")
+        expectClose(MixerRoutingSupport.steppedMasterVolume(current: 0.5, up: true, fine: true),
+                    0.5 + MixerRoutingSupport.fineMasterVolumeStep,
+                    "Option-Shift takes the software master a quarter step")
+        expectClose(MixerRoutingSupport.steppedMasterVolume(current: 1, up: true, fine: false),
+                    1,
+                    "the software master stops at 100%")
+        expectClose(MixerRoutingSupport.steppedMasterVolume(current: 0, up: false, fine: false),
+                    0,
+                    "the software master stops at silence")
+        expectClose(MixerRoutingSupport.steppedMasterVolume(current: 0.53, up: true, fine: false),
+                    0.5 + masterStep,
+                    "a level left off the grid by the slider snaps up onto it")
+        expectClose(MixerRoutingSupport.steppedMasterVolume(current: 0.53, up: false, fine: false),
+                    0.5,
+                    "a level left off the grid by the slider snaps down onto it")
+        expectClose(MixerRoutingSupport.steppedMasterVolume(current: .nan, up: false, fine: false),
+                    0,
+                    "a non-finite master never steps into a louder value")
         expectClose(MixerRoutingSupport.volumeFraction(fromPercentageText: "40",
                                                        maximumPercent: 200) ?? -1,
                     0.4,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -6957,6 +6957,24 @@ struct MetricsTests {
                                                    masterFactor: 1,
                                                    defaultOutputDeviceUID: hdmiUID),
                "an untouched row stays untapped when no master is turned down")
+        let overlaySize = CGSize(width: 200, height: 150)
+        expect(BrightnessSupport.centeredOverlayFrame(
+                size: overlaySize,
+                in: CGRect(x: 0, y: 0, width: 1000, height: 800))
+               == CGRect(x: 400, y: 325, width: 200, height: 150),
+               "the brightness overlay sits in the middle of its display")
+        expect(BrightnessSupport.cornerOverlayFrame(
+                size: overlaySize,
+                in: CGRect(x: 0, y: 0, width: 1000, height: 760),
+                inset: 10)
+               == CGRect(x: 790, y: 600, width: 200, height: 150),
+               "the volume overlay tucks under the menu bar at the right, clear of it")
+        expect(BrightnessSupport.cornerOverlayFrame(
+                size: overlaySize,
+                in: CGRect(x: 1000, y: 0, width: 1000, height: 760),
+                inset: 10)
+               == CGRect(x: 1790, y: 600, width: 200, height: 150),
+               "the volume overlay lands on the screen it was asked for, not the first one")
         expect(MixerRoutingSupport.isSystemSoundServer("systemsoundserverd"),
                "the process macOS plays its own sounds from is recognised")
         expect(!MixerRoutingSupport.isSystemSoundServer("com.apple.Music"),

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -6966,14 +6966,14 @@ struct MetricsTests {
         expect(BrightnessSupport.cornerOverlayFrame(
                 size: overlaySize,
                 in: CGRect(x: 0, y: 0, width: 1000, height: 760),
-                inset: 10)
-               == CGRect(x: 790, y: 600, width: 200, height: 150),
+                inset: CGSize(width: 10, height: 13))
+               == CGRect(x: 790, y: 597, width: 200, height: 150),
                "the volume overlay tucks under the menu bar at the right, clear of it")
         expect(BrightnessSupport.cornerOverlayFrame(
                 size: overlaySize,
                 in: CGRect(x: 1000, y: 0, width: 1000, height: 760),
-                inset: 10)
-               == CGRect(x: 1790, y: 600, width: 200, height: 150),
+                inset: CGSize(width: 10, height: 13))
+               == CGRect(x: 1790, y: 597, width: 200, height: 150),
                "the volume overlay lands on the screen it was asked for, not the first one")
         expect(MixerRoutingSupport.isSystemSoundServer("systemsoundserverd"),
                "the process macOS plays its own sounds from is recognised")


### PR DESCRIPTION
## Summary

HDMI, DisplayPort and optical outputs expose no settable volume property, so the panel's output slider was not drawn at all and the volume keys did nothing. This gives those devices a software master, using the render stage the mixer already runs for each app.

- The output slider appears whenever the current device has no settable hardware volume, and moves a software master instead of the hardware. A device that has a real volume control keeps the existing path untouched.
- A row's own slider never moves with the master. What reaches the device is `master × row`; the two stay independent controls.
- The volume keys move the master in the same sixteenths macOS uses — a quarter of that with Option-Shift held, or with "Use finer volume steps" on, which had no effect on these outputs before because re-posting the key reaches a volume macOS still refuses to set.
- The master is stored per output device UID, so a monitor that is unplugged and comes back brings its level with it.
- macOS' own alert and interface sounds follow the master when they play through the same device. They are carried by a row that is never listed, because there is nothing on it for the user to set.

## The direction question, first

#838 says the shared blocker for #1093 is that the render stage "covers apps routed through the mixer, not the Mac's whole output", and that both requests need it "promoted to a whole-output stage first". **This PR does not do that.** It multiplies the master into each row's gain rather than introducing one global tap, and I would rather name the consequence than have it found in review:

- While the master is below 100%, every row playing to that device is tapped. That crosses the rule the code states today — *"Nothing is ever tapped on behalf of an app the user never adjusted"* — and the CPU cost is one tap per playing app rather than one for the output.
- Coverage is whatever the row list covers. The system sound server needed its own case here (it owns no application, so `ResponsibleProcess.regularAppOwner` drops it); anything else with no regular app owner is still missed, and a newly launched app plays at full level until its tap exists.
- `CATapDescription(stereoGlobalTapButExcludeProcesses:)` would answer all of that with one engine, and the app already builds a global tap for the recorder. I did not take that route because it is a redesign of the mixer's engine model rather than an addition to it, and because the exclusion set has to track the per-app engines and the bypass list (Zoom, DAWs) exactly, which is where it can go wrong quietly.

If the whole-output stage is what this should be, say so and I will rework it that way rather than argue for this shape.

## Changes

- `MixerRoutingSupport` — the pure logic: the master's factor for a row (1 for a row routed elsewhere), the effective gain, the key step, the system sound server predicate.
- `AppVolumeMixer` — publishes the software master where the hardware value used to be, stores it per device, steps it for the keys, and carries the unlisted system sounds row rendered to the system sound device rather than the default one.
- `PreciseVolumeRollerService` — already owned the volume keys, so it takes the software path first and leaves the existing roller behaviour untouched on every other output. No second event tap.
- `BrightnessOSD` → `LevelOSD` — the overlay is now shared. Brightness keeps its own layout, its place in the middle of its display and its exclusion from screen capture, verbatim. Volume gets the shape macOS 26 draws for it, measured off that overlay rather than approximated: a 294×58 panel ten points in from the right and thirteen below the menu bar, a four-point track with the sixteen step marks under it, and the output device named above. The numbers sit in one place with the measurement recorded beside them.
  Its surface is a faded blurred material, not Liquid Glass. Glass refracts what is behind it inside the window and a borderless panel has nothing there, so the effect alone reads as frost; putting the behind-window material under the glass gives it something to bend and costs almost all of the detail — measured against the system overlay over one desktop, a third of its contrast and twenty tones darker. Fading the material instead lets the screen through unfiltered, which is what reads as transparent.
- `MixerSection` — the accessibility route the keys need, and the system sounds row kept out of the list.
- 19 assertions in `Tests/MetricsTests.swift`, checked in both directions (green on this branch, red with the logic reverted).

## Testing

`./build.sh`, `./build/Vorssaint --selftest` and `./build.sh --test` all pass, with no warnings.

Hardware: MacBook Pro (Mac17,9), macOS 27.0 (26A5425a), lid closed, a single external display over HDMI, app language Turkish, local build signed with `Tools/setup-signing.sh`. Verified by hand on that machine: the slider appears and attenuates; a row at 50% under a master at 50% plays at 25% while its slider still reads 50%; the master returns the output to untouched passthrough at 100%; the level survives unplugging the display; the keys step it and the finer-steps option changes the step; alert sounds follow the master when the system sound output is the same device, and are left alone when it is not.

The overlay was compared against the system one on screen, by capturing both over the same desktop and measuring the same pixels: tone within a few levels of it, and the detail coming through within about 15%.

**What I did not check.** The brightness overlay after the rename — the layout, position and call are unchanged and the tests pass, but I did not look at it on screen. Nothing was tested with more than one external display, on a Mac with a notch, on Intel, or with a hardware volume wheel while a software master is active. No Bluetooth or AirPlay output without a volume control was tried.

## Notes

**macOS shows the system-audio-recording indicator while the master is down.** A tap is a capture as far as the system is concerned, so the menu bar dot stays lit for as long as a row is tapped — which the mixer already does today whenever a row sits below 100%, and which the master extends to every row playing to that device. Nothing here can or should hide that; it is named because it is the first thing a user notices.

Refs #1093. It covers the software master, the device-level slider and the volume keys from that request; it does not add per-output profiles or user-defined virtual outputs, which are the rest of that thread.

Deliberately left out: drawing macOS' own volume overlay through the private `com.apple.OSDUIHelper` XPC service. It works on 26 (it draws the pre-Tahoe overlay — the corner banner belongs to Control Center and takes no callers), but it is a private surface `main` does not already load, which #838 puts behind a maintainer's call before a branch exists. Happy to open it separately if that call goes the other way.

This is larger than the median merged change here. If it should be split, the slider stands alone without the keys and the overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
