### PR TITLE
fix(monitor): fall back to named HID temperatures on m1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,9 +97,12 @@ tests.
 
 ## Sensors on new chips
 
-Temperature mapping lives in `SystemMonitor.prepareSensorsIfNeeded()`. CPU keys
+Temperature mapping lives in `TemperatureSensorSelector`. SMC CPU keys usually
 look like `Tp…` and `Te…`, GPU is `Tg…`, and battery runs from `TB0T` to
-`TB2T`. If a new Apple Silicon generation renames the keys, run this
+`TB2T`. On M1, missing CPU or GPU readings fall back to named HID temperature
+sensors. The diagnostic includes these with type `HID`; unknown SMC keys stay
+auxiliary until their identity is established. If a new Apple Silicon generation
+renames the keys, run this
 
 ```sh
 ./build/Vorssaint --sensors

--- a/Sources/HIDEventSystem/include/HIDEventSystem.h
+++ b/Sources/HIDEventSystem/include/HIDEventSystem.h
@@ -2,3 +2,11 @@
 #include <IOKit/hid/IOHIDManager.h>
 #include <IOKit/hidsystem/IOHIDEventSystemClient.h>
 #include <IOKit/hidsystem/IOHIDServiceClient.h>
+
+// Temperature events are exported by IOKit but absent from the public SDK.
+typedef struct CF_BRIDGED_TYPE(id) __IOHIDEvent *IOHIDEventRef;
+IOHIDEventSystemClientRef IOHIDEventSystemClientCreate(CFAllocatorRef allocator) CF_RETURNS_RETAINED;
+void IOHIDEventSystemClientSetMatching(IOHIDEventSystemClientRef client, CFDictionaryRef match);
+IOHIDEventRef IOHIDServiceClientCopyEvent(IOHIDServiceClientRef service, int64_t type,
+                                        int32_t options, int64_t timeout) CF_RETURNS_RETAINED;
+double IOHIDEventGetFloatValue(IOHIDEventRef event, int32_t field);

--- a/Sources/Vorssaint/Services/FanControl/FanControlHardware.swift
+++ b/Sources/Vorssaint/Services/FanControl/FanControlHardware.swift
@@ -43,6 +43,7 @@ final class FanControlHardware {
     private var didDiscoverForceTestKey = false
     private var activeTargets: [Double] = []
     private var temperatureKeys: TemperatureKeys?
+    private let hidTemperatureSampler = HIDTemperatureSampler()
     private let temperaturePlatform = TemperatureSensorSelector.currentPlatform()
 
     init?() {
@@ -234,11 +235,14 @@ final class FanControlHardware {
     func readTemperatures() -> [FanControlTemperatureReading] {
         let keys = discoverTemperatureKeys()
         let cpuReadings = temperatureReadings(keys.cpu)
+        let gpuReadings = temperatureReadings(keys.gpu).map(\.value)
+        let smcReadings = FanControlPolicy.aggregatedTemperatures(
+            cpuReadings: cpuReadings, gpuReadings: gpuReadings, platform: temperaturePlatform)
+        if smcReadings.contains(where: { $0.source == .hottestCPU }),
+           smcReadings.contains(where: { $0.source == .hottestGPU }) { return smcReadings }
         return FanControlPolicy.aggregatedTemperatures(
-            cpuReadings: cpuReadings,
-            gpuReadings: temperatureReadings(keys.gpu).map(\.value),
-            platform: temperaturePlatform
-        )
+            cpuReadings: cpuReadings, gpuReadings: gpuReadings, platform: temperaturePlatform,
+            hidReadings: hidTemperatureSampler.readings(platform: temperaturePlatform))
     }
 
     // MARK: - Discovery

--- a/Sources/Vorssaint/Services/FanControl/FanControlSupport.swift
+++ b/Sources/Vorssaint/Services/FanControl/FanControlSupport.swift
@@ -330,7 +330,8 @@ enum FanControlPolicy {
     static func aggregatedTemperatures(
         cpuReadings: [(key: String, value: Double)],
         gpuReadings: [Double],
-        platform: CPUTemperaturePlatform
+        platform: CPUTemperaturePlatform,
+        hidReadings: [(key: String, value: Double)] = []
     ) -> [FanControlTemperatureReading] {
         let validCPU = cpuReadings.filter {
             $0.value >= TemperatureSensorSelector.minimumChipTemperature
@@ -339,7 +340,7 @@ enum FanControlPolicy {
         let preferredCPU = validCPU.filter {
             TemperatureSensorSelector.isCPUCoreKey($0.key, platform: platform)
         }
-        let cpu: [Double]
+        var cpu: [Double]
         if TemperatureSensorSelector.hasCPUCoreSet(platform: platform) {
             cpu = preferredCPU.map(\.value)
         } else if platform == .generic {
@@ -347,8 +348,14 @@ enum FanControlPolicy {
         } else {
             cpu = []
         }
-        let gpu = gpuReadings.filter {
+        if cpu.isEmpty {
+            cpu = TemperatureSensorSelector.hidReadings(hidReadings, cpu: true, platform: platform).map(\.value)
+        }
+        var gpu = gpuReadings.filter {
             $0 >= TemperatureSensorSelector.minimumChipTemperature && validTemperature($0)
+        }
+        if gpu.isEmpty {
+            gpu = TemperatureSensorSelector.hidReadings(hidReadings, cpu: false, platform: platform).map(\.value)
         }
         let soc = cpu + gpu
 

--- a/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
+++ b/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
@@ -130,6 +130,22 @@ enum TemperatureSensorSelector {
         return platform == .appleM3Family && key.hasPrefix("Tf")
     }
 
+    static func hidTemperature(readings: [(key: String, value: Double)],
+                               cpu: Bool, platform: CPUTemperaturePlatform) -> Double? {
+        hidReadings(readings, cpu: cpu, platform: platform).map(\.value).max()
+    }
+
+    static func hidReadings(_ readings: [(key: String, value: Double)],
+                            cpu: Bool, platform: CPUTemperaturePlatform) -> [(key: String, value: Double)] {
+        guard platform == .appleM1Family else { return [] }
+        return readings.filter {
+            let matches = cpu
+                ? ($0.key.hasPrefix("pACC MTR Temp") || $0.key.hasPrefix("eACC MTR Temp"))
+                : $0.key.hasPrefix("GPU MTR Temp")
+            return matches && isPlausibleTemperature($0.value)
+        }
+    }
+
     static func stabilizedTemperature(_ reading: Double?,
                                       cache: inout CachedSensorReading?,
                                       now: TimeInterval,

--- a/Sources/Vorssaint/Services/SystemMonitor/HIDTemperatureSampler.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/HIDTemperatureSampler.swift
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+import HIDEventSystem
+
+/// Base M1 machines can expose named thermal sensors through HID even when
+/// AppleSMC has no mapped CPU cores or Tg keys. Match only temperature services.
+final class HIDTemperatureSampler {
+    private var client: IOHIDEventSystemClient?
+
+    func readings(platform: CPUTemperaturePlatform) -> [(key: String, value: Double)] {
+        guard platform == .appleM1Family else { return [] }
+        if client == nil {
+            client = IOHIDEventSystemClientCreate(kCFAllocatorDefault)
+            if let client {
+                IOHIDEventSystemClientSetMatching(client, [
+                    "PrimaryUsagePage": 0xff00,
+                    "PrimaryUsage": 5,
+                ] as CFDictionary)
+            }
+        }
+        guard let client,
+              let services = IOHIDEventSystemClientCopyServices(client) as? [IOHIDServiceClient]
+        else { return [] }
+        return services.compactMap { service in
+            guard let name = IOHIDServiceClientCopyProperty(service, "Product" as CFString) as? String,
+                  let event = IOHIDServiceClientCopyEvent(service, 15, 0, 0)
+            else { return nil }
+            return (name, IOHIDEventGetFloatValue(event, 15 << 16))
+        }
+    }
+}

--- a/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
@@ -164,6 +164,7 @@ final class SystemMonitor: ObservableObject {
     private var missedGPUUsageSamples = 0
     private var memoryCache: CachedMemoryReading?
     private var cpuTemperatureCache: CachedSensorReading?
+    private let hidTemperatureSampler = HIDTemperatureSampler()
     private var gpuTemperatureCache: CachedSensorReading?
     private var batteryTemperatureCache: CachedSensorReading?
     private var lastFanSpeeds: [Double] = []
@@ -738,7 +739,7 @@ final class SystemMonitor: ObservableObject {
             if plan.needCPUTemperature {
                 if take(.temperature) {
                     next.cpuTemperature = TemperatureSensorSelector.stabilizedTemperature(
-                        self.cpuTemperature(),
+                        self.cpuTemperature() ?? self.hidTemperature(cpu: true),
                         cache: &self.cpuTemperatureCache,
                         now: now,
                         maxAge: temperatureBridge,
@@ -753,7 +754,7 @@ final class SystemMonitor: ObservableObject {
             if plan.needGPUTemperature {
                 if take(.temperature) {
                     next.gpuTemperature = TemperatureSensorSelector.stabilizedTemperature(
-                        self.maxTemperature(of: self.gpuKeys),
+                        self.gpuTemperature(),
                         cache: &self.gpuTemperatureCache,
                         now: now,
                         maxAge: temperatureBridge,
@@ -940,6 +941,18 @@ final class SystemMonitor: ObservableObject {
         guard let smc, !fanKeys.isEmpty else { return nil }
         return FanControlPolicy.telemetryReadings(expectedCount: fanKeys.count,
                                                   readings: fanKeys.map { smc.readValue($0) })
+    }
+
+    private func hidTemperature(cpu: Bool) -> Double? {
+        TemperatureSensorSelector.hidTemperature(
+            readings: hidTemperatureSampler.readings(platform: cpuTemperaturePlatform),
+            cpu: cpu, platform: cpuTemperaturePlatform)
+    }
+
+    private func gpuTemperature() -> Double? {
+        if let value = maxTemperature(of: gpuKeys),
+           value >= TemperatureSensorSelector.minimumChipTemperature { return value }
+        return hidTemperature(cpu: false)
     }
 
     private func cpuTemperature() -> Double? {

--- a/Sources/Vorssaint/Support/SelfTest.swift
+++ b/Sources/Vorssaint/Support/SelfTest.swift
@@ -197,6 +197,15 @@ enum SensorDump {
                          locale: Locale(identifier: "en_US_POSIX"),
                          component as NSString, key.name, key.dataType, value))
         }
+        let hidReadings = HIDTemperatureSampler().readings(platform: cpuPlatform)
+        for cpu in [true, false] {
+            for reading in TemperatureSensorSelector.hidReadings(hidReadings, cpu: cpu, platform: cpuPlatform)
+                .sorted(by: { $0.key < $1.key }) {
+                print(String(format: "%@  %@  HID  %6.2f",
+                             locale: Locale(identifier: "en_US_POSIX"),
+                             cpu ? "cpu-core" : "gpu", reading.key, reading.value))
+            }
+        }
         exit(0)
     }
 }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1800,6 +1800,31 @@ struct MetricsTests {
             platform: .appleM1Family
         )
         expectClose(m1CPU ?? -1, 49.0, "M1 family uses hottest mapped CPU core")
+        let miniSMC = [(key: "Te0a", value: 36.31), (key: "Tp2b", value: 48.04),
+                       (key: "Tp4z", value: 64.61)]
+        expect(TemperatureSensorSelector.displayedCPUTemperature(
+            readings: miniSMC, platform: .appleM1Family
+        ) == nil, "Mac mini issue 1353 dump has no mapped SMC CPU core")
+        let miniHID = [(key: "eACC MTR Temp Sensor0", value: 38.0),
+                       (key: "pACC MTR Temp Sensor0", value: 49.0),
+                       (key: "GPU MTR Temp Sensor0", value: 45.0),
+                       (key: "SOC MTR Temp Sensor0", value: 90.0)]
+        expectClose(TemperatureSensorSelector.hidTemperature(
+            readings: miniHID, cpu: true, platform: .appleM1Family
+        ) ?? -1, 49, "M1 missing SMC cores use hottest named HID CPU sensor")
+        expectClose(TemperatureSensorSelector.hidTemperature(
+            readings: miniHID, cpu: false, platform: .appleM1Family
+        ) ?? -1, 45, "M1 without Tg keys uses named HID GPU sensors, excluding SOC")
+        expect(TemperatureSensorSelector.hidTemperature(
+            readings: miniSMC, cpu: true, platform: .appleM1Family
+        ) == nil, "unknown SMC keys are never relabeled as HID CPU cores")
+        expect(TemperatureSensorSelector.hidTemperature(
+            readings: miniHID, cpu: false, platform: .unmappedAppleSilicon
+        ) == nil, "M1 HID fallback does not broaden unknown chip support")
+        expect(TemperatureSensorSelector.hidTemperature(
+            readings: [("GPU MTR Temp Sensor0", 7), ("GPU MTR Temp Sensor1", .nan),
+                       ("GPU MTR Temp Sensor2", 125)], cpu: false, platform: .appleM1Family
+        ) == nil, "HID fallback rejects invalid and broken low chip readings")
         let m2CPU = TemperatureSensorSelector.displayedCPUTemperature(
             readings: [("Tp1h", 7.0), ("Tp0j", 52.0), ("Tp0k", 75.0)],
             platform: .appleM2Family
@@ -14641,6 +14666,35 @@ struct MetricsTests {
         expectClose(m3FanTemperatures.first { $0.source == .averageCPU }?.celsius ?? -1,
                     48.5,
                     "M3 fan curves exclude auxiliary Tf readings from the CPU average")
+        let hidFanReadings = [(key: "eACC MTR Temp Sensor0", value: 38.0),
+                              (key: "pACC MTR Temp Sensor0", value: 49.0),
+                              (key: "GPU MTR Temp Sensor0", value: 45.0)]
+        let miniFanTemperatures = FanControlPolicy.aggregatedTemperatures(
+            cpuReadings: [("Tp4z", 64.61)], gpuReadings: [], platform: .appleM1Family,
+            hidReadings: hidFanReadings)
+        expectClose(miniFanTemperatures.first { $0.source == .hottestCPU }?.celsius ?? -1,
+                    49, "M1 fan curves use named HID CPU temperatures when SMC cores are missing")
+        expectClose(miniFanTemperatures.first { $0.source == .averageCPU }?.celsius ?? -1,
+                    43.5, "HID CPU average includes both clusters")
+        expectClose(miniFanTemperatures.first { $0.source == .hottestGPU }?.celsius ?? -1,
+                    45, "M1 fan GPU source agrees with monitor HID fallback")
+        let preferredSMC = FanControlPolicy.aggregatedTemperatures(
+            cpuReadings: [("Tp01", 41)], gpuReadings: [42], platform: .appleM1Family,
+            hidReadings: hidFanReadings)
+        expectClose(preferredSMC.first { $0.source == .hottestCPU }?.celsius ?? -1,
+                    41, "valid SMC CPU reading remains preferred over HID")
+        expectClose(preferredSMC.first { $0.source == .hottestGPU }?.celsius ?? -1,
+                    42, "valid SMC GPU reading remains preferred over HID")
+        let mixedTemperatures = FanControlPolicy.aggregatedTemperatures(
+            cpuReadings: [("Tp01", 41)], gpuReadings: [7], platform: .appleM1Family,
+            hidReadings: hidFanReadings)
+        expectClose(mixedTemperatures.first { $0.source == .hottestCPU }?.celsius ?? -1,
+                    41, "GPU fallback does not replace a valid SMC CPU source")
+        expectClose(mixedTemperatures.first { $0.source == .hottestGPU }?.celsius ?? -1,
+                    45, "broken low SMC GPU readings allow a valid HID fallback")
+        expect(FanControlPolicy.aggregatedTemperatures(
+            cpuReadings: [], gpuReadings: [], platform: .appleM1Family).isEmpty,
+               "missing SMC and HID readings remain unavailable for fan control")
         let unmappedFanTemperatures = FanControlPolicy.aggregatedTemperatures(
             cpuReadings: [("Tp00", 48), ("Tp0W", 113)],
             gpuReadings: [],

--- a/build.sh
+++ b/build.sh
@@ -458,6 +458,8 @@ echo "▸ Compiling protected fan helper…"
 swiftc -O -target "$TARGET" -sdk "$SDK" "${SDK_COMPAT_FLAGS[@]}" "${BUILD_VARIANT_FLAGS[@]}" \
     Sources/Vorssaint/Services/FanControl/FanControlSupport.swift \
     Sources/Vorssaint/Services/FanControl/FanControlXPC.swift \
+    "${HID_EVENT_SYSTEM_FLAGS[@]}" \
+    Sources/Vorssaint/Services/SystemMonitor/HIDTemperatureSampler.swift \
     Sources/Vorssaint/Services/SystemMonitor/SMCClient.swift \
     Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift \
     Sources/Vorssaint/Services/FanControl/FanControlHardware.swift \


### PR DESCRIPTION
Refs #1353

Adds a named HID temperature fallback for M1 machines when a CPU or GPU temperature is unavailable through SMC. Valid SMC readings take precedence. With main's 3.3.4 CPU fix included, the reported Mac mini sensor dump retains its 64.61°C CPU reading; only its missing GPU reading needs the monitor's HID fallback.

The fallback accepts `eACC MTR Temp`, `pACC MTR Temp`, and `GPU MTR Temp` sensors and applies the existing chip-temperature limits. Fan curves retain their stricter mapped-core selection and can use named HID CPU readings when mapped SMC cores are absent. `--sensors` labels the named HID readings as CPU or GPU. No new SMC core mapping is inferred from the undocumented keys in the issue.

All four private HID functions are resolved at runtime. A missing symbol disables the fallback without preventing the app or fan helper from launching. The helper self-test covers each missing symbol. This follows the named HID temperature path used by [Stats](https://github.com/exelban/stats/blob/60e65d1454c647d9592550447757e509b01d5ebb/Modules/Sensors/readers.swift#L163) without adding a dependency.

The helper also provides `--temperature-diagnostics`, a read-only command that reports named HID samples and the same aggregated temperature inputs used by fan curves. It does not take fan ownership or write fan settings. `docs/M1-TEMPERATURE-VERIFICATION.md` describes running it in launchd's system domain on an affected M1.

Validation on an Apple M5 Pro:

- `./build.sh` passed, including the helper self-test.
- `./build/Vorssaint --selftest` returned `SELFTEST OK`.
- `./build.sh --test` passed 54,874 checks and preference cleanup tests.
- A focused probe passed all four missing-symbol cases and read 76 live HID temperature services in a user session.
- Neither built executable directly imports the four private HID symbols.
- The read-only helper diagnostic ran successfully on the host's normal M5 path.
- Working-tree and staged diff checks passed.

The affected M1 was unavailable. HID access from the M1 fan helper in launchd's system domain remains unverified, as do restoration of the reporter's displayed GPU temperature and physical fan-curve operation. The M5 user-session probe does not establish those results. No helper installation or system-service test was performed.
