### PR TITLE
Fix capture interruptions and invalid network measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project are documented here. The format follows
 ## [Unreleased]
 
 ### Summary
-Vorssaint adds app-based Keep Awake automation, app exceptions for Super key, centered half-width windows, edge snap controls and shortcuts for recent captures and keyboard brightness. It refines the radial menu, adds capture menu and magnifier zoom choices, and improves color picking, app icons, readability, localization, mouse reconnection, Command Bar responsiveness, system shortcut recovery, Scratchpad privacy and build checks.
+Vorssaint adds app-based Keep Awake automation, app exceptions for Super key, centered half-width windows, edge snap controls and shortcuts for recent captures and keyboard brightness. It refines the radial menu, adds capture menu and magnifier zoom choices, and improves recording safety, network readings, color picking, app icons, readability, localization, mouse reconnection, Command Bar responsiveness, system shortcut recovery, Scratchpad privacy and build checks.
 
 ### Added
 - Keep Awake can start automatically while selected apps are open, including in the background. Thanks to @Borisserz.
@@ -28,8 +28,11 @@ Vorssaint adds app-based Keep Awake automation, app exceptions for Super key, ce
 - The radial menu throws its actions out of the center one after another when it opens and gathers them back in when it closes.
 - The radial menu's highlight sweeps to the pointed slice, and its actions sit on the glass as raised buttons with guides between them.
 - Panel outlines answer the system's Increase Contrast, which they were ignoring while already following reduced motion and transparency.
+- Package installation and update logs use less processing.
 
 ### Fixed
+- Screenshot, text and color shortcuts leave active recordings alone, while the recording command still stops them.
+- Network readings recover from temporary counter failures without false spikes, and speed tests report server errors instead of misleading results.
 - Toggling Wi-Fi from the Command Bar no longer blocks clicks and scrolling while the system responds. Thanks to @mugurc.
 - App Switcher restores native shortcuts after crashes even when disabled, and its reverse window shortcut leaves screenshots available. Thanks to @owendaw.
 - Shortcut recording detects system shortcuts even when they have never been customized. Thanks to @owendaw.

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
@@ -496,10 +496,12 @@ enum HomebrewAnalytics {
 }
 
 enum HomebrewProgressParser {
+    private static let percentageRegex = try? NSRegularExpression(pattern: #"([0-9]{1,3}(?:\.[0-9]+)?)%"#)
+    private static let ansiRegex = try? NSRegularExpression(pattern: #"\u001B\[[0-9;?]*[ -/]*[@-~]"#)
+
     static func progressFraction(in output: String) -> Double? {
         var latest: Double?
-        let pattern = #"([0-9]{1,3}(?:\.[0-9]+)?)%"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        guard let regex = percentageRegex else { return nil }
         let range = NSRange(output.startIndex..<output.endIndex, in: output)
         regex.enumerateMatches(in: output, range: range) { match, _, _ in
             guard let match,
@@ -601,7 +603,7 @@ enum HomebrewProgressParser {
     }
 
     private static func stripANSI(_ value: String) -> String {
-        guard let regex = try? NSRegularExpression(pattern: #"\u001B\[[0-9;?]*[ -/]*[@-~]"#) else {
+        guard let regex = ansiRegex else {
             return value
         }
         let range = NSRange(value.startIndex..<value.endIndex, in: value)

--- a/Sources/Vorssaint/Services/Metrics/NetworkSampler.swift
+++ b/Sources/Vorssaint/Services/Metrics/NetworkSampler.swift
@@ -21,14 +21,14 @@ final class NetworkSampler {
     private var totalUp: UInt64 = 0
     private var counterFallback = NetworkCounterFallback()
     private var processDeltaTracker = NetworkProcessDeltaTracker(maxGap: 30)
-    private let counterReader: () -> NetworkCounters
+    private let counterReader: () -> NetworkCounters?
     private let processReader: () -> [NetworkProcessSample]?
 
     /// After a gap longer than this (sampling was paused), the previous reading
     /// is treated as a fresh baseline instead of producing a misleading spike.
     private static let maxGap: TimeInterval = 10
 
-    init(counterReader: @escaping () -> NetworkCounters = NetworkSampler.readCounters,
+    init(counterReader: @escaping () -> NetworkCounters? = NetworkSampler.readCounters,
          processReader: @escaping () -> [NetworkProcessSample]? = {
              NetworkProcessSupport.currentExternalActivitySamples()
          }) {
@@ -37,10 +37,15 @@ final class NetworkSampler {
     }
 
     func sample(now: TimeInterval) -> NetworkReading {
-        let counters = counterReader()
+        guard let counters = counterReader() else {
+            return NetworkReading(downBytesPerSec: nil, upBytesPerSec: nil,
+                                  totalDown: totalDown, totalUp: totalUp)
+        }
         defer { previous = (counters, now) }
 
         guard let prev = previous, now > prev.time, now - prev.time <= Self.maxGap else {
+            counterFallback.reset()
+            processDeltaTracker.reset()
             return NetworkReading(downBytesPerSec: nil, upBytesPerSec: nil,
                                   totalDown: totalDown, totalUp: totalUp)
         }
@@ -90,16 +95,16 @@ final class NetworkSampler {
     /// Sums received/sent bytes across the physical interfaces via the routing
     /// socket (`NET_RT_IFLIST2`), which reports 64-bit counters in `if_data64` —
     /// unlike `getifaddrs`, whose 32-bit counters wrap and corrupt totals.
-    static func readCounters() -> NetworkCounters {
+    static func readCounters() -> NetworkCounters? {
         var mib: [Int32] = [CTL_NET, PF_ROUTE, 0, 0, NET_RT_IFLIST2, 0]
         var length = 0
         guard sysctl(&mib, 6, nil, &length, nil, 0) == 0, length > 0 else {
-            return NetworkCounters()
+            return nil
         }
 
         var buffer = [UInt8](repeating: 0, count: length)
         guard sysctl(&mib, 6, &buffer, &length, nil, 0) == 0 else {
-            return NetworkCounters()
+            return nil
         }
 
         var result = NetworkCounters()

--- a/Sources/Vorssaint/Services/Metrics/SpeedTest.swift
+++ b/Sources/Vorssaint/Services/Metrics/SpeedTest.swift
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Vorssaint
 
+import Combine
 import Foundation
 
 /// A user-triggered internet speed test: latency, then download, then upload,
@@ -30,7 +31,7 @@ final class SpeedTest: NSObject, ObservableObject {
     private enum Kind { case none, download, upload }
 
     private let host = "https://speed.cloudflare.com"
-    private let sampleSeconds: Double = 5
+    private let sampleSeconds: TimeInterval
     // Cloudflare's __down caps the size just under 100 MB (100 MB+ returns ~nothing),
     // so request under that and loop chunks back-to-back until the time box — that
     // keeps a fast link's pipe full for a full measurement window.
@@ -44,15 +45,16 @@ final class SpeedTest: NSObject, ObservableObject {
     private var transferred: Int64 = 0       // touched only on `queue`
     private var startedAt: CFAbsoluteTime = 0
     private var finished = false
+    private var generation = 0
     private var stopWork: DispatchWorkItem?
 
-    private override init() {
+    init(configuration: URLSessionConfiguration = .ephemeral, sampleSeconds: TimeInterval = 5) {
+        self.sampleSeconds = sampleSeconds
         super.init()
         queue.maxConcurrentOperationCount = 1
-        let config = URLSessionConfiguration.ephemeral
-        config.requestCachePolicy = .reloadIgnoringLocalCacheData
-        config.timeoutIntervalForRequest = 20
-        session = URLSession(configuration: config, delegate: self, delegateQueue: queue)
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.timeoutIntervalForRequest = 20
+        session = URLSession(configuration: configuration, delegate: self, delegateQueue: queue)
     }
 
     func start() {
@@ -60,13 +62,16 @@ final class SpeedTest: NSObject, ObservableObject {
         latencyMs = nil; downloadMbps = nil; uploadMbps = nil
         setPhase(.latency)
         queue.addOperation { [weak self] in
-            self?.measureLatency(remaining: 5, best: .greatestFiniteMagnitude)
+            guard let self else { return }
+            self.generation += 1
+            self.measureLatency(remaining: 5, best: .greatestFiniteMagnitude)
         }
     }
 
     func cancel() {
         queue.addOperation { [weak self] in
             guard let self else { return }
+            self.generation += 1
             self.stopWork?.cancel(); self.stopWork = nil
             self.task?.cancel(); self.task = nil
             self.kind = .none
@@ -90,37 +95,45 @@ final class SpeedTest: NSObject, ObservableObject {
         }
         let url = URL(string: "\(host)/__down?bytes=0")!
         let started = CFAbsoluteTimeGetCurrent()
-        session.dataTask(with: url) { [weak self] _, response, error in
+        let generation = self.generation
+        task = session.dataTask(with: url) { [weak self] _, response, error in
             guard let self else { return }
-            let ok = error == nil && response is HTTPURLResponse
             let rtt = (CFAbsoluteTimeGetCurrent() - started) * 1000
             // Continue on the delegate queue so the transfer phase's `kind` is set
             // there too — otherwise the byte-counting delegate could miss it.
             self.queue.addOperation {
-                self.measureLatency(remaining: remaining - 1, best: ok ? min(best, rtt) : best)
+                guard self.generation == generation else { return }
+                guard error == nil, Self.isSuccessful(response) else {
+                    self.fail(error ?? URLError(.badServerResponse))
+                    return
+                }
+                self.measureLatency(remaining: remaining - 1, best: min(best, rtt))
             }
-        }.resume()
+        }
+        task?.resume()
     }
 
     // MARK: - Download / upload (delegate tasks), time-boxed
 
     private func startTransfer(_ transfer: Kind) {
-        queue.addOperation { [weak self] in
-            guard let self else { return }
-            self.kind = transfer
-            self.transferred = 0
-            self.finished = false
-            self.setPhase(transfer == .download ? .download : .upload)
-            self.startedAt = CFAbsoluteTimeGetCurrent()
+        generation += 1
+        kind = transfer
+        transferred = 0
+        finished = false
+        setPhase(transfer == .download ? .download : .upload)
+        startedAt = CFAbsoluteTimeGetCurrent()
 
-            let work = DispatchWorkItem { [weak self] in
-                self?.queue.addOperation { self?.finishTransfer(timedOut: true) }
+        let generation = self.generation
+        let work = DispatchWorkItem { [weak self] in
+            self?.queue.addOperation {
+                guard let self, self.generation == generation else { return }
+                self.finishTransfer(timedOut: true)
             }
-            self.stopWork?.cancel()   // defensive: never leave a previous time box armed
-            self.stopWork = work
-            DispatchQueue.global().asyncAfter(deadline: .now() + self.sampleSeconds, execute: work)
-            self.beginChunk()
         }
+        stopWork?.cancel()   // defensive: never leave a previous time box armed
+        stopWork = work
+        DispatchQueue.global().asyncAfter(deadline: .now() + sampleSeconds, execute: work)
+        beginChunk()
     }
 
     /// Starts one transfer. Download loops these (each capped under Cloudflare's
@@ -163,17 +176,46 @@ final class SpeedTest: NSObject, ObservableObject {
             setPhase(.done)
         }
     }
+
+    private static func isSuccessful(_ response: URLResponse?) -> Bool {
+        guard let response = response as? HTTPURLResponse else { return false }
+        return (200...299).contains(response.statusCode)
+    }
+
+    private func fail(_ error: Error) {
+        generation += 1
+        finished = true
+        stopWork?.cancel(); stopWork = nil
+        task?.cancel(); task = nil
+        kind = .none
+        setPhase(.failed(error.localizedDescription))
+    }
 }
 
 extension SpeedTest: URLSessionDataDelegate {
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask,
+                    didReceive response: URLResponse,
+                    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+        guard dataTask === task, kind != .none, !finished else {
+            completionHandler(.cancel)
+            return
+        }
+        guard Self.isSuccessful(response) else {
+            fail(URLError(.badServerResponse))
+            completionHandler(.cancel)
+            return
+        }
+        completionHandler(.allow)
+    }
+
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-        if kind == .download { transferred += Int64(data.count) }
+        if dataTask === task, kind == .download { transferred += Int64(data.count) }
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask,
                     didSendBodyData bytesSent: Int64, totalBytesSent: Int64,
                     totalBytesExpectedToSend: Int64) {
-        if kind == .upload { transferred = totalBytesSent }
+        if task === self.task, kind == .upload { transferred = totalBytesSent }
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
@@ -181,11 +223,7 @@ extension SpeedTest: URLSessionDataDelegate {
         // download chunk the time box just cancelled, arriving after upload began).
         guard task === self.task, kind != .none else { return }
         if let error = error as NSError?, error.code != NSURLErrorCancelled, transferred == 0 {
-            finished = true
-            stopWork?.cancel(); stopWork = nil
-            self.task = nil
-            kind = .none
-            setPhase(.failed(error.localizedDescription))
+            fail(error)
             return
         }
         if kind == .download, !finished {

--- a/Sources/Vorssaint/Services/QuickTools/ScreenCaptureService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenCaptureService.swift
@@ -107,10 +107,12 @@ final class ScreenCaptureService: ObservableObject {
     /// button merely picks the initial mode; the person can switch before
     /// selecting anything.
     func capture(initial preferred: ScreenCaptureTool? = nil, fromShortcut: Bool = false) {
-        if AppFeature.screenRecorder.isAvailable,
-           ScreenRecorderService.shared.stopOrCancelActiveCapture() {
+        let recorder = ScreenRecorderService.shared
+        if preferred == .recording, AppFeature.screenRecorder.isAvailable,
+           recorder.stopOrCancelActiveCapture() {
             return
         }
+        guard !recorder.hasActiveCapture else { return }
         if countdown != nil {
             cancelSelection()
             return

--- a/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
+++ b/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
@@ -334,6 +334,10 @@ final class ScreenRecorderService: ObservableObject {
         ScreenCaptureService.shared.capture(initial: .recording)
     }
 
+    var hasActiveCapture: Bool {
+        isRecording || session != nil || countdown != nil || isAwaitingMicrophone || isFinishing
+    }
+
     func stopOrCancelActiveCapture() -> Bool {
         if isRecording || session != nil {
             stop()

--- a/Sources/Vorssaint/Support/SelfTest.swift
+++ b/Sources/Vorssaint/Support/SelfTest.swift
@@ -64,10 +64,12 @@ enum SelfTest {
         // Network counters should be readable and never run backwards.
         let net1 = NetworkSampler.readCounters()
         let net2 = NetworkSampler.readCounters()
-        if net1 == NetworkCounters(), net2 == NetworkCounters() {
+        if let net1, let net2 {
+            if net2.received < net1.received || net2.sent < net1.sent {
+                failures.append("network counters decreased")
+            }
+        } else {
             warnings.append("network counters unavailable")
-        } else if net2.received < net1.received || net2.sent < net1.sent {
-            failures.append("network counters decreased")
         }
 
         let diskCounters = DiskSampler.readCounters()

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -13437,6 +13437,44 @@ struct MetricsTests {
         expect(fallbackProcessIndex == 2,
                "network sampler invokes the process reader only for suspect interface samples")
 
+        let intermittentCounters: [NetworkCounters?] = [
+            nil,
+            NetworkCounters(received: 1_000_000, sent: 500_000),
+            NetworkCounters(received: 1_000_200, sent: 500_100),
+            nil, nil,
+            NetworkCounters(received: 1_000_800, sent: 500_400),
+            nil,
+            NetworkCounters(received: 2_000_000, sent: 900_000),
+            NetworkCounters(received: 2_000_200, sent: 900_100),
+            NetworkCounters(),
+            NetworkCounters(received: 200, sent: 100),
+        ]
+        var intermittentCounterIndex = 0
+        var unexpectedProcessReads = 0
+        let intermittentSampler = NetworkSampler(counterReader: {
+            defer { intermittentCounterIndex += 1 }
+            return intermittentCounters[intermittentCounterIndex]
+        }, processReader: {
+            unexpectedProcessReads += 1
+            return nil
+        })
+        let intermittentTimes: [TimeInterval] = [0, 1, 2, 3, 4, 5, 6, 20, 21, 22, 23]
+        let expectedDownRates: [Double?] = [nil, nil, 200, nil, nil, 200, nil, nil, 200, 0, 200]
+        let expectedDownTotals: [UInt64] = [0, 0, 200, 200, 200, 800, 800, 800, 1_000, 1_000, 1_200]
+        for index in intermittentTimes.indices {
+            let reading = intermittentSampler.sample(now: intermittentTimes[index])
+            expect(reading.downBytesPerSec == expectedDownRates[index]
+                    && reading.upBytesPerSec == expectedDownRates[index].map { $0 / 2 },
+                   "network reading \(index) distinguishes unavailable counters from zero and averages short gaps")
+            expect(reading.totalDown == expectedDownTotals[index]
+                    && reading.totalUp == expectedDownTotals[index] / 2,
+                   "network reading \(index) preserves totals through failures, long gaps and valid counter resets")
+        }
+        expect(unexpectedProcessReads == 0,
+               "unavailable interface counters never trigger process sampling")
+
+        SpeedTestTests.run { expect($0, $1) }
+
         let nettopCSV = """
         time,,bytes_in,bytes_out,
         08:31:45.865507,Codex (Service).78844,78288,477660,

--- a/Tests/SpeedTestTests.swift
+++ b/Tests/SpeedTestTests.swift
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+enum SpeedTestTests {
+    static func run(expect: (Bool, String) -> Void) {
+        let cases: [(name: String, requests: [String])] = [
+            ("latency-500", ["latency"]),
+            ("latency-non-http", ["latency"]),
+            ("download-404", Array(repeating: "latency", count: 5) + ["download"]),
+            ("download-after-data-503", Array(repeating: "latency", count: 5) + ["download", "download"]),
+            ("upload-503", Array(repeating: "latency", count: 5) + ["download", "upload"]),
+            ("success-204", Array(repeating: "latency", count: 5) + ["download", "upload"]),
+        ]
+        for testCase in cases {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.protocolClasses = [SpeedTestProtocol.self]
+            configuration.httpAdditionalHeaders = ["X-Test-Scenario": testCase.name]
+            let test = SpeedTest(configuration: configuration, sampleSeconds: 0.1)
+            test.start()
+            let deadline = Date().addingTimeInterval(3)
+            var completed = false
+            repeat {
+                RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.01))
+                switch test.phase {
+                case .failed, .done: completed = true
+                default: break
+                }
+            } while !completed && Date() < deadline
+            expect(completed, "speed test \(testCase.name) reaches a terminal state")
+
+            let succeeded = testCase.name == "success-204"
+            if succeeded {
+                expect(test.phase == .done && test.latencyMs != nil
+                        && (test.downloadMbps ?? 0) > 0 && test.uploadMbps != nil,
+                       "successful HTTP responses complete every speed test phase")
+            } else {
+                if case .failed = test.phase {
+                    expect(true, "speed test \(testCase.name) reports a failure")
+                } else {
+                    expect(false, "speed test \(testCase.name) reports a failure")
+                }
+                expect(test.uploadMbps == nil,
+                       "speed test \(testCase.name) never publishes an upload result after rejection")
+                if testCase.name != "upload-503" {
+                    expect(test.downloadMbps == nil,
+                           "speed test \(testCase.name) never counts an error body as download traffic")
+                }
+                if testCase.name.hasPrefix("latency-") {
+                    expect(test.latencyMs == nil,
+                           "speed test \(testCase.name) never measures an invalid latency response")
+                }
+            }
+
+            // Let the cancelled time box expire: an error must stay terminal.
+            let phase = test.phase
+            let settled = Date().addingTimeInterval(0.15)
+            while Date() < settled {
+                RunLoop.main.run(mode: .default, before: Date().addingTimeInterval(0.01))
+            }
+            expect(test.phase == phase, "speed test \(testCase.name) stays terminal after its time box")
+            expect(SpeedTestProtocol.requests(for: testCase.name) == testCase.requests,
+                   "speed test \(testCase.name) stops requesting data at the failed phase")
+            test.cancel()
+        }
+    }
+}
+
+private final class SpeedTestProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private static var recordedRequests: [String: [String]] = [:]
+
+    static func requests(for scenario: String) -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedRequests[scenario] ?? []
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let scenario = request.value(forHTTPHeaderField: "X-Test-Scenario") ?? ""
+        let url = request.url!
+        let phase = url.path == "/__up" ? "upload" : url.query == "bytes=0" ? "latency" : "download"
+        Self.lock.lock()
+        Self.recordedRequests[scenario, default: []].append(phase)
+        let downloadCount = Self.recordedRequests[scenario, default: []].filter { $0 == "download" }.count
+        Self.lock.unlock()
+
+        if scenario == "latency-non-http" {
+            client?.urlProtocol(self, didReceive: URLResponse(url: url, mimeType: nil,
+                                                            expectedContentLength: 0, textEncodingName: nil),
+                                cacheStoragePolicy: .notAllowed)
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+        let rejects = scenario.hasPrefix(phase + "-")
+            && (scenario != "download-after-data-503" || downloadCount > 1)
+        let status = rejects ? (Int(scenario.split(separator: "-").last!) ?? 500)
+            : (phase == "download" ? 200 : 204)
+        let response = HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1", headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if rejects || phase == "download" {
+            client?.urlProtocol(self, didLoad: Data(repeating: 42, count: 1_024))
+        }
+        if rejects || phase != "download" || scenario == "download-after-data-503" {
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/build.sh
+++ b/build.sh
@@ -391,6 +391,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/ShellSupport.swift \
         Sources/Vorssaint/Services/Metrics/NetworkProcessSupport.swift \
         Sources/Vorssaint/Services/Metrics/NetworkSampler.swift \
+        Sources/Vorssaint/Services/Metrics/SpeedTest.swift \
         Sources/Vorssaint/Services/Metrics/PeripheralBatterySupport.swift \
         Sources/Vorssaint/Services/Metrics/DiskSupport.swift \
         Sources/Vorssaint/Services/Metrics/MonitorSamplingPolicy.swift \
@@ -409,6 +410,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/Uninstall/UninstallerSupport.swift \
         Sources/Vorssaint/Services/ManagedDownloads/WhatsAppDownloadSupport.swift \
         Tests/MetricsTests.swift \
+        Tests/SpeedTestTests.swift \
         -o build/metrics-tests
     # `set -e` would end the script on a failing run before the sweep below.
     test_status=0


### PR DESCRIPTION
Capture shortcuts could stop an active recording, failed interface reads could inflate network traffic, and unsuccessful HTTP responses could produce speed test results. This change addresses those confirmed problems and removes repeated compilation of fixed package progress expressions.

- Keep screenshot, text and color actions from stopping a recording or opening another capture while recording is starting, running or finishing. The recording command retains its stop/cancel behavior.
- Treat unreadable interface counters as unavailable, retain the last valid baseline across short gaps, and reset sampling state after long gaps without inflating session totals.
- Reject unsuccessful HTTP and non-HTTP responses during latency, download and upload, cancel the current request and time box, and keep late callbacks from restarting a failed or cancelled test.
- Reuse the existing percentage and ANSI expressions without changing parsing behavior or package commands.

Validation: `./build.sh --test` passed 10,144 checks, including simulated HTTP failures before and after received data, successful responses, short and long counter gaps, and real counter resets. `./build.sh --dev --install`, the installed executable's `--selftest`, and strict Developer ID signature verification passed. Isolated checks using the capture entry logic reproduced the original unintended stop and exercised all four tools across idle, starting, recording and finishing states. No visual or interactive UI testing was performed.

The reported mouse-focus observer leak is excluded: with the actual workspace notification center on the tested macOS 27 system, 25 enable/disable cycles of the existing registration and removal code produced no duplicate callbacks or retained observer tokens. That result does not establish behavior on every supported macOS version, but it did not justify including a leak fix here.
