### PR TITLE
fix(focus): keep the hover hit test out of our own tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project are documented here. The format follows
 ## [Unreleased]
 
 ### Summary
-Vorssaint adds app shortcuts, recording overlays, Keep Awake automation, minimalist window previews and Dock middle-click closing, and brings battery details together in Power. It expands capture, window and keyboard controls and improves recording and note safety, resource use, app updates, network readings, readability, localization, mouse exceptions, responsiveness and reconnection, focus, search, shortcut recovery, file moves and privacy disclosures.
+Vorssaint adds app shortcuts, recording overlays, Keep Awake automation, minimalist window previews and Dock middle-click closing, and brings battery details together in Power. It expands capture, window and keyboard controls and improves recording and note safety, resource use, app updates, network readings, readability, localization, mouse exceptions, responsiveness and reconnection, focus stability, search, shortcut recovery, file moves and privacy disclosures.
 
 ### Added
 - Optional minimal previews hide window titles, controls and decoration in the Dock and App Switcher while keeping selection visible.
@@ -41,6 +41,7 @@ Vorssaint adds app shortcuts, recording overlays, Keep Awake automation, minimal
 - Package installation and update logs use less processing.
 
 ### Fixed
+- Focus follows mouse avoids freezes over Vorssaint panels, reactivating current game windows, and changing focus while modifiers or mouse buttons are held.
 - Cut files can move into protected folders with system authentication, and canceling keeps unfinished items ready to paste again. Thanks to @aesophor.
 - App updates detect universal store apps using their Mac versions and warn when store checks cannot be completed.
 - Opening a recording with damaged pointer data no longer requests excessive memory.
@@ -52,7 +53,6 @@ Vorssaint adds app shortcuts, recording overlays, Keep Awake automation, minimal
 - Shortcut recording detects system shortcuts even when they have never been customized. Thanks to @owendaw.
 - Mouse acceleration stays disabled after disconnecting and reconnecting a mouse.
 - Mouse exception lists now offer running programs that are not packaged as apps. Thanks to @iltonandrew.
-- Focus follows mouse avoids reactivating the current game window and changing focus while a modifier key or mouse button is held.
 - The App Switcher shows supported alternate app icons without flickering during navigation. Thanks to @EugeneCarldotme and @hash00.
 - Color picking copies the sampled pixel's correct color and shows matching values in the magnifier. Thanks to @MaksimEgorov.
 - Installing a build you compiled yourself keeps its system permissions across rebuilds, where only the Developer variant was protected. Thanks to @hash00 and @PathGao.

--- a/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
+++ b/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
@@ -8,9 +8,6 @@ import CoreGraphics
 final class FocusFollowsMouseService {
     static let shared = FocusFollowsMouseService()
 
-    /// No cap on this one: on the system-wide element a timeout is the default
-    /// for every question this process asks, whoever asks it (#938).
-    private let systemElement = AXUIElementCreateSystemWide()
     private let queryQueue = DispatchQueue(label: "com.vorssaint.focus-follows-mouse")
     private var timer: Timer?
     private var mouseMonitor: Any?
@@ -129,8 +126,19 @@ final class FocusFollowsMouseService {
                   .focusFollowsMouse, at: evaluation.point)
         else { return }
 
+        // WindowServer cannot report ignoresMouseEvents. Read our windows on
+        // main so full-screen brightness overlays do not block focus everywhere.
+        let clickThroughWindowIDs = Set(NSApp.windows.filter(\.ignoresMouseEvents).compactMap {
+            CGWindowID(exactly: $0.windowNumber)
+        })
         queryQueue.async { [weak self] in
-            guard let self, let target = self.target(at: evaluation.point) else { return }
+            guard let self else { return }
+            let target = FocusFollowsMouseSupport.queryWindow(
+                in: WindowServerSupport.onScreenWindowInfo(), at: evaluation.point,
+                ownProcessID: ProcessInfo.processInfo.processIdentifier,
+                clickThroughWindowIDs: clickThroughWindowIDs
+            ) { self.target(at: evaluation.point, processID: $0) }
+            guard let target else { return }
             DispatchQueue.main.async { [weak self] in
                 guard let self, self.isRunning, self.nothingIsHeldDown,
                       self.state.isCurrent(evaluation),
@@ -150,22 +158,25 @@ final class FocusFollowsMouseService {
         }
     }
 
-    private func target(at point: CGPoint) -> Target? {
+    private func target(at point: CGPoint, processID: pid_t) -> Target? {
+        guard processID > 0, processID != ProcessInfo.processInfo.processIdentifier else { return nil }
+        // An app-scoped hit test cannot enter our tree if window stacking
+        // changes after the ownership lookup. Never fall back to a global query.
+        let application = AXUIElementCreateApplication(processID)
         var rawElement: AXUIElement?
-        guard AXUIElementCopyElementAtPosition(systemElement, Float(point.x), Float(point.y), &rawElement) == .success,
+        guard AXUIElementCopyElementAtPosition(application, Float(point.x), Float(point.y), &rawElement) == .success,
               let rawElement
         else { return nil }
         AXUIElementSetMessagingTimeout(rawElement, 0.25)
         guard let window = topLevelWindow(from: rawElement) else { return nil }
         AXUIElementSetMessagingTimeout(window, 0.25)
-        guard stringAttribute(window, kAXRoleAttribute as String) == (kAXWindowRole as String),
+        var windowProcessID: pid_t = 0
+        guard AXUIElementGetPid(window, &windowProcessID) == .success,
+              windowProcessID == processID,
+              stringAttribute(window, kAXRoleAttribute as String) == (kAXWindowRole as String),
               let windowID = AXWindowResolver.windowID(for: window)
         else { return nil }
 
-        var processID: pid_t = 0
-        guard AXUIElementGetPid(window, &processID) == .success,
-              processID != ProcessInfo.processInfo.processIdentifier
-        else { return nil }
         return Target(processID: processID,
                       windowID: windowID,
                       focusedWindowID: WindowActivator.focusedWindowID(for: processID))

--- a/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseSupport.swift
+++ b/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseSupport.swift
@@ -12,6 +12,38 @@ enum FocusFollowsMouseSupport {
         min(max(milliseconds, delayRange.lowerBound), delayRange.upperBound)
     }
 
+    /// Stop at the first visible surface, including our small and raised
+    /// panels. Only our known click-through overlays may be skipped: querying
+    /// our Accessibility tree from a worker can deadlock against the main thread.
+    static func queryWindow<Result>(in windows: [[String: Any]],
+                                    at point: CGPoint,
+                                    ownProcessID: pid_t,
+                                    clickThroughWindowIDs: Set<CGWindowID>,
+                                    query: (pid_t) -> Result?) -> Result? {
+        for window in windows {
+            guard let bounds = WindowServerSupport.bounds(from: window),
+                  bounds.contains(point),
+                  (window[kCGWindowAlpha as String] as? NSNumber)?.doubleValue ?? 1 > 0
+            else { continue }
+
+            guard let processID = (window[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+                  processID > 0 else { return nil }
+            if processID == ownProcessID {
+                guard let windowID = (window[kCGWindowNumber as String] as? NSNumber)?.uint32Value,
+                      clickThroughWindowIDs.contains(windowID) else { return nil }
+                continue
+            }
+            // The Dock, the menu bar, a banner and the desktop are not what
+            // hover follows, and neither is the app behind them, since the
+            // pointer is on them and not on it.
+            guard let layer = (window[kCGWindowLayer as String] as? NSNumber)?.intValue,
+                  MouseAppExceptionSupport.appWindowLayers.contains(layer)
+            else { return nil }
+            return query(processID)
+        }
+        return nil
+    }
+
     static func shouldActivate(targetWindowID: CGWindowID,
                                focusedWindowID: CGWindowID?,
                                targetAppIsFrontmost: Bool) -> Bool {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1590,6 +1590,9 @@ struct MetricsTests {
                     "sessionIsActive: SessionActivity.shared.isActive")
                 && focusFollowsMouseServiceSource.contains("AXIsProcessTrusted()"),
                "focus follows mouse owns no monitor or timer in a switched-away or untrusted session")
+        expect(!focusFollowsMouseServiceSource.isEmpty
+                && !focusFollowsMouseServiceSource.contains("AXUIElementCreateSystemWide"),
+               "focus follows mouse cannot re-enter its own Accessibility tree through a global hit test")
 
         // A wheel that reports continuously already measures in points, and
         // that field is the one to trust; the line field only fills in for a
@@ -10806,6 +10809,93 @@ struct MetricsTests {
                                                    ownProcessID: 501,
                                                    pidIsEligible: { $0 != 1001 })?.pid == 1002,
                "the click lookup carries on behind a window it was told to leave alone")
+
+        // Unlike the click scan, hover must stop at our interactive surfaces
+        // before making any Accessibility call, even for a tiny raised panel.
+        let focusHitPoint = CGPoint(x: -200, y: -100)
+        let focusHitFrame = CGRect(x: -300, y: -200, width: 400, height: 400)
+        let foreignFocusWindow = windowServerEntry(focusHitFrame, pid: 1001, number: 11)
+        let ownFocusWindow = windowServerEntry(focusHitFrame, pid: 501, number: 12)
+        var focusQueryPIDs: [pid_t] = []
+        func queryFocusWindow(_ windows: [[String: Any]],
+                              clickThroughWindowIDs: Set<CGWindowID> = [],
+                              querySucceeds: Bool = true) -> pid_t? {
+            focusQueryPIDs.removeAll()
+            return FocusFollowsMouseSupport.queryWindow(
+                in: windows, at: focusHitPoint, ownProcessID: 501,
+                clickThroughWindowIDs: clickThroughWindowIDs
+            ) { pid in
+                focusQueryPIDs.append(pid)
+                return querySucceeds ? pid : nil
+            }
+        }
+        for layer in [0, 3, 25, 1_000] {
+            var panel = windowServerEntry(
+                CGRect(x: -210, y: -110, width: 20, height: 20), pid: 501, number: 12)
+            panel[kCGWindowLayer as String] = NSNumber(value: layer)
+            expect(queryFocusWindow([panel, foreignFocusWindow]) == nil && focusQueryPIDs.isEmpty,
+                   "hover issues no Accessibility query through an own panel at layer \(layer)")
+        }
+        expect(queryFocusWindow([ownFocusWindow, foreignFocusWindow]) == nil && focusQueryPIDs.isEmpty,
+               "hover leaves both its own ordinary window and the app behind it untouched")
+        expect(queryFocusWindow([foreignFocusWindow, ownFocusWindow]) == 1001 && focusQueryPIDs == [1001],
+               "a foreign window covering our panel receives exactly one scoped query on an offset display")
+        expect(queryFocusWindow([]) == nil && focusQueryPIDs.isEmpty,
+               "an empty or unavailable window list never falls back to a global Accessibility query")
+        var unknownOwner = foreignFocusWindow
+        unknownOwner.removeValue(forKey: kCGWindowOwnerPID as String)
+        expect(queryFocusWindow([unknownOwner, foreignFocusWindow]) == nil && focusQueryPIDs.isEmpty,
+               "an unknown surface owner blocks hover without querying an app behind it")
+        for invalidPID: Int32 in [0, -1] {
+            let invalidWindow = windowServerEntry(focusHitFrame, pid: invalidPID, number: 13)
+            expect(queryFocusWindow([invalidWindow, foreignFocusWindow]) == nil && focusQueryPIDs.isEmpty,
+                   "hover never queries an invalid process identifier")
+        }
+        var transparentPanel = ownFocusWindow
+        transparentPanel[kCGWindowAlpha as String] = NSNumber(value: 0.0)
+        expect(queryFocusWindow([transparentPanel, foreignFocusWindow]) == 1001 && focusQueryPIDs == [1001],
+               "a fully invisible own surface does not block the app under the pointer")
+        transparentPanel[kCGWindowAlpha as String] = NSNumber(value: 0.1)
+        expect(queryFocusWindow([transparentPanel, foreignFocusWindow]) == nil && focusQueryPIDs.isEmpty,
+               "a translucent own panel still blocks hover before Accessibility")
+        let distantPanel = windowServerEntry(CGRect(x: 0, y: 0, width: 400, height: 400), pid: 501, number: 14)
+        expect(queryFocusWindow([distantPanel, foreignFocusWindow]) == 1001 && focusQueryPIDs == [1001],
+               "our panel elsewhere on the displays does not disable hover")
+        expect(queryFocusWindow([ownFocusWindow, foreignFocusWindow], clickThroughWindowIDs: [12]) == 1001
+                && focusQueryPIDs == [1001],
+               "a known own click-through overlay passes hover to the foreign app without querying itself")
+        expect(queryFocusWindow([ownFocusWindow, foreignFocusWindow], clickThroughWindowIDs: [14]) == nil
+                && focusQueryPIDs.isEmpty,
+               "only the exact own window marked click-through may be skipped")
+        var ownPanelWithoutID = ownFocusWindow
+        ownPanelWithoutID.removeValue(forKey: kCGWindowNumber as String)
+        expect(queryFocusWindow([ownPanelWithoutID, foreignFocusWindow], clickThroughWindowIDs: [12]) == nil
+                && focusQueryPIDs.isEmpty,
+               "an unidentified own panel is never assumed to be click-through")
+        let brightnessOverlay = windowServerEntry(focusHitFrame, pid: 501, number: 15)
+        expect(queryFocusWindow([brightnessOverlay, ownFocusWindow, foreignFocusWindow],
+                                clickThroughWindowIDs: [15]) == nil && focusQueryPIDs.isEmpty,
+               "a click-through overlay does not hide an interactive own panel from the guard")
+        expect(queryFocusWindow([brightnessOverlay, ownFocusWindow, foreignFocusWindow],
+                                clickThroughWindowIDs: [12, 15]) == 1001 && focusQueryPIDs == [1001],
+               "stacked own click-through overlays still allow normal hover focus")
+        expect(queryFocusWindow([foreignFocusWindow, ownFocusWindow], clickThroughWindowIDs: [11]) == 1001
+                && focusQueryPIDs == [1001],
+               "the click-through allowlist never skips another app's surface")
+        let secondForeignWindow = windowServerEntry(focusHitFrame, pid: 1002, number: 16)
+        expect(queryFocusWindow([foreignFocusWindow, secondForeignWindow], querySucceeds: false) == nil
+                && focusQueryPIDs == [1001],
+               "an unanswered scoped query never falls through to another app")
+        for foreignLayer in [-2_147_483_623, 4, 20, 24, 25] {
+            var furniture = foreignFocusWindow
+            furniture[kCGWindowLayer as String] = NSNumber(value: foreignLayer)
+            expect(queryFocusWindow([furniture, secondForeignWindow]) == nil && focusQueryPIDs.isEmpty,
+                   "hover stops at a surface outside the app window layers, at layer \(foreignLayer)")
+        }
+        var unknownDepth = foreignFocusWindow
+        unknownDepth.removeValue(forKey: kCGWindowLayer as String)
+        expect(queryFocusWindow([unknownDepth, secondForeignWindow]) == nil && focusQueryPIDs.isEmpty,
+               "a surface of unknown depth is never taken for an app window")
 
         expect(MiddleClickSupport.actionForClick(fingerCount: 3, frameAge: 0.05, settledFor: 0.2,
                                                  sinceLastTransformEnd: nil,


### PR DESCRIPTION
Focus follows mouse asked the system-wide element which app sits under the pointer, so hovering one of the app's own panels re-entered its accessibility tree from the query queue and could lock the main thread against it.

Ownership now comes from the window server first, and only the app that owns the window under the pointer is asked, through an app-scoped element. Our own windows stop the hover, except for the click-through overlays we know about, so a full-screen dimmer does not disable the feature. A surface that is not an app window, like the Dock, the menu bar, a banner or the desktop, stops it too, without asking anything.

Refs #1420