### PR TITLE
feat(homebrew): keep the last operation log

### DIFF
--- a/Sources/Vorssaint/Core/Localization.swift
+++ b/Sources/Vorssaint/Core/Localization.swift
@@ -513,6 +513,7 @@ struct Strings {
     let homebrewCancelOperation: String
     let homebrewClearLog: String
     let homebrewLogTitle: String
+    let homebrewViewLastLog: String
     let homebrewVersion: String
     let homebrewDescription: String
     let homebrewHomepage: String
@@ -1550,6 +1551,7 @@ extension Strings {
         homebrewCancelOperation: "Cancelar",
         homebrewClearLog: "Limpar log",
         homebrewLogTitle: "Log",
+        homebrewViewLastLog: "Ver último log",
         homebrewVersion: "Versão",
         homebrewDescription: "Tipo",
         homebrewHomepage: "Abrir site",
@@ -2560,6 +2562,7 @@ extension Strings {
         homebrewCancelOperation: "Cancel",
         homebrewClearLog: "Clear log",
         homebrewLogTitle: "Log",
+        homebrewViewLastLog: "View last log",
         homebrewVersion: "Version",
         homebrewDescription: "Type",
         homebrewHomepage: "Open website",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
@@ -385,6 +385,7 @@ extension Strings {
         homebrewCancelOperation: "取消",
         homebrewClearLog: "清空日志",
         homebrewLogTitle: "日志",
+        homebrewViewLastLog: "查看上次日志",
         homebrewVersion: "版本",
         homebrewDescription: "类型",
         homebrewHomepage: "打开网站",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
@@ -386,6 +386,7 @@ extension Strings {
         homebrewCancelOperation: "取消",
         homebrewClearLog: "清空記錄",
         homebrewLogTitle: "記錄",
+        homebrewViewLastLog: "查看上次記錄",
         homebrewVersion: "版本",
         homebrewDescription: "類型",
         homebrewHomepage: "開啟網站",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
@@ -386,6 +386,7 @@ extension Strings {
         homebrewCancelOperation: "取消",
         homebrewClearLog: "清空日誌",
         homebrewLogTitle: "日誌",
+        homebrewViewLastLog: "檢視上次日誌",
         homebrewVersion: "版本",
         homebrewDescription: "類型",
         homebrewHomepage: "開啟網站",

--- a/Sources/Vorssaint/Core/Localizations/Strings+French.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+French.swift
@@ -385,6 +385,7 @@ extension Strings {
         homebrewCancelOperation: "Annuler",
         homebrewClearLog: "Effacer le journal",
         homebrewLogTitle: "Journal",
+        homebrewViewLastLog: "Voir le dernier journal",
         homebrewVersion: "Version",
         homebrewDescription: "Type",
         homebrewHomepage: "Ouvrir le site",

--- a/Sources/Vorssaint/Core/Localizations/Strings+German.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+German.swift
@@ -385,6 +385,7 @@ extension Strings {
         homebrewCancelOperation: "Abbrechen",
         homebrewClearLog: "Protokoll leeren",
         homebrewLogTitle: "Protokoll",
+        homebrewViewLastLog: "Letztes Protokoll anzeigen",
         homebrewVersion: "Version",
         homebrewDescription: "Typ",
         homebrewHomepage: "Website öffnen",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
@@ -385,6 +385,7 @@ extension Strings {
         homebrewCancelOperation: "Annulla",
         homebrewClearLog: "Svuota registro",
         homebrewLogTitle: "Registro",
+        homebrewViewLastLog: "Mostra ultimo registro",
         homebrewVersion: "Versione",
         homebrewDescription: "Tipo",
         homebrewHomepage: "Apri sito",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
@@ -385,6 +385,7 @@ extension Strings {
         homebrewCancelOperation: "キャンセル",
         homebrewClearLog: "ログをクリア",
         homebrewLogTitle: "ログ",
+        homebrewViewLastLog: "直前のログを表示",
         homebrewVersion: "バージョン",
         homebrewDescription: "種類",
         homebrewHomepage: "サイトを開く",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
@@ -386,6 +386,7 @@ extension Strings {
         homebrewCancelOperation: "취소",
         homebrewClearLog: "로그 지우기",
         homebrewLogTitle: "로그",
+        homebrewViewLastLog: "최근 로그 보기",
         homebrewVersion: "버전",
         homebrewDescription: "설명",
         homebrewHomepage: "웹 사이트 열기",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
@@ -386,6 +386,7 @@ extension Strings {
         homebrewCancelOperation: "Отмена",
         homebrewClearLog: "Очистить лог",
         homebrewLogTitle: "Лог",
+        homebrewViewLastLog: "Показать последний лог",
         homebrewVersion: "Версия",
         homebrewDescription: "Тип",
         homebrewHomepage: "Открыть сайт",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
@@ -385,6 +385,7 @@ extension Strings {
         homebrewCancelOperation: "Cancelar",
         homebrewClearLog: "Borrar registro",
         homebrewLogTitle: "Registro",
+        homebrewViewLastLog: "Ver último registro",
         homebrewVersion: "Versión",
         homebrewDescription: "Tipo",
         homebrewHomepage: "Abrir sitio web",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
@@ -385,6 +385,7 @@ extension Strings {
         homebrewCancelOperation: "İptal",
         homebrewClearLog: "Günlüğü temizle",
         homebrewLogTitle: "Günlük",
+        homebrewViewLastLog: "Son günlüğü göster",
         homebrewVersion: "Sürüm",
         homebrewDescription: "Tür",
         homebrewHomepage: "Web sitesini aç",

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
@@ -604,38 +604,23 @@ final class HomebrewManager: ObservableObject {
                                                    targetID: String,
                                                    finishedAt: Date?) {
         completedOperationCleanup?.cancel()
-        guard result != .running,
-              let finishedAt else { return }
-        let delay: TimeInterval
-        let clearsWholeStatus: Bool
-        switch result {
-        case .succeeded:
-            delay = 8
-            clearsWholeStatus = true
-        case .cancelled:
-            delay = 6
-            clearsWholeStatus = true
-        case .failed, .needsTerminal:
-            delay = 20
-            clearsWholeStatus = false
-        case .running:
-            return
-        }
+        guard let finishedAt,
+              let plan = HomebrewCompletedOperationCleanupSupport.plan(for: result) else { return }
 
         let item = DispatchWorkItem { [weak self] in
             guard let self,
                   self.operation == nil,
                   self.operationStatus?.targetID == targetID,
                   self.operationStatus?.finishedAt == finishedAt else { return }
-            self.log = ""
-            if clearsWholeStatus {
+            // Keep `log` so Settings can offer "View last log" after status clears.
+            if plan.clearsWholeStatus {
                 self.terminalFallbackCommand = nil
                 self.operationStatus = nil
             }
             self.completedOperationCleanup = nil
         }
         completedOperationCleanup = item
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
+        DispatchQueue.main.asyncAfter(deadline: .now() + plan.delay, execute: item)
     }
 
     /// One click on the trust card: marks the tap as trusted for Homebrew

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
@@ -206,6 +206,37 @@ struct HomebrewPendingAction {
     }
 }
 
+/// Policy for the post-completion timer on Homebrew operations. The last log
+/// stays available for inspection; only the status chrome is optional to clear.
+enum HomebrewCompletedOperationCleanupSupport {
+    struct Plan: Equatable {
+        var delay: TimeInterval
+        var clearsWholeStatus: Bool
+        var clearsLog: Bool
+    }
+
+    static func plan(for result: HomebrewOperationResult) -> Plan? {
+        switch result {
+        case .running:
+            return nil
+        case .succeeded:
+            return Plan(delay: 8, clearsWholeStatus: true, clearsLog: false)
+        case .cancelled:
+            return Plan(delay: 6, clearsWholeStatus: true, clearsLog: false)
+        case .failed, .needsTerminal:
+            return Plan(delay: 20, clearsWholeStatus: false, clearsLog: false)
+        }
+    }
+
+    static func showsOperationFooter(hasStatus: Bool, logIsEmpty: Bool) -> Bool {
+        hasStatus || !logIsEmpty
+    }
+
+    static func showsLastLogEntry(hasStatus: Bool, logIsEmpty: Bool) -> Bool {
+        !hasStatus && !logIsEmpty
+    }
+}
+
 enum HomebrewCommandBuilder {
     static let candidatePaths = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"]
     static let installerCommand = #"/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)""#

--- a/Sources/Vorssaint/UI/Settings/HomebrewSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/HomebrewSettings.swift
@@ -471,7 +471,10 @@ struct HomebrewSettings: View {
                 .padding(16)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
-            if homebrew.operationStatus != nil {
+            if HomebrewCompletedOperationCleanupSupport.showsOperationFooter(
+                hasStatus: homebrew.operationStatus != nil,
+                logIsEmpty: homebrew.log.isEmpty
+            ) {
                 Divider()
                 operationLog
                     .padding(12)
@@ -559,6 +562,52 @@ struct HomebrewSettings: View {
                                         onCancel: homebrew.cancelOperation,
                                         onClear: homebrew.clearLog,
                                         onOpenTerminal: homebrew.openTerminalFallback)
+        } else if HomebrewCompletedOperationCleanupSupport.showsLastLogEntry(
+            hasStatus: false,
+            logIsEmpty: homebrew.log.isEmpty
+        ) {
+            lastOperationLog
+        }
+    }
+
+    private var lastOperationLog: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack(spacing: 8) {
+                Button {
+                    showOperationDetails.toggle()
+                } label: {
+                    Label(showOperationDetails
+                            ? l10n.s.homebrewOperationHideDetails
+                            : l10n.s.homebrewViewLastLog,
+                          systemImage: showOperationDetails ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 11, weight: .medium))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+                Button(l10n.s.homebrewClearLog) {
+                    homebrew.clearLog()
+                }
+                .controlSize(.mini)
+            }
+            if showOperationDetails {
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack(spacing: 8) {
+                        Text(l10n.s.homebrewLogTitle)
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(.tertiary)
+                        Spacer(minLength: 0)
+                    }
+                    ScrollView {
+                        Text(homebrew.log)
+                            .font(.system(size: 10, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .frame(height: 96)
+                }
+            }
         }
     }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -12343,6 +12343,26 @@ struct MetricsTests {
                 && !homebrewRunStreaming.contains("waitUntilExit"),
                "Homebrew operations wait on a bounded semaphore, not waitUntilExit")
 
+        let homebrewCleanup = homebrewManagerSource.components(separatedBy: "func scheduleCompletedOperationCleanup")
+            .dropFirst().first ?? ""
+        expect(!homebrewCleanup.contains("self.log = \"\""),
+               "completed-operation cleanup keeps the last Homebrew log")
+        expect(HomebrewCompletedOperationCleanupSupport.plan(for: .succeeded)?.clearsLog == false
+                && HomebrewCompletedOperationCleanupSupport.plan(for: .cancelled)?.clearsLog == false
+                && HomebrewCompletedOperationCleanupSupport.plan(for: .failed)?.clearsLog == false
+                && HomebrewCompletedOperationCleanupSupport.plan(for: .needsTerminal)?.clearsLog == false
+                && HomebrewCompletedOperationCleanupSupport.plan(for: .running) == nil,
+               "completion timer never erases the retained Homebrew log")
+        expect(HomebrewCompletedOperationCleanupSupport.plan(for: .succeeded)
+                == HomebrewCompletedOperationCleanupSupport.Plan(delay: 8, clearsWholeStatus: true, clearsLog: false),
+               "successful Homebrew cleanup clears status only")
+        expect(HomebrewCompletedOperationCleanupSupport.showsOperationFooter(hasStatus: false, logIsEmpty: false),
+               "settings still show a footer for the retained last log")
+        expect(HomebrewCompletedOperationCleanupSupport.showsLastLogEntry(hasStatus: false, logIsEmpty: false)
+                && !HomebrewCompletedOperationCleanupSupport.showsLastLogEntry(hasStatus: true, logIsEmpty: false)
+                && !HomebrewCompletedOperationCleanupSupport.showsLastLogEntry(hasStatus: false, logIsEmpty: true),
+               "view-last-log appears only when status is gone and a log remains")
+
         expect(HomebrewPackageKind.allCases == [.cask, .formula],
                "Homebrew package kinds keep casks before formulae")
         expect(HomebrewCommandBuilder.isValidToken("jq"), "simple Homebrew token is valid")


### PR DESCRIPTION
## Summary
- Completion cleanup no longer erases `log`; only status chrome clears on the success/cancel timer.
- Settings shows a “View last log” footer when status is gone but a retained log remains (Clear still works).
- Pure `HomebrewCompletedOperationCleanupSupport` policy + unit tests; strings in all locales.

## Test plan
- [x] `./build.sh --test` (10494 checks)
- [ ] Run a Homebrew install/upgrade in Settings → wait for status to clear → confirm “View last log” still shows output
- [ ] Tap Clear and confirm the footer disappears
- [ ] Failed/needs-terminal ops still keep status for ~20s and retain the log afterward

Refs #566