### PR TITLE
feat(switcher): pause hotkeys in frontmost apps

### DIFF
--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -71,6 +71,7 @@ enum DefaultsKey {
     static let mouseButtonExceptions = "mouseButtonExceptions"
     static let middleClickExceptions = "middleClickExceptions"
     static let superKeyExceptions = "superKeyExceptions"
+    static let switcherExceptions = "switcherExceptions"
     static let switcherEnabled = "switcherEnabled"
     static let switcherTakeOverSystemShortcuts = "switcherTakeOverSystemShortcuts"
     // Machine state, never exported: the system shortcuts this process owns,
@@ -887,6 +888,7 @@ enum Defaults {
         DefaultsKey.mouseButtonExceptions: [String](),
         DefaultsKey.middleClickExceptions: [String](),
         DefaultsKey.superKeyExceptions: [String](),
+        DefaultsKey.switcherExceptions: [String](),
         DefaultsKey.switcherEnabled: true,
         DefaultsKey.switcherTakeOverSystemShortcuts: false,
         DefaultsKey.switcherShortcut: "command:48",

--- a/Sources/Vorssaint/Core/MouseExceptionStrings.swift
+++ b/Sources/Vorssaint/Core/MouseExceptionStrings.swift
@@ -14,6 +14,7 @@ struct MouseExceptionStrings {
     let captionMiddleClick: String
     let captionFocusFollowsMouse: String
     let captionSuperKey: String
+    let captionSwitcher: String
     let pausedSuperKey: String
 
     func caption(for scope: MouseExceptionScope) -> String {
@@ -25,6 +26,7 @@ struct MouseExceptionStrings {
         case .buttonShortcuts: return captionButtonShortcuts
         case .middleClick: return captionMiddleClick
         case .superKey: return captionSuperKey
+        case .switcher: return captionSwitcher
         }
     }
 }
@@ -61,6 +63,7 @@ extension MouseExceptionStrings {
         captionMiddleClick: "A three finger click stays a normal click in these apps.",
         captionFocusFollowsMouse: "Hovering does not change focus or raise a window in these apps.",
         captionSuperKey: "While any of these apps is open, even in the background, Super Key pauses and the chosen key works normally.",
+        captionSwitcher: "While any of these apps is in front, App Switcher leaves its shortcuts alone so they reach that app instead.",
         pausedSuperKey: "Paused while a selected app is open"
     )
 
@@ -75,6 +78,7 @@ extension MouseExceptionStrings {
         captionMiddleClick: "Nestes apps o clique de três dedos continua um clique normal.",
         captionFocusFollowsMouse: "Nestes apps passar o mouse não muda o foco nem traz a janela para frente.",
         captionSuperKey: "Enquanto algum destes apps estiver aberto, mesmo em segundo plano, a Super Key pausa e a tecla escolhida funciona normalmente.",
+        captionSwitcher: "Enquanto algum destes apps estiver na frente, o App Switcher deixa os atalhos em paz para que cheguem a esse app.",
         pausedSuperKey: "Pausada enquanto um app selecionado está aberto"
     )
 
@@ -89,6 +93,7 @@ extension MouseExceptionStrings {
         captionMiddleClick: "Bu uygulamalarda üç parmak tıklaması normal tıklama olarak kalır.",
         captionFocusFollowsMouse: "Bu uygulamalarda imleci bekletmek odağı değiştirmez veya pencereyi öne getirmez.",
         captionSuperKey: "Bu uygulamalardan biri arka planda bile açıkken Super Key duraklatılır ve seçilen tuş normal çalışır.",
+        captionSwitcher: "Bu uygulamalardan biri öndeyken App Switcher kısayollarına dokunmaz; kısayollar o uygulamaya ulaşır.",
         pausedSuperKey: "Seçili bir uygulama açıkken duraklatıldı"
     )
 
@@ -103,6 +108,7 @@ extension MouseExceptionStrings {
         captionMiddleClick: "В этих приложениях щелчок тремя пальцами остаётся обычным щелчком.",
         captionFocusFollowsMouse: "В этих приложениях наведение не меняет фокус и не выводит окно на передний план.",
         captionSuperKey: "Пока любое из этих приложений открыто, даже в фоне, Super Key приостановлена, а выбранная клавиша работает как обычно.",
+        captionSwitcher: "Пока любое из этих приложений на переднем плане, App Switcher не перехватывает свои сочетания - они доходят до этого приложения.",
         pausedSuperKey: "Приостановлено, пока открыто выбранное приложение"
     )
 
@@ -117,6 +123,7 @@ extension MouseExceptionStrings {
         captionMiddleClick: "En estas apps el clic con tres dedos sigue siendo un clic normal.",
         captionFocusFollowsMouse: "En estas apps pasar el puntero no cambia el foco ni trae la ventana al frente.",
         captionSuperKey: "Mientras alguna de estas apps esté abierta, incluso en segundo plano, Super Key se pausa y la tecla elegida funciona normalmente.",
+        captionSwitcher: "Mientras alguna de estas apps esté al frente, App Switcher deja sus atajos en paz para que lleguen a esa app.",
         pausedSuperKey: "En pausa mientras una app seleccionada esté abierta"
     )
 
@@ -131,6 +138,7 @@ extension MouseExceptionStrings {
         captionMiddleClick: "In diesen Apps bleibt ein Klick mit drei Fingern ein normaler Klick.",
         captionFocusFollowsMouse: "In diesen Apps ändert ein Verweilen des Zeigers weder den Fokus noch die Fensterreihenfolge.",
         captionSuperKey: "Solange eine dieser Apps geöffnet ist, auch im Hintergrund, pausiert Super Key und die gewählte Taste funktioniert normal.",
+        captionSwitcher: "Solange eine dieser Apps im Vordergrund ist, lässt App Switcher seine Tastenkürzel durch, damit sie diese App erreichen.",
         pausedSuperKey: "Pausiert, solange eine ausgewählte App geöffnet ist"
     )
 
@@ -145,6 +153,7 @@ extension MouseExceptionStrings {
         captionMiddleClick: "Dans ces apps un clic à trois doigts reste un clic normal.",
         captionFocusFollowsMouse: "Dans ces apps le survol ne change pas le focus et ne place pas la fenêtre au premier plan.",
         captionSuperKey: "Tant qu’une de ces apps est ouverte, même en arrière-plan, Super Key est en pause et la touche choisie fonctionne normalement.",
+        captionSwitcher: "Tant qu’une de ces apps est au premier plan, App Switcher laisse ses raccourcis passer pour qu’ils atteignent cette app.",
         pausedSuperKey: "En pause tant qu’une app sélectionnée est ouverte"
     )
 
@@ -159,6 +168,7 @@ extension MouseExceptionStrings {
         captionMiddleClick: "In queste app un clic con tre dita resta un clic normale.",
         captionFocusFollowsMouse: "In queste app il passaggio del puntatore non cambia il focus né porta avanti la finestra.",
         captionSuperKey: "Finché una di queste app è aperta, anche in background, Super Key è in pausa e il tasto scelto funziona normalmente.",
+        captionSwitcher: "Finché una di queste app è in primo piano, App Switcher lascia passare le scorciatoie affinché raggiungano quell’app.",
         pausedSuperKey: "In pausa mentre un’app selezionata è aperta"
     )
 
@@ -173,6 +183,7 @@ extension MouseExceptionStrings {
         captionMiddleClick: "これらのAppでは3本指のクリックが普通のクリックのままです。",
         captionFocusFollowsMouse: "これらのAppではポインタを止めてもフォーカスやウインドウの前後関係は変わりません。",
         captionSuperKey: "これらのAppのいずれかが開いている間は、バックグラウンドでもSuper Keyが一時停止し、選択したキーは通常どおり動作します。",
+        captionSwitcher: "これらのAppが最前面の間は、App Switcherがショートカットをそのまま通し、そのAppに届きます。",
         pausedSuperKey: "選択したAppが開いている間は一時停止中"
     )
 
@@ -187,6 +198,7 @@ extension MouseExceptionStrings {
         captionMiddleClick: "이 앱들에서는 세 손가락 클릭이 보통 클릭으로 남습니다.",
         captionFocusFollowsMouse: "이 앱들에서는 포인터를 올려 두어도 포커스나 윈도우 순서가 바뀌지 않습니다.",
         captionSuperKey: "이 앱 중 하나라도 열려 있으면 백그라운드에서도 Super Key가 일시 정지되고 선택한 키가 정상적으로 작동합니다.",
+        captionSwitcher: "이 앱이 앞에 있을 때 App Switcher는 단축키를 그대로 두어 그 앱에 전달합니다.",
         pausedSuperKey: "선택한 앱이 열려 있는 동안 일시 정지됨"
     )
 
@@ -201,6 +213,7 @@ extension MouseExceptionStrings {
         captionMiddleClick: "在这些 App 里三指点按仍是普通点按。",
         captionFocusFollowsMouse: "在这些 App 里悬停不会改变焦点，也不会将窗口置于前方。",
         captionSuperKey: "这些 App 中任意一个打开时，即使在后台，Super Key 也会暂停，所选按键恢复正常功能。",
+        captionSwitcher: "这些 App 位于前台时，App Switcher 不会拦截快捷键，让它们直接送达该 App。",
         pausedSuperKey: "所选 App 打开期间已暂停"
     )
 
@@ -215,6 +228,7 @@ extension MouseExceptionStrings {
         captionMiddleClick: "在這些 App 裡三指點按仍是普通點按。",
         captionFocusFollowsMouse: "在這些 App 裡停留指標不會改變焦點，也不會將視窗移到最前方。",
         captionSuperKey: "這些 App 中任一個開啟時，即使在背景執行，Super Key 也會暫停，所選按鍵恢復正常功能。",
+        captionSwitcher: "這些 App 位於前景時，App Switcher 不會攔截快捷鍵，讓它們直接送到該 App。",
         pausedSuperKey: "所選 App 開啟期間已暫停"
     )
 
@@ -229,6 +243,7 @@ extension MouseExceptionStrings {
         captionMiddleClick: "在這些 App 裡三指點按仍是普通點按。",
         captionFocusFollowsMouse: "在這些 App 裡停留指標不會改變焦點，也不會將視窗移到最前方。",
         captionSuperKey: "這些 App 中任何一個開啟時，即使在背景執行，Super Key 也會暫停，所選按鍵恢復正常功能。",
+        captionSwitcher: "這些 App 位於前景時，App Switcher 不會攔截快捷鍵，讓它們直接送到該 App。",
         pausedSuperKey: "所選 App 開啟期間已暫停"
     )
 }

--- a/Sources/Vorssaint/Services/MouseExceptions/MouseAppExceptionSupport.swift
+++ b/Sources/Vorssaint/Services/MouseExceptions/MouseAppExceptionSupport.swift
@@ -4,8 +4,8 @@
 import CoreGraphics
 import Foundation
 
-/// The mouse and keyboard features that can be told to leave an app alone
-/// (issues #358, #741).
+/// The mouse, keyboard, and switcher features that can be told to leave an app
+/// alone (issues #358, #741, #1181).
 /// Each one keeps its OWN list, right under its switch in Settings: excepting
 /// an app from the wheel's glide must not also silence the side buttons there.
 enum MouseExceptionScope: String, CaseIterable {
@@ -16,6 +16,7 @@ enum MouseExceptionScope: String, CaseIterable {
     case buttonShortcuts
     case middleClick
     case superKey
+    case switcher
 
     var defaultsKey: String {
         switch self {
@@ -26,6 +27,7 @@ enum MouseExceptionScope: String, CaseIterable {
         case .buttonShortcuts: return DefaultsKey.mouseButtonExceptions
         case .middleClick: return DefaultsKey.middleClickExceptions
         case .superKey: return DefaultsKey.superKeyExceptions
+        case .switcher: return DefaultsKey.switcherExceptions
         }
     }
 
@@ -40,6 +42,7 @@ enum MouseExceptionScope: String, CaseIterable {
         case .buttonShortcuts: return .mouseButtonShortcuts
         case .middleClick: return .middleClick
         case .superKey: return .superKey
+        case .switcher: return .switcher
         }
     }
 }

--- a/Sources/Vorssaint/Services/MouseExceptions/MouseAppExceptions.swift
+++ b/Sources/Vorssaint/Services/MouseExceptions/MouseAppExceptions.swift
@@ -145,6 +145,16 @@ final class MouseAppExceptions: ObservableObject {
         return MouseAppExceptionSupport.isExcepted(frontmost, exceptions: exceptions)
     }
 
+    /// True when the app in front is on this feature's list. App Switcher asks
+    /// here before claiming ⌘Tab so a remote desktop session can keep it
+    /// (issue #1181).
+    func excludesFrontmost(_ scope: MouseExceptionScope) -> Bool {
+        let (exceptions, _) = lookup(scope)
+        guard !exceptions.isEmpty else { return false }
+        let frontmost = Self.onMain { Self.identity(for: NSWorkspace.shared.frontmostApplication) }
+        return MouseAppExceptionSupport.isExcepted(frontmost, exceptions: exceptions)
+    }
+
     /// Services that intercept wheel events call this with their tap lifecycle.
     /// With every such feature off, unavailable or carrying an empty list, no
     /// workspace observer or source cache remains alive.

--- a/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
+++ b/Sources/Vorssaint/Services/Switcher/AppSwitcher.swift
@@ -590,6 +590,13 @@ final class AppSwitcher: ObservableObject {
             case .routeShortcut:
                 guard matchesShortcut else { return Unmanaged.passUnretained(event) }
 
+                // Hand the shortcut to the frontmost app when it is on the
+                // switcher exception list (issue #1181). An already-open
+                // session keeps routing above; only a fresh claim is skipped.
+                if MouseAppExceptions.shared.excludesFrontmost(.switcher) {
+                    return Unmanaged.passUnretained(event)
+                }
+
                 let requestedShortcut = matchesWindows ? windowShortcut : shortcut
                 let requestedScope: SwitcherSessionScope = matchesWindows ? .frontmostApp : .allApps
                 let reversed: Bool

--- a/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
+++ b/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
@@ -436,6 +436,13 @@ enum SwitcherSupport {
         return excludedBundleIdentifiers.contains(frontmostBundleIdentifier)
     }
 
+    /// True when App Switcher should leave its hotkey alone so the frontmost
+    /// app receives it (issue #1181). Separate from thumbnail pause capture.
+    static func shouldPassHotkeyToFrontmost(frontmostBundleID: String?,
+                                            exceptions: Set<String>) -> Bool {
+        MouseAppExceptionSupport.isExcepted(frontmostBundleID, exceptions: exceptions)
+    }
+
     static func needsScreenRecording(switcherEnabled: Bool,
                                      simpleMode: Bool,
                                      dockPreviewEnabled: Bool) -> Bool {

--- a/Sources/Vorssaint/UI/Settings/SettingsView.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsView.swift
@@ -1278,6 +1278,9 @@ struct SwitcherSettings: View {
                                 GlobalShortcutRole.switcher.savedShortcut.displayString))
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                    if switcherEnabled {
+                        MouseExceptionsList(scope: .switcher)
+                    }
 
                     HStack {
                         Text(l10n.s.switcherAppearanceDelay)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -2433,6 +2433,14 @@ struct MetricsTests {
         expect(scopeAssign != nil && startLayout != nil
                && scopeAssign!.lowerBound < startLayout!.lowerBound,
                "the App Switcher session scope is assigned before the session-start layout pass")
+        expect(switcherSource.contains("excludesFrontmost(.switcher)")
+               && switcherSource.contains("Unmanaged.passUnretained(event)"),
+               "App Switcher passes its hotkey through while a listed frontmost app holds focus")
+        let switcherSettingsSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/UI/Settings/SettingsView.swift",
+            encoding: .utf8)) ?? ""
+        expect(switcherSettingsSource.contains("MouseExceptionsList(scope: .switcher)"),
+               "Switcher settings expose the frontmost-app hotkey exception list")
         expect(!SwitcherSupport.usesAppGroupsForMainShortcut(iconRowLayout: true,
                                                               windowRow: true)
                && SwitcherSupport.usesAppGroupsForMainShortcut(iconRowLayout: true,
@@ -2475,6 +2483,20 @@ struct MetricsTests {
                    frontmostBundleIdentifier: nil,
                    excludedBundleIdentifiers: ["com.example.focused"]),
                "window preview capture continues away from chosen apps or without a foreground app")
+        expect(SwitcherSupport.shouldPassHotkeyToFrontmost(
+            frontmostBundleID: "com.example.remote",
+            exceptions: ["com.example.remote"]),
+               "App Switcher passes its hotkey through while a chosen app is in front")
+        expect(!SwitcherSupport.shouldPassHotkeyToFrontmost(
+            frontmostBundleID: "com.example.other",
+            exceptions: ["com.example.remote"])
+               && !SwitcherSupport.shouldPassHotkeyToFrontmost(
+                   frontmostBundleID: nil,
+                   exceptions: ["com.example.remote"])
+               && !SwitcherSupport.shouldPassHotkeyToFrontmost(
+                   frontmostBundleID: "com.example.remote",
+                   exceptions: []),
+               "App Switcher keeps its hotkey away from chosen apps or with an empty list")
         expect(SpaceHopSupport.isParkedOnHiddenSpace(windowSpaces: [4], visibleSpaces: [3]),
                "a window whose only Space is not visible is parked on a hidden Space")
         expect(!SpaceHopSupport.isParkedOnHiddenSpace(windowSpaces: [3], visibleSpaces: [3]),
@@ -19968,10 +19990,13 @@ struct MetricsTests {
                 && MouseExceptionScope.navigation.feature == .mouseNavigation
                 && MouseExceptionScope.buttonShortcuts.feature == .mouseButtonShortcuts
                 && MouseExceptionScope.middleClick.feature == .middleClick
-                && MouseExceptionScope.superKey.feature == .superKey,
+                && MouseExceptionScope.superKey.feature == .superKey
+                && MouseExceptionScope.switcher.feature == .switcher,
                "each list knows the feature that owns it, so it hides with that feature")
-        expect(MouseExceptionScope.allCases.allSatisfy { $0.feature.group == .mouseKeyboard },
-               "every exception list belongs to a mouse-and-keyboard feature")
+        expect(MouseExceptionScope.allCases.filter { $0 != .switcher }
+                    .allSatisfy { $0.feature.group == .mouseKeyboard }
+                && MouseExceptionScope.switcher.feature.group == .windowsDock,
+               "mouse exception lists stay with mouse-and-keyboard features; switcher keeps its own")
         expect(Defaults.sanitizedBundleIdentifierList(["  com.example.a  ", "", "com.example.a", "com.example.b"])
                 == ["com.example.a", "com.example.b"],
                "the exception list drops blanks, spaces and repeats")


### PR DESCRIPTION
## Summary
- Add a separate App Switcher exception list (`MouseExceptionScope.switcher` / `switcherExceptions`) so listed frontmost apps receive ⌘Tab / Alt+Tab instead of Vorssaint claiming the shortcut.
- Wire `MouseExceptionsList(scope: .switcher)` into Switcher settings; pass-through uses `MouseAppExceptions.excludesFrontmost` + `SwitcherSupport.shouldPassHotkeyToFrontmost` before a session starts.
- Leaves Window thumbnails “Pause in these apps” unchanged.

Refs #1181

## Test plan
- [ ] Enable App Switcher, add a remote-desktop app to the new “Apps to leave alone” list under Switcher settings
- [ ] With that app frontmost, ⌘Tab / the configured switcher shortcut reaches the remote session (Vorssaint does not open)
- [ ] With any other app frontmost, the switcher still opens as before
- [ ] Mid-session switcher navigation still works after the panel is already open
- [ ] Thumbnail “Pause in these apps” still only affects preview capture