### PR TITLE
fix(command-bar): run the Wi-Fi toggle off the main thread

### DIFF
--- a/Sources/Vorssaint/Services/CommandBar/CommandBarCatalog.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarCatalog.swift
@@ -762,9 +762,7 @@ enum CommandBarCatalog {
                 keywords: "wifi wi-fi",
                 icon: .symbol(wifiOn ? "wifi.slash" : "wifi"),
                 isActive: wifiOn,
-                run: { _ in
-                    if !CommandBarExtras.setWiFiPower(!wifiOn) { NSSound.beep() }
-                }))
+                run: { _ in CommandBarExtras.setWiFiPower(!wifiOn) }))
         }
 
         // The folders every Mac has. A fixed set of destinations, never a

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarExtras.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarExtras.swift
@@ -104,14 +104,20 @@ enum CommandBarExtras {
         return interface.powerOn()
     }
 
-    @discardableResult
-    static func setWiFiPower(_ on: Bool) -> Bool {
-        guard let interface = CWWiFiClient.shared().interface() else { return false }
-        do {
-            try interface.setPower(on)
-            return true
-        } catch {
-            return false
+    /// Turns the radio on or off. The same crossing to the Wi-Fi daemon the read
+    /// above pays for and the heavier half of it, so it never runs on the
+    /// keystroke that ran the row; a failure reports itself with a beep.
+    static func setWiFiPower(_ on: Bool) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            guard let interface = CWWiFiClient.shared().interface() else {
+                DispatchQueue.main.async { NSSound.beep() }
+                return
+            }
+            do {
+                try interface.setPower(on)
+            } catch {
+                DispatchQueue.main.async { NSSound.beep() }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

The Command Bar's Wi-Fi row called `CWInterface.setPower` synchronously on the
thread that ran it. `finish(_:value:)` hides the bar before running the row, so
the main thread went into the daemon round trip with nothing left on screen to
explain the wait, and the three `.defaultTap` event taps attached to the main
run loop held scrolling and clicking for its duration.

The read beside it already carries the warning this needed. `readWiFiPowerState`
is documented "Blocking; callers run it on a background queue", and
`refreshWiFiState` keeps it on `DispatchQueue.global(qos: .utility)` with a
comment saying why. The write is the heavier of the two and had neither.

Measured on this Mac, calling `setPower` with the value it already holds — so no
radio transition at all, just the round trip:

```
interface: en0  powerOn=true
powerOn() read:       0.5 ms
setPower(same=true): 27.8 ms
setPower(same, 2nd): 32.6 ms
```

## The change

`setWiFiPower` does its own hop, the way `run(_ action:)` nine lines above it
already does, and reports failure with a beep instead of a return value. Its
only caller loses the branch and now reads like the power row it sits beside:

```swift
run: { _ in CommandBarExtras.run(action) }          // unchanged, line 754
run: { _ in CommandBarExtras.setWiFiPower(!wifiOn) } // this change, line 764
```

Putting the hop in the helper rather than at the call site is what the file
already does, and `setWiFiPower` has exactly one caller, so nothing else changes
shape. Nothing reads the old `Bool`: it fed one `NSSound.beep()`, which moved
inside.

`cachedWiFiPower` is untouched. It was already refreshed by the next
presentation rather than by this call, and the bar is closed by the time the
toggle lands either way.

## Why off-main is safe here

CoreWLAN is already used off the main thread in this file's own flow —
`refreshWiFiState` calls `readWiFiPowerState`, and therefore
`CWWiFiClient.shared().interface()`, from a global queue. There is no
main-thread requirement to violate, and no comment anywhere in the tree arguing
for one.

## Verification

MacBook Pro, Apple M5 Max, 18 cores, 48 GB, macOS 26.5.1 (25F80), own build from
source.

`./build.sh --test` on this branch: 1 of 10074 failed. The same command on
clean `main` at `05142d9`, the commit this branches from, in a detached worktree
in the same session: 1 of 10074 failed, and it is the same one. Both runs fail
only `App Switcher icon-row hints describe default app and window shortcuts`,
which is #1376 and has nothing to do with this change — that check pins a US
keycap and this Mac runs a Turkish layout. So the branch adds nothing to the
suite and removes nothing from it.

`./build.sh`: no warnings. `./build/Vorssaint --selftest`: `SELFTEST OK`.

Behaviour checked by hand: the row toggles the radio as before, the bar closes
the same way, and the title flips on the next opening.

## What I could not test

The measurement above is the no-op write only. I did not measure a real on/off
transition and have no number for one: Wi-Fi is the only active route on this
Mac, so measuring it would have cut the link I was working over. The transition
is certainly more expensive than the 28-33 ms floor, but I would rather give the
number I have than the one I assume.

I also could not exercise the failure branch — a Mac with no Wi-Fi interface, or
a `setPower` that throws — so the beep path is unverified at runtime. It is the
same two-line shape the surrounding code uses.

## Anything else

Refs #1381
