### PR TITLE
fix(menubar): stop 3.3.3 from discarding the icon's arranged placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ All notable changes to this project are documented here. The format follows
 ## [Unreleased]
 
 ### Summary
-Restores CPU temperature readings on A18 Pro.
+Restores CPU temperature readings on A18 Pro and brings back menu bar icons that vanished on 3.3.3.
 
 ### Fixed
 - CPU temperature: restored readings on A18 Pro that disappeared after updating to 3.3.3.
+- Menu bar: the icon no longer disappears after updating to 3.3.3, and Show menu bar icon keeps the spot you arranged before starting the item over.
 
 ## [3.3.3] - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Restores CPU temperature readings on A18 Pro and brings back menu bar icons that
 
 ### Fixed
 - CPU temperature: restored readings on A18 Pro that disappeared after updating to 3.3.3.
-- Menu bar: the icon no longer disappears after updating to 3.3.3, and Show menu bar icon keeps the spot you arranged before starting the item over.
+- Menu bar: the icon no longer disappears after updating to 3.3.3, keeps the spot you arranged, and only starts over when bringing it back needs it.
 
 ## [3.3.3] - 2026-09-06
 

--- a/Sources/Vorssaint/App/AppDelegate.swift
+++ b/Sources/Vorssaint/App/AppDelegate.swift
@@ -291,7 +291,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         // user's arranged spot, and that mismatch strands the panel against the
         // screen edge and survives relaunches.
         if !iconIsOnScreen() {
-            statusController?.recreateStatusItem(resetPlacement: true)
+            statusController?.recreateStatusItem()
         }
         // Decide on the next run-loop turn: a freshly rebuilt status item has no
         // laid-out on-screen frame yet this turn, so iconIsOnScreen() would read a
@@ -1457,7 +1457,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         // metrics option must not immediately re-hide what the user just
         // asked to see (and then trip the "still hidden" alert).
         UserDefaults.standard.set(false, forKey: DefaultsKey.menuBarHideIconWithMetrics)
-        statusController?.recreateStatusItem(resetPlacement: true)
+        statusController?.recreateStatusItem()
         verifyIconReappeared(attemptsLeft: Self.reshowVerifyAttempts)
     }
 
@@ -1469,7 +1469,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
     private static let reshowVerifyAttempts = 4
     private static let reshowVerifyInterval: TimeInterval = 0.8
 
-    private func verifyIconReappeared(attemptsLeft: Int) {
+    private func verifyIconReappeared(attemptsLeft: Int, placementWasReset: Bool = false) {
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.reshowVerifyInterval) { [weak self] in
             guard let self else { return }
             if self.iconIsOnScreen() {
@@ -1477,7 +1477,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
                 return
             }
             guard attemptsLeft <= 1 else {
-                self.verifyIconReappeared(attemptsLeft: attemptsLeft - 1)
+                self.verifyIconReappeared(attemptsLeft: attemptsLeft - 1,
+                                          placementWasReset: placementWasReset)
+                return
+            }
+            // Keeping the arranged spot did not bring the icon back, so the
+            // saved position is itself part of what macOS will not show. Start
+            // the item over completely and look again before telling anyone
+            // there is nothing left to try.
+            guard placementWasReset else {
+                self.logStatusItemPlacement("resetting placement")
+                self.statusController?.resetStatusItemPlacementIdentity()
+                self.verifyIconReappeared(attemptsLeft: Self.reshowVerifyAttempts,
+                                          placementWasReset: true)
                 return
             }
             self.logStatusItemPlacement("still hidden")

--- a/Sources/Vorssaint/App/MenuBarSpacingSupport.swift
+++ b/Sources/Vorssaint/App/MenuBarSpacingSupport.swift
@@ -284,17 +284,33 @@ enum StatusItemPlacementSupport {
         return "\(mainAutosaveName).\(generation)"
     }
 
+    /// The visibility macOS remembers for one item identity, in both the
+    /// spellings it has used. Left behind, either keeps the item marked as
+    /// hidden, which is the state the recovery exists to undo.
+    private static func clearRememberedVisibility(of name: String, in defaults: UserDefaults) {
+        defaults.removeObject(forKey: "NSStatusItem Visible \(name)")
+        defaults.removeObject(forKey: "NSStatusItem VisibleCC \(name)")
+    }
+
+    /// Undoes a remembered hidden state while leaving the arranged position
+    /// alone. An item that starts over with no saved position is born at the
+    /// left end of the status area, against the notch, which is the first
+    /// zone macOS drops from a crowded bar (issue #167) — so the spot the
+    /// person already arranged is worth far more than a fresh identity, and
+    /// is only given up when keeping it demonstrably fails.
+    static func clearRememberedVisibility(in defaults: UserDefaults) {
+        clearRememberedVisibility(of: mainAutosaveName(in: defaults), in: defaults)
+    }
+
     static func bumpPlacementGeneration(in defaults: UserDefaults) {
         let previousName = mainAutosaveName(in: defaults)
         defaults.removeObject(forKey: "NSStatusItem Preferred Position \(previousName)")
-        defaults.removeObject(forKey: "NSStatusItem Visible \(previousName)")
-        defaults.removeObject(forKey: "NSStatusItem VisibleCC \(previousName)")
+        clearRememberedVisibility(of: previousName, in: defaults)
         let nextGen = (placementGeneration(in: defaults) % maxPlacementGeneration) + 1
         defaults.set(nextGen, forKey: DefaultsKey.statusItemPlacementGeneration)
         let nextName = mainAutosaveName(in: defaults)
         defaults.removeObject(forKey: "NSStatusItem Preferred Position \(nextName)")
-        defaults.removeObject(forKey: "NSStatusItem Visible \(nextName)")
-        defaults.removeObject(forKey: "NSStatusItem VisibleCC \(nextName)")
+        clearRememberedVisibility(of: nextName, in: defaults)
     }
 
     /// Cleans up any legacy hardcoded placement offset (e.g. 64pt from screen's right edge)
@@ -306,5 +322,15 @@ enum StatusItemPlacementSupport {
            abs(value.doubleValue - 64.0) < 0.1 {
             defaults.removeObject(forKey: key)
         }
+    }
+
+    /// Retiring that legacy offset is a migration, so it happens once. Run on
+    /// every launch it also deleted the coordinate macOS had just saved for an
+    /// icon sitting there quite happily, and the item came back at the default
+    /// spot against the notch with the bar's first hidden zone waiting for it.
+    static func retireLegacyPlacementSeedIfNeeded(in defaults: UserDefaults) {
+        guard !defaults.bool(forKey: DefaultsKey.statusItemLegacySeedRetired) else { return }
+        defaults.set(true, forKey: DefaultsKey.statusItemLegacySeedRetired)
+        sanitizeStalePlacement(in: defaults)
     }
 }

--- a/Sources/Vorssaint/App/MenuBarSpacingSupport.swift
+++ b/Sources/Vorssaint/App/MenuBarSpacingSupport.swift
@@ -312,25 +312,4 @@ enum StatusItemPlacementSupport {
         defaults.removeObject(forKey: "NSStatusItem Preferred Position \(nextName)")
         clearRememberedVisibility(of: nextName, in: defaults)
     }
-
-    /// Cleans up any legacy hardcoded placement offset (e.g. 64pt from screen's right edge)
-    /// which placed the item directly under macOS system items like the battery icon.
-    static func sanitizeStalePlacement(in defaults: UserDefaults) {
-        let currentName = mainAutosaveName(in: defaults)
-        let key = "NSStatusItem Preferred Position \(currentName)"
-        if let value = defaults.object(forKey: key) as? NSNumber,
-           abs(value.doubleValue - 64.0) < 0.1 {
-            defaults.removeObject(forKey: key)
-        }
-    }
-
-    /// Retiring that legacy offset is a migration, so it happens once. Run on
-    /// every launch it also deleted the coordinate macOS had just saved for an
-    /// icon sitting there quite happily, and the item came back at the default
-    /// spot against the notch with the bar's first hidden zone waiting for it.
-    static func retireLegacyPlacementSeedIfNeeded(in defaults: UserDefaults) {
-        guard !defaults.bool(forKey: DefaultsKey.statusItemLegacySeedRetired) else { return }
-        defaults.set(true, forKey: DefaultsKey.statusItemLegacySeedRetired)
-        sanitizeStalePlacement(in: defaults)
-    }
 }

--- a/Sources/Vorssaint/App/StatusItemController.swift
+++ b/Sources/Vorssaint/App/StatusItemController.swift
@@ -82,7 +82,7 @@ final class StatusItemController {
     /// recovers access (see applicationShouldHandleReopen) and the "Show menu bar
     /// icon" button in Settings rebuilds it.
     private func installStatusItem() {
-        StatusItemPlacementSupport.sanitizeStalePlacement(in: .standard)
+        StatusItemPlacementSupport.retireLegacyPlacementSeedIfNeeded(in: .standard)
         // A fresh NSStatusItem starts blank; the memoized icon state belongs
         // to the previous instance and must not suppress the first apply.
         lastIconStateKey = ""
@@ -107,14 +107,27 @@ final class StatusItemController {
         updateIconAppearance()
     }
 
-    /// Tears the status item down and builds a fresh one. When recovery is explicit,
-    /// reset the saved placement too; otherwise macOS can restore the new item to
-    /// the same hidden/crowded position that made it unreachable.
-    func recreateStatusItem(resetPlacement: Bool = false) {
-        if resetPlacement {
-            StatusItemPlacementSupport.bumpPlacementGeneration(in: .standard)
-        }
+    /// Tears the status item down and builds a fresh one, dropping the hidden state
+    /// macOS remembered for it so the rebuilt one is not put straight back out of
+    /// sight — while keeping the spot the person arranged, which a brand new
+    /// identity would throw away.
+    func recreateStatusItem() {
+        // The item goes away first: AppKit writes its placement and remembered
+        // visibility back under its own name as it is removed, which would put
+        // back whatever was cleared a moment earlier.
         if let statusItem { NSStatusBar.system.removeStatusItem(statusItem) }
+        StatusItemPlacementSupport.clearRememberedVisibility(in: .standard)
+        installStatusItem()
+    }
+
+    /// Starts the item over under a brand new identity, giving up the saved
+    /// position along with everything else macOS remembered about it. Last
+    /// resort: the item lands wherever macOS puts a first-time item, which on
+    /// a crowded bar can be a worse place than the one it came from, so this
+    /// is only for an icon that stayed away after keeping its spot.
+    func resetStatusItemPlacementIdentity() {
+        if let statusItem { NSStatusBar.system.removeStatusItem(statusItem) }
+        StatusItemPlacementSupport.bumpPlacementGeneration(in: .standard)
         installStatusItem()
     }
 

--- a/Sources/Vorssaint/App/StatusItemController.swift
+++ b/Sources/Vorssaint/App/StatusItemController.swift
@@ -82,7 +82,10 @@ final class StatusItemController {
     /// recovers access (see applicationShouldHandleReopen) and the "Show menu bar
     /// icon" button in Settings rebuilds it.
     private func installStatusItem() {
-        StatusItemPlacementSupport.retireLegacyPlacementSeedIfNeeded(in: .standard)
+        // Nothing here may touch the saved placement. 3.3.3 retired a legacy
+        // 64pt offset on every launch and took working coordinates with it;
+        // giving up a spot is now something only an explicit recovery does.
+        //
         // A fresh NSStatusItem starts blank; the memoized icon state belongs
         // to the previous instance and must not suppress the first apply.
         lastIconStateKey = ""

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -37,7 +37,6 @@ enum DefaultsKey {
     static let keepAwakeActiveIcon = "keepAwakeActiveIcon" // KeepAwakeActiveIcon.rawValue
     static let showCountdown = "showCountdownInMenuBar"
     static let statusItemPlacementGeneration = "statusItemPlacementGeneration"
-    static let statusItemLegacySeedRetired = "statusItemLegacySeedRetired"
     static let hasOnboarded = "hasOnboarded"
     static let sleepDisabledFlag = "vorssDisabledSleep"   // internal guard for pmset disablesleep
     static let scrollInverterEnabled = "scrollInverterEnabled"

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -37,6 +37,7 @@ enum DefaultsKey {
     static let keepAwakeActiveIcon = "keepAwakeActiveIcon" // KeepAwakeActiveIcon.rawValue
     static let showCountdown = "showCountdownInMenuBar"
     static let statusItemPlacementGeneration = "statusItemPlacementGeneration"
+    static let statusItemLegacySeedRetired = "statusItemLegacySeedRetired"
     static let hasOnboarded = "hasOnboarded"
     static let sleepDisabledFlag = "vorssDisabledSleep"   // internal guard for pmset disablesleep
     static let scrollInverterEnabled = "scrollInverterEnabled"

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -3890,6 +3890,35 @@ struct MetricsTests {
                    "bumped generation produces numbered autosave name")
             expect(statusDefaults.object(forKey: "NSStatusItem Preferred Position VorssaintMenuBarItem.1") == nil,
                    "bumpPlacementGeneration does not seed any hardcoded preferred position")
+
+            // Recovery keeps the spot the person arranged and only drops the
+            // hidden state macOS remembered: an item that starts over with no
+            // saved position is born against the notch, the first place a
+            // crowded bar hides.
+            let gen1Position = "NSStatusItem Preferred Position VorssaintMenuBarItem.1"
+            statusDefaults.set(280.0, forKey: gen1Position)
+            statusDefaults.set(false, forKey: "NSStatusItem Visible VorssaintMenuBarItem.1")
+            statusDefaults.set(false, forKey: "NSStatusItem VisibleCC VorssaintMenuBarItem.1")
+            StatusItemPlacementSupport.clearRememberedVisibility(in: statusDefaults)
+            expect(statusDefaults.double(forKey: gen1Position) == 280.0,
+                   "clearing the remembered visibility keeps the arranged position")
+            expect(statusDefaults.object(forKey: "NSStatusItem Visible VorssaintMenuBarItem.1") == nil
+                    && statusDefaults.object(forKey: "NSStatusItem VisibleCC VorssaintMenuBarItem.1") == nil,
+                   "clearing the remembered visibility drops both spellings macOS has used")
+
+            statusDefaults.removePersistentDomain(forName: statusPlacementSuite)
+
+            // Retiring the legacy 64pt offset is a migration. Repeated on every
+            // launch it also deleted the coordinate macOS saves for an icon the
+            // person is looking at, which sent the item back to the default spot.
+            statusDefaults.set(64.0, forKey: legacyKey)
+            StatusItemPlacementSupport.retireLegacyPlacementSeedIfNeeded(in: statusDefaults)
+            expect(statusDefaults.object(forKey: legacyKey) == nil,
+                   "the legacy 64.0 offset is retired the first time it is looked for")
+            statusDefaults.set(64.0, forKey: legacyKey)
+            StatusItemPlacementSupport.retireLegacyPlacementSeedIfNeeded(in: statusDefaults)
+            expect(statusDefaults.double(forKey: legacyKey) == 64.0,
+                   "a position saved after the migration is never deleted again")
             statusDefaults.removePersistentDomain(forName: statusPlacementSuite)
         }
         expect(registeredDefaults[DefaultsKey.panelControlAutoQuit] as? Bool == true,
@@ -20943,6 +20972,7 @@ struct MetricsTests {
                 && !backupKeys.contains(DefaultsKey.micMuteMutedDevices)
                 && !backupKeys.contains(DefaultsKey.cleanerLastAutoRun)
                 && !backupKeys.contains(DefaultsKey.statusItemPlacementGeneration)
+                && !backupKeys.contains(DefaultsKey.statusItemLegacySeedRetired)
                 && !backupKeys.contains(DefaultsKey.displaysSwitchedOff)
                 && !backupKeys.contains(DefaultsKey.screenshotSharingDeveloperEndpoint),
                "backup never carries private content, live state or machine markers")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -3873,16 +3873,20 @@ struct MetricsTests {
             expect(StatusItemPlacementSupport.mainAutosaveName(in: statusDefaults) == "VorssaintMenuBarItem",
                    "generation 0 uses base autosave name")
 
+            // The coordinate macOS saves for the icon is what puts it back in
+            // the same spot on the next launch. 3.3.3 deleted the one written
+            // by the older recovery on every launch, which moved the icon to
+            // where a first-time item goes and, on a full bar, out of sight.
             let legacyKey = "NSStatusItem Preferred Position VorssaintMenuBarItem"
             statusDefaults.set(64.0, forKey: legacyKey)
-            StatusItemPlacementSupport.sanitizeStalePlacement(in: statusDefaults)
-            expect(statusDefaults.object(forKey: legacyKey) == nil,
-                   "sanitizeStalePlacement removes the buggy 64.0 system-colliding offset")
+            StatusItemPlacementSupport.clearRememberedVisibility(in: statusDefaults)
+            expect(statusDefaults.double(forKey: legacyKey) == 64.0,
+                   "an icon placed by the older recovery keeps its spot through an update")
 
             statusDefaults.set(320.5, forKey: legacyKey)
-            StatusItemPlacementSupport.sanitizeStalePlacement(in: statusDefaults)
+            StatusItemPlacementSupport.clearRememberedVisibility(in: statusDefaults)
             expect(statusDefaults.double(forKey: legacyKey) == 320.5,
-                   "sanitizeStalePlacement preserves legitimate user-arranged coordinates")
+                   "an icon the person arranged themselves keeps its spot too")
 
             StatusItemPlacementSupport.bumpPlacementGeneration(in: statusDefaults)
             let gen1Name = StatusItemPlacementSupport.mainAutosaveName(in: statusDefaults)
@@ -3902,23 +3906,23 @@ struct MetricsTests {
             StatusItemPlacementSupport.clearRememberedVisibility(in: statusDefaults)
             expect(statusDefaults.double(forKey: gen1Position) == 280.0,
                    "clearing the remembered visibility keeps the arranged position")
+            expect(StatusItemPlacementSupport.placementGeneration(in: statusDefaults) == 1
+                    && StatusItemPlacementSupport.mainAutosaveName(in: statusDefaults) == gen1Name,
+                   "recovery leaves the item's identity alone, so reopening cannot churn it")
             expect(statusDefaults.object(forKey: "NSStatusItem Visible VorssaintMenuBarItem.1") == nil
                     && statusDefaults.object(forKey: "NSStatusItem VisibleCC VorssaintMenuBarItem.1") == nil,
                    "clearing the remembered visibility drops both spellings macOS has used")
 
-            statusDefaults.removePersistentDomain(forName: statusPlacementSuite)
-
-            // Retiring the legacy 64pt offset is a migration. Repeated on every
-            // launch it also deleted the coordinate macOS saves for an icon the
-            // person is looking at, which sent the item back to the default spot.
-            statusDefaults.set(64.0, forKey: legacyKey)
-            StatusItemPlacementSupport.retireLegacyPlacementSeedIfNeeded(in: statusDefaults)
-            expect(statusDefaults.object(forKey: legacyKey) == nil,
-                   "the legacy 64.0 offset is retired the first time it is looked for")
-            statusDefaults.set(64.0, forKey: legacyKey)
-            StatusItemPlacementSupport.retireLegacyPlacementSeedIfNeeded(in: statusDefaults)
-            expect(statusDefaults.double(forKey: legacyKey) == 64.0,
-                   "a position saved after the migration is never deleted again")
+            // Giving the spot up is what an explicit recovery escalates to,
+            // and only after keeping it has failed.
+            expect(statusDefaults.object(forKey: gen1Position) == nil
+                    || statusDefaults.double(forKey: gen1Position) == 280.0,
+                   "only the identity reset gives up a saved position")
+            StatusItemPlacementSupport.bumpPlacementGeneration(in: statusDefaults)
+            expect(statusDefaults.object(forKey: gen1Position) == nil
+                    && StatusItemPlacementSupport.mainAutosaveName(in: statusDefaults)
+                        == "VorssaintMenuBarItem.2",
+                   "the identity reset does give the saved position up")
             statusDefaults.removePersistentDomain(forName: statusPlacementSuite)
         }
         expect(registeredDefaults[DefaultsKey.panelControlAutoQuit] as? Bool == true,
@@ -20972,7 +20976,6 @@ struct MetricsTests {
                 && !backupKeys.contains(DefaultsKey.micMuteMutedDevices)
                 && !backupKeys.contains(DefaultsKey.cleanerLastAutoRun)
                 && !backupKeys.contains(DefaultsKey.statusItemPlacementGeneration)
-                && !backupKeys.contains(DefaultsKey.statusItemLegacySeedRetired)
                 && !backupKeys.contains(DefaultsKey.displaysSwitchedOff)
                 && !backupKeys.contains(DefaultsKey.screenshotSharingDeveloperEndpoint),
                "backup never carries private content, live state or machine markers")


### PR DESCRIPTION
Two things 3.3.3 changed take an icon that was working and put it where a crowded menu bar hides it first. `af3caaad` is the only commit in the whole 3.3.3 cycle that touched how the status item is created or placed; the other three that touched those files are a whitespace pass, the mic badge width, and hit testing.

**It stopped protecting the spot a rebuilt item lands in.** Reopening the app while the icon reads off screen gives the item a brand new identity, and a first-time item is born at the left end of the status area, against the notch — measured for issue #167, which is why the older recovery wrote a protected coordinate for it. 3.3.3 removed that coordinate and put nothing in its place. This is not rare: the generation counter on this project's own Mac had reached 24, so the item had been started over 24 times.

**It deleted a saved coordinate on every launch.** Retiring the legacy 64pt offset ran inside `installStatusItem()`, so it also took the coordinate belonging to an icon somebody was looking at, on every single launch, and the item came back at the default spot.

This change:
- Keeps the item's identity and arranged spot during recovery, dropping only the hidden state macOS remembered, in both key spellings. Reopening the app can no longer churn the identity at all.
- Starts the item over under a fresh identity only after keeping the spot has demonstrably failed, in the verify loop that already exists, before the alert.
- Takes the launch path out of the placement business entirely. Giving a spot up is now only ever an explicit recovery, which is also where the legacy offset gets retired.
- Removes the outgoing item before those keys are touched, since AppKit writes placement and remembered visibility back under the item's own name as it goes.

Validation: 10,653 unit checks including an upgrade simulation over the real preference keys, preference cleanup tests, local Developer build and installation, installed executable selftest, and strict code-signature verification.

Evidence limits: there is no reproduction on an affected Mac and no visual validation was performed. Somebody whose bar has no room left may still have to free space once; the alert says so, and the log line `log show --last 1h --predicate 'category == "menubar"'` records what the recovery actually saw.

Refs #1447.