### PR TITLE
feat(homebrew): open elevated commands via .command

### DIFF
--- a/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Vorssaint
 
+import AppKit
 import Combine
 import Darwin
 import Foundation
@@ -329,21 +330,19 @@ final class HomebrewManager: ObservableObject {
 
     @discardableResult
     private func openTerminal(command: String) -> Bool {
-        let source = """
-        tell application "Terminal"
-            activate
-            do script \(appleScriptString(command))
-        end tell
-        """
-        // In-process Apple Events (see AppleScriptRunner): the Terminal Automation
-        // consent is attributed to this app and re-requested if it was lost,
-        // instead of a fragile osascript subprocess. Same permission as before.
-        let result = AppleScriptRunner.run(source)
-        if !result.ok {
-            errorMessage = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Write a `.command` and open it via NSWorkspace. The default handler for
+        // that type runs the script; this app never names a terminal.
+        do {
+            let url = try HomebrewCommandScript.write(command: command)
+            guard NSWorkspace.shared.open(url) else {
+                errorMessage = "Failed to open the Homebrew command."
+                return false
+            }
+            return true
+        } catch {
+            errorMessage = error.localizedDescription
             return false
         }
-        return true
     }
 
     private func perform(_ action: HomebrewOperation.Action,
@@ -817,12 +816,6 @@ final class HomebrewManager: ObservableObject {
         log.append(text)
     }
 
-    private func appleScriptString(_ value: String) -> String {
-        let escaped = value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-        return "\"\(escaped)\""
-    }
 }
 
 private struct PopularityCacheEntry {

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift
@@ -206,6 +206,27 @@ struct HomebrewPendingAction {
     }
 }
 
+/// Executable `.command` script for interactive Homebrew work.
+///
+/// Opened through `NSWorkspace` so the user's default handler (or any app that
+/// claims `.command`) runs it — Vorssaint never names Terminal, iTerm, or Ghostty.
+enum HomebrewCommandScript {
+    static func contents(command: String) -> String {
+        "#!/bin/zsh\n\(command)\n"
+    }
+
+    /// Writes `command` as an executable `.command` file under `directory`.
+    static func write(command: String,
+                      toDirectory directory: URL = FileManager.default.temporaryDirectory,
+                      fileManager: FileManager = .default) throws -> URL {
+        let name = "vorssaint-homebrew-\(ProcessInfo.processInfo.processIdentifier)-\(UUID().uuidString).command"
+        let url = directory.appendingPathComponent(name)
+        try contents(command: command).write(to: url, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url
+    }
+}
+
 enum HomebrewCommandBuilder {
     static let candidatePaths = ["/opt/homebrew/bin/brew", "/usr/local/bin/brew"]
     static let installerCommand = #"/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)""#

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -12436,6 +12436,40 @@ struct MetricsTests {
                "Homebrew install and upgrade preserve package details after success")
         expect(HomebrewCommandBuilder.needsTerminalFallback(output: "sudo: a terminal is required to read the password"),
                "sudo terminal error triggers Homebrew terminal fallback")
+
+        // .command scripts open via the default handler — no named terminal app.
+        expectEqual(HomebrewCommandScript.contents(command: "sudo brew install jq"),
+                    "#!/bin/zsh\nsudo brew install jq\n",
+                    "Homebrew command script uses a zsh shebang and the raw command")
+        expectEqual(HomebrewCommandScript.contents(command: #"echo "a'b""#),
+                    "#!/bin/zsh\necho \"a'b\"\n",
+                    "Homebrew command script preserves quoting inside the command body")
+        let commandDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vorssaint-homebrew-command-tests-\(UUID().uuidString)",
+                                    isDirectory: true)
+        expect((try? FileManager.default.createDirectory(at: commandDir,
+                                                         withIntermediateDirectories: true)) != nil,
+               "Homebrew command script test directory can be created")
+        let commandURL = try? HomebrewCommandScript.write(
+            command: "brew --version", toDirectory: commandDir)
+        expect(commandURL?.pathExtension == "command",
+               "Homebrew command script uses the .command extension")
+        expect(commandURL?.deletingLastPathComponent().path == commandDir.path,
+               "Homebrew command script is written into the requested directory")
+        let written = commandURL.flatMap { try? String(contentsOf: $0, encoding: .utf8) } ?? ""
+        expectEqual(written, "#!/bin/zsh\nbrew --version\n",
+                    "Homebrew command script file matches contents(command:)")
+        let mode = commandURL.flatMap {
+            (try? FileManager.default.attributesOfItem(atPath: $0.path)[.posixPermissions] as? NSNumber)?
+                .uint16Value
+        } ?? 0
+        expect(mode & 0o111 != 0, "Homebrew command script is executable")
+        try? FileManager.default.removeItem(at: commandDir)
+        expect(!managerSource.contains("tell application \"Terminal\""),
+               "Homebrew no longer hardcodes Terminal.app via AppleScript")
+        expect(managerSource.contains("HomebrewCommandScript")
+                && managerSource.contains("NSWorkspace.shared.open"),
+               "Homebrew opens a .command file through NSWorkspace")
         expect(HomebrewCommandBuilder.installerCommand == #"/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)""#,
                "Homebrew installer command matches the official install script entrypoint")
         expectEqual(HomebrewCommandBuilder.shellProfilePath(homeDirectory: "/Users/test", shellPath: "/bin/zsh"),


### PR DESCRIPTION
## Summary
- Replace hardcoded Terminal.app AppleScript in `HomebrewManager.openTerminal(command:)` with writing an executable `.command` script and opening it through `NSWorkspace` (default handler for that type).
- Pure helper `HomebrewCommandScript` builds shebang + command, writes under a temp directory, and `chmod`s executable — used by sudo fallback, installer, and shell setup.
- No Settings “Open with…” / terminal picker in this PR (keeps the change small; app still names no terminal).

## Test plan
- [x] `./build.sh --test` — 10498 checks passed
- [ ] On a Mac: trigger Homebrew sudo fallback / installer / shell setup and confirm the default `.command` handler runs the script (Terminal and iTerm typically do)
- [ ] Not verified here: Ghostty and Warp as `.command` handlers — needs a real Mac check before any Settings “Open with…” row

Refs #598