### PR TITLE
fix: restore A18 Pro CPU temperature readings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Summary
+Restores CPU temperature readings on A18 Pro.
+
+### Fixed
+- CPU temperature: restored readings on A18 Pro that disappeared after updating to 3.3.3.
+
 ## [3.3.3] - 2026-09-06
 
 ### Summary

--- a/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
+++ b/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
@@ -58,6 +58,9 @@ enum TemperatureSensorSelector {
 
     static func platform(brandString: String?) -> CPUTemperaturePlatform {
         let brand = brandString?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        // Preserve the established Tp/Te reading path for this supported chip
+        // until a verified per-core map is available.
+        if brand == "Apple A18 Pro" { return .generic }
         switch appleSiliconGeneration(in: brand) {
         case 1: return .appleM1Family
         case 2: return .appleM2Family

--- a/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
@@ -944,11 +944,9 @@ final class SystemMonitor: ObservableObject {
 
     private func cpuTemperature() -> Double? {
         guard smc != nil else { return nil }
-        // The core set decides the displayed value whenever it answers, so a
-        // normal tick reads only those keys; the remaining Tp/Te keys are
-        // swept exactly when they would have mattered before the split —
-        // unknown platforms (empty core set) or a tick with no plausible
-        // core reading.
+        // Mapped chips read only their verified core keys. The generic
+        // compatibility path reads the remaining Tp/Te keys when there is
+        // no mapped core set.
         var readings = temperatureReadings(of: preferredCPUKeys)
         if let value = TemperatureSensorSelector.displayedCPUTemperature(readings: readings,
                                                                          platform: cpuTemperaturePlatform) {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1787,8 +1787,48 @@ struct MetricsTests {
         expect(TemperatureSensorSelector.platform(brandString: "Apple M5") == .appleM5Family,
                "Apple M5 uses the mapped CPU core sensor set")
         expect(TemperatureSensorSelector.platform(brandString: "Apple M10") == .unmappedAppleSilicon
-               && TemperatureSensorSelector.platform(brandString: "Apple A18 Pro") == .unmappedAppleSilicon,
+               && TemperatureSensorSelector.platform(brandString: "Apple A19 Pro") == .unmappedAppleSilicon,
                "unmapped Apple Silicon never falls through to arbitrary CPU sensors")
+        let a18Platform = TemperatureSensorSelector.platform(brandString: "Apple A18 Pro")
+        expect(a18Platform == .generic,
+               "A18 Pro preserves the CPU temperature path available before 3.3.3")
+        expect(TemperatureSensorSelector.platform(brandString: "  Apple A18 Pro\n") == a18Platform,
+               "A18 Pro identification ignores surrounding whitespace")
+        expect(TemperatureSensorSelector.platform(brandString: "Apple A18 Pro Max") == .unmappedAppleSilicon,
+               "A18 Pro compatibility does not guess support for another chip")
+        expect(!TemperatureSensorSelector.hasCPUCoreSet(platform: a18Platform),
+               "A18 Pro discovery keeps its fallback readings without inventing a per-core map")
+        // A small hardware diagnostic sample, followed by synthetic failure cases.
+        let a18Sensors: [(key: String, value: Double)] = [
+            ("Te05", 66.3), ("Tp05", 66.6), ("Tp0t", 75.0),
+            ("Tg0D", 63.1), ("TB0T", 25.1),
+        ]
+        let a18CPUReadings = a18Sensors.filter {
+            TemperatureSensorSelector.isCPUTemperatureKey($0.key, platform: a18Platform)
+        }
+        expect(a18CPUReadings.map(\.key) == ["Te05", "Tp05", "Tp0t"],
+               "A18 Pro discovery retains both CPU families and excludes GPU and battery")
+        expectClose(TemperatureSensorSelector.displayedCPUTemperature(
+            readings: a18CPUReadings, platform: a18Platform
+        ) ?? -1, 75.0, "A18 Pro restores the previous hottest CPU-family reading")
+        for key in ["Te05", "Tp05", "Tp0t"] {
+            expectClose(TemperatureSensorSelector.displayedCPUTemperature(
+                readings: [(key, 66.3)], platform: a18Platform
+            ) ?? -1, 66.3, "A18 Pro keeps a readable CPU sensor when other sensors are absent: \(key)")
+        }
+        let a18InvalidReadings: [(key: String, value: Double)] = [
+            ("Tp00", 0), ("Tp01", 7), ("Te05", 125),
+            ("Te0S", .nan), ("Tp05", .infinity),
+        ]
+        expect(TemperatureSensorSelector.displayedCPUTemperature(
+            readings: a18InvalidReadings, platform: a18Platform
+        ) == nil, "A18 Pro rejects broken readings instead of fabricating a temperature")
+        expectClose(TemperatureSensorSelector.displayedCPUTemperature(
+            readings: a18InvalidReadings + [("Tp0t", 75)], platform: a18Platform
+        ) ?? -1, 75, "broken A18 Pro sensors do not suppress another valid reading")
+        expect(TemperatureSensorSelector.displayedCPUTemperature(
+            readings: [], platform: a18Platform
+        ) == nil, "A18 Pro remains unavailable when no CPU sensor answers")
         expect(TemperatureSensorSelector.platform(brandString: "Generic CPU") == .generic,
                "other processors keep the generic CPU sensor path")
         expect(TemperatureSensorSelector.isCPUTemperatureKey("Tf4E", platform: .appleM3Family)


### PR DESCRIPTION
## Summary
Updating from 3.3.2 to 3.3.3 hid CPU temperature on A18 Pro because the processor was classified as unmapped and all CPU temperature sensors were rejected. Restore the existing generic `Tp`/`Te` reading path for the exact `Apple A18 Pro` identifier, with regression coverage and an Unreleased note.

## Verification
- `./build.sh --test`: 10,648 checks passed, including A18 Pro discovery, missing sensors and invalid readings.
- 27,238 differential sensor-selection and cache cases matched 3.3.2; the low-level sensor reader is unchanged from that version.
- `./build.sh --dev --install`, installed `--selftest`, and strict signature verification passed on Apple M4 (Mac16,12), macOS 27.0 beta (26A5425a).

Physical A18 Pro execution has not been verified locally. The regression sample uses [public hardware readings](https://gist.github.com/Dreaminko/a14a0a1ae429982b388c1564e1a0ffd9); this restores the previous reading path without introducing an unverified per-core sensor map.
