### PR TITLE
fix(scratchpad): keep the pad's text out of the preferences

### DIFF
--- a/Sources/Vorssaint/Core/BackupStrings.swift
+++ b/Sources/Vorssaint/Core/BackupStrings.swift
@@ -41,7 +41,7 @@ extension FeatureStrings {
 extension BackupFeatureStrings {
     static let ko = BackupFeatureStrings(
         title: "백업",
-        description: "설정을 다른 Mac으로 옮기세요. 모든 환경설정을 파일로 내보낸 뒤 그곳에서 가져올 수 있습니다. 빠른 메모의 텍스트도 파일에 포함됩니다. 클립보드 기록, 선반 항목 및 시스템 권한은 이 Mac 밖으로 나가지 않습니다.",
+        description: "설정을 다른 Mac으로 옮기세요. 모든 환경설정을 파일로 내보낸 뒤 그곳에서 가져올 수 있습니다. 빠른 메모의 텍스트, 클립보드 기록, 선반 항목 및 시스템 권한은 이 Mac 밖으로 나가지 않습니다.",
         exportButton: "설정 내보내기…",
         importButton: "설정 가져오기…",
         exported: "백업을 저장했습니다",
@@ -55,7 +55,7 @@ extension BackupFeatureStrings {
 extension BackupFeatureStrings {
     static let enUS = BackupFeatureStrings(
         title: "Backup",
-        description: "Take your setup to another Mac: export every preference to a file and import it there. The file includes the text from your Scratchpad notes. Clipboard history, Shelf items and system permissions never leave this Mac.",
+        description: "Take your setup to another Mac: export every preference to a file and import it there. Your Scratchpad notes, clipboard history, Shelf items and system permissions never leave this Mac.",
         exportButton: "Export settings…",
         importButton: "Import settings…",
         exported: "Backup saved",
@@ -67,7 +67,7 @@ extension BackupFeatureStrings {
 
     static let ptBR = BackupFeatureStrings(
         title: "Backup",
-        description: "Leve sua configuração para outro Mac: exporte todas as preferências para um arquivo e importe lá. O texto das suas notas no Rascunho entra no arquivo. Histórico da área de transferência, itens da área temporária e permissões do sistema nunca saem deste Mac.",
+        description: "Leve sua configuração para outro Mac: exporte todas as preferências para um arquivo e importe lá. O texto das suas notas no Rascunho, o histórico da área de transferência, os itens da área temporária e as permissões do sistema nunca saem deste Mac.",
         exportButton: "Exportar configurações…",
         importButton: "Importar configurações…",
         exported: "Backup salvo",
@@ -79,7 +79,7 @@ extension BackupFeatureStrings {
 
     static let tr = BackupFeatureStrings(
         title: "Yedek",
-        description: "Kurulumunuzu başka bir Mac’e taşıyın: tüm tercihleri bir dosyaya aktarın ve orada içe aktarın. Karalama defteri notlarınızın metni dosyaya dahil edilir. Pano geçmişi, raf öğeleri ve sistem izinleri bu Mac’ten asla çıkmaz.",
+        description: "Kurulumunuzu başka bir Mac’e taşıyın: tüm tercihleri bir dosyaya aktarın ve orada içe aktarın. Karalama defteri notlarınızın metni, pano geçmişi, raf öğeleri ve sistem izinleri bu Mac’ten asla çıkmaz.",
         exportButton: "Ayarları dışa aktar…",
         importButton: "Ayarları içe aktar…",
         exported: "Yedek kaydedildi",
@@ -91,7 +91,7 @@ extension BackupFeatureStrings {
 
     static let ru = BackupFeatureStrings(
         title: "Резервная копия",
-        description: "Перенесите настройки на другой Mac: экспортируйте все параметры в файл и импортируйте его там. Текст заметок в Черновике включается в файл. История буфера обмена, объекты полки и системные разрешения никогда не покидают этот Mac.",
+        description: "Перенесите настройки на другой Mac: экспортируйте все параметры в файл и импортируйте его там. Текст заметок в Черновике, история буфера обмена, объекты полки и системные разрешения никогда не покидают этот Mac.",
         exportButton: "Экспортировать настройки…",
         importButton: "Импортировать настройки…",
         exported: "Копия сохранена",
@@ -103,7 +103,7 @@ extension BackupFeatureStrings {
 
     static let es = BackupFeatureStrings(
         title: "Copia de seguridad",
-        description: "Lleva tu configuración a otro Mac: exporta todas las preferencias a un archivo e impórtalo allí. El archivo incluye el texto de las notas de Borrador. El historial del portapapeles, los elementos del estante y los permisos del sistema nunca salen de este Mac.",
+        description: "Lleva tu configuración a otro Mac: exporta todas las preferencias a un archivo e impórtalo allí. El texto de las notas de Borrador, el historial del portapapeles, los elementos del estante y los permisos del sistema nunca salen de este Mac.",
         exportButton: "Exportar ajustes…",
         importButton: "Importar ajustes…",
         exported: "Copia guardada",
@@ -115,7 +115,7 @@ extension BackupFeatureStrings {
 
     static let de = BackupFeatureStrings(
         title: "Backup",
-        description: "Nimm deine Einrichtung mit auf einen anderen Mac: exportiere alle Einstellungen in eine Datei und importiere sie dort. Die Datei enthält den Text deiner Notizen im Schmierzettel. Zwischenablage-Verlauf, Ablage-Objekte und Systemberechtigungen verlassen diesen Mac nie.",
+        description: "Nimm deine Einrichtung mit auf einen anderen Mac: exportiere alle Einstellungen in eine Datei und importiere sie dort. Der Text deiner Notizen im Schmierzettel, Zwischenablage-Verlauf, Ablage-Objekte und Systemberechtigungen verlassen diesen Mac nie.",
         exportButton: "Einstellungen exportieren…",
         importButton: "Einstellungen importieren…",
         exported: "Backup gesichert",
@@ -127,7 +127,7 @@ extension BackupFeatureStrings {
 
     static let fr = BackupFeatureStrings(
         title: "Sauvegarde",
-        description: "Emportez votre configuration sur un autre Mac\u{00A0}: exportez toutes les préférences dans un fichier et importez-le là-bas. Le fichier inclut le texte de vos notes dans Brouillon. L’historique du presse-papiers, les éléments de l’étagère et les autorisations système ne quittent jamais ce Mac.",
+        description: "Emportez votre configuration sur un autre Mac\u{00A0}: exportez toutes les préférences dans un fichier et importez-le là-bas. Le texte de vos notes dans Brouillon, l’historique du presse-papiers, les éléments de l’étagère et les autorisations système ne quittent jamais ce Mac.",
         exportButton: "Exporter les réglages…",
         importButton: "Importer les réglages…",
         exported: "Sauvegarde enregistrée",
@@ -139,7 +139,7 @@ extension BackupFeatureStrings {
 
     static let it = BackupFeatureStrings(
         title: "Backup",
-        description: "Porta la tua configurazione su un altro Mac: esporta tutte le preferenze in un file e importalo lì. Il file include il testo delle note in Bozza. Cronologia degli appunti, elementi della mensola e permessi di sistema non lasciano mai questo Mac.",
+        description: "Porta la tua configurazione su un altro Mac: esporta tutte le preferenze in un file e importalo lì. Il testo delle note in Bozza, la cronologia degli appunti, gli elementi della mensola e i permessi di sistema non lasciano mai questo Mac.",
         exportButton: "Esporta impostazioni…",
         importButton: "Importa impostazioni…",
         exported: "Backup salvato",
@@ -151,7 +151,7 @@ extension BackupFeatureStrings {
 
     static let ja = BackupFeatureStrings(
         title: "バックアップ",
-        description: "設定を別のMacへ。すべての環境設定をファイルに書き出し、そちらで読み込みます。ファイルにはクイックメモの本文も含まれます。クリップボード履歴、シェルフの項目、システム権限がこのMacの外に出ることはありません。",
+        description: "設定を別のMacへ。すべての環境設定をファイルに書き出し、そちらで読み込みます。クイックメモの本文、クリップボード履歴、シェルフの項目、システム権限がこのMacの外に出ることはありません。",
         exportButton: "設定を書き出す…",
         importButton: "設定を読み込む…",
         exported: "バックアップを保存しました",
@@ -163,7 +163,7 @@ extension BackupFeatureStrings {
 
     static let zhHans = BackupFeatureStrings(
         title: "备份",
-        description: "把你的配置带到另一台 Mac：将所有偏好设置导出为文件并在那里导入。文件中也包含草稿板里的笔记文本。剪贴板历史、暂存架项目和系统权限永远不会离开这台 Mac。",
+        description: "把你的配置带到另一台 Mac：将所有偏好设置导出为文件并在那里导入。草稿板里的笔记文本、剪贴板历史、暂存架项目和系统权限永远不会离开这台 Mac。",
         exportButton: "导出设置…",
         importButton: "导入设置…",
         exported: "备份已存储",
@@ -175,7 +175,7 @@ extension BackupFeatureStrings {
 
     static let zhTW = BackupFeatureStrings(
         title: "備份",
-        description: "把你的設定帶到另一台 Mac:將所有偏好設定匯出為檔案並在那裡匯入。檔案也包含草稿板中的筆記文字。剪貼板歷史、暫存架項目和系統權限永遠不會離開這台 Mac。",
+        description: "把你的設定帶到另一台 Mac:將所有偏好設定匯出為檔案並在那裡匯入。草稿板中的筆記文字、剪貼板歷史、暫存架項目和系統權限永遠不會離開這台 Mac。",
         exportButton: "匯出設定…",
         importButton: "匯入設定…",
         exported: "備份已儲存",
@@ -187,7 +187,7 @@ extension BackupFeatureStrings {
 
     static let zhHK = BackupFeatureStrings(
         title: "備份",
-        description: "把你的設定帶到另一台 Mac:將所有偏好設定匯出為檔案並在那裡匯入。檔案亦包含草稿板入面嘅筆記文字。剪貼板歷史、暫存架項目和系統權限永遠不會離開這台 Mac。",
+        description: "把你的設定帶到另一台 Mac:將所有偏好設定匯出為檔案並在那裡匯入。草稿板入面嘅筆記文字、剪貼板歷史、暫存架項目和系統權限永遠不會離開這台 Mac。",
         exportButton: "匯出設定…",
         importButton: "匯入設定…",
         exported: "備份已儲存",

--- a/Sources/Vorssaint/Core/SettingsBackupSupport.swift
+++ b/Sources/Vorssaint/Core/SettingsBackupSupport.swift
@@ -30,7 +30,6 @@ enum SettingsBackupSupport {
         DefaultsKey.shelfEnabled,
         DefaultsKey.finderCutPasteEnabled,
         DefaultsKey.textSnippets,
-        DefaultsKey.scratchpadDocument,
         DefaultsKey.radialMenuItems,
         DefaultsKey.radialMenuProfiles,
         DefaultsKey.commandBarLinks,
@@ -263,9 +262,6 @@ enum SettingsBackupSupport {
     /// switch belongs, or text where a number belongs, would otherwise reach
     /// code that trusts its own settings.
     static func valueLooksRight(_ key: String, _ value: Any) -> Bool {
-        if key == DefaultsKey.scratchpadDocument {
-            return ScratchpadDocument.decoded(value as? Data, defaultName: "Scratchpad") != nil
-        }
         guard let expected = Defaults.registeredDefaults[key] else {
             // Not a registered setting, so there is nothing to compare
             // against; the allowed list is the only gate for these.

--- a/Sources/Vorssaint/Services/QuickTools/ScratchpadService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScratchpadService.swift
@@ -126,6 +126,13 @@ final class ScratchpadService: NSObject, ObservableObject, NSWindowDelegate {
         PrivateFileStore.containerURL?.appendingPathComponent("Scratchpad.txt")
     }
 
+    /// The pad holds whatever the user typed, so it belongs with the clipboard
+    /// and the shelf in the app's own container, not in the preferences people
+    /// copy between Macs and commit to dotfiles (issue #1197).
+    private static var storeURL: URL? {
+        PrivateFileStore.containerURL?.appendingPathComponent("Scratchpad.json")
+    }
+
     private func loadApplyingRetention() {
         hasLoaded = true
         if let document, document != lastSavedDocument {
@@ -137,16 +144,24 @@ final class ScratchpadService: NSObject, ObservableObject, NSWindowDelegate {
         let retention = ScratchpadRetention.sanitized(
             defaults.string(forKey: DefaultsKey.scratchpadRetention))
 
-        if let stored = defaults.object(forKey: DefaultsKey.scratchpadDocument) {
-            let data = stored as? Data
-            let decoded = data.flatMap { try? JSONDecoder().decode(ScratchpadDocument.self, from: $0) }
+        let storedData = Self.storeURL.flatMap { try? Data(contentsOf: $0) }
+        let preferenceData = defaults.data(forKey: DefaultsKey.scratchpadDocument)
+        if let data = storedData ?? preferenceData {
+            let decoded = try? JSONDecoder().decode(ScratchpadDocument.self, from: data)
             var loaded = decoded?.sanitized(defaultName: defaultName)
                 ?? .initial(defaultName: defaultName)
             loaded.applyRetention(retention, now: Date())
-            if loaded == decoded {
+            let alreadyOnDisk = storedData != nil && loaded == decoded
+            if alreadyOnDisk {
                 lastSavedDocument = loaded
             } else {
                 _ = persist(loaded)
+            }
+            // A pad written by an earlier version leaves the preferences only
+            // once it exists in the container, so it is never cleared from one
+            // place before it is safe in the other.
+            if preferenceData != nil, lastSavedDocument == loaded {
+                defaults.removeObject(forKey: DefaultsKey.scratchpadDocument)
             }
             apply(loaded)
             return
@@ -164,8 +179,11 @@ final class ScratchpadService: NSObject, ObservableObject, NSWindowDelegate {
             defaultName: defaultName,
             retention: retention,
             now: Date())
-        if persist(migrated), let legacyURL {
-            try? manager.removeItem(at: legacyURL)
+        if persist(migrated) {
+            // Clears a preference holding something that never decoded, so no
+            // shape of this key is left behind in the plist.
+            defaults.removeObject(forKey: DefaultsKey.scratchpadDocument)
+            if let legacyURL { try? manager.removeItem(at: legacyURL) }
         }
         apply(migrated)
     }
@@ -187,10 +205,11 @@ final class ScratchpadService: NSObject, ObservableObject, NSWindowDelegate {
     @discardableResult
     private func persist(_ document: ScratchpadDocument) -> Bool {
         if document == lastSavedDocument { return true }
-        guard let data = document.encoded() else { return false }
-        let defaults = UserDefaults.standard
-        defaults.set(data, forKey: DefaultsKey.scratchpadDocument)
-        guard defaults.data(forKey: DefaultsKey.scratchpadDocument) == data else { return false }
+        guard let data = document.encoded(),
+              let url = Self.storeURL,
+              PrivateFileStore.createDirectory(at: url.deletingLastPathComponent()),
+              PrivateFileStore.write(data, to: url)
+        else { return false }
         lastSavedDocument = document
         return true
     }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -14761,7 +14761,7 @@ struct MetricsTests {
                    "every mixer feature string is set for \(language.rawValue)")
             expect(FeatureStrings.backup(language).description.contains(
                 FeatureStrings.scratchpad(language).pageTitle),
-                   "every backup description discloses its Scratchpad note content (\(language.rawValue))")
+                   "every backup description accounts for the Scratchpad text (\(language.rawValue))")
             let guideValues = Mirror(reflecting: FeatureStrings.permissionGuide(language)).children
                 .compactMap { $0.value as? String }
             expect(!guideValues.isEmpty && guideValues.allSatisfy { !$0.isEmpty },

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -18660,15 +18660,8 @@ struct MetricsTests {
             key == DefaultsKey.scratchpadDocument ? scratchpadDocumentData : nil
         }
         let restoredScratchpadSettings = SettingsBackupSupport.sanitizedSettings(from: scratchpadBackup)
-        let restoredScratchpads = ScratchpadDocument.decoded(
-            restoredScratchpadSettings?[DefaultsKey.scratchpadDocument] as? Data,
-            defaultName: "Scratchpad")
-        expect(restoredScratchpads == renamedPad
-                && scratchpadDocumentData.map {
-                    SettingsBackupSupport.valueLooksRight(DefaultsKey.scratchpadDocument, $0)
-                } == true
-                && !SettingsBackupSupport.valueLooksRight(DefaultsKey.scratchpadDocument, "broken"),
-               "settings backup restores the complete scratchpad document and rejects wrong types")
+        expect(restoredScratchpadSettings?[DefaultsKey.scratchpadDocument] == nil,
+               "the scratchpad's own text stays out of a settings backup people copy around")
         let safeScratchpadExportName = ScratchpadSupport.exportFileName(
             title: "Work/Ideas: 1", date: scratchpadNow)
         expect(safeScratchpadExportName.hasPrefix("Work-Ideas- 1 ")
@@ -20184,9 +20177,11 @@ struct MetricsTests {
                 && backupKeys.contains(DefaultsKey.scratchpadRetention)
                 && backupKeys.contains(DefaultsKey.scratchpadCloseOnClickOutside)
                 && backupKeys.contains(DefaultsKey.scratchpadBackgroundOpacity)
-                && backupKeys.contains(DefaultsKey.scratchpadDocument)
-                && backupKeys.contains(DefaultsKey.panelUtilityScratchpad),
-               "scratchpad preferences and named tabs travel with the settings backup")
+                && backupKeys.contains(DefaultsKey.panelUtilityScratchpad)
+                // The pad's own text is the user's material, kept in the app's
+                // private container instead (issue #1197).
+                && !backupKeys.contains(DefaultsKey.scratchpadDocument),
+               "scratchpad preferences travel with the settings backup, its text does not")
         expect(backupKeys.contains(DefaultsKey.radialMenuEnabled)
                 && backupKeys.contains(DefaultsKey.radialMenuShortcut)
                 && backupKeys.contains(DefaultsKey.radialMenuAtPointer)


### PR DESCRIPTION
## Summary

The scratchpad document — every pad's text, its named tabs, the selection — was stored under `scratchpadDocument` in the preferences. Anyone who syncs their Mac through dotfiles, as the reporter does, published whatever they had typed into it, and the settings backup carried the same text between machines.

The document now lives in the app's own Application Support container as `Scratchpad.json`, written through `PrivateFileStore` like the clipboard, the shelf and the recordings — atomic and owner-only, so no other account on the Mac can read it.

A pad written by an earlier version is moved over on first load, and the preference is removed only after the document exists on disk, so it is never cleared from one place before it is safe in the other. The pre-existing `Scratchpad.txt` migration is untouched and now also clears the key, which covers a preference holding a value that never decoded.

`scratchpadDocument` leaves the settings backup's allowed list. That is a deliberate exclusion of private content, not an oversight: the scratchpad's own settings — shortcut, retention, close-on-click-outside, background opacity, panel entry — still travel. Its type check in `valueLooksRight` goes with it, since the key can no longer reach a backup.

The backup screen said, in every language, that the file carries the pad's
text. That sentence now lists the notes among what never leaves this Mac,
and the check that read the old promise reads what the description says.

## Verification

`./build.sh --dev --test` (TESTS OK, 10074 checks), `./build.sh --dev --install` and `--selftest` on the installed executable (SELFTEST OK).

The two backup checks covering this key now assert the opposite, that the text stays out. The migration path itself is exercised by construction rather than by a test: the load order is file, then preference, then the legacy text file, and the preference is dropped behind a successful write.

Refs #1197
