### PR TITLE
fix(quit-protection): yield keyboard input to the app switcher

### DIFF
--- a/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
+++ b/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
@@ -18,6 +18,7 @@ final class QuitProtectionService: ObservableObject {
         let event: CGEvent
         let mode: QuitProtectionMode
         let targetProcessIdentifier: pid_t?
+        let switcherSessionGeneration: UInt64
     }
 
     private static let syntheticMarker: Int64 = 0x5652535341494E54
@@ -180,6 +181,13 @@ final class QuitProtectionService: ObservableObject {
             return Unmanaged.passUnretained(event)
         }
 
+        // Ordinary typing still avoids consulting another service. A
+        // switcher-owned press must reach its tap, regardless of tap order.
+        if (hasPressInFlight || event.flags.contains(.maskCommand)),
+           deferToSwitcherIfNeeded() {
+            return Unmanaged.passUnretained(event)
+        }
+
         switch type {
         case .keyDown: return handleKeyDown(event)
         case .keyUp: return handleKeyUp(event)
@@ -285,9 +293,11 @@ final class QuitProtectionService: ObservableObject {
                     intervalMilliseconds: configuration.doublePressIntervalMilliseconds
                 ) {
                     let targetPid = pending.targetProcessIdentifier
+                    let generation = pending.switcherSessionGeneration
                     cancelPending()
                     swallowShortcut = shortcut
-                    confirm(shortcut: shortcut, event: event, targetProcessIdentifier: targetPid)
+                    confirm(shortcut: shortcut, event: event, targetProcessIdentifier: targetPid,
+                            switcherSessionGeneration: generation)
                     return nil
                 }
             }
@@ -381,6 +391,23 @@ final class QuitProtectionService: ObservableObject {
 
     // MARK: Confirmation state
 
+    /// A session may begin and end without this tap seeing a key: the
+    /// switcher can swallow it first. Invalidate old confirmations by the
+    /// existing session generation, not by panel visibility or notifications.
+    private func deferToSwitcherIfNeeded() -> Bool {
+        let ownership = AppSwitcher.shared.keyboardInputOwnership
+        let stalePending = pending.map {
+            $0.switcherSessionGeneration != ownership.generation
+        } ?? false
+        if ownership.isOwned || stalePending {
+            if hasPressInFlight {
+                cancelPending()
+                swallowShortcut = nil
+            }
+        }
+        return ownership.isOwned
+    }
+
     private func beginPending(shortcut: QuitProtectionShortcut,
                               mode: QuitProtectionMode,
                               event: CGEvent) {
@@ -391,7 +418,8 @@ final class QuitProtectionService: ObservableObject {
         pending = Pending(shortcut: shortcut,
                           event: event,
                           mode: mode,
-                          targetProcessIdentifier: frontmostProcessIdentifier)
+                          targetProcessIdentifier: frontmostProcessIdentifier,
+                          switcherSessionGeneration: AppSwitcher.shared.keyboardInputOwnership.generation)
 
         let configuration = configuration(for: shortcut)
         switch mode {
@@ -422,15 +450,18 @@ final class QuitProtectionService: ObservableObject {
     }
 
     private func completeHold() {
-        guard let pending, pending.mode == .hold else { return }
+        guard !deferToSwitcherIfNeeded(),
+              let pending, pending.mode == .hold else { return }
         let shortcut = pending.shortcut
         let event = pending.event
         let targetPid = pending.targetProcessIdentifier
+        let generation = pending.switcherSessionGeneration
 
         swallowShortcut = shortcut
         cancelPending()
 
-        confirm(shortcut: shortcut, event: event, targetProcessIdentifier: targetPid)
+        confirm(shortcut: shortcut, event: event, targetProcessIdentifier: targetPid,
+                switcherSessionGeneration: generation)
     }
 
     private func cancelPending() {
@@ -524,7 +555,15 @@ final class QuitProtectionService: ObservableObject {
     private func confirm(shortcut: QuitProtectionShortcut,
                          event: CGEvent,
                          targetProcessIdentifier: pid_t?,
-                         removing modifier: QuitProtectionExtraModifier? = nil) {
+                         removing modifier: QuitProtectionExtraModifier? = nil,
+                         switcherSessionGeneration: UInt64? = nil) {
+        let ownership = AppSwitcher.shared.keyboardInputOwnership
+        guard !ownership.isOwned,
+              switcherSessionGeneration.map({ $0 == ownership.generation }) ?? true else {
+            cancelPending()
+            swallowShortcut = nil
+            return
+        }
         if QuitProtectionSupport.usesNativeQuitRequest(for: shortcut),
            requestQuit(targetProcessIdentifier: targetProcessIdentifier) {
             return

--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -74,6 +74,18 @@ final class AppSwitcher: ObservableObject {
         get { routeLock.withLock { routeSessionActive } }
         set { routeLock.withLock { routeSessionActive = newValue } }
     }
+
+    /// Other keyboard filters must yield during enumeration as well as an
+    /// open session. Read the generation with the ownership flag so a pending
+    /// confirmation cannot survive a switcher session that has already ended.
+    var keyboardInputOwnership: (isOwned: Bool, generation: UInt64) {
+        routeLock.withLock {
+            (!routeCapturing && (routeSessionActive
+                || (routeCanStartSession && routePendingSessionStart != nil)),
+             sessionStartGeneration)
+        }
+    }
+
     private var panel: NSPanel?
     private var sessionItems: [SwitcherItem] = []
 


### PR DESCRIPTION
## Summary

Fix the conflict between Command-Q/Command-W protection and App Switcher keyboard handling. When the protection event tap receives a key first, it can consume a command intended for the switcher. For Q, confirmation terminates the foreground application's PID rather than the selected item's PID. For W, protection interferes through synthetic event replay; source inspection does not establish that every W confirmation necessarily closes the wrong window.

Quit protection now yields while a switcher session is active **or its startup is pending**. Keyboard ownership and the existing session generation are read together under `routeLock`. The generation invalidates stale confirmations even when the switcher starts and ends without the protection tap receiving intermediate events. Guards cover keyboard event routing, hold-timer completion, and confirmation dispatch.

Q/W inside the switcher retain their existing behavior: acting on the selection or entering search text when applicable. This change does not add quit/close confirmation to switcher-selected items. Outside the switcher, protection modes, scopes, and exceptions remain unchanged.

Two production files changed; no new dependencies, settings, translations, or changelog changes.

## Verification

Reviewed against `05142d90d8239f3d022d0506048f535cececf4f4`. The published commit is `91ac61022730dab641f7fdfcff6c013f1792dea1`, containing only the switcher ownership accessor and protection guards: 56 additions and 5 deletions across two files.

The earlier local verification used Linux x86_64 and Swift 6.2.1: **61 isolated assertions passed** in a local harness using the proposed ownership, invalidation, `completeHold`, and `confirm` bodies. macOS dependencies were replaced with call-recording implementations. A control using the original `confirm` body reproduced a call to the foreground PID during a simulated switcher session. This harness was not integrated into the repository test suite; these results are not an application build or an integration test.

Reviewed paths include both event taps, pending startup and transition to an active session, search, `closeSelectedWindow`, `quitSelectedApp`, all three protection modes, cancellation, timers, and native/synthetic confirmation.

**Not tested on a Mac.** The full build, module typecheck against the macOS SDK, `./build.sh --test`, `./build/Vorssaint --selftest`, and real event taps were not run locally.

## macOS validation

With application A in the foreground and B selected in the switcher, verify Q/W across all three protection modes and both feature activation orders. Also cover pending startup, search and pinned search, autorepeat, cancellation, normal protection after leaving the switcher, and a confirmation started before an intervening switcher session.

Supersedes #1402 with the same code changes. Opened as a non-draft pull request at the author's request; the verification limitations above still apply.

Refs #1341