### PR TITLE
Lay a picture over a screen recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ All notable changes to this project are documented here. The format follows
 ## [Unreleased]
 
 ### Summary
-Vorssaint adds app-based Keep Awake automation, app exceptions for Super key, centered half-width windows, edge snap controls and shortcuts for recent captures and keyboard brightness. It refines the radial menu, adds capture menu and magnifier zoom choices, and improves recording safety, network readings, color picking, app icons, readability, localization, mouse reconnection, Command Bar search and responsiveness, system shortcut recovery, Scratchpad privacy and build checks.
+Vorssaint adds pictures over screen recordings, app-based Keep Awake automation, app exceptions for Super key, centered half-width windows, edge snap controls and shortcuts for recent captures and keyboard brightness. It refines the radial menu, adds capture menu and magnifier zoom choices, and improves recording safety, network readings, color picking, app icons, readability, localization, mouse reconnection, Command Bar search and responsiveness, system shortcut recovery, Scratchpad privacy and build checks.
 
 ### Added
+- The recording editor can put a picture over the video, in any of nine spots and at the size and transparency you choose.
 - Keep Awake can start automatically while selected apps are open, including in the background. Thanks to @Borisserz.
 - Super key can pause while selected apps are open, restoring the chosen key’s normal behavior until they quit. Thanks to @Borisserz.
 - Window Layout can center a window at half the screen’s width, with an optional shortcut. Thanks to @Borisserz.

--- a/Sources/Vorssaint/Core/RecorderStrings.swift
+++ b/Sources/Vorssaint/Core/RecorderStrings.swift
@@ -132,6 +132,13 @@ struct RecorderFeatureStrings {
     let blurPickArea: String
     let blurPickAreaHint: String
     let blurCaption: String
+    let addImageButton: String
+    let imageLaneLabel: String
+    let imageLaneEmptyHint: String
+    let thisImageLabel: String
+    let imageSizeLabel: String
+    let imageOpacityLabel: String
+    let imagePositionLabel: String
 }
 
 extension FeatureStrings {
@@ -282,7 +289,14 @@ extension RecorderFeatureStrings {
         thisBlurLabel: "This blur",
         blurPickArea: "Choose the area",
         blurPickAreaHint: "Drag over what should stay hidden",
-        blurCaption: "Hidden for as long as its block lasts on the timeline."
+        blurCaption: "Hidden for as long as its block lasts on the timeline.",
+        addImageButton: "Add image",
+        imageLaneLabel: "Image",
+        imageLaneEmptyHint: "Click here to add an image",
+        thisImageLabel: "This image",
+        imageSizeLabel: "Size",
+        imageOpacityLabel: "Opacity",
+        imagePositionLabel: "Position"
     )
 
     static let ptBR = RecorderFeatureStrings(
@@ -412,7 +426,14 @@ extension RecorderFeatureStrings {
         thisBlurLabel: "Este desfoque",
         blurPickArea: "Escolher a área",
         blurPickAreaHint: "Arraste sobre o que deve ficar escondido",
-        blurCaption: "Fica escondido enquanto o bloco durar na linha do tempo."
+        blurCaption: "Fica escondido enquanto o bloco durar na linha do tempo.",
+        addImageButton: "Adicionar imagem",
+        imageLaneLabel: "Imagem",
+        imageLaneEmptyHint: "Clique aqui para adicionar uma imagem",
+        thisImageLabel: "Esta imagem",
+        imageSizeLabel: "Tamanho",
+        imageOpacityLabel: "Opacidade",
+        imagePositionLabel: "Posição"
     )
 
     static let tr = RecorderFeatureStrings(
@@ -542,7 +563,14 @@ extension RecorderFeatureStrings {
         thisBlurLabel: "Bu bulanıklık",
         blurPickArea: "Alanı seç",
         blurPickAreaHint: "Gizli kalması gerekenin üzerine sürükleyin",
-        blurCaption: "Zaman çizelgesindeki blok sürdüğü sürece gizli kalır."
+        blurCaption: "Zaman çizelgesindeki blok sürdüğü sürece gizli kalır.",
+        addImageButton: "Görsel ekle",
+        imageLaneLabel: "Görsel",
+        imageLaneEmptyHint: "Görsel eklemek için buraya tıklayın",
+        thisImageLabel: "Bu görsel",
+        imageSizeLabel: "Boyut",
+        imageOpacityLabel: "Matlık",
+        imagePositionLabel: "Konum"
     )
 
     static let ru = RecorderFeatureStrings(
@@ -672,7 +700,14 @@ extension RecorderFeatureStrings {
         thisBlurLabel: "Это размытие",
         blurPickArea: "Выбрать область",
         blurPickAreaHint: "Проведите по тому, что нужно скрыть",
-        blurCaption: "Скрыто, пока длится блок на шкале времени."
+        blurCaption: "Скрыто, пока длится блок на шкале времени.",
+        addImageButton: "Добавить изображение",
+        imageLaneLabel: "Изображение",
+        imageLaneEmptyHint: "Нажмите здесь, чтобы добавить изображение",
+        thisImageLabel: "Это изображение",
+        imageSizeLabel: "Размер",
+        imageOpacityLabel: "Непрозрачность",
+        imagePositionLabel: "Положение"
     )
 
     static let es = RecorderFeatureStrings(
@@ -802,7 +837,14 @@ extension RecorderFeatureStrings {
         thisBlurLabel: "Este desenfoque",
         blurPickArea: "Elegir el área",
         blurPickAreaHint: "Arrastra sobre lo que debe quedar oculto",
-        blurCaption: "Queda oculto mientras dure su bloque en la línea de tiempo."
+        blurCaption: "Queda oculto mientras dure su bloque en la línea de tiempo.",
+        addImageButton: "Añadir imagen",
+        imageLaneLabel: "Imagen",
+        imageLaneEmptyHint: "Haz clic aquí para añadir una imagen",
+        thisImageLabel: "Esta imagen",
+        imageSizeLabel: "Tamaño",
+        imageOpacityLabel: "Opacidad",
+        imagePositionLabel: "Posición"
     )
 
     static let de = RecorderFeatureStrings(
@@ -932,7 +974,14 @@ extension RecorderFeatureStrings {
         thisBlurLabel: "Diese Unschärfe",
         blurPickArea: "Bereich wählen",
         blurPickAreaHint: "Über das ziehen, was verborgen bleiben soll",
-        blurCaption: "Bleibt verborgen, solange der Block in der Zeitleiste dauert."
+        blurCaption: "Bleibt verborgen, solange der Block in der Zeitleiste dauert.",
+        addImageButton: "Bild hinzufügen",
+        imageLaneLabel: "Bild",
+        imageLaneEmptyHint: "Hier klicken, um ein Bild hinzuzufügen",
+        thisImageLabel: "Dieses Bild",
+        imageSizeLabel: "Größe",
+        imageOpacityLabel: "Deckkraft",
+        imagePositionLabel: "Position"
     )
 
     static let fr = RecorderFeatureStrings(
@@ -1062,7 +1111,14 @@ extension RecorderFeatureStrings {
         thisBlurLabel: "Ce flou",
         blurPickArea: "Choisir la zone",
         blurPickAreaHint: "Faites glisser sur ce qui doit rester caché",
-        blurCaption: "Reste caché tant que son bloc dure dans la chronologie."
+        blurCaption: "Reste caché tant que son bloc dure dans la chronologie.",
+        addImageButton: "Ajouter une image",
+        imageLaneLabel: "Image",
+        imageLaneEmptyHint: "Cliquez ici pour ajouter une image",
+        thisImageLabel: "Cette image",
+        imageSizeLabel: "Taille",
+        imageOpacityLabel: "Opacité",
+        imagePositionLabel: "Position"
     )
 
     static let it = RecorderFeatureStrings(
@@ -1192,7 +1248,14 @@ extension RecorderFeatureStrings {
         thisBlurLabel: "Questa sfocatura",
         blurPickArea: "Scegli l’area",
         blurPickAreaHint: "Trascina su ciò che deve restare nascosto",
-        blurCaption: "Resta nascosto finché dura il blocco nella timeline."
+        blurCaption: "Resta nascosto finché dura il blocco nella timeline.",
+        addImageButton: "Aggiungi immagine",
+        imageLaneLabel: "Immagine",
+        imageLaneEmptyHint: "Fai clic qui per aggiungere un’immagine",
+        thisImageLabel: "Questa immagine",
+        imageSizeLabel: "Dimensione",
+        imageOpacityLabel: "Opacità",
+        imagePositionLabel: "Posizione"
     )
 
     static let ja = RecorderFeatureStrings(
@@ -1322,7 +1385,14 @@ extension RecorderFeatureStrings {
         thisBlurLabel: "このぼかし",
         blurPickArea: "範囲を選ぶ",
         blurPickAreaHint: "隠したい部分をドラッグ",
-        blurCaption: "タイムラインのブロックが続く間は隠れたままです。"
+        blurCaption: "タイムラインのブロックが続く間は隠れたままです。",
+        addImageButton: "画像を追加",
+        imageLaneLabel: "画像",
+        imageLaneEmptyHint: "クリックして画像を追加",
+        thisImageLabel: "この画像",
+        imageSizeLabel: "サイズ",
+        imageOpacityLabel: "不透明度",
+        imagePositionLabel: "位置"
     )
 
     static let ko = RecorderFeatureStrings(
@@ -1452,7 +1522,14 @@ extension RecorderFeatureStrings {
         thisBlurLabel: "선택한 흐림",
         blurPickArea: "영역 선택",
         blurPickAreaHint: "숨길 부분 위로 드래그하세요",
-        blurCaption: "타임라인의 블록이 지속되는 동안 숨겨집니다."
+        blurCaption: "타임라인의 블록이 지속되는 동안 숨겨집니다.",
+        addImageButton: "이미지 추가",
+        imageLaneLabel: "이미지",
+        imageLaneEmptyHint: "여기를 클릭해 이미지를 추가하세요",
+        thisImageLabel: "선택한 이미지",
+        imageSizeLabel: "크기",
+        imageOpacityLabel: "불투명도",
+        imagePositionLabel: "위치"
     )
 
     static let zhHans = RecorderFeatureStrings(
@@ -1582,7 +1659,14 @@ extension RecorderFeatureStrings {
         thisBlurLabel: "当前模糊",
         blurPickArea: "选取区域",
         blurPickAreaHint: "拖过需要隐藏的内容",
-        blurCaption: "在时间线上的区块持续期间保持隐藏。"
+        blurCaption: "在时间线上的区块持续期间保持隐藏。",
+        addImageButton: "添加图片",
+        imageLaneLabel: "图片",
+        imageLaneEmptyHint: "点按此处添加图片",
+        thisImageLabel: "当前图片",
+        imageSizeLabel: "大小",
+        imageOpacityLabel: "不透明度",
+        imagePositionLabel: "位置"
     )
 
     static let zhTW = RecorderFeatureStrings(
@@ -1712,7 +1796,14 @@ extension RecorderFeatureStrings {
         thisBlurLabel: "這個模糊",
         blurPickArea: "選取區域",
         blurPickAreaHint: "拖曳過需要隱藏的內容",
-        blurCaption: "在時間軸上的區塊持續期間保持隱藏。"
+        blurCaption: "在時間軸上的區塊持續期間保持隱藏。",
+        addImageButton: "加入圖片",
+        imageLaneLabel: "圖片",
+        imageLaneEmptyHint: "按一下這裡加入圖片",
+        thisImageLabel: "這張圖片",
+        imageSizeLabel: "大小",
+        imageOpacityLabel: "不透明度",
+        imagePositionLabel: "位置"
     )
 
     static let zhHK = RecorderFeatureStrings(
@@ -1842,6 +1933,13 @@ extension RecorderFeatureStrings {
         thisBlurLabel: "這個模糊",
         blurPickArea: "選取區域",
         blurPickAreaHint: "拖曳過需要隱藏的內容",
-        blurCaption: "在時間軸上的區塊持續期間保持隱藏。"
+        blurCaption: "在時間軸上的區塊持續期間保持隱藏。",
+        addImageButton: "加入圖片",
+        imageLaneLabel: "圖片",
+        imageLaneEmptyHint: "點按這裡加入圖片",
+        thisImageLabel: "這張圖片",
+        imageSizeLabel: "大小",
+        imageOpacityLabel: "不透明度",
+        imagePositionLabel: "位置"
     )
 }

--- a/Sources/Vorssaint/Core/RecorderStrings.swift
+++ b/Sources/Vorssaint/Core/RecorderStrings.swift
@@ -139,6 +139,7 @@ struct RecorderFeatureStrings {
     let imageSizeLabel: String
     let imageOpacityLabel: String
     let imagePositionLabel: String
+    let imageImportFailed: String
 }
 
 extension FeatureStrings {
@@ -296,7 +297,8 @@ extension RecorderFeatureStrings {
         thisImageLabel: "This image",
         imageSizeLabel: "Size",
         imageOpacityLabel: "Opacity",
-        imagePositionLabel: "Position"
+        imagePositionLabel: "Position",
+        imageImportFailed: "Couldn’t add this image."
     )
 
     static let ptBR = RecorderFeatureStrings(
@@ -433,7 +435,8 @@ extension RecorderFeatureStrings {
         thisImageLabel: "Esta imagem",
         imageSizeLabel: "Tamanho",
         imageOpacityLabel: "Opacidade",
-        imagePositionLabel: "Posição"
+        imagePositionLabel: "Posição",
+        imageImportFailed: "Não foi possível adicionar esta imagem."
     )
 
     static let tr = RecorderFeatureStrings(
@@ -570,7 +573,8 @@ extension RecorderFeatureStrings {
         thisImageLabel: "Bu görsel",
         imageSizeLabel: "Boyut",
         imageOpacityLabel: "Matlık",
-        imagePositionLabel: "Konum"
+        imagePositionLabel: "Konum",
+        imageImportFailed: "Bu görsel eklenemedi."
     )
 
     static let ru = RecorderFeatureStrings(
@@ -707,7 +711,8 @@ extension RecorderFeatureStrings {
         thisImageLabel: "Это изображение",
         imageSizeLabel: "Размер",
         imageOpacityLabel: "Непрозрачность",
-        imagePositionLabel: "Положение"
+        imagePositionLabel: "Положение",
+        imageImportFailed: "Не удалось добавить это изображение."
     )
 
     static let es = RecorderFeatureStrings(
@@ -844,7 +849,8 @@ extension RecorderFeatureStrings {
         thisImageLabel: "Esta imagen",
         imageSizeLabel: "Tamaño",
         imageOpacityLabel: "Opacidad",
-        imagePositionLabel: "Posición"
+        imagePositionLabel: "Posición",
+        imageImportFailed: "No se pudo añadir esta imagen."
     )
 
     static let de = RecorderFeatureStrings(
@@ -981,7 +987,8 @@ extension RecorderFeatureStrings {
         thisImageLabel: "Dieses Bild",
         imageSizeLabel: "Größe",
         imageOpacityLabel: "Deckkraft",
-        imagePositionLabel: "Position"
+        imagePositionLabel: "Position",
+        imageImportFailed: "Dieses Bild konnte nicht hinzugefügt werden."
     )
 
     static let fr = RecorderFeatureStrings(
@@ -1118,7 +1125,8 @@ extension RecorderFeatureStrings {
         thisImageLabel: "Cette image",
         imageSizeLabel: "Taille",
         imageOpacityLabel: "Opacité",
-        imagePositionLabel: "Position"
+        imagePositionLabel: "Position",
+        imageImportFailed: "Impossible d’ajouter cette image."
     )
 
     static let it = RecorderFeatureStrings(
@@ -1255,7 +1263,8 @@ extension RecorderFeatureStrings {
         thisImageLabel: "Questa immagine",
         imageSizeLabel: "Dimensione",
         imageOpacityLabel: "Opacità",
-        imagePositionLabel: "Posizione"
+        imagePositionLabel: "Posizione",
+        imageImportFailed: "Impossibile aggiungere questa immagine."
     )
 
     static let ja = RecorderFeatureStrings(
@@ -1392,7 +1401,8 @@ extension RecorderFeatureStrings {
         thisImageLabel: "この画像",
         imageSizeLabel: "サイズ",
         imageOpacityLabel: "不透明度",
-        imagePositionLabel: "位置"
+        imagePositionLabel: "位置",
+        imageImportFailed: "この画像を追加できませんでした。"
     )
 
     static let ko = RecorderFeatureStrings(
@@ -1529,7 +1539,8 @@ extension RecorderFeatureStrings {
         thisImageLabel: "선택한 이미지",
         imageSizeLabel: "크기",
         imageOpacityLabel: "불투명도",
-        imagePositionLabel: "위치"
+        imagePositionLabel: "위치",
+        imageImportFailed: "이 이미지를 추가할 수 없습니다."
     )
 
     static let zhHans = RecorderFeatureStrings(
@@ -1666,7 +1677,8 @@ extension RecorderFeatureStrings {
         thisImageLabel: "当前图片",
         imageSizeLabel: "大小",
         imageOpacityLabel: "不透明度",
-        imagePositionLabel: "位置"
+        imagePositionLabel: "位置",
+        imageImportFailed: "无法添加此图片。"
     )
 
     static let zhTW = RecorderFeatureStrings(
@@ -1803,7 +1815,8 @@ extension RecorderFeatureStrings {
         thisImageLabel: "這張圖片",
         imageSizeLabel: "大小",
         imageOpacityLabel: "不透明度",
-        imagePositionLabel: "位置"
+        imagePositionLabel: "位置",
+        imageImportFailed: "無法加入這張圖片。"
     )
 
     static let zhHK = RecorderFeatureStrings(
@@ -1940,6 +1953,7 @@ extension RecorderFeatureStrings {
         thisImageLabel: "這張圖片",
         imageSizeLabel: "大小",
         imageOpacityLabel: "不透明度",
-        imagePositionLabel: "位置"
+        imagePositionLabel: "位置",
+        imageImportFailed: "無法加入這張圖片。"
     )
 }

--- a/Sources/Vorssaint/Services/Media/MediaSupport.swift
+++ b/Sources/Vorssaint/Services/Media/MediaSupport.swift
@@ -674,10 +674,12 @@ enum MediaSupport {
 
     static func watermarkLogo(atPath path: String, maxPixel: Int = 2_048) -> CGImage? {
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty,
-              let source = CGImageSourceCreateWithURL(URL(fileURLWithPath: trimmed) as CFURL, nil) else {
-            return nil
-        }
+        guard !trimmed.isEmpty else { return nil }
+        return imageThumbnail(at: URL(fileURLWithPath: trimmed), maxPixel: maxPixel)
+    }
+
+    static func imageThumbnail(at url: URL, maxPixel: Int) -> CGImage? {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
         return CGImageSourceCreateThumbnailAtIndex(source, 0, [
             kCGImageSourceCreateThumbnailFromImageAlways: true,
             kCGImageSourceCreateThumbnailWithTransform: true,

--- a/Sources/Vorssaint/Services/Recorder/RecorderBlurRegion.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderBlurRegion.swift
@@ -11,7 +11,7 @@ import Foundation
 /// origin, like a zoom's focus, so it stays on the same pixels whatever
 /// shape, quality or zoom the finished video ends up with. Unlike a caption
 /// it never fades: a blur that eases in shows what it is hiding.
-struct RecorderBlurRegion: Codable, Equatable, Identifiable {
+struct RecorderBlurRegion: Codable, Equatable, Identifiable, RecorderTimelineBlock {
     var id: UUID
     /// In the recording's own time, like everything else on the timeline.
     var start: Double

--- a/Sources/Vorssaint/Services/Recorder/RecorderComposer.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderComposer.swift
@@ -56,6 +56,11 @@ final class RecorderComposer {
         /// once like everything else, so a frame is a lookup.
         let texts: [RecorderTextOverlay]
         let textOpacity: [[Double]]
+        /// Pictures laid over the recording, each already resized to the
+        /// pixels it is drawn at, with the same per-frame solidity.
+        let images: [RecorderImageOverlay]
+        let imageSprites: [CGImage?]
+        let imageOpacity: [[Double]]
         /// Areas kept unreadable and, for each frame, whether each one is on.
         let blurs: [RecorderBlurRegion]
         let blurCovers: [[Bool]]
@@ -106,8 +111,30 @@ final class RecorderComposer {
         } else if let plate = plan.plate {
             content = content.composited(over: plate)
         }
+        content = drawImages(on: content, index: index)
         content = drawTexts(on: content, index: index)
         return content.cropped(to: CGRect(origin: .zero, size: plan.canvasSize))
+    }
+
+    /// Pictures share the captions' place above the zoom, and go under them:
+    /// a mark of your own belongs behind what the recording is saying.
+    private func drawImages(on content: CIImage, index: Int) -> CIImage {
+        guard !plan.images.isEmpty else { return content }
+        var result = content
+        for (order, overlay) in plan.images.enumerated() {
+            guard plan.imageOpacity.indices.contains(order),
+                  plan.imageOpacity[order].indices.contains(index),
+                  plan.imageSprites.indices.contains(order),
+                  let sprite = plan.imageSprites[order] else { continue }
+            let opacity = plan.imageOpacity[order][index]
+            guard opacity > 0.01 else { continue }
+            let size = CGSize(width: sprite.width, height: sprite.height)
+            let origin = overlay.anchor.origin(of: size, in: plan.canvasSize)
+            result = faded(CIImage(cgImage: sprite), opacity: opacity)
+                .transformed(by: CGAffineTransform(translationX: origin.x, y: origin.y))
+                .composited(over: result)
+        }
+        return result
     }
 
     /// Text sits on top of everything, including the background and the zoom:
@@ -125,9 +152,7 @@ final class RecorderComposer {
                                                          canvasHeight: plan.canvasSize.height)
             else { continue }
             let size = CGSize(width: image.width, height: image.height)
-            let origin = RecorderTextRenderer.origin(for: overlay,
-                                                     textSize: size,
-                                                     canvas: plan.canvasSize)
+            let origin = overlay.anchor.origin(of: size, in: plan.canvasSize)
             result = faded(CIImage(cgImage: image), opacity: opacity)
                 .transformed(by: CGAffineTransform(translationX: origin.x, y: origin.y))
                 .composited(over: result)

--- a/Sources/Vorssaint/Services/Recorder/RecorderComposerPlan.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderComposerPlan.swift
@@ -50,9 +50,10 @@ extension RecorderComposer {
         let needsCanvas = hasBackdrop || fullCanvas != RecorderSupport.evenSize(sourceSize)
         let hasCuts = !document.cuts.isEmpty
         let texts = RecorderTextOverlay.normalized(document.texts, duration: duration)
+        let images = RecorderImageOverlay.normalized(document.images, duration: duration)
         let blurs = RecorderBlurRegion.normalized(document.blurs, duration: duration)
         guard showsPointer || !segments.isEmpty || needsCanvas || hasCuts || !texts.isEmpty
-            || !blurs.isEmpty
+            || !images.isEmpty || !blurs.isEmpty
         else { return nil }
 
         // Everything the pointer track knows is in the RECORDING's own time,
@@ -195,6 +196,16 @@ extension RecorderComposer {
             }
         }
 
+        var imageOpacity: [[Double]] = []
+        var imageSprites: [CGImage?] = []
+        if !images.isEmpty {
+            imageOpacity = images.map { overlay in
+                (0..<frames).map { overlay.opacity(at: sourceTimes[$0]) }
+            }
+            // Read and resized here, once, at the canvas this plan draws on.
+            imageSprites = images.map { RecorderImageRenderer.image(for: $0, canvas: canvas) }
+        }
+
         var blurCovers: [[Bool]] = []
         if !blurs.isEmpty {
             blurCovers = blurs.map { region in
@@ -242,6 +253,9 @@ extension RecorderComposer {
                     mask: mask,
                     texts: texts,
                     textOpacity: textOpacity,
+                    images: images,
+                    imageSprites: imageSprites,
+                    imageOpacity: imageOpacity,
                     blurs: blurs,
                     blurCovers: blurCovers)
     }

--- a/Sources/Vorssaint/Services/Recorder/RecorderEditDocument.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderEditDocument.swift
@@ -43,6 +43,8 @@ struct RecorderEditDocument: Codable, Equatable {
     var zoomsGenerated: Bool
     /// Lines of text laid over the recording, in the recording's own time.
     var texts: [RecorderTextOverlay]
+    /// Pictures laid over the recording, in the recording's own time.
+    var images: [RecorderImageOverlay]
     /// Parts of the picture kept unreadable, in the recording's own time.
     var blurs: [RecorderBlurRegion]
     var keepsMicrophone: Bool
@@ -68,6 +70,7 @@ struct RecorderEditDocument: Codable, Equatable {
          zoomSegments: [RecorderTimeline.ZoomSegment] = [],
          zoomsGenerated: Bool = false,
          texts: [RecorderTextOverlay] = [],
+         images: [RecorderImageOverlay] = [],
          blurs: [RecorderBlurRegion] = [],
          keepsMicrophone: Bool = true,
          systemAudioGain: Double = 1,
@@ -91,6 +94,7 @@ struct RecorderEditDocument: Codable, Equatable {
         self.zoomSegments = zoomSegments
         self.zoomsGenerated = zoomsGenerated
         self.texts = texts
+        self.images = images
         self.blurs = blurs
         self.keepsMicrophone = keepsMicrophone
         self.systemAudioGain = systemAudioGain
@@ -125,6 +129,7 @@ struct RecorderEditDocument: Codable, Equatable {
                                                      forKey: .zoomSegments) ?? []
         zoomsGenerated = try container.decodeIfPresent(Bool.self, forKey: .zoomsGenerated) ?? false
         texts = try container.decodeIfPresent([RecorderTextOverlay].self, forKey: .texts) ?? []
+        images = try container.decodeIfPresent([RecorderImageOverlay].self, forKey: .images) ?? []
         blurs = try container.decodeIfPresent([RecorderBlurRegion].self, forKey: .blurs) ?? []
         keepsMicrophone = try container.decodeIfPresent(Bool.self, forKey: .keepsMicrophone) ?? true
         systemAudioGain = try container.decodeIfPresent(Double.self, forKey: .systemAudioGain) ?? 1
@@ -267,6 +272,7 @@ struct RecorderEditDocument: Codable, Equatable {
             || zoomSegments != other.zoomSegments
             || cuts != other.cuts
             || texts != other.texts
+            || images != other.images
             || blurs != other.blurs
     }
 
@@ -291,6 +297,7 @@ struct RecorderEditDocument: Codable, Equatable {
         return trim.start > 0.01 || trim.end < duration - 0.01 || !keepsSystemAudio
             || !keepsMicrophone || systemAudioGain != 1 || microphoneGain != 1
             || !cuts.isEmpty || !zoomSegments.isEmpty || !texts.isEmpty || !blurs.isEmpty
+            || !images.isEmpty
     }
 
     /// A damaged or hand-edited document can never wedge the editor: every
@@ -315,6 +322,7 @@ struct RecorderEditDocument: Codable, Equatable {
         document.zoomSegments = RecorderTimeline.normalized(segments: zoomSegments,
                                                             duration: duration)
         document.texts = RecorderTextOverlay.normalized(texts, duration: duration)
+        document.images = RecorderImageOverlay.normalized(images, duration: duration)
         document.blurs = RecorderBlurRegion.normalized(blurs, duration: duration)
         return document
     }

--- a/Sources/Vorssaint/Services/Recorder/RecorderEditorController.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderEditorController.swift
@@ -783,14 +783,20 @@ final class RecorderEditorModel: ObservableObject, BackdropEditing {
 
     // MARK: - Lanes
 
-    /// Both lanes speak the same language to the view, so there is one set of
+    /// Every lane speaks the same language to the view, so there is one set of
     /// gestures to learn and one implementation to keep right.
     @Published var selectedTextID: UUID?
+    @Published var selectedImageID: UUID?
     @Published var selectedBlurID: UUID?
 
     var selectedText: RecorderTextOverlay? {
         guard let selectedTextID else { return nil }
         return document.texts.first { $0.id == selectedTextID }
+    }
+
+    var selectedImage: RecorderImageOverlay? {
+        guard let selectedImageID else { return nil }
+        return document.images.first { $0.id == selectedImageID }
     }
 
     var selectedBlur: RecorderBlurRegion? {
@@ -817,6 +823,15 @@ final class RecorderEditorModel: ObservableObject, BackdropEditing {
                                       label: String($0.text.prefix(18)),
                                       glyph: "T")
             }
+        case .image:
+            return document.images.map {
+                RecorderZoomLane.Item(id: $0.id,
+                                      start: $0.start,
+                                      end: $0.end,
+                                      label: String(URL(fileURLWithPath: $0.path)
+                                        .deletingPathExtension().lastPathComponent.prefix(18)),
+                                      glyph: "\u{25A3}")
+            }
         case .blur:
             let label = FeatureStrings.recorder(L10n.shared.language).blurLaneLabel
             return document.blurs.map {
@@ -833,6 +848,7 @@ final class RecorderEditorModel: ObservableObject, BackdropEditing {
         switch kind {
         case .zoom: return selectedZoomID
         case .text: return selectedTextID
+        case .image: return selectedImageID
         case .blur: return selectedBlurID
         }
     }
@@ -843,12 +859,15 @@ final class RecorderEditorModel: ObservableObject, BackdropEditing {
             selectedZoomID = id
         case .text:
             selectedTextID = id
+        case .image:
+            selectedImageID = id
         case .blur:
             selectedBlurID = id
         }
         if id != nil {
             if kind != .zoom { selectedZoomID = nil }
             if kind != .text { selectedTextID = nil }
+            if kind != .image { selectedImageID = nil }
             if kind != .blur { selectedBlurID = nil }
         }
         // Drawing an area belongs to the blur that was selected; once that
@@ -860,43 +879,39 @@ final class RecorderEditorModel: ObservableObject, BackdropEditing {
         switch kind {
         case .zoom: addZoom(at: time)
         case .text: addText(at: time)
+        case .image: addImage(at: time)
         case .blur: addBlur(at: time)
         }
     }
 
     func moveLaneItem(_ kind: RecorderZoomLane.Kind, id: UUID, to start: Double) {
         switch kind {
-        case .zoom:
-            moveZoom(id, to: start)
-        case .text:
-            guard let overlay = document.texts.first(where: { $0.id == id }) else { return }
-            beginInteraction()
-            var next = document
-            let span = overlay.duration
-            let clamped = max(0, min(start, duration - span))
-            next.texts = next.texts.map { item -> RecorderTextOverlay in
-                guard item.id == id else { return item }
-                var copy = item
-                copy.start = clamped
-                copy.end = clamped + span
-                return copy
-            }
-            applyDuringInteraction(next)
-        case .blur:
-            guard let region = document.blurs.first(where: { $0.id == id }) else { return }
-            beginInteraction()
-            var next = document
-            let span = region.duration
-            let clamped = max(0, min(start, duration - span))
-            next.blurs = next.blurs.map { item -> RecorderBlurRegion in
-                guard item.id == id else { return item }
-                var copy = item
-                copy.start = clamped
-                copy.end = clamped + span
-                return copy
-            }
-            applyDuringInteraction(next)
+        case .zoom: moveZoom(id, to: start)
+        case .text: moveBlock(\.texts, id: id, to: start)
+        case .image: moveBlock(\.images, id: id, to: start)
+        case .blur: moveBlock(\.blurs, id: id, to: start)
         }
+    }
+
+    /// A block keeps its length wherever it is dropped, and never hangs off
+    /// the end of the recording.
+    private func moveBlock<Block: RecorderTimelineBlock>(
+        _ blocks: WritableKeyPath<RecorderEditDocument, [Block]>,
+        id: UUID,
+        to start: Double) {
+        guard let block = document[keyPath: blocks].first(where: { $0.id == id }) else { return }
+        beginInteraction()
+        let span = block.duration
+        let clamped = max(0, min(start, duration - span))
+        var next = document
+        next[keyPath: blocks] = next[keyPath: blocks].map { item -> Block in
+            guard item.id == id else { return item }
+            var copy = item
+            copy.start = clamped
+            copy.end = clamped + span
+            return copy
+        }
+        applyDuringInteraction(next)
     }
 
     func resizeLaneItem(_ kind: RecorderZoomLane.Kind,
@@ -904,43 +919,40 @@ final class RecorderEditorModel: ObservableObject, BackdropEditing {
                         edge: RecorderTimeline.Edge,
                         to time: Double) {
         switch kind {
-        case .zoom:
-            resizeZoom(id, edge: edge, to: time)
-        case .text:
-            guard let overlay = document.texts.first(where: { $0.id == id }) else { return }
-            beginInteraction()
-            var next = document
-            next.texts = next.texts.map { item -> RecorderTextOverlay in
-                guard item.id == id else { return item }
-                var copy = item
-                switch edge {
-                case .start: copy.start = max(0, min(time, overlay.end - 0.4))
-                case .end: copy.end = min(duration, max(time, overlay.start + 0.4))
-                }
-                return copy
-            }
-            applyDuringInteraction(next)
-        case .blur:
-            guard let region = document.blurs.first(where: { $0.id == id }) else { return }
-            beginInteraction()
-            var next = document
-            next.blurs = next.blurs.map { item -> RecorderBlurRegion in
-                guard item.id == id else { return item }
-                var copy = item
-                switch edge {
-                case .start: copy.start = max(0, min(time, region.end - 0.4))
-                case .end: copy.end = min(duration, max(time, region.start + 0.4))
-                }
-                return copy
-            }
-            applyDuringInteraction(next)
+        case .zoom: resizeZoom(id, edge: edge, to: time)
+        case .text: resizeBlock(\.texts, id: id, edge: edge, to: time)
+        case .image: resizeBlock(\.images, id: id, edge: edge, to: time)
+        case .blur: resizeBlock(\.blurs, id: id, edge: edge, to: time)
         }
+    }
+
+    /// Either end can be dragged past the other only until the block would
+    /// stop being a block, which is what keeps a lane grabbable.
+    private func resizeBlock<Block: RecorderTimelineBlock>(
+        _ blocks: WritableKeyPath<RecorderEditDocument, [Block]>,
+        id: UUID,
+        edge: RecorderTimeline.Edge,
+        to time: Double) {
+        guard let block = document[keyPath: blocks].first(where: { $0.id == id }) else { return }
+        beginInteraction()
+        var next = document
+        next[keyPath: blocks] = next[keyPath: blocks].map { item -> Block in
+            guard item.id == id else { return item }
+            var copy = item
+            switch edge {
+            case .start: copy.start = max(0, min(time, block.end - 0.4))
+            case .end: copy.end = min(duration, max(time, block.start + 0.4))
+            }
+            return copy
+        }
+        applyDuringInteraction(next)
     }
 
     func removeSelectedLaneItem(_ kind: RecorderZoomLane.Kind) {
         switch kind {
         case .zoom: removeSelectedZoom()
         case .text: removeSelectedText()
+        case .image: removeSelectedImage()
         case .blur: removeSelectedBlur()
         }
     }
@@ -982,6 +994,62 @@ final class RecorderEditorModel: ObservableObject, BackdropEditing {
         next.texts.removeAll { $0.id == id }
         applyDuringInteraction(next)
         selectedTextID = nil
+        commitZoomEdit()
+    }
+
+    // MARK: - Image
+
+    /// A picture is picked straight away: an empty block on a lane would say
+    /// nothing, and choosing the file is the first thing anyone does anyway.
+    ///
+    /// It runs to the end of the recording the way a blur does, because a mark
+    /// of your own is normally meant to stay on the whole video.
+    func addImage(at time: Double) {
+        guard duration > 0, let url = Self.chooseImage() else { return }
+        beginInteraction()
+        let start = max(0, min(time, max(0, duration - 0.4)))
+        let overlay = RecorderImageOverlay(path: url.path, start: start, end: duration)
+        var next = document
+        next.images.append(overlay)
+        applyDuringInteraction(next)
+        selectLaneItem(.image, id: overlay.id)
+        commitZoomEdit()
+    }
+
+    /// Only a file the person picked themselves, and only one the system can
+    /// really read as a picture: the document keeps the path and reads it
+    /// again whenever the picture has to be drawn at a new size.
+    private static func chooseImage() -> URL? {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.image]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        guard panel.runModal() == .OK, let url = panel.url,
+              MediaSupport.imageDisplaySize(at: url) != nil
+        else { return nil }
+        return url
+    }
+
+    func updateSelectedImage(_ change: (inout RecorderImageOverlay) -> Void) {
+        guard let id = selectedImageID else { return }
+        beginInteraction()
+        var next = document
+        next.images = next.images.map { item -> RecorderImageOverlay in
+            guard item.id == id else { return item }
+            var copy = item
+            change(&copy)
+            return copy
+        }
+        applyDuringInteraction(next)
+    }
+
+    func removeSelectedImage() {
+        guard let id = selectedImageID else { return }
+        beginInteraction()
+        var next = document
+        next.images.removeAll { $0.id == id }
+        applyDuringInteraction(next)
+        selectedImageID = nil
         commitZoomEdit()
     }
 

--- a/Sources/Vorssaint/Services/Recorder/RecorderEditorController.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderEditorController.swift
@@ -865,6 +865,7 @@ final class RecorderEditorModel: ObservableObject, BackdropEditing {
             selectedBlurID = id
         }
         if id != nil {
+            cutSelection = nil
             if kind != .zoom { selectedZoomID = nil }
             if kind != .text { selectedTextID = nil }
             if kind != .image { selectedImageID = nil }
@@ -1006,26 +1007,41 @@ final class RecorderEditorModel: ObservableObject, BackdropEditing {
     /// of your own is normally meant to stay on the whole video.
     func addImage(at time: Double) {
         guard duration > 0, let url = Self.chooseImage() else { return }
-        beginInteraction()
-        let start = max(0, min(time, max(0, duration - 0.4)))
-        let overlay = RecorderImageOverlay(path: url.path, start: start, end: duration)
-        var next = document
-        next.images.append(overlay)
-        applyDuringInteraction(next)
-        selectLaneItem(.image, id: overlay.id)
-        commitZoomEdit()
+        let take = take
+        Task { @MainActor [weak self] in
+            let imported = await Task.detached(priority: .userInitiated) {
+                RecorderTakeStore.shared.importImage(at: url, into: take)
+            }.value
+            guard let self else {
+                if let imported {
+                    try? FileManager.default.removeItem(at: imported.deletingLastPathComponent())
+                }
+                return
+            }
+            guard let imported else {
+                QuickToolHUD.show(icon: "photo",
+                                 message: FeatureStrings.recorder(L10n.shared.language).imageImportFailed)
+                return
+            }
+            self.beginInteraction()
+            let start = max(0, min(time, max(0, self.duration - 0.4)))
+            let overlay = RecorderImageOverlay(path: imported.path, start: start, end: self.duration)
+            var next = self.document
+            next.images.append(overlay)
+            self.applyDuringInteraction(next)
+            self.selectLaneItem(.image, id: overlay.id)
+            self.commitZoomEdit()
+        }
     }
 
     /// Only a file the person picked themselves, and only one the system can
-    /// really read as a picture: the document keeps the path and reads it
-    /// again whenever the picture has to be drawn at a new size.
+    /// copy into the recording. Decoding happens with the import off the UI thread.
     private static func chooseImage() -> URL? {
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [.image]
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
-        guard panel.runModal() == .OK, let url = panel.url,
-              MediaSupport.imageDisplaySize(at: url) != nil
+        guard panel.runModal() == .OK, let url = panel.url
         else { return nil }
         return url
     }
@@ -1630,6 +1646,14 @@ final class RecorderEditorController: NSObject, NSWindowDelegate {
                     self.model.removeSelectedZoom()
                     return nil
                 }
+                if self.model.selectedTextID != nil {
+                    self.model.removeSelectedText()
+                    return nil
+                }
+                if self.model.selectedImageID != nil {
+                    self.model.removeSelectedImage()
+                    return nil
+                }
                 if self.model.selectedBlurID != nil {
                     self.model.removeSelectedBlur()
                     return nil
@@ -1651,6 +1675,14 @@ final class RecorderEditorController: NSObject, NSWindowDelegate {
                 }
                 if self.model.selectedZoomID != nil {
                     self.model.selectZoom(nil)
+                    return nil
+                }
+                if self.model.selectedTextID != nil {
+                    self.model.selectLaneItem(.text, id: nil)
+                    return nil
+                }
+                if self.model.selectedImageID != nil {
+                    self.model.selectLaneItem(.image, id: nil)
                     return nil
                 }
                 if self.model.selectedBlurID != nil {

--- a/Sources/Vorssaint/Services/Recorder/RecorderImageOverlay.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderImageOverlay.swift
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import CoreGraphics
+import Foundation
+
+/// A picture laid over the recording for a while: a logo, a badge, a mark of
+/// your own.
+///
+/// It names the file instead of carrying it. Undo keeps a copy of the whole
+/// document for every step, and a logo copied into each of those would cost
+/// megabytes for every drag of a slider. The file is read again whenever the
+/// picture has to be drawn at a new size, and an overlay whose file went away
+/// simply draws nothing rather than wedging the export.
+struct RecorderImageOverlay: Codable, Equatable, Identifiable, RecorderTimelineBlock {
+    /// The same nine places a caption can take: one grid to learn, and a
+    /// corner mark stays in its corner whatever shape the video ends up.
+    typealias Anchor = RecorderTextOverlay.Anchor
+
+    var id: UUID
+    var path: String
+    /// In the recording's own time, like everything else on the timeline.
+    var start: Double
+    var end: Double
+    var anchor: Anchor
+    /// How wide the picture is drawn, as a share of the finished frame's
+    /// width. Its own proportions decide the height.
+    var size: Double
+    /// How solid the picture is at its most solid, before the ends are eased.
+    /// The picture's own transparency is kept underneath it.
+    var opacity: Double
+
+    init(id: UUID = UUID(),
+         path: String,
+         start: Double,
+         end: Double,
+         anchor: Anchor = .bottomTrailing,
+         size: Double = RecorderImageOverlay.defaultSize,
+         opacity: Double = 1) {
+        self.id = id
+        self.path = path
+        self.start = start
+        self.end = end
+        self.anchor = anchor
+        self.size = size
+        self.opacity = opacity
+    }
+
+    var duration: Double { max(0, end - start) }
+
+    static let sizeRange: ClosedRange<Double> = 0.04...0.6
+    static let opacityRange: ClosedRange<Double> = 0.05...1
+    static let defaultSize: Double = 0.18
+    static let fade: Double = 0.25
+
+    /// How solid the picture is at a moment: what was chosen, eased at both
+    /// ends so it never appears or vanishes on a single frame.
+    func opacity(at time: Double) -> Double {
+        opacity * RecorderMotion.overlayOpacity(at: time,
+                                                start: start,
+                                                end: end,
+                                                fade: Self.fade)
+    }
+
+    func sanitized(duration recordingDuration: Double) -> RecorderImageOverlay? {
+        guard recordingDuration > 0, start.isFinite, end.isFinite else { return nil }
+        var copy = self
+        copy.path = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !copy.path.isEmpty else { return nil }
+        copy.start = max(0, min(start, recordingDuration))
+        copy.end = max(0, min(end, recordingDuration))
+        copy.size = size.isFinite
+            ? min(Self.sizeRange.upperBound, max(Self.sizeRange.lowerBound, size))
+            : Self.defaultSize
+        copy.opacity = opacity.isFinite
+            ? min(Self.opacityRange.upperBound, max(Self.opacityRange.lowerBound, opacity))
+            : 1
+        guard copy.duration >= 0.2 else { return nil }
+        return copy
+    }
+
+    static func normalized(_ overlays: [RecorderImageOverlay],
+                           duration: Double) -> [RecorderImageOverlay] {
+        overlays.compactMap { $0.sanitized(duration: duration) }
+            .sorted { $0.start < $1.start }
+    }
+
+    /// The size the picture is drawn at, from its own proportions, never
+    /// larger than the frame it sits on.
+    static func drawnSize(source: CGSize, size: Double, canvas: CGSize) -> CGSize? {
+        guard source.width > 0, source.height > 0,
+              canvas.width > 0, canvas.height > 0 else { return nil }
+        var width = canvas.width * CGFloat(size)
+        var height = width * source.height / source.width
+        if height > canvas.height {
+            width *= canvas.height / height
+            height = canvas.height
+        }
+        let drawn = CGSize(width: width.rounded(), height: height.rounded())
+        guard drawn.width >= 1, drawn.height >= 1 else { return nil }
+        return drawn
+    }
+}

--- a/Sources/Vorssaint/Services/Recorder/RecorderImageOverlay.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderImageOverlay.swift
@@ -7,11 +7,8 @@ import Foundation
 /// A picture laid over the recording for a while: a logo, a badge, a mark of
 /// your own.
 ///
-/// It names the file instead of carrying it. Undo keeps a copy of the whole
-/// document for every step, and a logo copied into each of those would cost
-/// megabytes for every drag of a slider. The file is read again whenever the
-/// picture has to be drawn at a new size, and an overlay whose file went away
-/// simply draws nothing rather than wedging the export.
+/// It names a private copy beside the recording instead of carrying pixels
+/// through undo. Moving or replacing the original cannot change the edit.
 struct RecorderImageOverlay: Codable, Equatable, Identifiable, RecorderTimelineBlock {
     /// The same nine places a caption can take: one grid to learn, and a
     /// corner mark stays in its corner whatever shape the video ends up.
@@ -65,8 +62,7 @@ struct RecorderImageOverlay: Codable, Equatable, Identifiable, RecorderTimelineB
     func sanitized(duration recordingDuration: Double) -> RecorderImageOverlay? {
         guard recordingDuration > 0, start.isFinite, end.isFinite else { return nil }
         var copy = self
-        copy.path = path.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !copy.path.isEmpty else { return nil }
+        guard path.hasPrefix("/"), !path.contains("\0") else { return nil }
         copy.start = max(0, min(start, recordingDuration))
         copy.end = max(0, min(end, recordingDuration))
         copy.size = size.isFinite
@@ -88,14 +84,18 @@ struct RecorderImageOverlay: Codable, Equatable, Identifiable, RecorderTimelineB
     /// The size the picture is drawn at, from its own proportions, never
     /// larger than the frame it sits on.
     static func drawnSize(source: CGSize, size: Double, canvas: CGSize) -> CGSize? {
-        guard source.width > 0, source.height > 0,
-              canvas.width > 0, canvas.height > 0 else { return nil }
+        guard source.width.isFinite, source.height.isFinite,
+              canvas.width.isFinite, canvas.height.isFinite, size.isFinite,
+              source.width > 0, source.height > 0,
+              canvas.width > 0, canvas.height > 0, size > 0 else { return nil }
+        let margin = min(canvas.width, canvas.height) * 0.05
+        let available = CGSize(width: canvas.width - 2 * margin,
+                               height: canvas.height - 2 * margin)
         var width = canvas.width * CGFloat(size)
         var height = width * source.height / source.width
-        if height > canvas.height {
-            width *= canvas.height / height
-            height = canvas.height
-        }
+        let scale = min(1, min(available.width / width, available.height / height))
+        width *= scale
+        height *= scale
         let drawn = CGSize(width: width.rounded(), height: height.rounded())
         guard drawn.width >= 1, drawn.height >= 1 else { return nil }
         return drawn

--- a/Sources/Vorssaint/Services/Recorder/RecorderImageRenderer.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderImageRenderer.swift
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import CoreGraphics
+import Foundation
+
+/// Turns an overlay's picture into the pixels a frame composites, once.
+///
+/// The same bargain the caption renderer makes: the file is read and resized
+/// while the plan is built, so every frame after that is a composite of a
+/// texture already at the size it is drawn. Sizes repeat as soon as anything
+/// else about the edit changes, which is what the cache is for; it is held to
+/// a budget in pixels rather than in entries, because one mark covering most
+/// of a 4K frame is worth as much memory as a hundred captions.
+enum RecorderImageRenderer {
+
+    private static let pixelBudget = 24_000_000
+
+    private static var cache: [String: CGImage] = [:]
+    private static var cachedPixels = 0
+    private static let lock = NSLock()
+
+    static func image(for overlay: RecorderImageOverlay, canvas: CGSize) -> CGImage? {
+        let url = URL(fileURLWithPath: overlay.path)
+        guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey,
+                                                             .fileSizeKey,
+                                                             .contentModificationDateKey]),
+              values.isRegularFile == true,
+              let source = MediaSupport.imageDisplaySize(at: url),
+              let drawn = RecorderImageOverlay.drawnSize(source: source,
+                                                         size: overlay.size,
+                                                         canvas: canvas),
+              MediaSupport.imageRenderSizeIsSafe(drawn)
+        else { return nil }
+
+        // The file's own size and date are part of the key: a logo replaced on
+        // disk while the editor is open is a different picture, not the same
+        // one at the same size.
+        let stamp = "\(values.fileSize ?? 0)|"
+            + "\(values.contentModificationDate?.timeIntervalSinceReferenceDate ?? 0)"
+        let key = "\(overlay.path)|\(Int(drawn.width))x\(Int(drawn.height))|\(stamp)"
+        lock.lock()
+        if let hit = cache[key] {
+            lock.unlock()
+            return hit
+        }
+        lock.unlock()
+
+        guard let image = render(overlay.path, drawn: drawn) else { return nil }
+        lock.lock()
+        if cachedPixels > pixelBudget {
+            cache.removeAll()
+            cachedPixels = 0
+        }
+        cache[key] = image
+        cachedPixels += image.width * image.height
+        lock.unlock()
+        return image
+    }
+
+    /// Decoded no larger than it is drawn, then drawn at exactly that size, so
+    /// a photograph never arrives at full resolution and a small logo asked to
+    /// fill half the frame is still resampled smoothly instead of blocking up.
+    private static func render(_ path: String, drawn: CGSize) -> CGImage? {
+        let width = Int(drawn.width)
+        let height = Int(drawn.height)
+        guard let picture = MediaSupport.watermarkLogo(atPath: path,
+                                                       maxPixel: max(width, height)),
+              let space = CGColorSpace(name: CGColorSpace.sRGB),
+              let context = CGContext(data: nil,
+                                      width: width,
+                                      height: height,
+                                      bitsPerComponent: 8,
+                                      bytesPerRow: 0,
+                                      space: space,
+                                      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        else { return nil }
+        context.interpolationQuality = .high
+        context.draw(picture, in: CGRect(origin: .zero, size: drawn))
+        return context.makeImage()
+    }
+}

--- a/Sources/Vorssaint/Services/Recorder/RecorderImageRenderer.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderImageRenderer.swift
@@ -64,8 +64,8 @@ enum RecorderImageRenderer {
     private static func render(_ path: String, drawn: CGSize) -> CGImage? {
         let width = Int(drawn.width)
         let height = Int(drawn.height)
-        guard let picture = MediaSupport.watermarkLogo(atPath: path,
-                                                       maxPixel: max(width, height)),
+        guard let picture = MediaSupport.imageThumbnail(at: URL(fileURLWithPath: path),
+                                                        maxPixel: max(width, height)),
               let space = CGColorSpace(name: CGColorSpace.sRGB),
               let context = CGContext(data: nil,
                                       width: width,

--- a/Sources/Vorssaint/Services/Recorder/RecorderMotion.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderMotion.swift
@@ -298,6 +298,22 @@ enum RecorderMotion {
         return x * x * x * (10 - 15 * x + 6 * x * x)
     }
 
+    /// How solid something laid over the picture is at a moment, eased at both
+    /// ends so it never appears or vanishes on a single frame. A block too
+    /// short to hold the whole ramp gets a shorter one rather than none.
+    static func overlayOpacity(at time: Double,
+                               start: Double,
+                               end: Double,
+                               fade: Double) -> Double {
+        let duration = end - start
+        guard duration > 0, time >= start, time <= end else { return 0 }
+        let ramp = min(fade, duration / 2)
+        guard ramp > 0 else { return 1 }
+        if time < start + ramp { return smoothstep((time - start) / ramp) }
+        if time > end - ramp { return smoothstep((end - time) / ramp) }
+        return 1
+    }
+
     // MARK: - Zoom segments
 
     struct ZoomSegment: Equatable {

--- a/Sources/Vorssaint/Services/Recorder/RecorderTakeStore.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderTakeStore.swift
@@ -95,6 +95,35 @@ final class RecorderTakeStore: @unchecked Sendable {
         return availableBytes - fileSize >= RecorderSupport.minimumFreeBytesToContinue
     }
 
+    /// Keep one independent file for both preview and export. Its folder lives
+    /// until the take closes, including while undo can still restore the image.
+    func importImage(at sourceURL: URL, into take: Take) -> URL? {
+        guard let values = try? sourceURL.resourceValues(
+            forKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey]),
+              values.isRegularFile == true, values.isSymbolicLink != true,
+              let fileSize = values.fileSize,
+              Self.canImport(fileSize: Int64(fileSize), availableBytes: freeBytes(at: take.folder))
+        else { return nil }
+
+        let folder = take.folder.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let destination = folder.appendingPathComponent(sourceURL.lastPathComponent)
+        do {
+            // Never recreate a take that closed while this import was queued.
+            try manager.createDirectory(at: folder, withIntermediateDirectories: false,
+                                        attributes: [.posixPermissions: 0o700])
+            try manager.copyItem(at: sourceURL, to: destination)
+            try manager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: destination.path)
+            guard MediaSupport.imageThumbnail(at: destination, maxPixel: 1) != nil else {
+                try? manager.removeItem(at: folder)
+                return nil
+            }
+            return destination
+        } catch {
+            try? manager.removeItem(at: folder)
+            return nil
+        }
+    }
+
     private func freeBytes(at url: URL) -> Int64 {
         let values = try? url.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
         return values?.volumeAvailableCapacityForImportantUsage ?? 0

--- a/Sources/Vorssaint/Services/Recorder/RecorderTextOverlay.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderTextOverlay.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Placed on a corner or an edge rather than dragged to an arbitrary spot:
 /// nine places cover what people actually do with a caption, they read at a
 /// glance, and they keep working when the shape of the video changes.
-struct RecorderTextOverlay: Codable, Equatable, Identifiable {
+struct RecorderTextOverlay: Codable, Equatable, Identifiable, RecorderTimelineBlock {
 
     enum Anchor: String, Codable, CaseIterable {
         case topLeading, top, topTrailing
@@ -30,6 +30,19 @@ struct RecorderTextOverlay: Codable, Equatable, Identifiable {
             case .bottom: return CGPoint(x: 0.5, y: 1)
             case .bottomTrailing: return CGPoint(x: 1, y: 1)
             }
+        }
+
+        /// Where something of `contentSize` sits on the canvas, in Core
+        /// Image's bottom-left space, with a margin off every edge it touches.
+        /// Captions and pictures place the same way, so the nine places mean
+        /// the same thing whatever is put in them.
+        func origin(of contentSize: CGSize, in canvas: CGSize) -> CGPoint {
+            let margin = min(canvas.width, canvas.height) * 0.05
+            let point = unitPoint
+            let x = margin + (canvas.width - contentSize.width - margin * 2) * point.x
+            // The anchor counts down from the top, the way the screen does.
+            let topY = margin + (canvas.height - contentSize.height - margin * 2) * point.y
+            return CGPoint(x: x, y: canvas.height - topY - contentSize.height)
         }
     }
 
@@ -85,17 +98,7 @@ struct RecorderTextOverlay: Codable, Equatable, Identifiable {
     /// How solid the text is at a moment, eased at both ends so it never
     /// appears or vanishes on a single frame.
     func opacity(at time: Double) -> Double {
-        guard duration > 0 else { return 0 }
-        let ramp = min(Self.fade, duration / 2)
-        if time < start || time > end { return 0 }
-        if ramp <= 0 { return 1 }
-        if time < start + ramp {
-            return RecorderMotion.smoothstep((time - start) / ramp)
-        }
-        if time > end - ramp {
-            return RecorderMotion.smoothstep((end - time) / ramp)
-        }
-        return 1
+        RecorderMotion.overlayOpacity(at: time, start: start, end: end, fade: Self.fade)
     }
 
     func sanitized(duration recordingDuration: Double) -> RecorderTextOverlay? {

--- a/Sources/Vorssaint/Services/Recorder/RecorderTextRenderer.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderTextRenderer.swift
@@ -89,17 +89,4 @@ enum RecorderTextRenderer {
         NSGraphicsContext.restoreGraphicsState()
         return context.makeImage()
     }
-
-    /// Where the rasterized line sits on the canvas, in Core Image's
-    /// bottom-left space, with a margin off every edge it touches.
-    static func origin(for overlay: RecorderTextOverlay,
-                       textSize: CGSize,
-                       canvas: CGSize) -> CGPoint {
-        let margin = min(canvas.width, canvas.height) * 0.05
-        let point = overlay.anchor.unitPoint
-        let x = margin + (canvas.width - textSize.width - margin * 2) * point.x
-        // The anchor counts down from the top, the way the screen does.
-        let topY = margin + (canvas.height - textSize.height - margin * 2) * point.y
-        return CGPoint(x: x, y: canvas.height - topY - textSize.height)
-    }
 }

--- a/Sources/Vorssaint/Services/Recorder/RecorderTimeline.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderTimeline.swift
@@ -4,6 +4,16 @@
 import CoreGraphics
 import Foundation
 
+/// A block that can be picked up and stretched on a lane: a caption, a
+/// picture, a blur. They behave identically on the timeline, so one
+/// implementation of moving and stretching serves every kind.
+protocol RecorderTimelineBlock {
+    var id: UUID { get }
+    var start: Double { get set }
+    var end: Double { get set }
+    var duration: Double { get }
+}
+
 /// The editable timeline: what is kept, what is cut out of the middle, and
 /// where the picture leans in.
 ///

--- a/Sources/Vorssaint/UI/Recorder/RecorderEditorView.swift
+++ b/Sources/Vorssaint/UI/Recorder/RecorderEditorView.swift
@@ -324,6 +324,13 @@ struct RecorderEditorView: View {
                         .frame(height: 30)
                 }
             }
+            if !model.document.images.isEmpty {
+                timelineRow(strings.imageLaneLabel) {
+                    RecorderZoomLane(model: model, kind: .image,
+                                     emptyHint: strings.imageLaneEmptyHint)
+                        .frame(height: 30)
+                }
+            }
             if !model.document.blurs.isEmpty {
                 timelineRow(strings.blurLaneLabel) {
                     RecorderZoomLane(model: model, kind: .blur,
@@ -388,6 +395,15 @@ struct RecorderEditorView: View {
                 model.addText(at: model.sourceTime)
             } label: {
                 Label(strings.addTextButton, systemImage: "textformat")
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .buttonStyle(.borderless)
+            .foregroundStyle(Color(white: 0.8))
+
+            Button {
+                model.addImage(at: model.sourceTime)
+            } label: {
+                Label(strings.addImageButton, systemImage: "photo")
                     .font(.system(size: 12, weight: .medium))
             }
             .buttonStyle(.borderless)

--- a/Sources/Vorssaint/UI/Recorder/RecorderInspector.swift
+++ b/Sources/Vorssaint/UI/Recorder/RecorderInspector.swift
@@ -36,6 +36,8 @@ struct RecorderInspector: View {
                 // swap is what teaches the selection model, without a word.
                 if let text = model.selectedText {
                     selectedTextSection(text)
+                } else if let image = model.selectedImage {
+                    selectedImageSection(image)
                 } else if model.selectedBlur != nil {
                     selectedBlurSection
                 } else if let selected = model.selectedZoom {
@@ -376,7 +378,9 @@ struct RecorderInspector: View {
                 Text(strings.textPositionLabel)
                     .font(.system(size: 11))
                     .foregroundStyle(Color(white: 0.72))
-                anchorGrid(overlay)
+                anchorGrid(selected: overlay.anchor) { anchor in
+                    model.updateSelectedText { $0.anchor = anchor }
+                }
             }
 
             VStack(alignment: .leading, spacing: 5) {
@@ -405,6 +409,75 @@ struct RecorderInspector: View {
             }
 
             Button(strings.removeText) { model.removeSelectedText() }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .frame(maxWidth: .infinity)
+        }
+    }
+
+    // MARK: - One picture
+
+    /// The picture itself was chosen when the block was made, so what is left
+    /// here is how big it is, how solid it is and where it sits.
+    private func selectedImageSection(_ overlay: RecorderImageOverlay) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Button {
+                model.selectLaneItem(.image, id: nil)
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 10, weight: .semibold))
+                    Text(strings.backToOptions)
+                        .font(.system(size: 11, weight: .medium))
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.borderless)
+            .foregroundStyle(Color.accentColor)
+            .keyboardShortcut(.escape, modifiers: [])
+            sectionTitle(strings.thisImageLabel)
+
+            Text(URL(fileURLWithPath: overlay.path).lastPathComponent)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            valueSlider(title: strings.imageSizeLabel,
+                        value: overlay.size,
+                        range: RecorderImageOverlay.sizeRange,
+                        format: "%.0f%%",
+                        scale: 100,
+                        onChange: { value in model.updateSelectedImage { $0.size = value } },
+                        onCommit: { model.commitZoomEdit() },
+                        onReset: {
+                            model.updateSelectedImage { $0.size = RecorderImageOverlay.defaultSize }
+                            model.commitZoomEdit()
+                        })
+
+            valueSlider(title: strings.imageOpacityLabel,
+                        value: overlay.opacity,
+                        range: RecorderImageOverlay.opacityRange,
+                        format: "%.0f%%",
+                        scale: 100,
+                        onChange: { value in model.updateSelectedImage { $0.opacity = value } },
+                        onCommit: { model.commitZoomEdit() },
+                        onReset: {
+                            model.updateSelectedImage { $0.opacity = 1 }
+                            model.commitZoomEdit()
+                        })
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(strings.imagePositionLabel)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Color(white: 0.72))
+                anchorGrid(selected: overlay.anchor) { anchor in
+                    model.updateSelectedImage { $0.anchor = anchor }
+                }
+            }
+
+            Button(strings.removeText) { model.removeSelectedImage() }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
                 .frame(maxWidth: .infinity)
@@ -456,8 +529,11 @@ struct RecorderInspector: View {
     }
 
     /// Nine places instead of a drag: it reads at a glance, needs no gesture
-    /// on the picture, and covers what people actually do with a caption.
-    private func anchorGrid(_ overlay: RecorderTextOverlay) -> some View {
+    /// on the picture, and covers what people actually do with a caption or a
+    /// mark of their own.
+    private func anchorGrid(selected: RecorderTextOverlay.Anchor,
+                            onSelect: @escaping (RecorderTextOverlay.Anchor) -> Void)
+        -> some View {
         let rows: [[RecorderTextOverlay.Anchor]] = [
             [.topLeading, .top, .topTrailing],
             [.leading, .center, .trailing],
@@ -468,12 +544,12 @@ struct RecorderInspector: View {
                 HStack(spacing: 4) {
                     ForEach(rows[row], id: \.rawValue) { anchor in
                         RoundedRectangle(cornerRadius: 4, style: .continuous)
-                            .fill(overlay.anchor == anchor
+                            .fill(selected == anchor
                                   ? Color.accentColor.opacity(0.85)
                                   : Color.white.opacity(0.08))
                             .frame(height: 20)
                             .onTapGesture {
-                                model.updateSelectedText { $0.anchor = anchor }
+                                onSelect(anchor)
                                 model.commitZoomEdit()
                             }
                     }

--- a/Sources/Vorssaint/UI/Recorder/RecorderZoomLane.swift
+++ b/Sources/Vorssaint/UI/Recorder/RecorderZoomLane.swift
@@ -14,11 +14,12 @@ import SwiftUI
 /// the only way the wrong one never fires. It is also what makes the pointer
 /// change shape over an edge, and without that the handles are invisible.
 struct RecorderZoomLane: NSViewRepresentable {
-    /// Which of the two lanes this is. They behave identically on purpose:
-    /// one set of gestures to learn, whatever kind of thing is on the rail.
+    /// Which lane this is. They behave identically on purpose: one set of
+    /// gestures to learn, whatever kind of thing is on the rail.
     enum Kind {
         case zoom
         case text
+        case image
         case blur
     }
 
@@ -277,6 +278,7 @@ struct RecorderZoomLane: NSViewRepresentable {
             switch kind {
             case .zoom: accent = NSColor.controlAccentColor.usingColorSpace(.sRGB) ?? .systemBlue
             case .text: accent = .systemPurple
+            case .image: accent = .systemOrange
             case .blur: accent = .systemTeal
             }
             for segment in segments {
@@ -294,6 +296,7 @@ struct RecorderZoomLane: NSViewRepresentable {
                 switch kind {
                 case .zoom: ramp = RecorderMotion.zoomRampIn
                 case .text: ramp = RecorderTextOverlay.fade
+                case .image: ramp = RecorderImageOverlay.fade
                 case .blur: ramp = 0
                 }
                 let rampIn = min(ramp, (segment.end - segment.start) / 2)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15087,7 +15087,7 @@ struct MetricsTests {
                    "no em-dash in WhatsApp organizer strings (\(language.rawValue))")
             let recorderValues = Mirror(reflecting: FeatureStrings.recorder(language)).children
                 .compactMap { $0.value as? String }
-            expect(recorderValues.count == 127 && recorderValues.allSatisfy { !$0.isEmpty },
+            expect(recorderValues.count == 134 && recorderValues.allSatisfy { !$0.isEmpty },
                    "every screen recorder string is set for \(language.rawValue)")
             expect(recorderValues.allSatisfy { !$0.contains("—") },
                    "no em-dash in visible screen recorder strings (\(language.rawValue))")
@@ -22657,6 +22657,67 @@ struct MetricsTests {
         expect(RecorderTextOverlay.Anchor.bottom.unitPoint.y == 1
                 && RecorderTextOverlay.Anchor.topLeading.unitPoint == CGPoint(x: 0, y: 0),
                "the nine places mean what they say, counting down from the top")
+
+        // MARK: Screen recorder pictures
+
+        let mark = RecorderImageOverlay(path: "/tmp/logo.png", start: 2, end: 6)
+        expect(mark.opacity(at: 1.9) == 0 && mark.opacity(at: 6.1) == 0,
+               "a picture is not there before it starts or after it ends")
+        expect(mark.opacity(at: 4) == 1,
+               "a picture is at full strength in the middle of its own time")
+        expect(mark.opacity(at: 2.1) > 0 && mark.opacity(at: 2.1) < 1,
+               "a picture eases in like a caption instead of appearing on one frame")
+        expectClose(RecorderImageOverlay(path: "/tmp/logo.png", start: 0, end: 10, opacity: 0.5)
+                        .opacity(at: 5),
+                    0.5,
+                    "a picture never goes past the strength it was given")
+        expect(RecorderImageOverlay(path: "   ", start: 1, end: 5).sanitized(duration: 10) == nil,
+               "a picture with no file behind it is dropped rather than drawn")
+        expect(RecorderImageOverlay(path: "/tmp/logo.png", start: 9, end: 30)
+                .sanitized(duration: 10)?.end == 10,
+               "a picture that runs past the recording is brought back inside it")
+        expect(RecorderImageOverlay(path: "/tmp/logo.png", start: 5, end: 5.05)
+                .sanitized(duration: 10) == nil,
+               "a picture too brief to see is not kept")
+        expect(RecorderImageOverlay(path: "/tmp/logo.png", start: 1, end: 5, size: 9)
+                .sanitized(duration: 10)?.size == RecorderImageOverlay.sizeRange.upperBound,
+               "an impossible picture size is clamped instead of filling the frame")
+        expect(RecorderImageOverlay(path: "/tmp/logo.png", start: 1, end: 5, opacity: 0)
+                .sanitized(duration: 10)?.opacity == RecorderImageOverlay.opacityRange.lowerBound,
+               "a picture turned invisible keeps the least strength that can still be seen")
+        expect(RecorderImageOverlay.drawnSize(source: CGSize(width: 200, height: 100),
+                                              size: 0.5,
+                                              canvas: CGSize(width: 1000, height: 500))
+                == CGSize(width: 500, height: 250),
+               "a picture is drawn at its share of the frame's width, in its own proportions")
+        expect(RecorderImageOverlay.drawnSize(source: CGSize(width: 100, height: 1000),
+                                              size: 0.6,
+                                              canvas: CGSize(width: 1000, height: 500))
+                == CGSize(width: 50, height: 500),
+               "a picture taller than the frame is brought down instead of hanging off it")
+        expect(RecorderImageOverlay.drawnSize(source: .zero,
+                                              size: 0.2,
+                                              canvas: CGSize(width: 1000, height: 500)) == nil,
+               "a picture with no size of its own is not drawn")
+        expect(RecorderTextOverlay.Anchor.topLeading
+                .origin(of: CGSize(width: 100, height: 50),
+                        in: CGSize(width: 1000, height: 500)) == CGPoint(x: 25, y: 425),
+               "a place keeps its margin off both edges it touches, counting down from the top")
+        expect(RecorderTextOverlay.Anchor.bottomTrailing
+                .origin(of: CGSize(width: 100, height: 50),
+                        in: CGSize(width: 1000, height: 500)) == CGPoint(x: 875, y: 25),
+               "the opposite corner keeps the same margin, handed over from the bottom")
+        let markedDocument = RecorderEditDocument.decoded(
+            RecorderEditDocument(images: [mark]).encoded())
+        expect(markedDocument.images == [mark],
+               "a picture written next to the recording comes back exactly as it was")
+        expect(RecorderEditDocument().affectsPicture(markedDocument)
+                && !RecorderEditDocument().affectsTiming(markedDocument)
+                && markedDocument.isEdited(duration: 10),
+               "adding a picture redraws the preview without rebuilding the timeline, and counts as an edit")
+        expect(RecorderEditDocument(images: [RecorderImageOverlay(path: "", start: 1, end: 5)])
+                .sanitized(duration: 10).images.isEmpty,
+               "a damaged picture is dropped by the same repair that fixes every other field")
 
         // MARK: Screen recorder blur
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15101,7 +15101,7 @@ struct MetricsTests {
                    "no em-dash in WhatsApp organizer strings (\(language.rawValue))")
             let recorderValues = Mirror(reflecting: FeatureStrings.recorder(language)).children
                 .compactMap { $0.value as? String }
-            expect(recorderValues.count == 134 && recorderValues.allSatisfy { !$0.isEmpty },
+            expect(recorderValues.count == 135 && recorderValues.allSatisfy { !$0.isEmpty },
                    "every screen recorder string is set for \(language.rawValue)")
             expect(recorderValues.allSatisfy { !$0.contains("—") },
                    "no em-dash in visible screen recorder strings (\(language.rawValue))")
@@ -22707,8 +22707,32 @@ struct MetricsTests {
         expect(RecorderImageOverlay.drawnSize(source: CGSize(width: 100, height: 1000),
                                               size: 0.6,
                                               canvas: CGSize(width: 1000, height: 500))
-                == CGSize(width: 50, height: 500),
+                == CGSize(width: 45, height: 450),
                "a picture taller than the frame is brought down instead of hanging off it")
+        for canvas in [CGSize(width: 1000, height: 500), CGSize(width: 500, height: 1000)] {
+            for source in [CGSize(width: 100, height: 1000), CGSize(width: 1000, height: 100)] {
+                for anchor in RecorderImageOverlay.Anchor.allCases {
+                    let drawn = RecorderImageOverlay.drawnSize(source: source, size: 0.6,
+                                                                canvas: canvas) ?? .zero
+                    let origin = anchor.origin(of: drawn, in: canvas)
+                    let margin = min(canvas.width, canvas.height) * 0.05
+                    expect(drawn.width > 0 && drawn.height > 0
+                            && origin.x >= margin && origin.y >= margin
+                            && origin.x + drawn.width <= canvas.width - margin
+                            && origin.y + drawn.height <= canvas.height - margin,
+                           "the entire picture fits inside its margins at every anchor and aspect")
+                }
+            }
+        }
+        expect(RecorderImageOverlay.drawnSize(source: CGSize(width: 10, height: 10),
+                                              size: .nan, canvas: CGSize(width: 500, height: 500)) == nil,
+               "nonfinite picture geometry cannot reach the renderer")
+        expect(RecorderImageOverlay(path: "relative.png", start: 0, end: 2)
+                .sanitized(duration: 3) == nil,
+               "a damaged picture path never resolves against the app's working directory")
+        expect(RecorderImageOverlay(path: "/tmp/picture.png ", start: 0, end: 2)
+                .sanitized(duration: 3)?.path == "/tmp/picture.png ",
+               "a picked filename keeps its actual whitespace")
         expect(RecorderImageOverlay.drawnSize(source: .zero,
                                               size: 0.2,
                                               canvas: CGSize(width: 1000, height: 500)) == nil,
@@ -22732,6 +22756,59 @@ struct MetricsTests {
         expect(RecorderEditDocument(images: [RecorderImageOverlay(path: "", start: 1, end: 5)])
                 .sanitized(duration: 10).images.isEmpty,
                "a damaged picture is dropped by the same repair that fixes every other field")
+
+        let pictureRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("recorder-image-test-" + UUID().uuidString, isDirectory: true)
+        let pictureTake = RecorderTakeStore.Take(id: UUID(),
+                                                  folder: pictureRoot.appendingPathComponent("take"))
+        try? FileManager.default.createDirectory(at: pictureTake.folder,
+                                                 withIntermediateDirectories: true)
+        let pictureSource = pictureRoot.appendingPathComponent("picture.png ")
+        let pictureContext = CGContext(data: nil, width: 2, height: 2, bitsPerComponent: 8,
+                                       bytesPerRow: 0, space: CGColorSpaceCreateDeviceRGB(),
+                                       bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)
+        if let picture = pictureContext?.makeImage(),
+           let destination = CGImageDestinationCreateWithURL(pictureSource as CFURL,
+                                                              "public.png" as CFString, 1, nil) {
+            CGImageDestinationAddImage(destination, picture, nil)
+            expect(CGImageDestinationFinalize(destination), "the image import fixture is written")
+        } else {
+            expect(false, "the image import fixture can be created")
+        }
+        let originalPictureBytes = try? Data(contentsOf: pictureSource)
+        let storedPicture = RecorderTakeStore.shared.importImage(at: pictureSource, into: pictureTake)
+        let secondPicture = RecorderTakeStore.shared.importImage(at: pictureSource, into: pictureTake)
+        expect(storedPicture != nil && secondPicture != nil && storedPicture != secondPicture,
+               "images with the same filename get independent copies inside the recording")
+        if let storedPicture {
+            expect(MediaSupport.imageThumbnail(at: storedPicture, maxPixel: 2) != nil,
+                   "the picked filename is decoded without trimming away meaningful whitespace")
+            let attributes = try? FileManager.default.attributesOfItem(atPath: storedPicture.path)
+            let permissions = attributes?[.posixPermissions] as? NSNumber
+            expect(permissions?.intValue == 0o600,
+                   "the private picture copy is readable only by its owner")
+            try? Data("replacement".utf8).write(to: pictureSource)
+            expect((try? Data(contentsOf: storedPicture)) == originalPictureBytes,
+                   "replacing the original leaves the edit's picture unchanged")
+            try? FileManager.default.removeItem(at: pictureSource)
+            expect((try? Data(contentsOf: storedPicture)) == originalPictureBytes,
+                   "removing the original leaves the edit's picture available for export and undo")
+        }
+        let badPicture = pictureRoot.appendingPathComponent("broken.png")
+        try? Data("not an image".utf8).write(to: badPicture)
+        let beforeBadImport = try? FileManager.default.contentsOfDirectory(atPath: pictureTake.folder.path)
+        expect(RecorderTakeStore.shared.importImage(at: badPicture, into: pictureTake) == nil,
+               "an unreadable picture never becomes an invisible timeline block")
+        expect((try? FileManager.default.contentsOfDirectory(atPath: pictureTake.folder.path))?
+                .sorted() == beforeBadImport?.sorted(),
+               "a failed image import leaves no partial file or folder")
+        RecorderTakeStore.shared.delete(pictureTake)
+        expect(RecorderTakeStore.shared.importImage(at: badPicture, into: pictureTake) == nil
+                && !FileManager.default.fileExists(atPath: pictureTake.folder.path),
+               "a queued image import cannot recreate a recording after its editor closes")
+        expect(FileManager.default.fileExists(atPath: badPicture.path),
+               "closing the recording never removes the original picture")
+        try? FileManager.default.removeItem(at: pictureRoot)
 
         // MARK: Screen recorder blur
 

--- a/build.sh
+++ b/build.sh
@@ -290,6 +290,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/Recorder/RecorderTypingTrack.swift \
         Sources/Vorssaint/Services/Recorder/RecorderTimeline.swift \
         Sources/Vorssaint/Services/Recorder/RecorderTextOverlay.swift \
+        Sources/Vorssaint/Services/Recorder/RecorderImageOverlay.swift \
         Sources/Vorssaint/Services/Recorder/RecorderBlurRegion.swift \
         Sources/Vorssaint/Services/Recorder/RecorderEditDocument.swift \
         Sources/Vorssaint/Core/AppInfo.swift \


### PR DESCRIPTION
The recording editor can add timed pictures with nine positions, adjustable size and transparency, and the same composition in preview, video and GIF exports. Each imported picture stays with the recording, so moving, deleting or replacing its original cannot change the edit.

Pictures fit inside the frame margins. Delete and Escape handle selected picture and text blocks, and selecting a block clears any previous cut selection.

Validation: 10,279 automated checks, a local Developer build and installation, the installed executable's selftest and signature verification, and MP4/GIF export checks using generated media. The export checks cover position, transparency, source alpha, fade-in and keeping the picture after its original is deleted. No visual inspection or synthetic input was used.
