### PR TITLE
feat(menu-bar): optional battery percent without icon

### DIFF
--- a/Sources/Vorssaint/App/MenuBarBatteryPresentation.swift
+++ b/Sources/Vorssaint/App/MenuBarBatteryPresentation.swift
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+/// How the internal-battery charge reading appears in the menu bar when that
+/// metric is enabled. The default keeps the familiar glyph beside the percent;
+/// hide-icon drops the glyph so only the charge text occupies the slot.
+enum MenuBarBatteryPresentation: Equatable {
+    case iconAndPercent
+    case percentOnly
+
+    static func resolve(hideIcon: Bool) -> MenuBarBatteryPresentation {
+        hideIcon ? .percentOnly : .iconAndPercent
+    }
+
+    static var current: MenuBarBatteryPresentation {
+        resolve(hideIcon: UserDefaults.standard.bool(forKey: DefaultsKey.menuBarBatteryHideIcon))
+    }
+
+    var showsIcon: Bool { self == .iconAndPercent }
+
+    /// Character-width budget for the dense status title layout. Percent-only
+    /// needs less room without the SF Symbol column.
+    var denseWidthUnits: Int {
+        showsIcon ? 11 : 6
+    }
+
+    /// Clamped charge string shared by dense and block layouts.
+    static func percentText(percent: Int) -> String {
+        "\(max(0, min(100, percent)))%"
+    }
+
+    /// Dense-mode body after an optional symbol. With the icon, keep the
+    /// existing "BAT 85%" label; without it, show the bare percent so the
+    /// slot stays as compact as the request asks for. Charging state is not
+    /// re-encoded here — without the bolt glyph it is less visible on purpose.
+    func denseBodyText(percent: Int) -> String {
+        let value = Self.percentText(percent: percent)
+        return showsIcon ? "BAT " + value : value
+    }
+}

--- a/Sources/Vorssaint/App/MenuBarRenderer.swift
+++ b/Sources/Vorssaint/App/MenuBarRenderer.swift
@@ -197,7 +197,7 @@ enum MenuBarSegment {
     case usageBarBlock(label: String, fraction: Double?, style: MenuBarBlockStyle, pressure: MemoryPressure?)
     case networkBlock(down: String, up: String, style: MenuBarBlockStyle)
     case diskActivityBlock(read: String, write: String, style: MenuBarBlockStyle)
-    case batteryBlock(percent: Int, isCharging: Bool, style: MenuBarBlockStyle)
+    case batteryBlock(percent: Int, isCharging: Bool, style: MenuBarBlockStyle, hideIcon: Bool)
     case dot(MemoryPressure)
     case separator
 }
@@ -416,11 +416,18 @@ enum MenuBarRenderer {
                 }
             case .battery:
                 if let charge = snapshot.power?.chargePercent {
-                    let symbol = (snapshot.power?.isCharging ?? false) ? "battery.100.bolt" : metric.symbolName
-                    let text = "BAT " + percent(Double(charge) / 100.0)
-                    items.append(MetricItem(metric: metric,
-                                            segments: [.symbol(symbol), .text(" " + text)],
-                                            width: reservedWidth(for: metric, preset: preset)))
+                    let presentation = MenuBarBatteryPresentation.current
+                    let body = presentation.denseBodyText(percent: charge)
+                    if presentation.showsIcon {
+                        let symbol = (snapshot.power?.isCharging ?? false) ? "battery.100.bolt" : metric.symbolName
+                        items.append(MetricItem(metric: metric,
+                                                segments: [.symbol(symbol), .text(" " + body)],
+                                                width: presentation.denseWidthUnits))
+                    } else {
+                        items.append(MetricItem(metric: metric,
+                                                segments: [.text(body)],
+                                                width: presentation.denseWidthUnits))
+                    }
                 }
             case .batteryTime:
                 if let power = snapshot.power,
@@ -639,7 +646,8 @@ enum MenuBarRenderer {
                     } else if let chargePercent = enabled.contains(.battery) ? snapshot.power?.chargePercent : nil {
                         groups.append([.batteryBlock(percent: chargePercent,
                                                      isCharging: snapshot.power?.isCharging ?? false,
-                                                     style: style)])
+                                                     style: style,
+                                                     hideIcon: !MenuBarBatteryPresentation.current.showsIcon)])
                     } else if let temperature {
                         groups.append([.metricBlock(label: temperatureLabel("BAT"),
                                                     value: temperature,
@@ -662,7 +670,8 @@ enum MenuBarRenderer {
                 if let charge = snapshot.power?.chargePercent {
                     groups.append([.batteryBlock(percent: charge,
                                                  isCharging: snapshot.power?.isCharging ?? false,
-                                                 style: style)])
+                                                 style: style,
+                                                 hideIcon: !MenuBarBatteryPresentation.current.showsIcon)])
                 }
             case .batteryTime:
                 if let power = snapshot.power,
@@ -780,8 +789,10 @@ enum MenuBarRenderer {
             return 11      // symbol + " DSK 100%"
         case (_, .diskActivity):
             return 15      // R1.0G + W1.0G
-        case (_, .battery), (_, .power):
-            return 11      // symbol + " BAT 100%" / " PWR 99W"
+        case (_, .battery):
+            return MenuBarBatteryPresentation.current.denseWidthUnits
+        case (_, .power):
+            return 11      // symbol + " PWR 99W"
         case (_, .batteryTime):
             return 12      // clock symbol + "99h 59m"
         case (_, .fanSpeed):
@@ -851,10 +862,11 @@ enum MenuBarRenderer {
                 result.append(networkBlockAttachment(down: down, up: up, style: style))
             case let .diskActivityBlock(read, write, style):
                 result.append(diskActivityBlockAttachment(read: read, write: write, style: style))
-            case let .batteryBlock(percent, isCharging, style):
+            case let .batteryBlock(percent, isCharging, style, hideIcon):
                 result.append(batteryBlockAttachment(percent: percent,
                                                      isCharging: isCharging,
-                                                     style: style))
+                                                     style: style,
+                                                     hideIcon: hideIcon))
             case let .dot(pressure):
                 result.append(NSAttributedString(string: "●", attributes: [.foregroundColor: nsColor(for: pressure)]))
             case .separator:
@@ -957,10 +969,12 @@ enum MenuBarRenderer {
 
     private static func batteryBlockAttachment(percent: Int,
                                                isCharging: Bool,
-                                               style: MenuBarBlockStyle) -> NSAttributedString {
+                                               style: MenuBarBlockStyle,
+                                               hideIcon: Bool) -> NSAttributedString {
         let image = batteryBlockImage(percent: percent,
                                       isCharging: isCharging,
-                                      style: style)
+                                      style: style,
+                                      hideIcon: hideIcon)
         let attachment = NSTextAttachment()
         attachment.image = image
         attachment.bounds = NSRect(x: 0,
@@ -1183,43 +1197,47 @@ enum MenuBarRenderer {
 
     private static func batteryBlockImage(percent: Int,
                                           isCharging: Bool,
-                                          style: MenuBarBlockStyle) -> NSImage {
+                                          style: MenuBarBlockStyle,
+                                          hideIcon: Bool) -> NSImage {
         let clampedPercent = max(0, min(100, percent))
-        let cacheKey = "battery|\(clampedPercent)|\(isCharging)|\(style)" as NSString
+        let cacheKey = "battery|\(clampedPercent)|\(isCharging)|\(style)|\(hideIcon)" as NSString
         if let cached = blockImageCache.object(forKey: cacheKey) { return cached }
 
-        let symbolName = batterySymbol(for: percent, isCharging: isCharging)
-        let symbolPointSize: CGFloat = style == .readable ? 17.0 : 15.5
         let valueFont = NSFont.monospacedDigitSystemFont(ofSize: style == .readable ? 13.0 : 12.0,
                                                          weight: .semibold)
-        let value = "\(clampedPercent)%"
+        let value = MenuBarBatteryPresentation.percentText(percent: clampedPercent)
         let sizingValueAttrs: [NSAttributedString.Key: Any] = [.font: valueFont]
         let valueSize = (value as NSString).size(withAttributes: sizingValueAttrs)
         let reservedValueSize = max(valueSize.width, ("100%" as NSString).size(withAttributes: sizingValueAttrs).width)
-        let symbolWidth: CGFloat = style == .readable ? 20 : 18
-        let gap: CGFloat = style == .readable ? 5 : 4
+        let showsIcon = !hideIcon
+        let symbolWidth: CGFloat = showsIcon ? (style == .readable ? 20 : 18) : 0
+        let gap: CGFloat = showsIcon ? (style == .readable ? 5 : 4) : 0
         let height: CGFloat = style == .readable ? 22 : 20
         let imageSize = NSSize(width: ceil(symbolWidth + gap + reservedValueSize), height: height)
         let image = NSImage(size: imageSize, flipped: false) { rect in
             NSColor.clear.setFill()
             rect.fill()
-            let symbolConfig = NSImage.SymbolConfiguration(pointSize: symbolPointSize, weight: .regular)
-                .applying(NSImage.SymbolConfiguration(paletteColors: [.labelColor]))
-            if let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
-                .withSymbolConfiguration(symbolConfig) {
-                let symbolSize = symbol.size
-                // draw(in:) stretches the image to exactly fill the rect, so
-                // clamping only the width while leaving height at
-                // the symbol's full natural size squished wide glyphs like
-                // the battery icon. Scale both dimensions together to keep
-                // the glyph's own proportions.
-                let scale = min(symbolWidth / symbolSize.width, 1)
-                let drawSize = NSSize(width: symbolSize.width * scale, height: symbolSize.height * scale)
-                let symbolRect = NSRect(x: 0,
-                                        y: (height - drawSize.height) / 2,
-                                        width: drawSize.width,
-                                        height: drawSize.height)
-                symbol.draw(in: symbolRect)
+            if showsIcon {
+                let symbolName = batterySymbol(for: percent, isCharging: isCharging)
+                let symbolPointSize: CGFloat = style == .readable ? 17.0 : 15.5
+                let symbolConfig = NSImage.SymbolConfiguration(pointSize: symbolPointSize, weight: .regular)
+                    .applying(NSImage.SymbolConfiguration(paletteColors: [.labelColor]))
+                if let symbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
+                    .withSymbolConfiguration(symbolConfig) {
+                    let symbolSize = symbol.size
+                    // draw(in:) stretches the image to exactly fill the rect, so
+                    // clamping only the width while leaving height at
+                    // the symbol's full natural size squished wide glyphs like
+                    // the battery icon. Scale both dimensions together to keep
+                    // the glyph's own proportions.
+                    let scale = min(symbolWidth / symbolSize.width, 1)
+                    let drawSize = NSSize(width: symbolSize.width * scale, height: symbolSize.height * scale)
+                    let symbolRect = NSRect(x: 0,
+                                            y: (height - drawSize.height) / 2,
+                                            width: drawSize.width,
+                                            height: drawSize.height)
+                    symbol.draw(in: symbolRect)
+                }
             }
             let valueAttrs = dynamicTextAttributes(font: valueFont)
             let valueY = (height - valueSize.height) / 2

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -308,6 +308,7 @@ enum DefaultsKey {
     static let menuBarDiskUsage = "menuBarDiskUsage"
     static let menuBarDiskActivity = "menuBarDiskActivity"
     static let menuBarBattery = "menuBarBattery"
+    static let menuBarBatteryHideIcon = "menuBarBatteryHideIcon" // charge percent without the battery glyph
     static let menuBarBatteryTime = "menuBarBatteryTime"
     static let menuBarPeripheralBattery = "menuBarPeripheralBattery"
     static let menuBarPower = "menuBarPower"
@@ -1095,6 +1096,7 @@ enum Defaults {
         DefaultsKey.menuBarCPUTemperature: false,
         DefaultsKey.menuBarGPUTemperature: false,
         DefaultsKey.menuBarBatteryTemperature: false,
+        DefaultsKey.menuBarBatteryHideIcon: false,
         DefaultsKey.menuBarBatteryTime: false,
         DefaultsKey.menuBarDiskUsage: false,
         DefaultsKey.menuBarDiskActivity: false,

--- a/Sources/Vorssaint/Core/Localization.swift
+++ b/Sources/Vorssaint/Core/Localization.swift
@@ -900,6 +900,7 @@ struct Strings {
     let menuBarSpacingCompact: String
     let menuBarHideIconToggle: String
     let menuBarHideIconCaption: String
+    let menuBarBatteryHideIconToggle: String
     let monitorLabelStyleLabel: String
     let menuBarLabelStyleCompact: String
     let menuBarLabelStyleClassic: String
@@ -1919,6 +1920,7 @@ extension Strings {
         menuBarSpacingCompact: "Compacto",
         menuBarHideIconToggle: "Ocultar o ícone do app enquanto houver métricas",
         menuBarHideIconCaption: "O ícone volta sozinho quando as métricas saem da barra e quando há algo a avisar (atualização pronta ou microfone silenciado).",
+        menuBarBatteryHideIconToggle: "Só a porcentagem",
         monitorLabelStyleLabel: "Rótulos",
         menuBarLabelStyleCompact: "Compactos",
         menuBarLabelStyleClassic: "Clássicos",
@@ -2929,6 +2931,7 @@ extension Strings {
         menuBarSpacingCompact: "Compact",
         menuBarHideIconToggle: "Hide the app icon while metrics are shown",
         menuBarHideIconCaption: "The icon returns by itself when metrics leave the bar and when there is something to signal (an update ready or the microphone muted).",
+        menuBarBatteryHideIconToggle: "Percent only",
         monitorLabelStyleLabel: "Labels",
         menuBarLabelStyleCompact: "Compact",
         menuBarLabelStyleClassic: "Classic",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
@@ -754,6 +754,7 @@ extension Strings {
         menuBarSpacingCompact: "紧凑",
         menuBarHideIconToggle: "显示指标时隐藏 App 图标",
         menuBarHideIconCaption: "当指标离开菜单栏，或有需要提示的内容（更新就绪或麦克风已静音）时，图标会自动回来。",
+        menuBarBatteryHideIconToggle: "仅显示百分比",
         monitorLabelStyleLabel: "标签",
         menuBarLabelStyleCompact: "紧凑",
         menuBarLabelStyleClassic: "经典",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
@@ -755,6 +755,7 @@ extension Strings {
         menuBarSpacingCompact: "緊湊",
         menuBarHideIconToggle: "顯示指標時隱藏 App 圖示",
         menuBarHideIconCaption: "當指標離開選單列，或有需要提示的內容（更新就緒或麥克風已靜音）時，圖示會自動回來。",
+        menuBarBatteryHideIconToggle: "只顯示百分比",
         monitorLabelStyleLabel: "標籤",
         menuBarLabelStyleCompact: "緊湊",
         menuBarLabelStyleClassic: "經典",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
@@ -755,6 +755,7 @@ extension Strings {
         menuBarSpacingCompact: "緊湊",
         menuBarHideIconToggle: "顯示指標時隱藏 App 圖示",
         menuBarHideIconCaption: "當指標離開選單列，或有需要提示的內容（更新就緒或麥克風已靜音）時，圖示會自動回來。",
+        menuBarBatteryHideIconToggle: "僅顯示百分比",
         monitorLabelStyleLabel: "標籤",
         menuBarLabelStyleCompact: "精簡",
         menuBarLabelStyleClassic: "經典",

--- a/Sources/Vorssaint/Core/Localizations/Strings+French.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+French.swift
@@ -754,6 +754,7 @@ extension Strings {
         menuBarSpacingCompact: "Compact",
         menuBarHideIconToggle: "Masquer l’icône de l’app quand des métriques sont affichées",
         menuBarHideIconCaption: "L’icône revient d’elle-même quand les métriques quittent la barre et quand il y a quelque chose à signaler (une mise à jour prête ou le micro coupé).",
+        menuBarBatteryHideIconToggle: "Pourcentage seul",
         monitorLabelStyleLabel: "Libellés",
         menuBarLabelStyleCompact: "Compacts",
         menuBarLabelStyleClassic: "Classiques",

--- a/Sources/Vorssaint/Core/Localizations/Strings+German.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+German.swift
@@ -754,6 +754,7 @@ extension Strings {
         menuBarSpacingCompact: "Kompakt",
         menuBarHideIconToggle: "App-Symbol ausblenden, solange Messwerte angezeigt werden",
         menuBarHideIconCaption: "Das Symbol kehrt von selbst zurück, wenn die Messwerte die Leiste verlassen und wenn es etwas zu melden gibt (ein Update bereit oder das Mikrofon stumm).",
+        menuBarBatteryHideIconToggle: "Nur Prozent",
         monitorLabelStyleLabel: "Beschriftungen",
         menuBarLabelStyleCompact: "Kompakt",
         menuBarLabelStyleClassic: "Klassisch",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
@@ -754,6 +754,7 @@ extension Strings {
         menuBarSpacingCompact: "Compatta",
         menuBarHideIconToggle: "Nascondi l’icona dell’app mentre sono mostrate le metriche",
         menuBarHideIconCaption: "L’icona torna da sola quando le metriche lasciano la barra e quando c’è qualcosa da segnalare (un aggiornamento pronto o il microfono silenziato).",
+        menuBarBatteryHideIconToggle: "Solo percentuale",
         monitorLabelStyleLabel: "Etichette",
         menuBarLabelStyleCompact: "Compatte",
         menuBarLabelStyleClassic: "Classiche",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
@@ -754,6 +754,7 @@ extension Strings {
         menuBarSpacingCompact: "コンパクト",
         menuBarHideIconToggle: "メトリクス表示中はアプリのアイコンを隠す",
         menuBarHideIconCaption: "メトリクスがバーから消えたときや、知らせることがあるとき（アップデートの準備完了やマイクの消音）は、アイコンが自動的に戻ります。",
+        menuBarBatteryHideIconToggle: "パーセントのみ",
         monitorLabelStyleLabel: "ラベル",
         menuBarLabelStyleCompact: "短縮",
         menuBarLabelStyleClassic: "標準",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
@@ -755,6 +755,7 @@ extension Strings {
         menuBarSpacingCompact: "좁게",
         menuBarHideIconToggle: "지표가 표시될 때 앱 아이콘 숨기기",
         menuBarHideIconCaption: "지표가 막대에서 사라지거나 알릴 내용이 있을 때(업데이트 준비 완료 또는 마이크 음소거) 아이콘이 자동으로 돌아옵니다.",
+        menuBarBatteryHideIconToggle: "퍼센트만",
         monitorLabelStyleLabel: "레이블",
         menuBarLabelStyleCompact: "축약",
         menuBarLabelStyleClassic: "표준",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
@@ -755,6 +755,7 @@ extension Strings {
         menuBarSpacingCompact: "Компактный",
         menuBarHideIconToggle: "Скрывать значок приложения, пока показаны метрики",
         menuBarHideIconCaption: "Значок возвращается сам, когда метрики исчезают из строки меню, а также когда есть что сообщить (готово обновление или выключен микрофон).",
+        menuBarBatteryHideIconToggle: "Только проценты",
         monitorLabelStyleLabel: "Подписи",
         menuBarLabelStyleCompact: "Компактные",
         menuBarLabelStyleClassic: "Классические",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
@@ -754,6 +754,7 @@ extension Strings {
         menuBarSpacingCompact: "Compacto",
         menuBarHideIconToggle: "Ocultar el icono de la app mientras se muestran métricas",
         menuBarHideIconCaption: "El icono vuelve solo cuando las métricas salen de la barra y cuando hay algo que avisar (una actualización lista o el micrófono silenciado).",
+        menuBarBatteryHideIconToggle: "Solo el porcentaje",
         monitorLabelStyleLabel: "Etiquetas",
         menuBarLabelStyleCompact: "Compactas",
         menuBarLabelStyleClassic: "Clásicas",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
@@ -754,6 +754,7 @@ extension Strings {
         menuBarSpacingCompact: "Sıkışık",
         menuBarHideIconToggle: "Metrikler gösterilirken uygulama simgesini gizle",
         menuBarHideIconCaption: "Metrikler çubuktan kalktığında ve bildirilecek bir şey olduğunda (güncelleme hazır veya mikrofon sessizde) simge kendiliğinden geri döner.",
+        menuBarBatteryHideIconToggle: "Yalnızca yüzde",
         monitorLabelStyleLabel: "Etiketler",
         menuBarLabelStyleCompact: "Kompakt",
         menuBarLabelStyleClassic: "Klasik",

--- a/Sources/Vorssaint/UI/MenuBarMetricsPreview.swift
+++ b/Sources/Vorssaint/UI/MenuBarMetricsPreview.swift
@@ -18,6 +18,7 @@ struct MenuBarMetricsPreview: View {
     @AppStorage(DefaultsKey.menuBarDiskUsage) private var diskUsage = false
     @AppStorage(DefaultsKey.menuBarDiskActivity) private var diskActivity = false
     @AppStorage(DefaultsKey.menuBarBattery) private var battery = false
+    @AppStorage(DefaultsKey.menuBarBatteryHideIcon) private var batteryHideIcon = false
     @AppStorage(DefaultsKey.menuBarBatteryTime) private var batteryTime = false
     @AppStorage(DefaultsKey.menuBarPeripheralBattery) private var peripheralBattery = false
     @AppStorage(DefaultsKey.menuBarPower) private var power = false
@@ -97,6 +98,7 @@ struct MenuBarMetricsPreview: View {
         let _ = diskUsage
         let _ = diskActivity
         let _ = battery
+        let _ = batteryHideIcon
         let _ = batteryTime
         let _ = peripheralBattery
         let _ = power
@@ -164,11 +166,13 @@ struct MenuBarMetricsPreview: View {
             .frame(width: MenuBarRenderer.rateBlockWidth(style: style),
                    height: style == .readable ? 22 : 20,
                    alignment: .center)
-        case let .batteryBlock(percent, isCharging, style):
-            HStack(spacing: style == .readable ? 5 : 4) {
-                Image(systemName: MenuBarRenderer.batterySymbol(for: percent, isCharging: isCharging))
-                    .font(.system(size: style == .readable ? 17 : 15.5, weight: .regular))
-                Text("\(max(0, min(100, percent)))%")
+        case let .batteryBlock(percent, isCharging, style, hideIcon):
+            HStack(spacing: hideIcon ? 0 : (style == .readable ? 5 : 4)) {
+                if !hideIcon {
+                    Image(systemName: MenuBarRenderer.batterySymbol(for: percent, isCharging: isCharging))
+                        .font(.system(size: style == .readable ? 17 : 15.5, weight: .regular))
+                }
+                Text(MenuBarBatteryPresentation.percentText(percent: percent))
                     .font(.system(size: style == .readable ? 13 : 12,
                                   weight: .semibold,
                                   design: .monospaced))

--- a/Sources/Vorssaint/UI/Settings/MonitorSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/MonitorSettings.swift
@@ -302,6 +302,10 @@ private struct MenuBarMetricOrderEditor: View {
                         MemoryMenuBarOrderOption()
                     }
 
+                    if metric == .battery {
+                        BatteryMenuBarOrderOption()
+                    }
+
                     if metric == .network {
                         NetworkMenuBarOrderOption()
                     }
@@ -380,6 +384,18 @@ private struct MemoryMenuBarOrderOption: View {
                 .onAppear {
                     memoryStyle = Defaults.sanitizedMenuBarMemoryStyle(memoryStyle)
                 }
+        }
+    }
+}
+
+private struct BatteryMenuBarOrderOption: View {
+    @ObservedObject private var l10n = L10n.shared
+    @AppStorage(DefaultsKey.menuBarBattery) private var menuBarBattery = false
+    @AppStorage(DefaultsKey.menuBarBatteryHideIcon) private var hideIcon = false
+
+    var body: some View {
+        if menuBarBattery, PowerSampler.hasInternalBattery {
+            MetricRowOptionToggle(label: l10n.s.menuBarBatteryHideIconToggle, isOn: $hideIcon)
         }
     }
 }

--- a/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
@@ -100,7 +100,8 @@ enum SettingsDirectory {
                                                            FeatureStrings.bluetoothSleep(language).enable]),
                                        ]),
                 SettingsDirectoryItem(page: .monitor, title: s.tabMonitor, icon: "chart.line.uptrend.xyaxis",
-                                       keywords: [s.menuBarSpacingLabel, s.menuBarHideIconToggle],
+                                       keywords: [s.menuBarSpacingLabel, s.menuBarHideIconToggle,
+                                                  s.menuBarBatteryHideIconToggle],
                                        featureKeywords: [
                                         (.monitorMemory, [s.monitorMemoryPressureDot]),
                                         (.fanControl, [FeatureStrings.fanControl(language).menuBarTitle]),

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -3744,6 +3744,26 @@ struct MetricsTests {
                "a screen too short for the panel still shows its top")
         expect(registeredDefaults[DefaultsKey.menuBarHideIconWithMetrics] as? Bool == false,
                "the menu bar icon stays visible by default")
+        expect(registeredDefaults[DefaultsKey.menuBarBatteryHideIcon] as? Bool == false,
+               "menu bar battery keeps its icon by default")
+        expect(MenuBarBatteryPresentation.resolve(hideIcon: false) == .iconAndPercent,
+               "battery presentation keeps the glyph when hide-icon is off")
+        expect(MenuBarBatteryPresentation.resolve(hideIcon: true) == .percentOnly,
+               "battery presentation drops the glyph when hide-icon is on")
+        expect(MenuBarBatteryPresentation.resolve(hideIcon: false).showsIcon
+                && !MenuBarBatteryPresentation.resolve(hideIcon: true).showsIcon,
+               "showsIcon mirrors the resolved presentation")
+        expect(MenuBarBatteryPresentation.percentText(percent: 7) == "7%"
+                && MenuBarBatteryPresentation.percentText(percent: 100) == "100%"
+                && MenuBarBatteryPresentation.percentText(percent: -3) == "0%"
+                && MenuBarBatteryPresentation.percentText(percent: 140) == "100%",
+               "battery percent text clamps to 0...100")
+        expect(MenuBarBatteryPresentation.resolve(hideIcon: false).denseBodyText(percent: 85) == "BAT 85%"
+                && MenuBarBatteryPresentation.resolve(hideIcon: true).denseBodyText(percent: 85) == "85%",
+               "dense body keeps the BAT label with the icon and drops it for percent-only")
+        expect(MenuBarBatteryPresentation.resolve(hideIcon: false).denseWidthUnits == 11
+                && MenuBarBatteryPresentation.resolve(hideIcon: true).denseWidthUnits < 11,
+               "percent-only battery reserves a narrower dense width")
         expect(MenuBarSpacingSupport.shouldHideStatusIcon(optionEnabled: true, separateMetrics: false,
                                                           metricsEnabled: true, renderedTitleLength: 12,
                                                           mustShowForSignal: false),

--- a/build.sh
+++ b/build.sh
@@ -333,6 +333,7 @@ if (( TEST )); then
         Sources/Vorssaint/UI/Settings/SettingsSearchSupport.swift \
         Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift \
         Sources/Vorssaint/App/MenuBarSpacingSupport.swift \
+        Sources/Vorssaint/App/MenuBarBatteryPresentation.swift \
         Sources/Vorssaint/App/StatusItemAnchorSupport.swift \
         Sources/Vorssaint/Services/DockClick/DockClickSupport.swift \
         Sources/Vorssaint/Services/Finder/CutPasteProgressSupport.swift \


### PR DESCRIPTION
## Summary
- Adds a Monitor setting under the Battery metric to show charge as percent text only (no battery glyph) via `menuBarBatteryHideIcon` (default off).
- Covers both the readable `batteryBlock` path and dense `MetricItem` path; charging stays less visible without the bolt icon by design.
- Unit-tests `MenuBarBatteryPresentation` for resolve / width / dense body choices.

## Out of scope
Part 2 of #1316 (Low Power Mode button in the battery menu) is **not** included in this PR.

## Test plan
- [x] `./build.sh --test` (10560 checks)
- [ ] Enable Battery in Monitor → menu bar metrics; confirm icon + percent by default
- [ ] Turn on **Percent only** under Battery; confirm menu bar and settings preview show `NN%` without the battery SF Symbol
- [ ] Toggle charging (plug/unplug) with percent-only on; confirm percent still updates

Refs #1316