### PR TITLE
test(switcher): read the hint keycaps from the active layout

### DIFF
--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -10020,13 +10020,26 @@ struct MetricsTests {
         }
         let defaultSwitcherHints = SwitcherSupport.shortcutHints(for: .switcherDefault,
                                                                  windowShortcut: .switcherWindowDefault)
-        expect(defaultSwitcherHints.apps == "⌘Tab" && defaultSwitcherHints.windows == "⌘ `",
+        // Grave and J print the cap the active keyboard layout carries, not the
+        // US one: that is what #1047 changed. Pinning "⌘ `" and "⌘J" here made
+        // the check fail on Turkish QWERTY and every other layout that moves
+        // them. Ask the layout, and keep the rule the hint depends on: a lone
+        // symbol takes a space after the modifiers, a letter does not.
+        let commandKeyHint: (String, Int64, String) -> String = { modifiers, keyCode, ansiCap in
+            let cap = GlobalShortcut.layoutKeyLabel(for: keyCode, usesCommand: true) ?? ansiCap
+            let needsSeparator = cap.count == 1
+                && cap.rangeOfCharacter(from: .alphanumerics) == nil
+            return modifiers + (needsSeparator ? " " : "") + cap
+        }
+        expect(defaultSwitcherHints.apps == "⌘Tab"
+                && defaultSwitcherHints.windows == commandKeyHint("⌘", Int64(kVK_ANSI_Grave), "`"),
                "App Switcher icon-row hints describe default app and window shortcuts")
         let customSwitcherHints = SwitcherSupport.shortcutHints(
             for: GlobalShortcut(keyCode: Int64(kVK_Tab), modifiers: [.option]),
             windowShortcut: GlobalShortcut(keyCode: Int64(kVK_ANSI_J), modifiers: [.command])
         )
-        expect(customSwitcherHints.apps == "⌥Tab" && customSwitcherHints.windows == "⌘J",
+        expect(customSwitcherHints.apps == "⌥Tab"
+                && customSwitcherHints.windows == commandKeyHint("⌘", Int64(kVK_ANSI_J), "J"),
                "App Switcher icon-row hints show custom app and window shortcuts independently")
         expect(SwitcherSupport.shouldNavigateBackwardOnShiftPress(shiftIsNavigationModifier: true,
                                                                   wasShiftHeld: false,


### PR DESCRIPTION
## Summary

The App Switcher icon-row hint check pinned `⌘ \`` and `⌘J`. The app does not: `displayString` resolves a key outside the special-key table through `GlobalShortcut.layoutKeyLabel`, which reads the live keyboard layout, and that is deliberate — it is what #1047 changed so AZERTY, QWERTZ and the non-Latin layouts show their own keys.

So `./build.sh --test` failed on an untouched checkout for anyone whose layout moves Grave or J. On Turkish QWERTY the window hint is `⌘ <`, and the check called the app wrong.

The expected hint now comes from the same layout lookup the app uses, falling back to the same ANSI caps (`` ` `` and `J`) the app falls back to when the layout cannot answer. The separator rule the hint depends on — a lone symbol takes a space after the modifiers, a letter does not — is kept in the check rather than assumed, so it still fails if that rule breaks.

Both assertions in the block were affected; the custom-shortcut one used `J`, which moves on Dvorak.

## Verification

`./build.sh --dev --test` (TESTS OK, 10074 checks) on a US layout. The layout-dependent path cannot be exercised here without changing the machine's input source; it is covered by construction, since expectation and app now read the same lookup and share the same fallback table.

Refs #1376
