### PR TITLE
fix(menu bar): stop reserving room for 20000 RPM in the fan readout

### DIFF
--- a/Sources/Vorssaint/App/MenuBarRenderer.swift
+++ b/Sources/Vorssaint/App/MenuBarRenderer.swift
@@ -699,11 +699,15 @@ enum MenuBarRenderer {
                 }
             case .fanSpeed:
                 if let value = FanControlPolicy.menuBarValue(for: snapshot.fanSpeeds) {
-                    let minimumValue = Array(repeating: "20000", count: snapshot.fanSpeeds.count)
-                        .joined(separator: "/")
+                    // No room held for a value the hardware cannot reach: the
+                    // policy's sane ceiling is 20000 a fan, which reserved
+                    // eleven characters and drew 0/0 in all of them. The block
+                    // takes the width of what it shows, and the label keeps a
+                    // floor under it, so the strip settles at RPM rather than
+                    // at a number no fan reports.
                     groups.append([.metricBlock(label: "RPM",
                                                 value: value,
-                                                minimumValue: minimumValue,
+                                                minimumValue: value,
                                                 style: style,
                                                 pressure: nil)])
                 }


### PR DESCRIPTION
## Summary

With the fans idle the menu bar fan readout shows `0/0` in the middle of a slot wide enough for `2323/2501`, and the strip looks stuck at its widest. It is not a measurement bug: the fan block reserved room for `20000` a fan — the policy's sane ceiling, not a speed any fan reaches — and drew the value centred in it. With two fans that is eleven characters, about 85 points, so `0/0` sat with 36 points of nothing either side.

The block now takes the width of what it shows, with the `RPM` label as its floor.

## Measured

On the reporting Mac, combined status item, fans at 0/0, read through the accessibility frame and a screen capture of the strip:

| | before | after |
|---|---|---|
| status item width | 268 pt | 221 pt |
| gap between `PWR` and `RPM` | 36 pt | 14 pt |
| trailing space after `0/0` | 36 pt | 21 pt (label floor + button inset) |

## The trade-off, stated

The reservation was buying stability: the block changes width when the digit count does, so what sits to its right moves by a character as a fan crosses 999 or 9999. Every other metric here reserves for its worst case for that reason — but their worst cases are real (`100%`, `999°`); 20000 RPM is not. If the strip is preferred steady, the alternative is a one-line change: reserve four digits a fan (`9999/9999`), which no MacBook fan exceeds and which is still two characters narrower than today. I would take either; this one is what the reporter asked for.

## Testing

`./build.sh`, `./build/Vorssaint --selftest`, `./build.sh --test` pass with no warnings. Verified on a MacBook Pro (Mac17,9), macOS 27.0 (26A5425a), lid closed, one external display over HDMI, app language Turkish, local build, combined status item in the compact block style. Not checked: the separate-items layout, the readable block style, and what the strip does at the 999→1000 boundary while the fans spin up — that one is visible only with the fans under load.

No unit test: the change removes a placeholder string; the width it produced is only observable on screen and is recorded above.

Refs #712, #725 (the other fan readout threads) — this covers only the idle width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
