### PR TITLE
fix(focus-follows-mouse): hit test the application under the pointer, never the whole system

### DIFF
--- a/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
+++ b/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift
@@ -8,9 +8,6 @@ import CoreGraphics
 final class FocusFollowsMouseService {
     static let shared = FocusFollowsMouseService()
 
-    /// No cap on this one: on the system-wide element a timeout is the default
-    /// for every question this process asks, whoever asks it (#938).
-    private let systemElement = AXUIElementCreateSystemWide()
     private let queryQueue = DispatchQueue(label: "com.vorssaint.focus-follows-mouse")
     private var timer: Timer?
     private var mouseMonitor: Any?
@@ -129,8 +126,21 @@ final class FocusFollowsMouseService {
                   .focusFollowsMouse, at: evaluation.point)
         else { return }
 
+        // The window server's own answer to "what would a click here hit",
+        // which the on-screen window list cannot express: it honours other
+        // applications' click-through windows and the transparent parts of
+        // shaped ones. It is AppKit, so it is asked here on the main thread.
+        // The evaluation point is CoreGraphics (top-left origin) and this
+        // wants Cocoa global coordinates, flipped against the primary screen
+        // the way ``AssistiveKeyboard/ownsCocoaPoint(_:)`` flips them back.
+        let cocoaPoint = NSPoint(x: evaluation.point.x,
+                                 y: (NSScreen.screens.first?.frame.maxY ?? 0) - evaluation.point.y)
+        let hitWindowNumber = NSWindow.windowNumber(at: cocoaPoint, belowWindowWithWindowNumber: 0)
         queryQueue.async { [weak self] in
-            guard let self, let target = self.target(at: evaluation.point) else { return }
+            guard let self,
+                  let target = self.target(at: evaluation.point,
+                                           hitWindowNumber: hitWindowNumber)
+            else { return }
             DispatchQueue.main.async { [weak self] in
                 guard let self, self.isRunning, self.nothingIsHeldDown,
                       self.state.isCurrent(evaluation),
@@ -150,9 +160,30 @@ final class FocusFollowsMouseService {
         }
     }
 
-    private func target(at point: CGPoint) -> Target? {
+    private func target(at point: CGPoint, hitWindowNumber: Int) -> Target? {
+        // A system-wide hit test is served inside this process whenever the
+        // pointer rests on one of its own windows, and that re-entry is the
+        // deadlock (#1420). Only the application owning the window a click
+        // would hit is asked, so this process never is. Turning the number
+        // into its owner is a window server read: no main thread, no
+        // Accessibility lock, so it belongs on this queue. The process check
+        // further down stays as the invariant it now documents.
+        //
+        // The number is clamped because `CGWindowID` is unsigned; 0, which is
+        // what the click target reads as over no window, describes nothing.
+        let hitWindow = CGWindowListCopyWindowInfo(
+            [.optionIncludingWindow], CGWindowID(max(hitWindowNumber, 0))) as? [[String: Any]] ?? []
+        guard let ownerProcessID = FocusFollowsMouseSupport.hitTestOwner(
+            of: hitWindow,
+            ownProcessID: ProcessInfo.processInfo.processIdentifier)
+        else { return nil }
+
+        // No cap here: the application element inherits the wait this process
+        // installs for every element it asks (#938), as the system-wide one
+        // this replaced did.
+        let applicationElement = AXUIElementCreateApplication(ownerProcessID)
         var rawElement: AXUIElement?
-        guard AXUIElementCopyElementAtPosition(systemElement, Float(point.x), Float(point.y), &rawElement) == .success,
+        guard AXUIElementCopyElementAtPosition(applicationElement, Float(point.x), Float(point.y), &rawElement) == .success,
               let rawElement
         else { return nil }
         AXUIElementSetMessagingTimeout(rawElement, 0.25)

--- a/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseSupport.swift
+++ b/Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseSupport.swift
@@ -8,6 +8,23 @@ enum FocusFollowsMouseSupport {
     static let defaultDelayMilliseconds = 250
     static let delayRange = 100...1_000
 
+    /// The process to put the Accessibility hit test to, read from the window
+    /// server's description of the window a click at that point would land
+    /// on. Asking one application instead of the system keeps this process
+    /// out of the answer, and a hit test that lands in this process is what
+    /// deadlocks it against its own main thread (#1420).
+    ///
+    /// Nil for one of this app's own windows, which focuses nothing, the same
+    /// answer the process check after the hit test already produced; nil too
+    /// for an empty list, which is how a point over no window is described.
+    static func hitTestOwner(of descriptions: [[String: Any]],
+                             ownProcessID: pid_t) -> pid_t? {
+        guard let pid = (descriptions.first?[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+              pid != ownProcessID
+        else { return nil }
+        return pid
+    }
+
     static func sanitizedDelay(_ milliseconds: Int) -> Int {
         min(max(milliseconds, delayRange.lowerBound), delayRange.upperBound)
     }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1537,6 +1537,28 @@ struct MetricsTests {
                 targetWindowID: 42, focusedWindowID: focusedWindowID, targetAppIsFrontmost: false),
                    "hover can activate a background app regardless of its last focused window")
         }
+        // The window server names the window a click would hit; all that is
+        // left to decide is which process to put the question to, and that
+        // this app is never it.
+        func focusHitDescription(pid: Int32) -> [String: Any] {
+            [kCGWindowOwnerPID as String: NSNumber(value: pid),
+             kCGWindowNumber as String: NSNumber(value: 11)]
+        }
+        let focusOwnProcessID: pid_t = 9
+        expect(FocusFollowsMouseSupport.hitTestOwner(
+            of: [focusHitDescription(pid: 5)], ownProcessID: focusOwnProcessID) == 5,
+               "focus follows mouse asks the application owning the window a click would hit")
+        expect(FocusFollowsMouseSupport.hitTestOwner(
+            of: [focusHitDescription(pid: focusOwnProcessID)],
+            ownProcessID: focusOwnProcessID) == nil,
+               "focus follows mouse asks no application when the click would land on its own window")
+        expect(FocusFollowsMouseSupport.hitTestOwner(
+            of: [], ownProcessID: focusOwnProcessID) == nil,
+               "focus follows mouse asks no application when a click would hit no window")
+        expect(FocusFollowsMouseSupport.hitTestOwner(
+            of: [[kCGWindowNumber as String: NSNumber(value: 11)]],
+            ownProcessID: focusOwnProcessID) == nil,
+               "focus follows mouse asks no application for a window with no owner")
         var focusFollowsMouseState = FocusFollowsMouseState()
         expect(!focusFollowsMouseState.hasPendingEvaluation,
                "focus follows mouse starts without work to poll")
@@ -1576,6 +1598,66 @@ struct MetricsTests {
         let focusFollowsMouseServiceSource = (try? String(
             contentsOfFile: "Sources/Vorssaint/Services/FocusFollowsMouse/FocusFollowsMouseService.swift",
             encoding: .utf8)) ?? ""
+        let focusFollowsMouseServiceCode = focusFollowsMouseServiceSource
+            .components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        let focusOwnerBinding = focusFollowsMouseServiceCode
+            .components(separatedBy: "\n")
+            .first { $0.contains("= FocusFollowsMouseSupport.hitTestOwner(") }
+            .flatMap {
+                $0.components(separatedBy: "= FocusFollowsMouseSupport.hitTestOwner(")[0]
+                    .split(separator: " ").last.map(String.init)
+            }
+        expect(focusOwnerBinding.map {
+            focusFollowsMouseServiceCode.contains("AXUIElementCreateApplication(\($0))")
+        } ?? false,
+               "focus follows mouse hit tests the application the window server named")
+        expect(!focusFollowsMouseServiceCode.contains("AXUIElementCreateSystemWide"),
+               "focus follows mouse never hit tests the whole system")
+        let focusApplicationElement = focusFollowsMouseServiceCode
+            .components(separatedBy: "\n")
+            .first { $0.contains("= AXUIElementCreateApplication(") }
+            .flatMap {
+                $0.components(separatedBy: "= AXUIElementCreateApplication(")[0]
+                    .split(separator: " ").last.map(String.init)
+            }
+        expect(focusApplicationElement.map {
+            !focusFollowsMouseServiceCode.contains("AXUIElementSetMessagingTimeout(\($0)")
+        } ?? false,
+               "focus follows mouse lets the application element keep the wait this process installs")
+        expect(focusApplicationElement.map {
+            focusFollowsMouseServiceCode.contains("AXUIElementCopyElementAtPosition(\($0),")
+        } ?? false,
+               "focus follows mouse puts the position question to that application's element")
+        let focusHitNumberAt = focusFollowsMouseServiceCode.range(
+            of: "NSWindow.windowNumber(at:")?.lowerBound
+        expect(focusHitNumberAt.map { number in
+            focusFollowsMouseServiceCode.range(of: "queryQueue.async")
+                .map { number < $0.lowerBound } ?? false
+        } ?? false,
+               "focus follows mouse reads the click target on the main thread before querying")
+        let focusHitNumberName = focusFollowsMouseServiceCode
+            .components(separatedBy: "\n")
+            .first { $0.contains("= NSWindow.windowNumber(at:") }
+            .flatMap {
+                $0.components(separatedBy: "= NSWindow.windowNumber(at:")[0]
+                    .split(separator: " ").last.map(String.init)
+            }
+        expect(focusHitNumberName.map {
+            focusFollowsMouseServiceCode.contains("hitWindowNumber: \($0)")
+        } ?? false,
+               "focus follows mouse hands the query the click target it read")
+        let focusWindowInfoArguments = focusFollowsMouseServiceCode
+            .range(of: "CGWindowListCopyWindowInfo(")
+            .flatMap { call in
+                focusFollowsMouseServiceCode[call.upperBound...].range(of: ") as?")
+                    .map { String(focusFollowsMouseServiceCode[call.upperBound..<$0.lowerBound]) }
+            }
+        expect(focusWindowInfoArguments.map {
+            $0.components(separatedBy: ",").dropFirst().joined().contains("hitWindowNumber")
+        } ?? false,
+               "focus follows mouse describes the window the click target named")
         expect(focusFollowsMouseServiceSource.contains(".leftMouseDragged")
                 && focusFollowsMouseServiceSource.contains(".rightMouseDragged")
                 && focusFollowsMouseServiceSource.contains(".otherMouseDragged")


### PR DESCRIPTION
Refs #1420 — the lock inversion in the report: `FocusFollowsMouseService.target(at:)` ran the system-wide Accessibility hit test on its own queue, and when the pointer rested on one of Vorssaint's own SwiftUI windows HIServices served that hit test in-process on the calling thread, which then waited for the main thread while the main thread waited on the HIServices lock the query thread held. The existing self-PID guard ran only after the hit test, too late.

The hit test is no longer system-wide, so this process can never be the one it is served in. The window a click would hit is read first, on the main thread where the settle timer already runs, from `NSWindow.windowNumber(at:belowWindowWithWindowNumber:)` — the window server's own hit target, which honours other applications' click-through windows and the transparent parts of shaped ones, things the on-screen window list cannot express — with the CoreGraphics evaluation point flipped to Cocoa against the primary screen the way `AssistiveKeyboard.ownsCocoaPoint` flips it back. The number goes to the query queue, where its owner is read from `CGWindowListCopyWindowInfo([.optionIncludingWindow], …)` (a window server read: no main thread, no Accessibility lock) and the question is put to `AXUIElementCreateApplication(pid)`, which walks only that application's windows. When the click target is one of ours the query ends with no target, today's outcome via the PID guard, so hovering our own Settings window still does not activate the app behind it; over no window (number 0) nothing is focused. Nothing waits on the main thread from the query queue, and the one stale read that remains is benign by construction: a window that moves between the two reads costs one hover evaluation asking the wrong foreign application, which answers from its own windows and fails the existing role, window-id and PID checks — it can never aim the hit test at this process. The application element carries no timeout of its own, so it inherits the process-wide 0.35 s the system-wide element inherited (#938); the 0.25 s caps below it and the post-hoc PID guard are unchanged, the latter now documenting an invariant rather than enforcing one.

That the owner lookup resolves at all was measured on live window numbers rather than assumed: `CGWindowListCreateDescriptionFromArray` handed an `NSArray` of `NSNumber` returns zero descriptions for every window (it reads the array's element slots as ids), which would have made this a silent no-op with every check green; `.optionIncludingWindow` returns the right owner for each, and returns nothing for id 0 or an unknown id. Treating `NSWindow.windowNumber` as the `CGWindowID` and asking `.optionIncludingWindow` on its own are both how this repo already does it (`ShelfService`, `ScreenshotCaptureEngine`, `WindowEnumerator`, the screenshot controllers).

One narrowing worth naming: the click target is read on main and the owner resolved on the queue a moment later, so a window that closes in between yields nothing for that one evaluation and the window it uncovered is not considered until the pointer moves again; the old system-wide call, made at query time, would have seen the uncovered window. A pointer resting on a window that vanishes under it is the only case, and it fails safe.

The decision is pure — `FocusFollowsMouseSupport.hitTestOwner(of:ownProcessID:)` — and behaviour-checked: a foreign owner is returned, our own pid gives nil, an empty description list gives nil, a description without an owner gives nil. Four comment-stripped source-shape checks pin the dataflow rather than presence: the identifier bound from the helper is the one passed to `AXUIElementCreateApplication`, `AXUIElementCreateSystemWide` no longer appears in the file, no messaging timeout is set on the application element's identifier, and the click-target read precedes the query dispatch. Each goes red under its own mutation: helper forced to `nil` or to a constant pid (four checks between them), the application element built from this process's pid, the system-wide element restored, the timeout re-added, and the click-target read moved inside the queue.

Verification: Mac17,9 (M5 Pro), macOS 26.6.2 (25G83), 3024×1964 built-in display, local Developer build. `./build.sh` warning-free; `./build.sh --test` → `TESTS OK` (one run tripped the unrelated wall-clock check `a child inheriting stdout cannot leave the subprocess reader blocked` under load; the re-run was clean); `./build/Vorssaint --selftest` → `SELFTEST OK`, after rebasing onto `00df68b`. Not tested: the reporter's live freeze on macOS 15.2 (no deterministic trigger, not reproduced here); the new path on macOS 15.2 itself; what `windowNumber(at:)` answers over the bare desktop and the menu bar, and hands-on hovering with the dev build — this Mac's screen stayed locked for the whole session, so every probe point returned the lock shield and the evidence is the gates, the unit checks and the window-server measurements above, not a hover I watched. If AppKit reports no window over the bare desktop, hovering the desktop would stop bringing Finder forward; one probe on an unlocked Mac settles it and I will post the result here.
