### PR TITLE
fix(mouse): list running programs that are not apps in the exceptions picker

### DIFF
--- a/Sources/Vorssaint/Services/InstalledApps.swift
+++ b/Sources/Vorssaint/Services/InstalledApps.swift
@@ -17,6 +17,14 @@ enum InstalledApps {
         /// search wants them; every other picker leaves them empty rather than
         /// paying Spotlight for a list nobody is going to type into.
         var alternateNames: [String] = []
+        /// What the running process answers to when the row was built from a
+        /// process rather than a bundle on disk, so the picker stores exactly
+        /// what the taps will compare against.
+        var explicitIdentity: String? = nil
+
+        var identity: String? {
+            explicitIdentity ?? bundleID
+        }
 
         var icon: NSImage {
             NSWorkspace.shared.icon(forFile: url.path)
@@ -185,35 +193,86 @@ enum InstalledApps {
                             isSystem: isSystemApplication(at: url))
     }
 
+    /// A program with no .app bundle (the Java a game launcher starts, issue #865)
+    /// is listed only for lists that store path identities, because a list that
+    /// takes only apps would drop the pick silently and show a row that does nothing.
+    static func runningApplication(activationPolicy: NSApplication.ActivationPolicy,
+                                   bundleID: String?,
+                                   bundleURL: URL?,
+                                   executableURL: URL?,
+                                   localizedName: String?,
+                                   acceptsExecutables: Bool) -> InstalledApp? {
+        guard activationPolicy == .regular else { return nil }
+
+        if let bundleID, bundleID.isEmpty { return nil }
+        let isAppBundle = bundleURL?.pathExtension.caseInsensitiveCompare("app") == .orderedSame
+
+        if let bundleID, let bundleURL, isAppBundle {
+            let name = localizedName ?? FileManager.default.displayName(atPath: bundleURL.path)
+            return InstalledApp(id: bundleURL.standardizedFileURL.path,
+                                name: name,
+                                bundleID: bundleID,
+                                url: bundleURL,
+                                isSystem: isSystemApplication(at: bundleURL),
+                                explicitIdentity: nil)
+        }
+
+        guard acceptsExecutables, let executableURL else { return nil }
+        guard let identity = MouseAppExceptionSupport.identity(
+            bundleID: bundleID,
+            executablePath: executableURL.path
+        ) else { return nil }
+
+        let isPathIdentity = MouseAppExceptionSupport.isExecutablePathIdentity(identity)
+        let url = isPathIdentity ? URL(fileURLWithPath: identity) : executableURL
+        let name = localizedName ?? FileManager.default.displayName(atPath: url.path)
+
+        return InstalledApp(id: identity,
+                            name: name,
+                            bundleID: isPathIdentity ? nil : identity,
+                            url: url,
+                            isSystem: isSystemApplication(at: url),
+                            explicitIdentity: identity)
+    }
+
+    static func runningApplication(_ app: NSRunningApplication,
+                                   acceptsExecutables: Bool) -> InstalledApp? {
+        runningApplication(activationPolicy: app.activationPolicy,
+                           bundleID: app.bundleIdentifier,
+                           bundleURL: app.bundleURL,
+                           executableURL: app.executableURL,
+                           localizedName: app.localizedName,
+                           acceptsExecutables: acceptsExecutables)
+    }
+
+    static func deduplicatedAndFiltered(_ apps: [InstalledApp],
+                                        excluding excludedIdentities: Set<String>) -> [InstalledApp] {
+        var seen = Set<String>()
+        return apps.filter { app in
+            guard let identity = app.identity,
+                  !excludedIdentities.contains(identity),
+                  seen.insert(identity).inserted else { return false }
+            return true
+        }.sorted {
+            let byName = $0.name.localizedCaseInsensitiveCompare($1.name)
+            // Equal display names — three runtimes all named "java" — fall
+            // back to the identity so the rows hold one order between renders.
+            return byName == .orderedSame
+                ? ($0.identity ?? "") < ($1.identity ?? "")
+                : byName == .orderedAscending
+        }
+    }
+
     static func installedBundleApplications(excluding excludedBundleIDs: Set<String>,
-                                            includeRunningApplications: Bool = false) -> [InstalledApp] {
+                                            includeRunningApplications: Bool = false,
+                                            acceptsExecutables: Bool = false) -> [InstalledApp] {
         var apps = installedApplications(includeSystemApplications: true)
         if includeRunningApplications {
             apps += NSWorkspace.shared.runningApplications.compactMap { runningApp in
-                guard runningApp.activationPolicy == .regular,
-                      let bundleID = runningApp.bundleIdentifier,
-                      !bundleID.isEmpty,
-                      let url = runningApp.bundleURL,
-                      url.pathExtension.caseInsensitiveCompare("app") == .orderedSame else {
-                    return nil
-                }
-                let name = runningApp.localizedName ?? FileManager.default.displayName(atPath: url.path)
-                return InstalledApp(id: url.standardizedFileURL.path,
-                                    name: name,
-                                    bundleID: bundleID,
-                                    url: url,
-                                    isSystem: isSystemApplication(at: url))
+                runningApplication(runningApp, acceptsExecutables: acceptsExecutables)
             }
         }
 
-        var seen = Set<String>()
-        return apps.filter { app in
-            guard let bundleID = app.bundleID,
-                  !excludedBundleIDs.contains(bundleID),
-                  seen.insert(bundleID).inserted else { return false }
-            return true
-        }.sorted {
-            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-        }
+        return deduplicatedAndFiltered(apps, excluding: excludedBundleIDs)
     }
 }

--- a/Sources/Vorssaint/UI/Settings/AppBundleList.swift
+++ b/Sources/Vorssaint/UI/Settings/AppBundleList.swift
@@ -156,9 +156,16 @@ struct AppBundleList<Accessory: View>: View {
                   acceptsExecutables
                       || !MouseAppExceptionSupport.isExecutablePathIdentity(identity) else { return }
             onAdd(identity)
+        } onSelectApp: { app in
+            showingAppPicker = false
+            guard let identity = app.explicitIdentity ?? MouseAppExceptionSupport.pickedIdentity(for: app.url),
+                  acceptsExecutables
+                      || !MouseAppExceptionSupport.isExecutablePathIdentity(identity) else { return }
+            onAdd(identity)
         } loadApps: {
             InstalledApps.installedBundleApplications(excluding: listed,
-                                                       includeRunningApplications: reachesEveryApp)
+                                                       includeRunningApplications: reachesEveryApp,
+                                                       acceptsExecutables: acceptsExecutables)
         }
     }
 }

--- a/Sources/Vorssaint/UI/Uninstall/AppPickerView.swift
+++ b/Sources/Vorssaint/UI/Uninstall/AppPickerView.swift
@@ -21,18 +21,21 @@ struct AppPickerView: View {
     var loadApps: () -> [InstalledApps.InstalledApp] = { InstalledApps.installedApplications() }
     var onCancel: () -> Void
     var onSelect: (URL) -> Void
+    var onSelectApp: ((InstalledApps.InstalledApp) -> Void)? = nil
 
     init(compact: Bool = false,
          canBrowseApplications: Bool = false,
          acceptsExecutables: Bool = false,
          onCancel: @escaping () -> Void,
          onSelect: @escaping (URL) -> Void,
+         onSelectApp: ((InstalledApps.InstalledApp) -> Void)? = nil,
          loadApps: @escaping () -> [InstalledApps.InstalledApp] = { InstalledApps.installedApplications() }) {
         self.compact = compact
         self.canBrowseApplications = canBrowseApplications
         self.acceptsExecutables = acceptsExecutables
         self.onCancel = onCancel
         self.onSelect = onSelect
+        self.onSelectApp = onSelectApp
         self.loadApps = loadApps
     }
 
@@ -42,6 +45,7 @@ struct AppPickerView: View {
         return apps.filter { app in
             app.name.localizedCaseInsensitiveContains(trimmed)
                 || (app.bundleID?.localizedCaseInsensitiveContains(trimmed) ?? false)
+                || (app.identity?.localizedCaseInsensitiveContains(trimmed) ?? false)
         }
     }
 
@@ -112,7 +116,11 @@ struct AppPickerView: View {
                 LazyVStack(alignment: .leading, spacing: 2) {
                     ForEach(apps) { app in
                         Button {
-                            onSelect(app.url)
+                            if let onSelectApp {
+                                onSelectApp(app)
+                            } else {
+                                onSelect(app.url)
+                            }
                         } label: {
                             AppPickerRow(app: app, compact: compact)
                         }
@@ -148,14 +156,15 @@ private struct AppPickerRow: View {
                 .resizable()
                 .frame(width: compact ? 20 : 28, height: compact ? 20 : 28)
             VStack(alignment: .leading, spacing: 1) {
+                let location = app.identity.flatMap(InstalledApps.location(for:))
                 Text(app.name)
                     .font(.system(size: compact ? 11 : 13, weight: .medium))
                     .lineLimit(1)
-                Text(app.bundleID ?? app.url.path)
+                Text(location ?? app.bundleID ?? app.url.path)
                     .font(.system(size: compact ? 9 : 11))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
-                    .truncationMode(.middle)
+                    .truncationMode(location == nil ? .middle : .head)
             }
             Spacer(minLength: 0)
         }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -20105,6 +20105,183 @@ struct MetricsTests {
         expect(InstalledApps.location(for: "/opt/game/bin/java") == "/opt/game/bin",
                "a path outside home keeps its absolute directory")
 
+        // Running programs that are not packaged as apps (issue #865): a bare
+        // executable run under .regular activation policy (e.g. a Minecraft
+        // launcher's Java process) answers to its resolved file path when it
+        // has no bundle identifier, while an ordinary .app bundle keeps its
+        // bundle row and background/accessory processes stay excluded.
+        let runningTestRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vorssaint-running-\(getpid())", isDirectory: true)
+        let runningTargetBinary = runningTestRoot.appendingPathComponent("bin/java")
+        let runningSymlinkBinary = runningTestRoot.appendingPathComponent("bin/java_link")
+        try? FileManager.default.createDirectory(at: runningTargetBinary.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: runningTargetBinary.path, contents: Data())
+        try? FileManager.default.createSymbolicLink(at: runningSymlinkBinary, withDestinationURL: runningTargetBinary)
+        let resolvedRunningPath = MouseAppExceptionSupport.executablePathIdentity(runningTargetBinary.path)
+
+        let regularBareApp = InstalledApps.runningApplication(
+            activationPolicy: .regular,
+            bundleID: nil,
+            bundleURL: runningSymlinkBinary,
+            executableURL: runningSymlinkBinary,
+            localizedName: "java",
+            acceptsExecutables: true
+        )
+        if let regularBareApp, let resolvedRunningPath {
+            expect(regularBareApp.identity == resolvedRunningPath
+                    && regularBareApp.bundleID == nil
+                    && regularBareApp.name == "java"
+                    && regularBareApp.url.path == resolvedRunningPath,
+                   "a running regular bare executable produces a path row with its resolved path identity")
+        } else {
+            expect(false, "a running regular bare executable resolves its path row setup")
+        }
+
+        let runningWrapper = runningTestRoot.appendingPathComponent("zulu-8.jre", isDirectory: true)
+        let runningWrapperBinary = runningWrapper.appendingPathComponent("bin/java")
+        try? FileManager.default.createDirectory(at: runningWrapperBinary.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: runningWrapperBinary.path, contents: Data())
+        let wrapperBareApp = InstalledApps.runningApplication(
+            activationPolicy: .regular,
+            bundleID: nil,
+            bundleURL: runningWrapper,
+            executableURL: runningWrapperBinary,
+            localizedName: "java",
+            acceptsExecutables: true
+        )
+        let resolvedWrapperPath = MouseAppExceptionSupport.executablePathIdentity(runningWrapperBinary.path)
+        if let wrapperBareApp, let resolvedWrapperPath {
+            expect(wrapperBareApp.identity == resolvedWrapperPath
+                    && wrapperBareApp.bundleID == nil
+                    && wrapperBareApp.url.path == resolvedWrapperPath,
+                   "a running executable inside a non-app wrapper produces a path row")
+        } else {
+            expect(false, "a non-app wrapper executable resolves its path row setup")
+        }
+
+        let appBundleURL = URL(fileURLWithPath: "/Applications/TextEdit.app")
+        let regularBundleApp = InstalledApps.runningApplication(
+            activationPolicy: .regular,
+            bundleID: "com.apple.TextEdit",
+            bundleURL: appBundleURL,
+            executableURL: appBundleURL.appendingPathComponent("Contents/MacOS/TextEdit"),
+            localizedName: "TextEdit",
+            acceptsExecutables: true
+        )
+        expect(regularBundleApp != nil
+                && regularBundleApp?.identity == "com.apple.TextEdit"
+                && regularBundleApp?.bundleID == "com.apple.TextEdit"
+                && regularBundleApp?.url == appBundleURL
+                && regularBundleApp?.name == "TextEdit",
+               "a running regular app bundle produces an unchanged bundle row")
+
+        let accessoryBareApp = InstalledApps.runningApplication(
+            activationPolicy: .accessory,
+            bundleID: nil,
+            bundleURL: nil,
+            executableURL: runningTargetBinary,
+            localizedName: "java",
+            acceptsExecutables: true
+        )
+        let prohibitedBareApp = InstalledApps.runningApplication(
+            activationPolicy: .prohibited,
+            bundleID: nil,
+            bundleURL: nil,
+            executableURL: runningTargetBinary,
+            localizedName: "java",
+            acceptsExecutables: true
+        )
+        expect(accessoryBareApp == nil && prohibitedBareApp == nil,
+               "an accessory or prohibited bare executable is ignored")
+
+        let embeddedBundleBareApp = InstalledApps.runningApplication(
+            activationPolicy: .regular,
+            bundleID: "com.example.embedded",
+            bundleURL: nil,
+            executableURL: runningTargetBinary,
+            localizedName: "embedded_tool",
+            acceptsExecutables: true
+        )
+        expect(embeddedBundleBareApp != nil
+                && embeddedBundleBareApp?.identity == "com.example.embedded"
+                && embeddedBundleBareApp?.bundleID == "com.example.embedded"
+                && embeddedBundleBareApp?.identity != runningTargetBinary.path,
+               "a bare executable that reports a bundle identifier uses that identifier and not its path")
+
+        let duplicateProcessApp = InstalledApps.runningApplication(
+            activationPolicy: .regular,
+            bundleID: nil,
+            bundleURL: nil,
+            executableURL: runningTargetBinary,
+            localizedName: "java",
+            acceptsExecutables: true
+        )
+        if let regularBareApp, let duplicateProcessApp, let resolvedRunningPath {
+            let deduplicated = InstalledApps.deduplicatedAndFiltered(
+                [regularBareApp, duplicateProcessApp],
+                excluding: []
+            )
+            expect(deduplicated.count == 1
+                    && deduplicated.first?.identity == resolvedRunningPath,
+                   "duplicate processes with the same path identity collapse to one entry")
+
+            let excludedPathApps = InstalledApps.deduplicatedAndFiltered(
+                [regularBareApp],
+                excluding: [resolvedRunningPath]
+            )
+            let unexcludedPathApps = InstalledApps.deduplicatedAndFiltered(
+                [regularBareApp],
+                excluding: ["/other/path/java"]
+            )
+            expect(excludedPathApps.isEmpty && unexcludedPathApps.count == 1,
+                   "an exclusion set containing a path identity drops that program")
+        } else {
+            expect(false, "running path identities resolve before they are deduplicated or excluded")
+        }
+
+        let reverseJavaApps = InstalledApps.deduplicatedAndFiltered([
+            InstalledApps.InstalledApp(id: "/runtimes/zulu/bin/java",
+                                       name: "java",
+                                       bundleID: nil,
+                                       url: URL(fileURLWithPath: "/runtimes/zulu/bin/java"),
+                                       isSystem: false,
+                                       explicitIdentity: "/runtimes/zulu/bin/java"),
+            InstalledApps.InstalledApp(id: "/runtimes/temurin/bin/java",
+                                       name: "java",
+                                       bundleID: nil,
+                                       url: URL(fileURLWithPath: "/runtimes/temurin/bin/java"),
+                                       isSystem: false,
+                                       explicitIdentity: "/runtimes/temurin/bin/java")
+        ], excluding: [])
+        expect(reverseJavaApps.compactMap(\.identity) == ["/runtimes/temurin/bin/java", "/runtimes/zulu/bin/java"],
+               "same-named executable rows sort by identity")
+
+        let unacceptedBareApp = InstalledApps.runningApplication(
+            activationPolicy: .regular,
+            bundleID: nil,
+            bundleURL: nil,
+            executableURL: runningTargetBinary,
+            localizedName: "java",
+            acceptsExecutables: false
+        )
+        expect(unacceptedBareApp == nil,
+               "a bare executable is omitted when the caller does not accept executables")
+
+        let emptyIdentifierBareApp = InstalledApps.runningApplication(
+            activationPolicy: .regular,
+            bundleID: "",
+            bundleURL: runningSymlinkBinary,
+            executableURL: runningSymlinkBinary,
+            localizedName: "java",
+            acceptsExecutables: true
+        )
+        expect(emptyIdentifierBareApp == nil,
+               "an empty bundle identifier is dropped, as the taps would never match it")
+
+        try? FileManager.default.removeItem(at: runningTestRoot)
+
         // Both ends of that agreement live outside this binary: the picker
         // stores from AppBundleList and the taps match from MouseAppExceptions.
         // An identity resolved at one end and taken raw at the other silently
@@ -20115,19 +20292,16 @@ struct MetricsTests {
         let pickerLines = ((try? String(
             contentsOfFile: "Sources/Vorssaint/UI/Settings/AppBundleList.swift",
             encoding: .utf8)) ?? "").components(separatedBy: "\n")
-        var resolvedNames: Set<String> = []
-        for line in pickerLines where line.contains("= MouseAppExceptionSupport.") {
-            guard let bound = line.components(separatedBy: "let ").last?
-                    .components(separatedBy: " =").first else { continue }
-            resolvedNames.insert(bound.trimmingCharacters(in: .whitespaces))
-        }
         var resolvedAddSites: [String] = []
         var rawAddSites: [String] = []
         for (index, line) in pickerLines.enumerated()
         where !line.trimmingCharacters(in: .whitespaces).hasPrefix("//") && line.contains("onAdd(") {
             let added = (line.components(separatedBy: "onAdd(").last?
                 .components(separatedBy: ")").first ?? "").trimmingCharacters(in: .whitespaces)
-            if resolvedNames.contains(added) {
+            let nearbyLines = pickerLines[..<index].suffix(4)
+            if nearbyLines.contains(where: {
+                $0.contains("let \(added) =") && $0.contains("MouseAppExceptionSupport.")
+            }) {
                 resolvedAddSites.append("AppBundleList.swift:\(index + 1)")
             } else {
                 rawAddSites.append("AppBundleList.swift:\(index + 1) adds \(added)")
@@ -20140,18 +20314,24 @@ struct MetricsTests {
         // every bundled runtime displays as "java" (issue #1009) — and sibling
         // runtimes differ only after a long shared directory prefix, so the
         // caption must truncate from the HEAD: cutting the middle or tail
-        // would hide the one component that differs. AppBundleList is not
-        // compiled into this binary, so the shape is pinned here.
-        var locationSites: [Int] = []
-        var headTruncationSites: [Int] = []
-        for (index, line) in pickerLines.enumerated()
-        where !line.trimmingCharacters(in: .whitespaces).hasPrefix("//") {
-            if line.contains("InstalledApps.location(for:") { locationSites.append(index + 1) }
-            if line.contains(".truncationMode(.head)") { headTruncationSites.append(index + 1) }
+        // would hide the one component that differs. Neither picker is
+        // compiled into this binary, so their shapes are pinned here.
+        let appPickerLines = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/UI/Uninstall/AppPickerView.swift",
+            encoding: .utf8)) ?? "").components(separatedBy: "\n")
+        let captionPickerLines = ["AppBundleList.swift": pickerLines,
+                                  "AppPickerView.swift": appPickerLines]
+        var captionFiles: [String] = []
+        for (file, lines) in captionPickerLines {
+            let sourceLines = lines.filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            if sourceLines.contains(where: { $0.contains("InstalledApps.location(for:") })
+                && sourceLines.contains(where: { $0.contains(".truncationMode(") && $0.contains(".head") }) {
+                captionFiles.append(file)
+            }
         }
-        expect(!locationSites.isEmpty && !headTruncationSites.isEmpty,
-               "a path identity row shows where its file sits and truncates from the head: "
-                   + "\(locationSites) \(headTruncationSites)")
+        expect(captionFiles.count == captionPickerLines.count,
+               "each path identity picker shows where its file sits and truncates from the head: "
+                   + "\(captionFiles)")
 
         var resolvedMatchSites: [String] = []
         var rawMatchSites: [String] = []


### PR DESCRIPTION
Refs #865 — the running-apps half of the report. Since #1023 the Choose… sheet in "Apps to leave alone" accepts a bare program and stores it by path, but the list behind Add an app… still offered only running programs packaged as .app bundles, so the Java a game launcher starts never showed up there.

Running `.regular` programs without an app bundle are now listed, only for lists that store path identities (`acceptsExecutables`). A row is keyed by the same identity the event taps compare against — `MouseAppExceptionSupport.identity(bundleID:executablePath:)`, the bundle identifier when the process reports one, else the resolved executable path — and the row carries that identity explicitly, so picking it stores what `MouseAppExceptions.identity(for:)` will report at runtime rather than re-deriving it from a URL. A process reporting an empty bundle identifier is dropped, as before, because the taps would never match it. Rows are deduplicated and excluded by identity (the stored lists already mix both kinds), equal display names tie-break on identity so three runtimes all named "java" hold one order between renders, path rows show their directory head-truncated the way the list itself does, and the search box matches the path. Lists that take only apps — Shelf, Auto-quit, Quit protection, the uninstaller — pass no `onSelectApp` and keep the old bundle-only behaviour by construction.

The decision is pure — `InstalledApps.runningApplication(activationPolicy:bundleID:bundleURL:executableURL:localizedName:acceptsExecutables:)` and `deduplicatedAndFiltered(_:excluding:)` — and behaviour-checked: the measured shape of a bare binary (`bundleIdentifier` nil, `bundleURL` = the binary, launched directly or through a symlink) yields a path row with the resolved path; a `.jre`-style wrapper directory that is not an `.app` still yields a path row; an `.app` bundle yields the unchanged bundle row; accessory/prohibited processes and empty identifiers are dropped; a reported bundle identifier wins over the path; duplicates collapse; exclusions apply to paths; equal names sort by identity. The existing pins on `AppBundleList` (every added value is resolved by the support enum; caption truncates from the head) were widened to cover the new add site and the picker row.

Measured on this Mac with a throwaway bare executable under `.regular` policy: `NSRunningApplication` reports `bundleIdentifier = nil`, `bundleURL = /private/tmp/<binary>`, `executableURL = /private/tmp/<binary>` (or `/tmp/<link>` when launched through a symlink); current main omits it from the picker, this branch lists it with identity `/private/tmp/<binary>`, and `MouseAppExceptions.identity(for:)` resolves the symlinked launch to the same string.

Verification: Mac17,9 (M5 Pro), macOS 26.6.2 (25G83), 3024×1964 built-in display, local Developer build. `./build.sh` warning-free; `./build.sh --test` → `TESTS OK`; `./build/Vorssaint --selftest` → `SELFTEST OK`, all after rebasing onto `00df68b`. Reverting the bundle-less branch turns four named checks red without crashing the suite. Not tested: a real Minecraft/Java process (no Java runtime on this Mac), a process that reports a bundle identifier from an embedded Info.plist without an `.app` (covered only by the pure check), other macOS releases, and the picker under a non-English language (no strings changed).

One thing deliberately left alone: a reviewer noted the fallthrough is gated on `acceptsExecutables` rather than on the row being a path identity, so a `.regular` process that reports a bundle identifier but has no `.app` bundle stays hidden from bundle-only lists (as today). Listing those in every picker is a wider change than this report asks for; happy to follow up if you want it.
