### PR TITLE
fix(clean-url): rewrite share links with rich pasteboard types

### DIFF
--- a/Sources/Vorssaint/Core/URLCleaning.swift
+++ b/Sources/Vorssaint/Core/URLCleaning.swift
@@ -123,6 +123,35 @@ enum URLCleaning {
         return result.url == trimmed ? .unchanged : .rewritten
     }
 
+    /// Whether automatic clipboard rewrite may replace the pasteboard.
+    /// Safe string/URL flavors always qualify. Extra rich types (HTML/RTF
+    /// from Share) are allowed only when `string` is a single http(s) URL,
+    /// so a share link can still be cleaned without touching mixed text.
+    static func shouldAutomaticallyRewrite(
+        string: String,
+        types: [String],
+        allowedTypes: Set<String>
+    ) -> Bool {
+        guard !types.isEmpty else { return false }
+        if Set(types).isSubset(of: allowedTypes) { return true }
+        return isLoneHTTPURL(string)
+    }
+
+    /// True when the whole clipboard string is one http(s) URL (optional
+    /// surrounding whitespace). Prose that merely contains a link is not.
+    static func isLoneHTTPURL(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
+              let components = URLComponents(string: trimmed),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              components.host != nil else {
+            return false
+        }
+        return true
+    }
+
     /// Reads the three stored strings into one value. The global additions
     /// keep the plain comma-separated key they have always used, so nothing
     /// has to be migrated when site rules arrive.

--- a/Sources/Vorssaint/Services/URLCleanerService.swift
+++ b/Sources/Vorssaint/Services/URLCleanerService.swift
@@ -156,7 +156,7 @@ final class URLCleanerService: ObservableObject {
         guard let text = pasteboard.string(forType: .string),
               let cleaned = URLCleaning.clean(text, rules: rules),
               cleaned.url != text.trimmingCharacters(in: .whitespacesAndNewlines),
-              canSafelyRewriteAutomatically(pasteboard),
+              canSafelyRewriteAutomatically(string: text, pasteboard: pasteboard),
               !token.isCancelled else {
             return PollResult(changeCount: changeCount, cleaned: nil)
         }
@@ -165,9 +165,15 @@ final class URLCleanerService: ObservableObject {
         return PollResult(changeCount: rewrittenChangeCount, cleaned: cleaned)
     }
 
-    private static func canSafelyRewriteAutomatically(_ pasteboard: NSPasteboard) -> Bool {
-        guard let types = pasteboard.types, !types.isEmpty else { return false }
-        return Set(types).isSubset(of: automaticRewriteTypes)
+    private static func canSafelyRewriteAutomatically(
+        string: String,
+        pasteboard: NSPasteboard
+    ) -> Bool {
+        guard let types = pasteboard.types else { return false }
+        return URLCleaning.shouldAutomaticallyRewrite(
+            string: string,
+            types: types.map(\.rawValue),
+            allowedTypes: Set(automaticRewriteTypes.map(\.rawValue)))
     }
 
     private static var rules: URLCleaning.Rules {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -12390,6 +12390,42 @@ struct MetricsTests {
                     "https://www.reddit.com/r/swift/comments/abc/?sort=new",
                     "URL cleaner strips Reddit's deep-link tracking in either spelling")
 
+        // Automatic rewrite may clear the pasteboard. Plain string/URL flavors
+        // stay safe as before. Share sheets often add HTML/RTF next to a lone
+        // http(s) link; those rich companions must not block cleaning (#1422).
+        let automaticRewriteAllowedTypes: Set<String> = [
+            "public.utf8-plain-text",
+            "public.url",
+            "public.url-name",
+            "NSStringPboardType",
+            "NSURLPboardType",
+        ]
+        expect(URLCleaning.shouldAutomaticallyRewrite(
+                string: "https://youtu.be/TImSMeurR84?si=Xq1",
+                types: ["public.utf8-plain-text", "public.url"],
+                allowedTypes: automaticRewriteAllowedTypes),
+               "string and URL pasteboard flavors still rewrite automatically")
+        expect(URLCleaning.shouldAutomaticallyRewrite(
+                string: "https://www.youtube.com/watch?v=1&si=x",
+                types: ["public.utf8-plain-text", "public.html", "public.rtf"],
+                allowedTypes: automaticRewriteAllowedTypes),
+               "a lone YouTube share URL rewrites even when HTML/RTF ride along")
+        expect(!URLCleaning.shouldAutomaticallyRewrite(
+                string: "Watch https://youtu.be/TImSMeurR84?si=Xq1 tonight",
+                types: ["public.utf8-plain-text", "public.html"],
+                allowedTypes: automaticRewriteAllowedTypes),
+               "rich pasteboard types still block rewrite when the string is not a lone URL")
+        expect(!URLCleaning.shouldAutomaticallyRewrite(
+                string: "https://youtu.be/TImSMeurR84?si=Xq1",
+                types: [],
+                allowedTypes: automaticRewriteAllowedTypes),
+               "an empty type list never rewrites automatically")
+        expect(!URLCleaning.shouldAutomaticallyRewrite(
+                string: "not a url",
+                types: ["public.utf8-plain-text", "public.html"],
+                allowedTypes: automaticRewriteAllowedTypes),
+               "rich types with non-URL text never rewrite automatically")
+
         // MARK: Homebrew command building and parsing
 
         let homebrewManagerSource = (try? String(


### PR DESCRIPTION
## Summary
- Allow Clean URL auto-rewrite when the pasteboard string is a lone http(s) URL, even if Share added HTML/RTF companions.
- Keep refusing rewrite for mixed/prose clipboard content or an empty type list.
- Extract `URLCleaning.shouldAutomaticallyRewrite` for unit coverage without NSPasteboard.

## Test plan
- [ ] `./build.sh --test`
- [ ] Enable Clean URL, share a YouTube link (Share sheet → Copy), confirm `?si=` is stripped from the clipboard
- [ ] Copy mixed text that contains a URL plus rich types; confirm the clipboard is left alone

Refs #1422