### PR TITLE
fix: paste cut files into folders the account cannot write

### DIFF
--- a/Sources/Vorssaint/Services/Finder/CutPastePrivilegeSupport.swift
+++ b/Sources/Vorssaint/Services/Finder/CutPastePrivilegeSupport.swift
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+enum CutPastePrivilegeSupport {
+    static func needsPrivileges(_ error: Error) -> Bool {
+        let error = error as NSError
+        var candidates = [error]
+        if let underlying = error.userInfo[NSUnderlyingErrorKey] as? NSError {
+            candidates.append(underlying)
+        }
+        return candidates.contains(where: isPermissionDenied)
+    }
+
+    private static func isPermissionDenied(_ error: NSError) -> Bool {
+        switch error.domain {
+        case NSCocoaErrorDomain:
+            return error.code == NSFileWriteNoPermissionError
+                || error.code == NSFileReadNoPermissionError
+        case NSPOSIXErrorDomain:
+            return error.code == Int(EACCES) || error.code == Int(EPERM)
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/Vorssaint/Services/Finder/CutPastePrivilegeSupport.swift
+++ b/Sources/Vorssaint/Services/Finder/CutPastePrivilegeSupport.swift
@@ -4,6 +4,27 @@
 import Foundation
 
 enum CutPastePrivilegeSupport {
+    /// Cancellation can follow a partial move. Only retain items that have not
+    /// landed; lack of permission to inspect a source is not proof it moved.
+    static func reconcile(_ urls: [URL], into directory: URL, canceled: Bool,
+                          fm: FileManager) -> (moved: Int, failed: Int, stillCut: [URL]) {
+        let remaining = urls.filter { source in
+            do {
+                _ = try fm.attributesOfItem(atPath: source.path)
+                return true
+            } catch {
+                let error = error as NSError
+                let missing = (error.domain == NSCocoaErrorDomain
+                    && error.code == NSFileReadNoSuchFileError)
+                    || (error.domain == NSPOSIXErrorDomain && error.code == Int(ENOENT))
+                let destination = directory.appendingPathComponent(source.lastPathComponent)
+                return !missing || !fm.fileExists(atPath: destination.path)
+            }
+        }
+        return (urls.count - remaining.count, canceled ? 0 : remaining.count,
+                canceled ? remaining : [])
+    }
+
     static func needsPrivileges(_ error: Error) -> Bool {
         let error = error as NSError
         var candidates = [error]

--- a/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
@@ -533,13 +533,12 @@ final class FinderCutPaste: ObservableObject {
             }
             var stillCut: [URL] = []
             if !refused.isEmpty {
-                switch Self.moveThroughFinder(refused, into: dir, fm: fm) {
-                case .declined:
-                    stillCut = refused
-                case .attempted(let landed):
-                    moved += landed
-                    failed += refused.count - landed
-                }
+                let canceled = FinderBridge.move(refused, into: dir).canceled
+                let result = CutPastePrivilegeSupport.reconcile(
+                    refused, into: dir, canceled: canceled, fm: fm)
+                moved += result.moved
+                failed += result.failed
+                stillCut = result.stillCut
             }
             DispatchQueue.main.async {
                 self?.finishPaste(generation: generation, moved: moved, failed: failed,
@@ -664,17 +663,6 @@ final class FinderCutPaste: ObservableObject {
         } catch {
             return CutPastePrivilegeSupport.needsPrivileges(error) ? .needsPrivileges : .failed
         }
-    }
-
-    private enum ElevatedMove {
-        case declined
-        case attempted(landed: Int)
-    }
-
-    private static func moveThroughFinder(_ urls: [URL], into dir: URL,
-                                          fm: FileManager) -> ElevatedMove {
-        if FinderBridge.move(urls, into: dir).canceled { return .declined }
-        return .attempted(landed: urls.filter { !fm.fileExists(atPath: $0.path) }.count)
     }
 
     /// Appends " 2", " 3"… before the extension when a name already exists,
@@ -827,7 +815,7 @@ private enum FinderBridge {
             tell application "Finder"
                 set targets to {}
                 \(targets)
-                move targets to folder (POSIX file \(AppleScriptRunner.literal(dir.path)) as alias)
+                move targets to folder (POSIX file \(AppleScriptRunner.literal(dir.path)) as alias) without replacing
             end tell
         end timeout
         """

--- a/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
@@ -491,7 +491,8 @@ final class FinderCutPaste: ObservableObject {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let destPath = FinderBridge.insertionLocationPath() else {
                 DispatchQueue.main.async {
-                    self?.finishPaste(generation: generation, moved: 0, failed: urls.count)
+                    self?.finishPaste(generation: generation, moved: 0, failed: urls.count,
+                                      stillCut: [])
                 }
                 return
             }
@@ -499,6 +500,7 @@ final class FinderCutPaste: ObservableObject {
             let fm = FileManager.default
             let plan = Self.progressPlan(urls: urls, dir: dir)
             var moved = 0, failed = 0
+            var refused: [URL] = []
             var finishedBytes: Int64 = 0
             for (index, src) in urls.enumerated() {
                 if plan.showsProgress {
@@ -511,7 +513,7 @@ final class FinderCutPaste: ObservableObject {
                                               totalBytes: plan.totalBytes))
                 }
                 var poller: DispatchSourceTimer?
-                let success = Self.move(src, into: dir, fm: fm) { dest in
+                let outcome = Self.move(src, into: dir, fm: fm) { dest in
                     guard plan.showsProgress, plan.totalBytes > 0 else { return }
                     poller = self?.makeBytePoller(destination: dest,
                                                   generation: generation,
@@ -522,10 +524,26 @@ final class FinderCutPaste: ObservableObject {
                 }
                 poller?.cancel()
                 finishedBytes += plan.sizes[index] ?? 0
-                if success { moved += 1 } else { failed += 1 }
+                switch outcome {
+                case .moved: moved += 1
+                case .failed: failed += 1
+                case .needsPrivileges:
+                    refused.append(src)
+                }
+            }
+            var stillCut: [URL] = []
+            if !refused.isEmpty {
+                switch Self.moveThroughFinder(refused, into: dir, fm: fm) {
+                case .declined:
+                    stillCut = refused
+                case .attempted(let landed):
+                    moved += landed
+                    failed += refused.count - landed
+                }
             }
             DispatchQueue.main.async {
-                self?.finishPaste(generation: generation, moved: moved, failed: failed)
+                self?.finishPaste(generation: generation, moved: moved, failed: failed,
+                                  stillCut: stillCut)
             }
         }
     }
@@ -602,38 +620,61 @@ final class FinderCutPaste: ObservableObject {
         }
     }
 
-    private func finishPaste(generation: Int, moved: Int, failed: Int) {
+    private func finishPaste(generation: Int, moved: Int, failed: Int, stillCut: [URL]) {
         guard generation == operationGeneration else { return }
         // Invalidate the generation so a progress publish still in flight from
         // a just-cancelled poller can't revive the moving state after this.
         operationGeneration += 1
         moveInProgress = false
         moveProgress = nil
-        marked = []
-        markedChangeCount = 0
+        marked = stillCut.isEmpty ? [] : marked.filter { stillCut.contains($0.url) }
+        if marked.isEmpty {
+            markedChangeCount = 0
+        }
+        guard moved > 0 || failed > 0 else {
+            refreshPanel()
+            return
+        }
         lastResult = MoveResult(moved: moved, failed: failed)
         refreshPanel()
         scheduleResultDismiss()
+    }
+
+    private enum MoveOutcome {
+        case moved
+        case failed
+        case needsPrivileges
     }
 
     /// `willCopy` fires with the final destination just before the actual
     /// move, and only when one happens (not for no-op moves into the same
     /// folder), so the caller can watch the destination grow.
     private static func move(_ src: URL, into dir: URL, fm: FileManager,
-                             willCopy: (URL) -> Void = { _ in }) -> Bool {
+                             willCopy: (URL) -> Void = { _ in }) -> MoveOutcome {
         // A no-op move (already in the destination) counts as success.
         if src.deletingLastPathComponent().standardizedFileURL.path == dir.standardizedFileURL.path {
-            return true
+            return .moved
         }
-        guard fm.fileExists(atPath: src.path) else { return false }
+        guard fm.fileExists(atPath: src.path) else { return .failed }
         let dest = uniqueDestination(for: src.lastPathComponent, in: dir, fm: fm)
         willCopy(dest)
         do {
             try fm.moveItem(at: src, to: dest)
-            return true
+            return .moved
         } catch {
-            return false
+            return CutPastePrivilegeSupport.needsPrivileges(error) ? .needsPrivileges : .failed
         }
+    }
+
+    private enum ElevatedMove {
+        case declined
+        case attempted(landed: Int)
+    }
+
+    private static func moveThroughFinder(_ urls: [URL], into dir: URL,
+                                          fm: FileManager) -> ElevatedMove {
+        if FinderBridge.move(urls, into: dir).canceled { return .declined }
+        return .attempted(landed: urls.filter { !fm.fileExists(atPath: $0.path) }.count)
     }
 
     /// Appends " 2", " 3"… before the extension when a name already exists,
@@ -772,6 +813,26 @@ private enum FinderBridge {
         guard result.ok else { return [] }
         return result.output.split(whereSeparator: \.isNewline)
             .map { URL(fileURLWithPath: String($0)) }
+    }
+
+    static func move(_ urls: [URL], into dir: URL) -> (ok: Bool, canceled: Bool) {
+        guard AppleScriptRunner.consentToAutomate(bundleID: finderBundleID) else {
+            return (false, false)
+        }
+        let targets = urls
+            .map { "set end of targets to (POSIX file \(AppleScriptRunner.literal($0.path)) as alias)" }
+            .joined(separator: "\n")
+        let script = """
+        with timeout of 600 seconds
+            tell application "Finder"
+                set targets to {}
+                \(targets)
+                move targets to folder (POSIX file \(AppleScriptRunner.literal(dir.path)) as alias)
+            end tell
+        end timeout
+        """
+        let result = AppleScriptRunner.runDetailed(script)
+        return (result.ok, result.errorNumber == -128)
     }
 
     static func insertionLocationPath() -> String? {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -8744,6 +8744,37 @@ struct MetricsTests {
         expect(CutPasteProgressSupport.displayPosition(completed: 5, total: 5) == 5,
                "the counter never runs past the batch size")
 
+        expect(CutPastePrivilegeSupport.needsPrivileges(
+            NSError(domain: NSCocoaErrorDomain, code: NSFileWriteNoPermissionError)),
+               "a destination the account cannot write is worth handing to Finder")
+        expect(CutPastePrivilegeSupport.needsPrivileges(
+            NSError(domain: NSPOSIXErrorDomain, code: Int(EACCES))),
+               "a POSIX permission refusal reaches the same retry")
+        expect(CutPastePrivilegeSupport.needsPrivileges(
+            NSError(domain: NSCocoaErrorDomain, code: NSFileWriteFileExistsError,
+                    userInfo: [NSUnderlyingErrorKey: NSError(domain: NSPOSIXErrorDomain,
+                                                             code: Int(EPERM))])),
+               "the refusal is found in the underlying error too")
+        expect(!CutPastePrivilegeSupport.needsPrivileges(
+            NSError(domain: NSCocoaErrorDomain, code: NSFileWriteOutOfSpaceError)),
+               "a full disk fails the same way for Finder, so it never asks")
+        expect(!CutPastePrivilegeSupport.needsPrivileges(
+            NSError(domain: NSCocoaErrorDomain, code: NSFileWriteVolumeReadOnlyError)),
+               "a read-only volume never raises a dialog it cannot use")
+        expect(!CutPastePrivilegeSupport.needsPrivileges(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotWriteToFile)),
+               "an unrelated error domain stays a plain failure")
+        let cutPasteSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Finder/FinderCutPaste.swift",
+            encoding: .utf8)) ?? ""
+        expect(cutPasteSource.contains("CutPastePrivilegeSupport.needsPrivileges(error)"),
+               "only a refused permission sends the paste through Finder")
+        expect(cutPasteSource.contains("FinderBridge.move(urls, into: dir).canceled"),
+               "the refused move is handed to Finder, which owns the elevation")
+        expect(cutPasteSource.contains("case .declined:")
+                && cutPasteSource.contains("stillCut = refused"),
+               "a dismissed authentication dialog keeps those items cut for the next ⌘V")
+
         // MARK: Paste copied image as file (issue #429)
 
         expect(FinderPasteImageSupport.preferredImageType(in: ["public.utf8-plain-text"]) == nil,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -8764,16 +8764,43 @@ struct MetricsTests {
         expect(!CutPastePrivilegeSupport.needsPrivileges(
             NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotWriteToFile)),
                "an unrelated error domain stays a plain failure")
-        let cutPasteSource = (try? String(
-            contentsOfFile: "Sources/Vorssaint/Services/Finder/FinderCutPaste.swift",
-            encoding: .utf8)) ?? ""
-        expect(cutPasteSource.contains("CutPastePrivilegeSupport.needsPrivileges(error)"),
-               "only a refused permission sends the paste through Finder")
-        expect(cutPasteSource.contains("FinderBridge.move(urls, into: dir).canceled"),
-               "the refused move is handed to Finder, which owns the elevation")
-        expect(cutPasteSource.contains("case .declined:")
-                && cutPasteSource.contains("stillCut = refused"),
-               "a dismissed authentication dialog keeps those items cut for the next ⌘V")
+        do {
+            let fm = FileManager.default
+            let root = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            let destination = root.appendingPathComponent("destination")
+            try fm.createDirectory(at: destination, withIntermediateDirectories: true)
+            defer { try? fm.removeItem(at: root) }
+            let first = root.appendingPathComponent("first")
+            let second = root.appendingPathComponent("second")
+            try Data([1]).write(to: first)
+            try Data([2]).write(to: second)
+            let canceled = CutPastePrivilegeSupport.reconcile(
+                [first, second], into: destination, canceled: true, fm: fm)
+            expect(canceled.moved == 0 && canceled.failed == 0
+                && canceled.stillCut == [first, second],
+                   "canceling before a move keeps the whole selection")
+            try fm.moveItem(at: first, to: destination.appendingPathComponent("first"))
+            let partial = CutPastePrivilegeSupport.reconcile(
+                [first, second], into: destination, canceled: true, fm: fm)
+            expect(partial.moved == 1 && partial.failed == 0 && partial.stillCut == [second],
+                   "canceling after a partial move retains only the unmoved file")
+            let failure = CutPastePrivilegeSupport.reconcile(
+                [first, second], into: destination, canceled: false, fm: fm)
+            expect(failure.moved == 1 && failure.failed == 1 && failure.stillCut.isEmpty,
+                   "a partial failure reports the files that actually landed")
+            try fm.removeItem(at: second)
+            let vanished = CutPastePrivilegeSupport.reconcile(
+                [second], into: destination, canceled: false, fm: fm)
+            expect(vanished.moved == 0 && vanished.failed == 1,
+                   "a missing source without a destination is not a successful move")
+            try Data([2]).write(to: destination.appendingPathComponent("second"))
+            let success = CutPastePrivilegeSupport.reconcile(
+                [first, second], into: destination, canceled: false, fm: fm)
+            expect(success.moved == 2 && success.failed == 0 && success.stillCut.isEmpty,
+                   "a completed batch clears every cut mark")
+        } catch {
+            expect(false, "protected-folder move fixtures: \(error)")
+        }
 
         // MARK: Paste copied image as file (issue #429)
 

--- a/build.sh
+++ b/build.sh
@@ -335,6 +335,7 @@ if (( TEST )); then
         Sources/Vorssaint/App/StatusItemAnchorSupport.swift \
         Sources/Vorssaint/Services/DockClick/DockClickSupport.swift \
         Sources/Vorssaint/Services/Finder/CutPasteProgressSupport.swift \
+        Sources/Vorssaint/Services/Finder/CutPastePrivilegeSupport.swift \
         Sources/Vorssaint/Services/Finder/FinderPasteImageSupport.swift \
         Sources/Vorssaint/Services/MiddleClick/MiddleClickSupport.swift \
         Sources/Vorssaint/Services/MouseNavigation/MouseNavigationSupport.swift \


### PR DESCRIPTION
## Summary
For instance, when I try to cmd-x and cmd-v an app into /Application/Utilities, vorssaint will simply fail because my account doesn't have write permission to /Application/Utilities.
<img width="329" height="96" alt="Screenshot 2026-09-06 at 6 36 02 PM" src="https://github.com/user-attachments/assets/554a8f43-580d-4fb4-bf64-d931ecd3c068" />

On App Store, there's a free app called "Command X" which handles this scenario by prompting the user for the password / touch ID.
<img width="568" height="353" alt="Screenshot 2026-09-06 at 6 29 20 PM" src="https://github.com/user-attachments/assets/aa9f82f0-8778-475c-831e-c67c6a5ce907" />

This PR brings this behavior from "Command X" to vorssaint.

## Verification
Verified on a MacBook Pro (MacBookPro18,3, M1 Pro), macOS 27.0 (26A5425a), local release build signed ad hoc.
- cut and paste one item into /Application/Utilities ✅ 
- cut and paste multiple items into /Application/Utilities ✅ 

Misc
- ./build.sh ✅ release build, no warnings
- ./build.sh --test ✅ 10,498 checks pass — a clean main checkout runs 10,489, so the 9 added here all pass and nothing regressed
- ./build/Vorssaint --selftest ✅ selftest ok
