### PR TITLE
feat(menu-bar): show the current Space number

### DIFF
--- a/Sources/Vorssaint/App/AppDelegate.swift
+++ b/Sources/Vorssaint/App/AppDelegate.swift
@@ -388,7 +388,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
     }
 
     private func showMetricPanel(for metric: MenuBarMetric, anchoredTo button: NSStatusBarButton) {
-        let detailKind = metric.detailKind
+        guard let detailKind = metric.detailKind else {
+            // Space has no panel section; open the main menu like the app icon.
+            MenuPanelFocus.shared.clearMetricFocus()
+            if popover.isShown {
+                closePopover(animated: false)
+                return
+            }
+            showPopover(anchor: button)
+            return
+        }
         if popover.isShown {
             if MenuPanelFocus.shared.activeMetric == detailKind {
                 metricAnchorSwitchSerial &+= 1

--- a/Sources/Vorssaint/App/MenuBarRenderer.swift
+++ b/Sources/Vorssaint/App/MenuBarRenderer.swift
@@ -5,7 +5,7 @@ import AppKit
 
 /// A live reading the user can pin next to the menu bar icon.
 enum MenuBarMetric: String, CaseIterable, Identifiable {
-    case cpu, gpu, memory, cpuTemperature, gpuTemperature, batteryTemperature, network, diskUsage, diskActivity, battery, batteryTime, peripheralBattery, power, fanSpeed
+    case cpu, gpu, memory, cpuTemperature, gpuTemperature, batteryTemperature, network, diskUsage, diskActivity, battery, batteryTime, peripheralBattery, power, fanSpeed, space
 
     var id: String { rawValue }
 
@@ -25,6 +25,7 @@ enum MenuBarMetric: String, CaseIterable, Identifiable {
         case .peripheralBattery: return DefaultsKey.menuBarPeripheralBattery
         case .power: return DefaultsKey.menuBarPower
         case .fanSpeed: return DefaultsKey.menuBarFanSpeed
+        case .space: return DefaultsKey.menuBarSpace
         }
     }
 
@@ -44,6 +45,7 @@ enum MenuBarMetric: String, CaseIterable, Identifiable {
         case .peripheralBattery: return "keyboard"
         case .power: return "powerplug.fill"
         case .fanSpeed: return "fanblades"
+        case .space: return "macwindow.on.rectangle"
         }
     }
 
@@ -63,6 +65,7 @@ enum MenuBarMetric: String, CaseIterable, Identifiable {
         case .peripheralBattery: return strings.monitorShowPeripheralBattery
         case .power: return strings.monitorShowPowerLabel
         case .fanSpeed: return FeatureStrings.fanControl(L10n.shared.language).menuBarTitle
+        case .space: return strings.monitorShowSpace
         }
     }
 
@@ -71,7 +74,7 @@ enum MenuBarMetric: String, CaseIterable, Identifiable {
         .gpu, .gpuTemperature,
         .memory,
         .battery, .batteryTime, .batteryTemperature, .peripheralBattery,
-        .network, .diskUsage, .diskActivity, .power, .fanSpeed,
+        .network, .diskUsage, .diskActivity, .power, .fanSpeed, .space,
     ]
 
     static func order(in defaults: UserDefaults) -> [MenuBarMetric] {
@@ -96,6 +99,7 @@ enum MenuBarMetric: String, CaseIterable, Identifiable {
         case .diskUsage, .diskActivity: return .monitorDisk
         case .battery, .batteryTime, .batteryTemperature, .peripheralBattery, .power: return .monitorPower
         case .fanSpeed: return .fanControl
+        case .space: return .switcher // display only; availability is not gated (see enabled)
         }
     }
 
@@ -110,10 +114,17 @@ enum MenuBarMetric: String, CaseIterable, Identifiable {
         }
     }
 
+    /// Space reads Mission Control topology; it does not need SystemMonitor sampling.
+    var needsSystemMonitorSampling: Bool { self != .space }
+
+    /// Space stays available even when Switcher is off in the hub — the digit
+    /// only needs SpaceWindowBridge, which is already linked for window work.
+    var isFeatureGated: Bool { self != .space }
+
     static func enabled(in defaults: UserDefaults) -> [MenuBarMetric] {
         order(in: defaults).filter {
             defaults.bool(forKey: $0.defaultsKey)
-                && defaults.bool(forKey: $0.feature.availabilityKey)
+                && (!$0.isFeatureGated || defaults.bool(forKey: $0.feature.availabilityKey))
                 && $0.isAvailableOnCurrentHardware
         }
     }
@@ -121,9 +132,13 @@ enum MenuBarMetric: String, CaseIterable, Identifiable {
     static func anyEnabled(in defaults: UserDefaults) -> Bool {
         allCases.contains {
             defaults.bool(forKey: $0.defaultsKey)
-                && defaults.bool(forKey: $0.feature.availabilityKey)
+                && (!$0.isFeatureGated || defaults.bool(forKey: $0.feature.availabilityKey))
                 && $0.isAvailableOnCurrentHardware
         }
+    }
+
+    static func anySystemMonitorSampledEnabled(in defaults: UserDefaults) -> Bool {
+        enabled(in: defaults).contains(where: \.needsSystemMonitorSampling)
     }
 }
 
@@ -455,6 +470,13 @@ enum MenuBarRenderer {
                                             segments: [.symbol(metric.symbolName), .text(" " + value + " RPM")],
                                             width: reservedWidth(for: metric, preset: preset)))
                 }
+            case .space:
+                if let value = spaceNumberText() {
+                    // InstantSpaceSwitcher-style bare digit — no label chrome.
+                    items.append(MetricItem(metric: metric,
+                                            segments: [.text(value)],
+                                            width: reservedWidth(for: metric, preset: preset)))
+                }
             }
         }
         return items
@@ -707,6 +729,10 @@ enum MenuBarRenderer {
                                                 style: style,
                                                 pressure: nil)])
                 }
+            case .space:
+                if let value = spaceNumberText() {
+                    groups.append([.text(value)])
+                }
             }
         }
         return blockJoined(groups, style: style)
@@ -787,6 +813,8 @@ enum MenuBarRenderer {
         case (_, .fanSpeed):
             let count = max(1, SystemMonitor.fanTelemetryCount)
             return FanControlPolicy.menuBarWidthUnits(fanCount: count)
+        case (_, .space):
+            return 2  // bare "99"
         }
     }
 
@@ -1306,6 +1334,21 @@ enum MenuBarRenderer {
         let writeValues = devices.compactMap(\.writeBytesPerSec)
         guard !readValues.isEmpty || !writeValues.isEmpty else { return nil }
         return (readValues.reduce(0, +), writeValues.reduce(0, +))
+    }
+
+    /// Current Space digit for the menu-bar display. Fullscreen Spaces keep
+    /// their index in that display's full Mission Control row.
+    private static func spaceNumberText() -> String? {
+        guard let topology = SpaceWindowBridge.topology() else { return nil }
+        let menuBarID = (NSScreen.main?.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?
+            .uint32Value
+        let displays = topology.displays.map {
+            SpaceMenuBarSupport.DisplayRow(id: $0.displayID, spaces: $0.spaces, current: $0.currentSpace)
+        }
+        guard let row = SpaceMenuBarSupport.row(forMenuBarDisplayID: menuBarID, displays: displays),
+              let number = SpaceMenuBarSupport.number(current: row.current, spaces: row.spaces)
+        else { return nil }
+        return String(number)
     }
 
     static func nsColor(for pressure: MemoryPressure) -> NSColor {

--- a/Sources/Vorssaint/App/StatusItemController.swift
+++ b/Sources/Vorssaint/App/StatusItemController.swift
@@ -17,6 +17,7 @@ final class StatusItemController {
     private var cancellables = Set<AnyCancellable>()
     private var titleTimer: Timer?
     private var defaultsObserver: NSObjectProtocol?
+    private var spaceObserver: NSObjectProtocol?
     /// Last combination applied by updateIconAppearance, so refresh ticks
     /// don't re-render an unchanged icon every 2 seconds.
     private var lastIconStateKey = ""
@@ -155,6 +156,15 @@ final class StatusItemController {
             }
             .store(in: &cancellables)
 
+        spaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard MenuBarMetric.enabled(in: .standard).contains(.space) else { return }
+            self?.refresh()
+        }
+
         defaultsObserver = NotificationCenter.default.addObserver(forName: UserDefaults.didChangeNotification,
                                                                   object: nil,
                                                                   queue: .main) { [weak self] _ in
@@ -185,6 +195,7 @@ final class StatusItemController {
         // a block observer that outlives this instance.
         titleTimer?.invalidate()
         if let defaultsObserver { NotificationCenter.default.removeObserver(defaultsObserver) }
+        if let spaceObserver { NSWorkspace.shared.notificationCenter.removeObserver(spaceObserver) }
         for item in metricStatusItems.values {
             NSStatusBar.system.removeStatusItem(item)
         }
@@ -196,7 +207,7 @@ final class StatusItemController {
         let defaults = UserDefaults.standard
         let interval = Defaults.sanitizedMonitorInterval(defaults.integer(forKey: DefaultsKey.monitorInterval))
         SystemMonitor.shared.setInterval(seconds: interval)
-        SystemMonitor.shared.setMenuBarActive(MenuBarMetric.anyEnabled(in: defaults))
+        SystemMonitor.shared.setMenuBarActive(MenuBarMetric.anySystemMonitorSampledEnabled(in: defaults))
     }
 
     private func syncTitleTimer(keepAwakeActive: Bool,
@@ -568,7 +579,7 @@ final class StatusItemController {
                                      temperature: .batteryTemperature,
                                      primaryTitle: strings.batteryLabel)
             case .memory, .network, .diskUsage, .diskActivity, .batteryTime, .peripheralBattery, .power,
-                 .fanSpeed:
+                 .fanSpeed, .space:
                 let id = metric.rawValue
                 guard emittedIDs.insert(id).inserted else { continue }
                 groups.append(MetricStatusGroup(id: id,

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -312,6 +312,7 @@ enum DefaultsKey {
     static let menuBarPeripheralBattery = "menuBarPeripheralBattery"
     static let menuBarPower = "menuBarPower"
     static let menuBarFanSpeed = "menuBarFanSpeed"
+    static let menuBarSpace = "menuBarSpace"
     static let menuBarPreset = "menuBarPreset"           // dense
     static let menuBarMetricSpacing = "menuBarMetricSpacing" // standard | compact
     static let menuBarMetricAppearance = "menuBarMetricAppearance" // values | bars
@@ -827,7 +828,7 @@ enum Defaults {
         "gpu", "gpuTemperature",
         "memory",
         "battery", "batteryTime", "batteryTemperature", "peripheralBattery",
-        "network", "diskUsage", "diskActivity", "power", "fanSpeed",
+        "network", "diskUsage", "diskActivity", "power", "fanSpeed", "space",
     ]
     static let allowedMenuBarLabelStyles = ["compact", "classic"]
     static let allowedMenuBarMemoryStyles = ["dot", "percent", "both"]
@@ -1100,6 +1101,7 @@ enum Defaults {
         DefaultsKey.menuBarDiskActivity: false,
         DefaultsKey.menuBarPeripheralBattery: false,
         DefaultsKey.menuBarFanSpeed: false,
+        DefaultsKey.menuBarSpace: false,
         DefaultsKey.menuBarPreset: "dense",
         DefaultsKey.menuBarMetricSpacing: "compact",  // owner's call: compact by default in 3.1.8
         DefaultsKey.menuBarMetricAppearance: "values",

--- a/Sources/Vorssaint/Core/Localization.swift
+++ b/Sources/Vorssaint/Core/Localization.swift
@@ -882,6 +882,7 @@ struct Strings {
     let monitorShowGPUTemperature: String
     let monitorShowBatteryTemperature: String
     let monitorShowPeripheralBattery: String
+    let monitorShowSpace: String
     let peripheralBatteryNoDevices: String
     let monitorGraphsSection: String
     let monitorGraphsCaption: String
@@ -1902,6 +1903,7 @@ extension Strings {
         monitorShowGPUTemperature: "Temperatura da GPU",
         monitorShowBatteryTemperature: "Temperatura da bateria",
         monitorShowPeripheralBattery: "Bateria dos periféricos",
+        monitorShowSpace: "Espaço",
         peripheralBatteryNoDevices: "Nenhum periférico encontrado",
         monitorGraphsSection: "Gráficos",
         monitorGraphsCaption: "Escolha quais métricas mostram um gráfico ao longo do tempo.",
@@ -2912,6 +2914,7 @@ extension Strings {
         monitorShowGPUTemperature: "GPU temperature",
         monitorShowBatteryTemperature: "Battery temperature",
         monitorShowPeripheralBattery: "Peripheral battery",
+        monitorShowSpace: "Space",
         peripheralBatteryNoDevices: "No devices found",
         monitorGraphsSection: "Graphs",
         monitorGraphsCaption: "Choose which metrics show a graph over time.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
@@ -737,6 +737,7 @@ extension Strings {
         monitorShowGPUTemperature: "GPU 温度",
         monitorShowBatteryTemperature: "电池温度",
         monitorShowPeripheralBattery: "外设电池",
+        monitorShowSpace: "空间",
         peripheralBatteryNoDevices: "未找到外设",
         monitorGraphsSection: "图表",
         monitorGraphsCaption: "选择哪些指标显示随时间变化的图表。",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
@@ -738,6 +738,7 @@ extension Strings {
         monitorShowGPUTemperature: "GPU 溫度",
         monitorShowBatteryTemperature: "電池溫度",
         monitorShowPeripheralBattery: "外置電池",
+        monitorShowSpace: "空間",
         peripheralBatteryNoDevices: "無外置電池",
         monitorGraphsSection: "圖表",
         monitorGraphsCaption: "選取哪些指標顯示隨時間變化的圖表。",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
@@ -738,6 +738,7 @@ extension Strings {
         monitorShowGPUTemperature: "GPU 溫度",
         monitorShowBatteryTemperature: "電池溫度",
         monitorShowPeripheralBattery: "外接裝置電池",
+        monitorShowSpace: "空間",
         peripheralBatteryNoDevices: "未發現外接裝置電池",
         monitorGraphsSection: "圖表",
         monitorGraphsCaption: "選擇要以圖表顯示隨時間變化的指標。",

--- a/Sources/Vorssaint/Core/Localizations/Strings+French.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+French.swift
@@ -737,6 +737,7 @@ extension Strings {
         monitorShowGPUTemperature: "Température GPU",
         monitorShowBatteryTemperature: "Température batterie",
         monitorShowPeripheralBattery: "Batterie des périphériques",
+        monitorShowSpace: "Espace",
         peripheralBatteryNoDevices: "Aucun périphérique trouvé",
         monitorGraphsSection: "Graphiques",
         monitorGraphsCaption: "Choisissez quelles mesures affichent un graphique dans le temps.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+German.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+German.swift
@@ -737,6 +737,7 @@ extension Strings {
         monitorShowGPUTemperature: "GPU-Temperatur",
         monitorShowBatteryTemperature: "Batterietemperatur",
         monitorShowPeripheralBattery: "Peripheriebatterie",
+        monitorShowSpace: "Space",
         peripheralBatteryNoDevices: "Keine Geräte gefunden",
         monitorGraphsSection: "Diagramme",
         monitorGraphsCaption: "Wähle, welche Werte ein Diagramm über die Zeit anzeigen.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
@@ -737,6 +737,7 @@ extension Strings {
         monitorShowGPUTemperature: "Temperatura GPU",
         monitorShowBatteryTemperature: "Temperatura batteria",
         monitorShowPeripheralBattery: "Batteria periferiche",
+        monitorShowSpace: "Spazio",
         peripheralBatteryNoDevices: "Nessuna periferica trovata",
         monitorGraphsSection: "Grafici",
         monitorGraphsCaption: "Scegli quali metriche mostrano un grafico nel tempo.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
@@ -737,6 +737,7 @@ extension Strings {
         monitorShowGPUTemperature: "GPU温度",
         monitorShowBatteryTemperature: "バッテリー温度",
         monitorShowPeripheralBattery: "周辺機器のバッテリー",
+        monitorShowSpace: "スペース",
         peripheralBatteryNoDevices: "周辺機器が見つかりません",
         monitorGraphsSection: "グラフ",
         monitorGraphsCaption: "経過に応じてグラフを表示する項目を選びます。",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
@@ -738,6 +738,7 @@ extension Strings {
         monitorShowGPUTemperature: "GPU 온도",
         monitorShowBatteryTemperature: "배터리 온도",
         monitorShowPeripheralBattery: "주변 기기 배터리",
+        monitorShowSpace: "스페이스",
         peripheralBatteryNoDevices: "주변 기기를 찾을 수 없습니다",
         monitorGraphsSection: "그래프",
         monitorGraphsCaption: "시간 흐름에 따라 그래프로 표시할 항목을 선택합니다.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
@@ -738,6 +738,7 @@ extension Strings {
         monitorShowGPUTemperature: "Температура GPU",
         monitorShowBatteryTemperature: "Температура батареи",
         monitorShowPeripheralBattery: "Батарея аксессуаров",
+        monitorShowSpace: "Рабочий стол",
         peripheralBatteryNoDevices: "Устройства не найдены",
         monitorGraphsSection: "Графики",
         monitorGraphsCaption: "Выберите, для каких метрик показывать график во времени.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
@@ -737,6 +737,7 @@ extension Strings {
         monitorShowGPUTemperature: "Temperatura de GPU",
         monitorShowBatteryTemperature: "Temperatura de batería",
         monitorShowPeripheralBattery: "Batería de periféricos",
+        monitorShowSpace: "Espacio",
         peripheralBatteryNoDevices: "No se encontraron periféricos",
         monitorGraphsSection: "Gráficas",
         monitorGraphsCaption: "Elige qué métricas muestran una gráfica a lo largo del tiempo.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
@@ -737,6 +737,7 @@ extension Strings {
         monitorShowGPUTemperature: "GPU sıcaklığı",
         monitorShowBatteryTemperature: "Pil sıcaklığı",
         monitorShowPeripheralBattery: "Çevre birimi pili",
+        monitorShowSpace: "Space",
         peripheralBatteryNoDevices: "Aygıt bulunamadı",
         monitorGraphsSection: "Grafikler",
         monitorGraphsCaption: "Hangi metriklerin zaman içinde grafik göstereceğini seç.",

--- a/Sources/Vorssaint/Services/Switcher/SpaceMenuBarSupport.swift
+++ b/Sources/Vorssaint/Services/Switcher/SpaceMenuBarSupport.swift
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import CoreGraphics
+import Foundation
+
+/// Pure helpers for the optional menu bar Space digit.
+///
+/// Numbering matches Mission Control's left-to-right row for one display:
+/// 1-based index of `current` in that display's `spaces` array. Fullscreen
+/// Spaces stay in that row, so a fullscreen desktop keeps its full-row index
+/// rather than being renumbered among ordinary desktops only.
+enum SpaceMenuBarSupport {
+    struct DisplayRow {
+        let id: CGDirectDisplayID?
+        let spaces: [UInt64]
+        let current: UInt64?
+    }
+
+    /// 1-based index of `current` in `spaces`, or nil when it is missing.
+    static func number(current: UInt64?, spaces: [UInt64]) -> Int? {
+        guard let current, let index = spaces.firstIndex(of: current) else { return nil }
+        return index + 1
+    }
+
+    /// Picks the Spaces row for the display that owns the menu bar. When that
+    /// id is unknown, falls back to the first display so a single digit still
+    /// appears on multi-display setups.
+    static func row(forMenuBarDisplayID menuBarDisplayID: CGDirectDisplayID?,
+                    displays: [DisplayRow]) -> DisplayRow? {
+        if let menuBarDisplayID,
+           let match = displays.first(where: { $0.id == menuBarDisplayID }) {
+            return match
+        }
+        return displays.first
+    }
+
+    static func row(forMenuBarDisplayID menuBarDisplayID: CGDirectDisplayID?,
+                    displays: [(id: CGDirectDisplayID?, spaces: [UInt64], current: UInt64?)]) -> DisplayRow? {
+        row(forMenuBarDisplayID: menuBarDisplayID,
+            displays: displays.map { DisplayRow(id: $0.id, spaces: $0.spaces, current: $0.current) })
+    }
+}

--- a/Sources/Vorssaint/UI/MenuBarMetricsPreview.swift
+++ b/Sources/Vorssaint/UI/MenuBarMetricsPreview.swift
@@ -21,6 +21,7 @@ struct MenuBarMetricsPreview: View {
     @AppStorage(DefaultsKey.menuBarBatteryTime) private var batteryTime = false
     @AppStorage(DefaultsKey.menuBarPeripheralBattery) private var peripheralBattery = false
     @AppStorage(DefaultsKey.menuBarPower) private var power = false
+    @AppStorage(DefaultsKey.menuBarSpace) private var space = false
     @AppStorage(DefaultsKey.menuBarMetricOrder) private var metricOrder = ""
     @AppStorage(DefaultsKey.menuBarCombineTemperatures) private var combineTemperatures = true
     @AppStorage(DefaultsKey.menuBarMetricAppearance) private var metricAppearance = "values"

--- a/Sources/Vorssaint/UI/MenuPanel/MetricDetailView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/MetricDetailView.swift
@@ -90,7 +90,8 @@ enum MetricDetailKind: String, Equatable, Identifiable {
 }
 
 extension MenuBarMetric {
-    var detailKind: MetricDetailKind {
+    /// Nil for Space: there is no monitor panel section for Mission Control.
+    var detailKind: MetricDetailKind? {
         switch self {
         case .cpu, .cpuTemperature:
             return .cpu
@@ -108,6 +109,8 @@ extension MenuBarMetric {
             return .power
         case .fanSpeed:
             return .fan
+        case .space:
+            return nil
         }
     }
 }

--- a/Sources/Vorssaint/UI/Settings/MonitorSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/MonitorSettings.swift
@@ -320,7 +320,7 @@ private struct MenuBarMetricOrderEditor: View {
     /// Metrics whose family left the hub keep their saved slot but stay out
     /// of the editor until they return.
     private var visibleOrder: [MenuBarMetric] {
-        order.filter { $0.feature.isAvailable && $0.isAvailableOnCurrentHardware }
+        order.filter { (!$0.isFeatureGated || $0.feature.isAvailable) && $0.isAvailableOnCurrentHardware }
     }
 }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -3951,8 +3951,10 @@ struct MetricsTests {
                "menu bar peripheral battery is opt-in")
         expect(registeredDefaults[DefaultsKey.menuBarFanSpeed] as? Bool == false,
                "menu bar fan speed is opt-in")
+        expect(registeredDefaults[DefaultsKey.menuBarSpace] as? Bool == false,
+               "menu bar Space number is opt-in")
         expect(registeredDefaults[DefaultsKey.menuBarMetricOrder] as? String
-               == "cpu,cpuTemperature,gpu,gpuTemperature,memory,battery,batteryTime,batteryTemperature,peripheralBattery,network,diskUsage,diskActivity,power,fanSpeed",
+               == "cpu,cpuTemperature,gpu,gpuTemperature,memory,battery,batteryTime,batteryTemperature,peripheralBattery,network,diskUsage,diskActivity,power,fanSpeed,space",
                "menu bar metric order keeps temperature sensors next to their components and disk near live I/O")
         expect(registeredDefaults[DefaultsKey.menuBarCombineTemperatures] as? Bool == true,
                "menu bar combines usage and temperature by default")
@@ -5212,13 +5214,45 @@ struct MetricsTests {
         expect(Defaults.sanitizedMenuBarMemoryStyle("dot") == "dot", "valid memory style is preserved")
         expect(Defaults.sanitizedMenuBarMemoryStyle("both") == "both", "combined memory style is preserved")
         expect(Defaults.sanitizedMenuBarMemoryStyle("bad") == "percent", "invalid memory style falls back to percent")
+
+        // MARK: Space menu bar number
+        expect(SpaceMenuBarSupport.number(current: 10, spaces: [10, 20, 30]) == 1,
+               "first Space is number 1")
+        expect(SpaceMenuBarSupport.number(current: 20, spaces: [10, 20, 30]) == 2,
+               "middle Space is number 2")
+        expect(SpaceMenuBarSupport.number(current: 30, spaces: [10, 20, 30]) == 3,
+               "last Space is number 3")
+        expect(SpaceMenuBarSupport.number(current: 99, spaces: [10, 20, 30]) == nil,
+               "unknown Space id yields nil")
+        expect(SpaceMenuBarSupport.number(current: nil, spaces: [10, 20]) == nil,
+               "missing current Space yields nil")
+        expect(SpaceMenuBarSupport.number(current: 10, spaces: []) == nil,
+               "empty Spaces row yields nil")
+        // Fullscreen Spaces stay in the managed-display row; the digit is that
+        // full-row 1-based index (not an ordinary-desktop-only renumbering).
+        expect(SpaceMenuBarSupport.number(current: 40, spaces: [10, 20, 40]) == 3,
+               "fullscreen Space keeps its full-row index")
+        let picked = SpaceMenuBarSupport.row(forMenuBarDisplayID: 2,
+                                             displays: [
+                                                (id: 1, spaces: [10, 11], current: 10),
+                                                (id: 2, spaces: [20, 21, 22], current: 21),
+                                             ])
+        expect(picked.map { SpaceMenuBarSupport.number(current: $0.current, spaces: $0.spaces) } == 2,
+               "multi-display uses the menu-bar display's Spaces row")
+        let fallback = SpaceMenuBarSupport.row(forMenuBarDisplayID: 99,
+                                               displays: [
+                                                  (id: 1, spaces: [10, 11], current: 11),
+                                               ])
+        expect(fallback.map { SpaceMenuBarSupport.number(current: $0.current, spaces: $0.spaces) } == 2,
+               "unknown menu-bar display id falls back to the first display")
+
         expect(Defaults.sanitizedMenuBarMetricOrder("cpu,gpu,memory,network,battery,power")
                == ["cpu", "gpu", "memory", "network", "battery", "power",
-                   "cpuTemperature", "gpuTemperature", "batteryTime", "batteryTemperature", "peripheralBattery", "diskUsage", "diskActivity", "fanSpeed"],
+                   "cpuTemperature", "gpuTemperature", "batteryTime", "batteryTemperature", "peripheralBattery", "diskUsage", "diskActivity", "fanSpeed", "space"],
                "menu bar metric order appends temperature sensors without rewriting existing saved order")
         expect(Defaults.sanitizedMenuBarMetricOrder("temperature,cpu,cpu,bad")
                == ["cpuTemperature", "gpuTemperature", "batteryTemperature",
-                   "cpu", "gpu", "memory", "battery", "batteryTime", "peripheralBattery", "network", "diskUsage", "diskActivity", "power", "fanSpeed"],
+                   "cpu", "gpu", "memory", "battery", "batteryTime", "peripheralBattery", "network", "diskUsage", "diskActivity", "power", "fanSpeed", "space"],
                "menu bar metric order migrates the old generic temperature value")
         expect(Defaults.sanitizedBundleIdentifierList([" com.example.One ", "", "com.example.One", "com.example.Two"])
                == ["com.example.One", "com.example.Two"],
@@ -20427,6 +20461,7 @@ struct MetricsTests {
                 && backupKeys.contains(DefaultsKey.fanControlCoolingLevel)
                 && backupKeys.contains(DefaultsKey.fanControlCurves)
                 && backupKeys.contains(DefaultsKey.menuBarFanSpeed)
+                && backupKeys.contains(DefaultsKey.menuBarSpace)
                 && !backupKeys.contains(DefaultsKey.fanControlRecoveryNeeded)
                 && !backupKeys.contains(DefaultsKey.fanControlHelperVersion),
                "fan display and cooling preferences travel while helper recovery state stays on one Mac")

--- a/build.sh
+++ b/build.sh
@@ -382,6 +382,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/Switcher/SwitcherModels.swift \
         Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift \
         Sources/Vorssaint/Services/Switcher/SpaceHopSupport.swift \
+        Sources/Vorssaint/Services/Switcher/SpaceMenuBarSupport.swift \
         Sources/Vorssaint/Services/Switcher/WindowUseOrder.swift \
         Sources/Vorssaint/Services/Metrics/MetricFormat.swift \
         Sources/Vorssaint/Services/Metrics/VMStatisticsDecoder.swift \


### PR DESCRIPTION
## Summary
- Adds optional `MenuBarMetric.space` (default off): bare digit from `SpaceWindowBridge` topology for the menu-bar display.
- Pure `SpaceMenuBarSupport` numbering (1-based index in that display’s Space row, including fullscreen Spaces).
- Space is not feature-gated on Switcher and does not keep SystemMonitor sampling warm by itself; refreshes on `activeSpaceDidChange`.

## Test plan
- [x] `./build.sh --test` (10499 checks)
- [ ] Settings → Monitor → enable Space → confirm digit matches Mission Control for the menu-bar display
- [ ] Switch Spaces / enter fullscreen Space and confirm the digit updates
- [ ] With only Space enabled (no other metrics), confirm monitor sampling stays idle

Refs #603