### PR TITLE
fix(switcher): confirm protected quit and close on the selected item

### DIFF
--- a/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
+++ b/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
@@ -519,6 +519,43 @@ final class QuitProtectionService: ObservableObject {
 
     private func hideHUD() { hud.hide() }
 
+    // MARK: Selection confirmation
+
+    /// What the switcher needs to confirm a protected Q or W on its own. It
+    /// acts on the item it has selected rather than on the frontmost app, so
+    /// the tap above deliberately yields and cannot answer for it.
+    struct SelectionConfirmation {
+        let intervalMilliseconds: Double
+        let showsFeedback: Bool
+    }
+
+    /// Nil when this shortcut is unprotected for that app, which leaves the
+    /// switcher's immediate behavior exactly as it was.
+    func selectionConfirmation(for shortcut: QuitProtectionShortcut,
+                               bundleIdentifier: String?) -> SelectionConfirmation? {
+        guard AppFeature.quitWindowProtection.isAvailable else { return nil }
+        let configuration = configuration(for: shortcut)
+        guard configuration.enabled,
+              QuitProtectionSupport.scopeAllows(configuration.scope,
+                                                bundleIdentifier: bundleIdentifier,
+                                                exceptions: configuration.exceptions)
+        else { return nil }
+        return SelectionConfirmation(
+            intervalMilliseconds: QuitProtectionSupport.sanitizedDoublePressInterval(
+                configuration.doublePressIntervalMilliseconds),
+            showsFeedback: configuration.showFeedback)
+    }
+
+    /// The same panel the tap uses, so both places ask for the second press
+    /// in the same words and the same place.
+    func showSelectionHUD(for shortcut: QuitProtectionShortcut) {
+        let strings = FeatureStrings.quitProtection(L10n.shared.language)
+        hud.show(title: String(format: strings.doubleHUDFormat, shortcut.character.uppercased()),
+                 detail: strings.cancelHint)
+    }
+
+    func hideSelectionHUD() { hud.hide() }
+
     private func modifierSymbol(_ modifier: QuitProtectionExtraModifier) -> String {
         switch modifier {
         case .shift: return "⇧"

--- a/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
+++ b/Sources/Vorssaint/Services/QuitProtection/QuitProtectionService.swift
@@ -548,10 +548,11 @@ final class QuitProtectionService: ObservableObject {
 
     /// The same panel the tap uses, so both places ask for the second press
     /// in the same words and the same place.
-    func showSelectionHUD(for shortcut: QuitProtectionShortcut) {
+    func showSelectionHUD(for shortcut: QuitProtectionShortcut, on screen: NSScreen?) {
         let strings = FeatureStrings.quitProtection(L10n.shared.language)
         hud.show(title: String(format: strings.doubleHUDFormat, shortcut.character.uppercased()),
-                 detail: strings.cancelHint)
+                 detail: strings.cancelHint,
+                 on: screen)
     }
 
     func hideSelectionHUD() { hud.hide() }

--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -1289,7 +1289,7 @@ final class AppSwitcher: ObservableObject {
                                                              itemID: item.id,
                                                              expiry: expiry)
         if confirmation.showsFeedback {
-            QuitProtectionService.shared.showSelectionHUD(for: shortcut)
+            QuitProtectionService.shared.showSelectionHUD(for: shortcut, on: placementScreen)
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + confirmation.intervalMilliseconds / 1_000,
                                       execute: expiry)

--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -46,6 +46,7 @@ final class AppSwitcher: ObservableObject {
     @Published private(set) var selectedIndex = 0 {
         didSet {
             guard oldValue != selectedIndex else { return }
+            cancelLetterConfirmation()
             updateIconRowLayoutForCurrentSelection()
             revealSelectedIconInVisibleRow()
             if sessionActive, usesIconRowLayout {
@@ -130,6 +131,14 @@ final class AppSwitcher: ObservableObject {
     /// The card currently under the pointer. Kept separate from selection so
     /// a middle click on panel chrome can never close an unrelated window.
     private var hoveredWindowIndex: Int?
+    /// A protected Q or W waiting for its second press. Tied to the item that
+    /// was selected when it started, so moving on never confirms by surprise.
+    private struct PendingLetterConfirmation {
+        let action: SwitcherLetterAction
+        let itemID: String
+        let expiry: DispatchWorkItem
+    }
+    private var pendingLetterConfirmation: PendingLetterConfirmation?
     private var swallowingMiddleMouseUp = false
     /// Fires while the pointer stays on the last visible overflow icon.
     private var iconRowEdgeHoverWork: DispatchWorkItem?
@@ -801,8 +810,7 @@ final class AppSwitcher: ObservableObject {
                 // through the list closing or quitting everything on the way.
                 if event.getIntegerValueField(.keyboardEventAutorepeat) == 0 {
                     switch action {
-                    case .closeWindow: closeSelectedWindow()
-                    case .quitApp: quitSelectedApp()
+                    case .closeWindow, .quitApp: runProtectedLetterAction(action)
                     case .pinSearch: isSearchPinned = true
                     }
                 }
@@ -1253,6 +1261,55 @@ final class AppSwitcher: ObservableObject {
                                                                           delta: delta)
     }
 
+    /// W and Q act on the selected item, which quit protection's own tap cannot
+    /// see: it yields the keyboard for the whole session. Ask for the second
+    /// press here instead, so turning the protection on still means something
+    /// where a single letter closes a window the user is not looking at.
+    private func runProtectedLetterAction(_ action: SwitcherLetterAction) {
+        guard windows.indices.contains(selectedIndex) else { return }
+        let item = windows[selectedIndex]
+        let shortcut: QuitProtectionShortcut = action == .quitApp ? .quit : .close
+        guard let confirmation = QuitProtectionService.shared.selectionConfirmation(
+            for: shortcut,
+            bundleIdentifier: NSRunningApplication(processIdentifier: item.pid)?.bundleIdentifier
+        ) else {
+            performLetterAction(action)
+            return
+        }
+
+        let pending = pendingLetterConfirmation
+        cancelLetterConfirmation()
+        if let pending, pending.action == action, pending.itemID == item.id {
+            performLetterAction(action)
+            return
+        }
+
+        let expiry = DispatchWorkItem { [weak self] in self?.cancelLetterConfirmation() }
+        pendingLetterConfirmation = PendingLetterConfirmation(action: action,
+                                                             itemID: item.id,
+                                                             expiry: expiry)
+        if confirmation.showsFeedback {
+            QuitProtectionService.shared.showSelectionHUD(for: shortcut)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + confirmation.intervalMilliseconds / 1_000,
+                                      execute: expiry)
+    }
+
+    private func performLetterAction(_ action: SwitcherLetterAction) {
+        switch action {
+        case .closeWindow: closeSelectedWindow()
+        case .quitApp: quitSelectedApp()
+        case .pinSearch: break
+        }
+    }
+
+    private func cancelLetterConfirmation() {
+        guard let pending = pendingLetterConfirmation else { return }
+        pending.expiry.cancel()
+        pendingLetterConfirmation = nil
+        QuitProtectionService.shared.hideSelectionHUD()
+    }
+
     /// Closes the highlighted window (⌘Tab → W) and keeps the session open, so
     /// the app stays running and the panel moves on to the next window. Same
     /// path as the card's close button.
@@ -1434,6 +1491,7 @@ final class AppSwitcher: ObservableObject {
     }
 
     private func endSession() {
+        cancelLetterConfirmation()
         SwitcherAppIconCache.endSession()
         sessionActive = false
         pendingShow?.cancel()

--- a/Sources/Vorssaint/UI/QuitProtection/QuitProtectionHUD.swift
+++ b/Sources/Vorssaint/UI/QuitProtection/QuitProtectionHUD.swift
@@ -21,7 +21,9 @@ final class QuitProtectionHUD {
                height: minimumSize.height)
     }
 
-    func show(title: String, detail: String) {
+    /// `screen` is for callers that already place a panel of their own, so the
+    /// confirmation cannot land on a different display than what it confirms.
+    func show(title: String, detail: String, on screen: NSScreen? = nil) {
         if panel == nil {
             let panel = NSPanel(contentRect: CGRect(origin: .zero, size: size),
                                 styleMask: [.borderless, .nonactivatingPanel],
@@ -46,7 +48,7 @@ final class QuitProtectionHUD {
         content.update(title: title, detail: detail)
         size = Self.fittingSize(content)
         panel?.setContentSize(size)
-        positionPanel()
+        positionPanel(on: screen)
         panel?.alphaValue = 1
         panel?.orderFrontRegardless()
         // Event taps can arrive between normal AppKit drawing passes. Draw now
@@ -58,9 +60,10 @@ final class QuitProtectionHUD {
         panel?.orderOut(nil)
     }
 
-    private func positionPanel() {
+    private func positionPanel(on preferredScreen: NSScreen?) {
         guard let panel,
-              let screen = NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) })
+              let screen = preferredScreen
+                ?? NSScreen.screens.first(where: { $0.frame.contains(NSEvent.mouseLocation) })
                 ?? NSScreen.main
                 ?? NSScreen.screens.first
         else { return }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -24245,7 +24245,7 @@ struct MetricsTests {
         expect(!quitHUDCode.contains("size(withAttributes:"),
                "the confirmation HUD does not size itself from a separate text measurement")
         let quitHUDShow = quitHUDCode
-            .components(separatedBy: "func show(title: String, detail: String) {").last ?? ""
+            .components(separatedBy: "func show(title: String, detail: String").last ?? ""
         let quitHUDShowBody = quitHUDShow.components(separatedBy: "\n    func ").first ?? ""
         if let filled = quitHUDShowBody.range(of: "content.update("),
            let sized = quitHUDShowBody.range(of: "fittingSize(content)"),


### PR DESCRIPTION
## Summary

Quit and close protection yields the keyboard while the App Switcher is open, so its tap never sees Q or W there. A single letter acted at once on the selected item, which means turning the protection on had no effect in the one place where one keystroke closes a window the user is not looking at.

Q and W in the switcher now ask for a second press before acting, against the item that was selected when the first press arrived. The confirmation honours the shortcut's enabled state, app scope, exceptions, double-press interval and feedback preference. It is dropped when the selection moves, when the session ends and when the interval runs out.

The confirmation panel also follows the switcher's own screen placement, where it previously always used the screen holding the pointer. On more than one display the ask could otherwise appear away from the panel it belongs to.

Unprotected shortcuts keep acting immediately, so the switcher is unchanged for anyone who has the protection off. No new preference, string or dependency: the wording and panel are the ones the protection already uses in every language.

The HUD source-shape check is re-anchored to the `show` signature it now has; the ordering it asserts is unchanged.

## Verification

`./build.sh --dev --test` (TESTS OK, 10074 checks), `./build.sh --dev --install`, `--selftest` on the installed executable (SELFTEST OK) and `codesign --verify --deep --strict`.

Follows #1403, which fixed the switcher acting on the wrong app.

Refs #1341