### PR TITLE
feat(dock-preview): optional creation-time window order

### DIFF
--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -99,6 +99,7 @@ enum DefaultsKey {
     static let dockPreviewBackgroundOpacity = "dockPreviewBackgroundOpacity" // how solid the preview panel's material is drawn (DockPreviewSupport.backgroundOpacityRange)
     static let dockPreviewOpenDelay = "dockPreviewOpenDelay" // milliseconds the cursor must rest on a Dock icon before its panel opens (DockPreviewSupport.openDelayMillisecondsRange)
     static let dockPreviewQuitAppOnClose = "dockPreviewQuitAppOnClose" // the preview card's close button quits the owning app instead of closing one window
+    static let dockPreviewOrderByCreation = "dockPreviewOrderByCreation" // order Dock Preview windows by ascending window ID (creation proxy) instead of last use
     static let dockClickMinimize = "dockClickMinimize"    // click the active app's Dock icon to minimize its windows
     static let dockClickHide = "dockClickHide"            // click the active app's Dock icon to hide the app
     static let dockClickCycleWindows = "dockClickCycleWindows" // click the active app's Dock icon to cycle through its windows
@@ -909,6 +910,7 @@ enum Defaults {
         DefaultsKey.dockPreviewBackgroundOpacity: 1.0,
         DefaultsKey.dockPreviewOpenDelay: DockPreviewSupport.defaultOpenDelayMilliseconds,
         DefaultsKey.dockPreviewQuitAppOnClose: false,
+        DefaultsKey.dockPreviewOrderByCreation: false,
         DefaultsKey.dockClickMinimize: false,
         DefaultsKey.dockClickHide: false,
         DefaultsKey.dockClickCycleWindows: false,

--- a/Sources/Vorssaint/Core/Localization.swift
+++ b/Sources/Vorssaint/Core/Localization.swift
@@ -364,6 +364,8 @@ struct Strings {
     let dockPreviewOpenDelayCaption: String
     let dockPreviewQuitAppOnClose: String
     let dockPreviewQuitAppOnCloseCaption: String
+    let dockPreviewOrderByCreation: String
+    let dockPreviewOrderByCreationCaption: String
     let dockClickMinimize: String
     let dockClickMinimizeCaption: String
     let dockClickCycleWindows: String
@@ -1406,6 +1408,8 @@ extension Strings {
         dockPreviewOpenDelayCaption: "Quanto tempo o ponteiro precisa ficar sobre um ícone antes de o painel abrir.",
         dockPreviewQuitAppOnClose: "Encerrar o app com o botão ×",
         dockPreviewQuitAppOnCloseCaption: "No Dock Preview, × encerra o app inteiro em vez de fechar apenas aquela janela.",
+        dockPreviewOrderByCreation: "Ordenar janelas por criação",
+        dockPreviewOrderByCreationCaption: "Mostra primeiro as janelas mais antigas em vez das usadas mais recentemente.",
         dockClickMinimize: "Clicar no Dock minimiza",
         dockClickMinimizeCaption: "As janelas do app ativo são minimizadas ao clicar no ícone dele no Dock. Clique de novo para trazê-las de volta.",
         dockClickCycleWindows: "Clicar no Dock alterna janelas",
@@ -2416,6 +2420,8 @@ extension Strings {
         dockPreviewOpenDelayCaption: "How long the pointer has to rest on an icon before its panel opens.",
         dockPreviewQuitAppOnClose: "Quit the app with the × button",
         dockPreviewQuitAppOnCloseCaption: "In Dock Preview, × quits the whole app instead of closing only that window.",
+        dockPreviewOrderByCreation: "Order windows by creation time",
+        dockPreviewOrderByCreationCaption: "Show older windows first instead of the ones you used most recently.",
         dockClickMinimize: "Click the Dock icon to minimize",
         dockClickMinimizeCaption: "The active app’s windows minimize when you click its Dock icon. Click again to bring them back.",
         dockClickCycleWindows: "Click the Dock icon to cycle windows",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
@@ -241,6 +241,8 @@ extension Strings {
         dockPreviewOpenDelayCaption: "指针停在图标上多久之后才打开面板。",
         dockPreviewQuitAppOnClose: "使用 × 按钮退出 App",
         dockPreviewQuitAppOnCloseCaption: "在 Dock Preview 中，× 会退出整个 App，而不只是关闭该窗口。",
+        dockPreviewOrderByCreation: "按创建时间排序窗口",
+        dockPreviewOrderByCreationCaption: "先显示较早创建的窗口，而不是最近使用的窗口。",
         dockClickMinimize: "点按 Dock 图标最小化",
         dockClickMinimizeCaption: "点按最前面 App 的 Dock 图标可将其窗口最小化。再次点按即可恢复。",
         dockClickCycleWindows: "点按 Dock 图标切换窗口",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
@@ -242,6 +242,8 @@ extension Strings {
         dockPreviewOpenDelayCaption: "指標停在圖示上多久之後才打開面板。",
         dockPreviewQuitAppOnClose: "使用 × 按鈕結束 App",
         dockPreviewQuitAppOnCloseCaption: "在 Dock Preview 中，× 會結束整個 App，而不只是關閉該視窗。",
+        dockPreviewOrderByCreation: "按建立時間排序視窗",
+        dockPreviewOrderByCreationCaption: "先顯示較早建立的視窗，而非最近使用的視窗。",
         dockClickMinimize: "點按 Dock 圖示最小化",
         dockClickMinimizeCaption: "點按最前面 App 的 Dock 圖示可將其視窗最小化。再點按一次即可還原。",
         dockClickCycleWindows: "點按 Dock 圖示切換視窗",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
@@ -242,6 +242,8 @@ extension Strings {
         dockPreviewOpenDelayCaption: "指標停在圖示上多久之後才打開面板。",
         dockPreviewQuitAppOnClose: "使用 × 按鈕結束 App",
         dockPreviewQuitAppOnCloseCaption: "在 Dock Preview 中，× 會結束整個 App，而不只是關閉該視窗。",
+        dockPreviewOrderByCreation: "依建立時間排序視窗",
+        dockPreviewOrderByCreationCaption: "先顯示較早建立的視窗，而非最近使用的視窗。",
         dockClickMinimize: "點按 Dock 圖示最小化",
         dockClickMinimizeCaption: "點按最前方 App 的 Dock 圖示可將其視窗最小化。再點按一次即可還原。",
         dockClickCycleWindows: "點按 Dock 圖示切換視窗",

--- a/Sources/Vorssaint/Core/Localizations/Strings+French.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+French.swift
@@ -241,6 +241,8 @@ extension Strings {
         dockPreviewOpenDelayCaption: "Combien de temps le pointeur doit rester sur une icône avant que le panneau s’ouvre.",
         dockPreviewQuitAppOnClose: "Quitter l’app avec le bouton ×",
         dockPreviewQuitAppOnCloseCaption: "Dans Dock Preview, × quitte toute l’app au lieu de fermer uniquement cette fenêtre.",
+        dockPreviewOrderByCreation: "Ordonner les fenêtres par date de création",
+        dockPreviewOrderByCreationCaption: "Afficher d’abord les fenêtres plus anciennes plutôt que les plus récemment utilisées.",
         dockClickMinimize: "Réduire d’un clic sur le Dock",
         dockClickMinimizeCaption: "Les fenêtres de l’app active se réduisent d’un clic sur son icône du Dock. Cliquez à nouveau pour les faire revenir.",
         dockClickCycleWindows: "Clic sur le Dock pour alterner les fenêtres",

--- a/Sources/Vorssaint/Core/Localizations/Strings+German.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+German.swift
@@ -241,6 +241,8 @@ extension Strings {
         dockPreviewOpenDelayCaption: "Wie lange der Zeiger auf einem Symbol ruhen muss, bevor sich das Panel öffnet.",
         dockPreviewQuitAppOnClose: "App mit der ×-Taste beenden",
         dockPreviewQuitAppOnCloseCaption: "In Dock Preview beendet × die gesamte App, statt nur dieses Fenster zu schließen.",
+        dockPreviewOrderByCreation: "Fenster nach Erstellungszeit sortieren",
+        dockPreviewOrderByCreationCaption: "Ältere Fenster zuerst anzeigen statt der zuletzt genutzten.",
         dockClickMinimize: "Klick aufs Dock-Symbol minimiert",
         dockClickMinimizeCaption: "Die Fenster der aktiven App werden beim Klick auf ihr Dock-Symbol im Dock abgelegt. Ein weiterer Klick holt sie zurück.",
         dockClickCycleWindows: "Klick aufs Dock-Symbol wechselt Fenster",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
@@ -241,6 +241,8 @@ extension Strings {
         dockPreviewOpenDelayCaption: "Quanto a lungo il puntatore deve restare su un’icona prima che il pannello si apra.",
         dockPreviewQuitAppOnClose: "Chiudi l’app con il pulsante ×",
         dockPreviewQuitAppOnCloseCaption: "In Dock Preview, × chiude l’intera app invece della sola finestra.",
+        dockPreviewOrderByCreation: "Ordina le finestre per creazione",
+        dockPreviewOrderByCreationCaption: "Mostra prima le finestre più vecchie invece di quelle usate di recente.",
         dockClickMinimize: "Riduci con un clic sul Dock",
         dockClickMinimizeCaption: "Le finestre dell’app attiva si riducono nel Dock cliccando la sua icona. Fai clic di nuovo per ripristinarle.",
         dockClickCycleWindows: "Clic sul Dock per alternare le finestre",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
@@ -241,6 +241,8 @@ extension Strings {
         dockPreviewOpenDelayCaption: "ポインタをアイコンに置いてからパネルが開くまでの時間です。",
         dockPreviewQuitAppOnClose: "× ボタンでアプリを終了",
         dockPreviewQuitAppOnCloseCaption: "Dock Preview では、× はそのウインドウだけを閉じる代わりにアプリ全体を終了します。",
+        dockPreviewOrderByCreation: "ウインドウを作成順に並べる",
+        dockPreviewOrderByCreationCaption: "最近使ったものではなく、古いウインドウから順に表示します。",
         dockClickMinimize: "Dock クリックでしまう",
         dockClickMinimizeCaption: "手前のアプリの Dock アイコンをクリックするとウインドウをしまいます。もう一度クリックすると戻ります。",
         dockClickCycleWindows: "Dock クリックでウインドウを切り替え",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
@@ -242,6 +242,8 @@ extension Strings {
         dockPreviewOpenDelayCaption: "포인터가 아이콘 위에 머문 뒤 패널이 열리기까지의 시간입니다.",
         dockPreviewQuitAppOnClose: "× 버튼으로 앱 종료",
         dockPreviewQuitAppOnCloseCaption: "Dock Preview에서 ×는 해당 윈도우만 닫는 대신 앱 전체를 종료합니다.",
+        dockPreviewOrderByCreation: "생성 시간순으로 윈도우 정렬",
+        dockPreviewOrderByCreationCaption: "최근에 사용한 윈도우 대신 오래된 윈도우를 먼저 표시합니다.",
         dockClickMinimize: "Dock 클릭으로 최소화",
         dockClickMinimizeCaption: "앞에 있는 앱의 Dock 아이콘을 클릭하면 윈도우를 최소화합니다. 다시 클릭하면 복원됩니다.",
         dockClickCycleWindows: "Dock 클릭으로 윈도우 전환",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
@@ -242,6 +242,8 @@ extension Strings {
         dockPreviewOpenDelayCaption: "Сколько указатель должен оставаться на значке, прежде чем откроется панель.",
         dockPreviewQuitAppOnClose: "Завершать приложение кнопкой ×",
         dockPreviewQuitAppOnCloseCaption: "В Dock Preview кнопка × завершает всё приложение, а не закрывает только это окно.",
+        dockPreviewOrderByCreation: "Сортировать окна по времени создания",
+        dockPreviewOrderByCreationCaption: "Показывать сначала старые окна, а не те, что использовались недавно.",
         dockClickMinimize: "Сворачивать кликом по Dock",
         dockClickMinimizeCaption: "Окна активного приложения сворачиваются при клике по его значку в Dock. Кликните ещё раз, чтобы вернуть их.",
         dockClickCycleWindows: "Кликом по Dock переключать окна",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
@@ -241,6 +241,8 @@ extension Strings {
         dockPreviewOpenDelayCaption: "Cuánto tiempo debe reposar el puntero sobre un icono antes de que se abra el panel.",
         dockPreviewQuitAppOnClose: "Salir de la app con el botón ×",
         dockPreviewQuitAppOnCloseCaption: "En Dock Preview, × cierra toda la app en lugar de cerrar solo esa ventana.",
+        dockPreviewOrderByCreation: "Ordenar ventanas por creación",
+        dockPreviewOrderByCreationCaption: "Muestra primero las ventanas más antiguas en lugar de las usadas más recientemente.",
         dockClickMinimize: "Clic en el Dock para minimizar",
         dockClickMinimizeCaption: "Las ventanas de la app activa se minimizan al hacer clic en su icono del Dock. Vuelve a hacer clic para recuperarlas.",
         dockClickCycleWindows: "Clic en el Dock para alternar ventanas",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
@@ -241,6 +241,8 @@ extension Strings {
         dockPreviewOpenDelayCaption: "Panelin açılması için imlecin bir simgenin üzerinde ne kadar bekleyeceği.",
         dockPreviewQuitAppOnClose: "× düğmesiyle uygulamadan çık",
         dockPreviewQuitAppOnCloseCaption: "Dock Preview’da × yalnızca o pencereyi kapatmak yerine uygulamadan tamamen çıkar.",
+        dockPreviewOrderByCreation: "Pencereleri oluşturma zamanına göre sırala",
+        dockPreviewOrderByCreationCaption: "En son kullanılanlar yerine önce daha eski pencereleri göster.",
         dockClickMinimize: "Dock simgesine tıklayınca küçült",
         dockClickMinimizeCaption: "Etkin uygulamanın pencereleri Dock simgesine tıklandığında küçülür. Geri getirmek için yeniden tıklayın.",
         dockClickCycleWindows: "Dock simgesine tıklayınca pencere değiştir",

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewService.swift
@@ -667,8 +667,11 @@ final class DockPreviewService: ObservableObject {
     }
 
     private static func previewableWindows(for pid: pid_t) -> [SwitcherItem] {
-        WindowEnumerator.listWindows(for: pid, maximumCount: 12)
+        let windows = WindowEnumerator.listWindows(for: pid, maximumCount: 12)
             .filter { $0.windowID != nil }
+        let order = DockPreviewWindowOrder.fromDefaults(
+            orderByCreation: UserDefaults.standard.bool(forKey: DefaultsKey.dockPreviewOrderByCreation))
+        return DockPreviewSupport.orderedWindows(windows, order: order)
     }
 
     private func beginHoverIfStillValid(token: UUID, initialHit: DockHit) {

--- a/Sources/Vorssaint/Services/DockPreview/DockPreviewSupport.swift
+++ b/Sources/Vorssaint/Services/DockPreview/DockPreviewSupport.swift
@@ -94,6 +94,16 @@ struct HoverCorridor: Equatable {
     }
 }
 
+
+enum DockPreviewWindowOrder: Equatable {
+    case lastUse
+    case creation
+
+    static func fromDefaults(orderByCreation: Bool) -> DockPreviewWindowOrder {
+        orderByCreation ? .creation : .lastUse
+    }
+}
+
 enum DockPreviewSupport {
     static func handlesMiddleClick(eventType: NSEvent.EventType, buttonNumber: Int,
                                    point: CGPoint, visibleRect: CGRect, isHidden: Bool) -> Bool {
@@ -104,6 +114,21 @@ enum DockPreviewSupport {
     static func closeAction(quitAppOnClose: Bool) -> DockPreviewCloseAction {
         quitAppOnClose ? .quitApp : .closeWindow
     }
+
+    /// Reorders Dock Preview cards. Last-use keeps the enumerator’s MRU order;
+    /// creation sorts by ascending window ID (a stable creation-time proxy).
+    static func orderedWindows(_ windows: [SwitcherItem],
+                               order: DockPreviewWindowOrder) -> [SwitcherItem] {
+        switch order {
+        case .lastUse:
+            return windows
+        case .creation:
+            return windows.sorted { lhs, rhs in
+                (lhs.windowID ?? 0) < (rhs.windowID ?? 0)
+            }
+        }
+    }
+
 
     static func performCloseAction(quitAppOnClose: Bool,
                                    requestQuit: () -> Bool,

--- a/Sources/Vorssaint/UI/Settings/SettingsView.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsView.swift
@@ -1217,6 +1217,7 @@ struct SwitcherSettings: View {
     @AppStorage(DefaultsKey.dockPreviewBackgroundOpacity) private var dockPreviewBackgroundOpacity = 1.0
     @AppStorage(DefaultsKey.dockPreviewOpenDelay) private var dockPreviewOpenDelay = DockPreviewSupport.defaultOpenDelayMilliseconds
     @AppStorage(DefaultsKey.dockPreviewQuitAppOnClose) private var dockPreviewQuitAppOnClose = false
+    @AppStorage(DefaultsKey.dockPreviewOrderByCreation) private var dockPreviewOrderByCreation = false
     @AppStorage(DefaultsKey.dockClickMinimize) private var dockClickMinimize = false
     @AppStorage(DefaultsKey.dockClickHide) private var dockClickHide = false
     @AppStorage(DefaultsKey.dockClickCycleWindows) private var dockClickCycleWindows = false
@@ -1420,6 +1421,9 @@ struct SwitcherSettings: View {
                             Toggle(l10n.s.dockPreviewQuitAppOnClose,
                                    isOn: $dockPreviewQuitAppOnClose)
                             SettingsCaptionText(l10n.s.dockPreviewQuitAppOnCloseCaption)
+                            Toggle(l10n.s.dockPreviewOrderByCreation,
+                                   isOn: $dockPreviewOrderByCreation)
+                            SettingsCaptionText(l10n.s.dockPreviewOrderByCreationCaption)
                         }
                     }
                 } header: {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -3145,6 +3145,23 @@ struct MetricsTests {
                "the Dock Preview panel starts fully solid")
         expect(registeredDefaults[DefaultsKey.dockPreviewQuitAppOnClose] as? Bool == false,
                "the Dock Preview close button closes one window by default")
+        expect(registeredDefaults[DefaultsKey.dockPreviewOrderByCreation] as? Bool == false,
+               "Dock Preview keeps last-use window order by default")
+        func dockPreviewWindow(id: CGWindowID) -> SwitcherItem {
+            SwitcherItem(id: "w.\(id)", title: "Window \(id)", appName: "App",
+                         pid: 1, windowOwnerPID: 1, windowID: id,
+                         isOnScreen: true, isAppHidden: false, isMinimized: false,
+                         isFullscreen: false, isOnHiddenSpace: false, frame: .zero)
+        }
+        let lastUseOrder = [dockPreviewWindow(id: 30), dockPreviewWindow(id: 10), dockPreviewWindow(id: 20)]
+        expect(DockPreviewSupport.orderedWindows(lastUseOrder, order: .lastUse).map(\.windowID)
+                == [30, 10, 20],
+               "last-use order leaves the enumerated window list unchanged")
+        expect(DockPreviewSupport.orderedWindows(lastUseOrder, order: .creation).map(\.windowID)
+                == [10, 20, 30],
+               "creation order sorts windows by ascending window ID")
+        expect(DockPreviewSupport.orderedWindows([], order: .creation).isEmpty,
+               "creation order keeps an empty list empty")
         expect(DockPreviewSupport.closeAction(quitAppOnClose: false) == .closeWindow
                 && DockPreviewSupport.closeAction(quitAppOnClose: true) == .quitApp,
                "the Dock Preview close preference selects exactly one close action")


### PR DESCRIPTION
## Summary
- Adds `dockPreviewOrderByCreation` (default `false`) so Dock Preview can keep last-use order or sort windows by ascending `windowID` (creation-time proxy).
- Pure helper `DockPreviewSupport.orderedWindows(_:order:)` with unit tests; settings toggle + strings in all locales.

## Test plan
- [x] `./build.sh --test` (10493 checks)
- [x] `./build.sh --dev` compiles
- [ ] Enable Dock Preview → Settings → toggle “Order windows by creation time” → hover a multi-window app and confirm older windows appear first
- [ ] Leave toggle off and confirm last-use order is unchanged

Refs #1257