### PR TITLE
Avoid idle work and excessive resource allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project are documented here. The format follows
 ## [Unreleased]
 
 ### Summary
-Vorssaint adds app-based Keep Awake automation, app exceptions for Super key, centered half-width windows, edge snap controls and shortcuts for recent captures and keyboard brightness. It refines the radial menu, adds capture menu and magnifier zoom choices, and improves recording safety, network readings, color picking, app icons, readability, localization, mouse reconnection, Command Bar search and responsiveness, system shortcut recovery, Scratchpad privacy and build checks.
+Vorssaint adds app-based Keep Awake automation, app exceptions for Super key, centered half-width windows, edge snap controls and shortcuts for recent captures and keyboard brightness. It refines the radial menu, adds capture menu and magnifier zoom choices, and improves recording safety, resource use, network readings, color picking, app icons, readability, localization, mouse reconnection, Command Bar search and responsiveness, system shortcut recovery, Scratchpad privacy and build checks.
 
 ### Added
 - Keep Awake can start automatically while selected apps are open, including in the background. Thanks to @Borisserz.
@@ -21,6 +21,7 @@ Vorssaint adds app-based Keep Awake automation, app exceptions for Super key, ce
 - Window Layout has a visual map for turning each edge and corner snap area on or off, thanks to @levelupimprovement.
 
 ### Changed
+- Focus follows mouse, window previews, clipboard history and recent captures avoid unnecessary polling, image processing, icon retention and history writes.
 - Command Bar remembers search choices across launches, tolerates short typos, and offers more emoji through its category or a colon. Thanks to @MaximilianMauroner.
 - Scratchpad notes stay in the app's private storage instead of the preferences, so a settings export no longer carries what you typed. Thanks to @CSkjolden.
 - Build checks read the keycap your keyboard layout shows, where they expected the US one. Thanks to @mugurc.
@@ -32,6 +33,7 @@ Vorssaint adds app-based Keep Awake automation, app exceptions for Super key, ce
 - Package installation and update logs use less processing.
 
 ### Fixed
+- Opening a recording with damaged pointer data no longer requests excessive memory.
 - Screenshot, text and color shortcuts leave active recordings alone, while the recording command still stops them.
 - Network readings recover from temporary counter failures without false spikes, and speed tests report server errors instead of misleading results.
 - Toggling Wi-Fi from the Command Bar no longer blocks clicks and scrolling while the system responds. Thanks to @mugurc.

--- a/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
+++ b/Sources/Vorssaint/Services/Clipboard/ClipboardHistoryService.swift
@@ -663,7 +663,7 @@ final class ClipboardHistoryService: ObservableObject {
         -> (data: Data, width: Int, height: Int)? {
         let png = pasteboard.data(forType: .png)
         guard let source = png ?? pasteboard.data(forType: .tiff),
-              source.count <= maxRawImageBytes,
+              source.count <= (png == nil ? maxRawImageBytes : maxImageBytes),
               let rep = NSBitmapImageRep(data: source),
               rep.pixelsWide > 0, rep.pixelsHigh > 0
         else { return nil }
@@ -865,7 +865,8 @@ final class ClipboardHistoryService: ObservableObject {
         normalizeEntryOrder()
         trimToLimit()
         // Sweep image files that lost their entry (crash between write and save).
-        ClipboardImageStore.cleanup(keeping: Set(entries.compactMap(\.imageFile)))
+        ClipboardImageStore.cleanup(keeping: Set(entries.compactMap(\.imageFile)),
+                                    filePaths: Set(entries.flatMap(\.filePaths)))
         // A history read from the legacy blob migrates right away instead of
         // waiting for the next copy: launching once is enough to leave
         // UserDefaults behind.
@@ -906,7 +907,8 @@ final class ClipboardHistoryService: ObservableObject {
                        encoded.entries != snapshot {
                         self.entries = encoded.entries
                     }
-                    ClipboardImageStore.cleanup(keeping: Set(self.entries.compactMap(\.imageFile)))
+                    ClipboardImageStore.cleanup(keeping: Set(self.entries.compactMap(\.imageFile)),
+                                                filePaths: Set(self.entries.flatMap(\.filePaths)))
                 }
             }
             guard let url = Self.storeURL else {
@@ -1392,10 +1394,17 @@ enum ClipboardImageStore {
         if let cached = fileIcons.object(forKey: path as NSString) { return cached }
         let icon = NSWorkspace.shared.icon(forFile: path)
         fileIcons.setObject(icon, forKey: path as NSString)
+        fileIconPaths = fileIconPaths.filter { fileIcons.object(forKey: $0 as NSString) != nil }
+        fileIconPaths.insert(path)
         return icon
     }
 
-    private static let fileIcons = NSCache<NSString, NSImage>()
+    private static var fileIconPaths: Set<String> = []
+    private static let fileIcons: NSCache<NSString, NSImage> = {
+        let cache = NSCache<NSString, NSImage>()
+        cache.countLimit = 120
+        return cache
+    }()
 
     static func isImageFile(atPath path: String) -> Bool {
         ClipboardHistoryImageSupport.isImageFilePath(path)
@@ -1452,7 +1461,11 @@ enum ClipboardImageStore {
         return ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
     }
 
-    static func cleanup(keeping names: Set<String>) {
+    static func cleanup(keeping names: Set<String>, filePaths: Set<String>) {
+        for path in fileIconPaths where !filePaths.contains(path) {
+            fileIcons.removeObject(forKey: path as NSString)
+        }
+        fileIconPaths.formIntersection(filePaths)
         guard let directory,
               let files = try? FileManager.default.contentsOfDirectory(at: directory,
                                                                        includingPropertiesForKeys: nil)

--- a/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
+++ b/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
@@ -44,13 +44,11 @@ final class FocusFollowsMouseService {
     }
 
     func stop() {
-        timer?.invalidate()
-        timer = nil
+        resetMovement()
         if let mouseMonitor { NSEvent.removeMonitor(mouseMonitor) }
         mouseMonitor = nil
         observers.forEach(NotificationCenter.default.removeObserver)
         observers.removeAll()
-        state.reset()
         isRunning = false
     }
 
@@ -72,34 +70,47 @@ final class FocusFollowsMouseService {
         let workspaceCenter = NSWorkspace.shared.notificationCenter
         observers.append(workspaceCenter.addObserver(forName: NSWorkspace.activeSpaceDidChangeNotification,
                                                       object: nil, queue: .main) { [weak self] _ in
-            self?.state.reset()
+            self?.resetMovement()
         })
         observers.append(workspaceCenter.addObserver(forName: NSWorkspace.didWakeNotification,
                                                       object: nil, queue: .main) { [weak self] _ in
-            self?.state.reset()
+            self?.resetMovement()
         })
         observers.append(NotificationCenter.default.addObserver(
             forName: NSApplication.didChangeScreenParametersNotification,
-            object: nil, queue: .main) { [weak self] _ in self?.state.reset() })
-
-        let timer = Timer(timeInterval: 0.05, repeats: true) { [weak self] _ in self?.evaluateIfSettled() }
-        timer.tolerance = 0.01
-        RunLoop.main.add(timer, forMode: .common)
-        self.timer = timer
+            object: nil, queue: .main) { [weak self] _ in self?.resetMovement() })
         isRunning = true
     }
 
     private func recordMovement(to point: CGPoint) {
-        if Thread.isMainThread {
-            state.recordMovement(to: point, at: ProcessInfo.processInfo.systemUptime)
-        } else {
+        guard Thread.isMainThread else {
             DispatchQueue.main.async { [weak self] in
-                self?.state.recordMovement(to: point, at: ProcessInfo.processInfo.systemUptime)
+                self?.recordMovement(to: point)
             }
+            return
         }
+        guard isRunning else { return }
+        state.recordMovement(to: point, at: ProcessInfo.processInfo.systemUptime)
+        guard timer == nil else { return }
+        let timer = Timer(timeInterval: 0.05, repeats: true) { [weak self] _ in self?.evaluateIfSettled() }
+        timer.tolerance = 0.01
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    private func resetMovement() {
+        state.reset()
+        timer?.invalidate()
+        timer = nil
     }
 
     private func evaluateIfSettled() {
+        defer {
+            if !state.hasPendingEvaluation {
+                timer?.invalidate()
+                timer = nil
+            }
+        }
         guard AXIsProcessTrusted(),
               NSEvent.pressedMouseButtons == 0,
               NSEvent.modifierFlags.intersection([.command, .control, .option, .shift]).isEmpty,

--- a/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseSupport.swift
+++ b/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseSupport.swift
@@ -24,6 +24,10 @@ struct FocusFollowsMouseState: Equatable {
     private(set) var generation: UInt64 = 0
     private var evaluatedGeneration: UInt64?
 
+    var hasPendingEvaluation: Bool {
+        point != nil && evaluatedGeneration != generation
+    }
+
     mutating func recordMovement(to point: CGPoint, at time: TimeInterval) {
         self.point = point
         movedAt = time
@@ -40,7 +44,7 @@ struct FocusFollowsMouseState: Equatable {
     mutating func nextEvaluation(at time: TimeInterval,
                                  delayMilliseconds: Int) -> FocusFollowsMouseEvaluation? {
         guard let point,
-              evaluatedGeneration != generation,
+              hasPendingEvaluation,
               time - movedAt >= Double(FocusFollowsMouseSupport.sanitizedDelay(delayMilliseconds)) / 1_000
         else { return nil }
         evaluatedGeneration = generation

--- a/Sources/Vorssaint/Services/QuickTools/RecentCaptureService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/RecentCaptureService.swift
@@ -47,6 +47,7 @@ final class RecentCaptureService: ObservableObject {
     private let generationLock = NSLock()
     private let thumbnailCache = NSCache<NSString, NSImage>()
     private var storedEntries: [RecentCaptureEntry] = []
+    private var persistedEntries: [RecentCaptureEntry]?
     private var loaded = false
     private var clearGeneration = 0
     private var panel: NSPanel?
@@ -437,6 +438,7 @@ final class RecentCaptureService: ObservableObject {
         if let indexURL, Self.isRegularFile(indexURL),
            let data = try? Data(contentsOf: indexURL),
            let decoded = try? JSONDecoder().decode([RecentCaptureEntry].self, from: data) {
+            persistedEntries = decoded
             storedEntries = decoded.sorted { $0.createdAt > $1.createdAt }
         } else {
             storedEntries = []
@@ -502,12 +504,13 @@ final class RecentCaptureService: ObservableObject {
     }
 
     private func persist() {
-        guard let root, let indexURL else { return }
+        guard storedEntries != persistedEntries, let root, let indexURL else { return }
         do {
             try prepareRoot(root)
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.sortedKeys]
             try write(encoder.encode(storedEntries), to: indexURL)
+            persistedEntries = storedEntries
         } catch {
             return
         }

--- a/Sources/Vorssaint/Services/Recorder/RecorderPointerTrack.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderPointerTrack.swift
@@ -69,6 +69,7 @@ struct RecorderPointerTrack: Equatable {
     private static let headerSize = 28
     private static let sampleSize = 16
     private static let clickSize = 8
+    private static let shapeHeaderSize = 20
 
     func encoded() -> Data {
         var data = Data(capacity: Self.headerSize
@@ -151,15 +152,16 @@ struct RecorderPointerTrack: Equatable {
         }
 
         var shapes: [CursorShape] = []
-        shapes.reserveCapacity(max(0, declaredShapes))
-        for _ in 0..<max(0, declaredShapes) {
+        let shapeLimit = min(declaredShapes, max(0, (data.count - offset) / shapeHeaderSize))
+        shapes.reserveCapacity(shapeLimit)
+        for _ in 0..<shapeLimit {
             guard let hotX = data.readFloat(at: offset),
                   let hotY = data.readFloat(at: offset + 4),
                   let width = data.readFloat(at: offset + 8),
                   let height = data.readFloat(at: offset + 12),
                   let length = data.readUInt32(at: offset + 16)
             else { break }
-            let start = offset + 20
+            let start = offset + shapeHeaderSize
             let end = start + Int(length)
             guard length > 0, end <= data.count else { break }
             let png = data.subdata(in: (data.startIndex + start)..<(data.startIndex + end))

--- a/Sources/Vorssaint/Services/Switcher/WindowPreviewProvider.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowPreviewProvider.swift
@@ -113,6 +113,8 @@ final class WindowPreviewProvider {
                     // Never show the tilted strip artwork. When nothing better
                     // is cached, an upright rectified version stands in until
                     // the window becomes active and a clean capture replaces it.
+                    let needsPreview = await MainActor.run { !Task.isCancelled && self.cache[target.id] == nil }
+                    guard needsPreview else { continue }
                     if let rectified = Self.rectifiedStripCapture(image) {
                         let copy = Self.bitmapCopy(rectified)
                         await MainActor.run {
@@ -186,6 +188,8 @@ final class WindowPreviewProvider {
                 // it; rectify it as a stand-in when nothing better is cached.
                 if let grid = SwitcherSupport.alphaGrid(of: image),
                    SwitcherSupport.captureLooksTransformed(alphaGrid: grid) {
+                    let needsPreview = await MainActor.run { !Task.isCancelled && self.cache[target.id] == nil }
+                    guard needsPreview else { continue }
                     if let rectified = Self.rectifiedStripCapture(image) {
                         let copy = Self.bitmapCopy(rectified)
                         await MainActor.run {
@@ -438,10 +442,12 @@ final class WindowPreviewProvider {
                     guard let image = Self.captureViaWindowServer(id) else { continue }
                     if let grid = SwitcherSupport.alphaGrid(of: image),
                        SwitcherSupport.captureLooksTransformed(alphaGrid: grid) {
+                        let needsPreview = await MainActor.run { !Task.isCancelled && self.cache[id] == nil }
+                        guard needsPreview else { continue }
                         if let rectified = Self.rectifiedStripCapture(image) {
                             let copy = Self.bitmapCopy(rectified)
                             await MainActor.run {
-                                guard self.cache[id] == nil else { return }
+                                guard !Task.isCancelled, self.cache[id] == nil else { return }
                                 self.store(copy, for: id)
                             }
                         }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1524,8 +1524,11 @@ struct MetricsTests {
                 == FocusFollowsMouseSupport.delayRange.upperBound,
                "focus follows mouse clamps a damaged delay preference")
         var focusFollowsMouseState = FocusFollowsMouseState()
+        expect(!focusFollowsMouseState.hasPendingEvaluation,
+               "focus follows mouse starts without work to poll")
         focusFollowsMouseState.recordMovement(to: CGPoint(x: 40, y: 70), at: 10)
-        expect(focusFollowsMouseState.nextEvaluation(at: 10.20, delayMilliseconds: 250) == nil,
+        expect(focusFollowsMouseState.nextEvaluation(at: 10.20, delayMilliseconds: 250) == nil
+                && focusFollowsMouseState.hasPendingEvaluation,
                "focus follows mouse waits for the pointer to settle")
         let settledFocus = focusFollowsMouseState.nextEvaluation(at: 10.25, delayMilliseconds: 250)
         expect(settledFocus?.point == CGPoint(x: 40, y: 70)
@@ -1533,11 +1536,22 @@ struct MetricsTests {
                "focus follows mouse evaluates the settled pointer once")
         expect(focusFollowsMouseState.nextEvaluation(at: 11, delayMilliseconds: 250) == nil,
                "focus follows mouse does not refocus without new movement")
+        expect(!focusFollowsMouseState.hasPendingEvaluation,
+               "a consumed focus evaluation leaves no work to poll while its lookup finishes")
         focusFollowsMouseState.recordMovement(to: CGPoint(x: 90, y: 20), at: 12)
-        expect(settledFocus.map(focusFollowsMouseState.isCurrent) == false,
+        expect(settledFocus.map(focusFollowsMouseState.isCurrent) == false
+                && focusFollowsMouseState.hasPendingEvaluation,
                "a stale window lookup cannot focus after the pointer moves")
+        focusFollowsMouseState.recordMovement(to: CGPoint(x: 100, y: 20), at: 12.2)
+        expect(focusFollowsMouseState.nextEvaluation(at: 12.25, delayMilliseconds: 250) == nil
+                && focusFollowsMouseState.hasPendingEvaluation,
+               "new movement restarts the settling delay without dropping pending work")
+        expect(focusFollowsMouseState.nextEvaluation(at: 13, delayMilliseconds: 250)?.point
+                == CGPoint(x: 100, y: 20),
+               "a deferred focus check can consume the settled target after input protections lift")
+        focusFollowsMouseState.recordMovement(to: CGPoint(x: 110, y: 20), at: 14)
         focusFollowsMouseState.reset()
-        expect(focusFollowsMouseState.point == nil,
+        expect(focusFollowsMouseState.point == nil && !focusFollowsMouseState.hasPendingEvaluation,
                "space and wake resets discard the old pointer target")
         expect(Defaults.registeredDefaults[DefaultsKey.focusFollowsMouseEnabled] as? Bool == false
                 && Defaults.registeredDefaults[DefaultsKey.focusFollowsMouseDelay] as? Int
@@ -22745,6 +22759,31 @@ struct MetricsTests {
                "an unrelated file is not mistaken for a pointer track")
         expect(RecorderPointerTrack.decoded(nil).isEmpty,
                "a recording with no track at all reads as no track")
+
+        let pointerShape = RecorderPointerTrack.CursorShape(
+            png: Data([1, 2, 3]), hotSpot: CGPoint(x: 2, y: 3),
+            pointSize: CGSize(width: 16, height: 24))
+        let shapedTrack = RecorderPointerTrack(
+            samples: trackRoundTrip.samples, clicks: trackRoundTrip.clicks,
+            shapes: [pointerShape, pointerShape], systemScale: 2)
+        expect(RecorderPointerTrack.decoded(shapedTrack.encoded()) == shapedTrack,
+               "bounding shape allocation preserves complete pointer tracks")
+        let partialShapes = RecorderPointerTrack.decoded(shapedTrack.encoded().dropLast())
+        expect(partialShapes.shapes == [pointerShape]
+                && partialShapes.samples == shapedTrack.samples
+                && partialShapes.clicks == shapedTrack.clicks,
+               "a truncated pointer image preserves earlier complete shapes, samples and clicks")
+        var oversizedShapeCount = RecorderPointerTrack().encoded()
+        oversizedShapeCount.replaceSubrange(24..<28, with: [0, 0, 1, 0])
+        let emptyShapeTrack = RecorderPointerTrack.decoded(oversizedShapeCount)
+        expect(emptyShapeTrack.shapes.isEmpty && emptyShapeTrack.shapes.capacity == 0,
+               "a header declaring many absent pointer images reserves no shape storage")
+        var overstatedShapes = shapedTrack.encoded()
+        overstatedShapes.replaceSubrange(24..<28, with: [0, 0, 1, 0])
+        let boundedShapeTrack = RecorderPointerTrack.decoded(overstatedShapes)
+        expect(boundedShapeTrack == shapedTrack
+                && boundedShapeTrack.shapes.capacity <= overstatedShapes.count / 20,
+               "an overstated image count keeps complete records without reserving the claimed capacity")
 
         // MARK: Screen recorder canvas
 


### PR DESCRIPTION
## Summary

Six existing paths performed avoidable work or trusted allocation sizes that the input could not justify:

- Stop the 50 ms focus-following timer when an evaluation is consumed or reset, and rearm it on movement. Keep the configured delay, drag and modifier protections, app exceptions, and stale-target checks.
- Check for a cached preview before rectifying and copying transformed window captures in all three fallback paths. Keep a final check against cancellation and newer previews.
- Limit the clipboard file-icon cache to 120 entries and discard icons for paths removed from history while retaining icons still in use.
- Reject existing PNG payloads above 16 MiB before bitmap preparation. Preserve TIFF conversion, its 64 MiB input limit, and the 16 MiB output limit.
- Skip capture-index encoding and writes when entries match the last successful save. Continue checking for removed files and retrying failed saves.
- Bound pointer-shape reservations by the remaining recording data, preserving complete records in truncated files.

## Verification

Apple M4 (Mac16,12), macOS 27.0 (26A5425a), macOS 26 SDK:

- `./build.sh --test`: **10,213 checks passed**, including added focus-state and malformed/truncated pointer-track regressions.
- **55 isolated fixture checks passed** using the affected production method bodies, covering timer lifetime and input guards, PNG/TIFF limits, icon retention, unchanged/retried history writes, and all three preview fallback paths including late-result protection. System input and capture operations were replaced with fixtures.
- `./build.sh --dev --install`: passed without compiler warnings.
- Installed Developer executable `--selftest`: **SELFTEST OK**.
- Installed Developer ID signature verified; the built and installed executables have identical compiled sections.

Live window interaction and physical battery savings were not measured. The change removes the identified work; it does not claim a measured CPU, GPU, or battery improvement.
