### PR TITLE
fix(monitor): restore CPU temperature on Macs without their mapped sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ All notable changes to this project are documented here. The format follows
 ## [Unreleased]
 
 ### Summary
-Restores CPU temperature readings on A18 Pro.
+Restores CPU temperature readings that disappeared on Apple Silicon Macs after updating to 3.3.3.
 
 ### Fixed
 - CPU temperature: restored readings on A18 Pro that disappeared after updating to 3.3.3.
+- CPU temperature: restored readings on Macs whose chip does not carry the sensors its generation normally has, including affected M1 Macs.
 
 ## [3.3.3] - 2026-09-06
 

--- a/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
+++ b/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
@@ -92,13 +92,12 @@ enum TemperatureSensorSelector {
         if let value = core.map({ $0.value }).max() {
             return value
         }
-        // Not every Mac carries the sensors its chip generation is mapped to,
-        // and one that does not showed a reading anyway until 3.3.3. It gets
-        // that reading back. A mapped sensor that is present but unreadable
-        // this sample is a different matter and is never replaced by another
-        // one; fan control keeps requiring its own mapped readings either way.
-        guard !readings.contains(where: { isCPUCoreKey($0.key, platform: platform) })
-        else { return nil }
+        // Not every Mac carries the sensors its chip generation is mapped to.
+        // One that does not showed the hottest reading of its CPU families
+        // instead, for as long as the app has had this panel, until 3.3.3
+        // restricted the answer to the mapped sensors and left those Macs with
+        // nothing. This is that reading, restored exactly. Fan control is a
+        // separate decision and keeps requiring its own mapped readings.
         return valid.map { $0.value }.max()
     }
 

--- a/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
+++ b/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
@@ -92,13 +92,14 @@ enum TemperatureSensorSelector {
         if let value = core.map({ $0.value }).max() {
             return value
         }
-        switch platform {
-        case .generic:
-            return valid.map { $0.value }.max()
-        case .appleM1Family, .appleM2Family, .appleM3Family, .appleM4Family,
-             .appleM5Family, .unmappedAppleSilicon:
-            return nil
-        }
+        // Not every Mac carries the sensors its chip generation is mapped to,
+        // and one that does not showed a reading anyway until 3.3.3. It gets
+        // that reading back. A mapped sensor that is present but unreadable
+        // this sample is a different matter and is never replaced by another
+        // one; fan control keeps requiring its own mapped readings either way.
+        guard !readings.contains(where: { isCPUCoreKey($0.key, platform: platform) })
+        else { return nil }
+        return valid.map { $0.value }.max()
     }
 
     static func hasCPUCoreSet(platform: CPUTemperaturePlatform) -> Bool {
@@ -128,7 +129,6 @@ enum TemperatureSensorSelector {
 
     static func isCPUTemperatureKey(_ key: String,
                                     platform: CPUTemperaturePlatform) -> Bool {
-        if platform == .unmappedAppleSilicon { return false }
         if key.hasPrefix("Tp") || key.hasPrefix("Te") { return true }
         return platform == .appleM3Family && key.hasPrefix("Tf")
     }

--- a/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
@@ -912,10 +912,12 @@ final class SystemMonitor: ObservableObject {
         preferredCPUKeys = cpuKeys.filter {
             TemperatureSensorSelector.isCPUCoreKey($0.name, platform: cpuTemperaturePlatform)
         }
-        // A Mac that carries the verified core sensors of its own chip reads
-        // only those. One that carries none of them keeps the compatibility
-        // sweep it had before 3.3.3 instead of showing nothing at all.
-        fallbackCPUKeys = preferredCPUKeys.isEmpty ? cpuKeys : []
+        // Everything that is not a verified core of this chip, swept only when
+        // the core set goes silent. 3.3.3 emptied this list for every mapped
+        // chip, which is what left a Mac carrying none of its generation's
+        // core sensors with no reading at all.
+        let preferredNames = Set(preferredCPUKeys.map(\.name))
+        fallbackCPUKeys = cpuKeys.filter { !preferredNames.contains($0.name) }
         gpuKeys = all.filter { $0.name.hasPrefix("Tg") }
         batteryKeys = all.filter { $0.name.hasPrefix("TB") }
     }
@@ -944,9 +946,11 @@ final class SystemMonitor: ObservableObject {
 
     private func cpuTemperature() -> Double? {
         guard smc != nil else { return nil }
-        // Mapped chips read only their verified core keys. The compatibility
-        // path reads the remaining Tp/Te keys when this Mac carries none of
-        // the core sensors its chip generation is mapped to.
+        // The core set decides the displayed value whenever it answers, so a
+        // normal tick reads only those keys; the remaining Tp/Te keys are
+        // swept exactly when they would have mattered before the split — a
+        // Mac without this chip's core sensors, or a tick with no plausible
+        // core reading.
         var readings = temperatureReadings(of: preferredCPUKeys)
         if let value = TemperatureSensorSelector.displayedCPUTemperature(readings: readings,
                                                                          platform: cpuTemperaturePlatform) {

--- a/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
@@ -912,10 +912,10 @@ final class SystemMonitor: ObservableObject {
         preferredCPUKeys = cpuKeys.filter {
             TemperatureSensorSelector.isCPUCoreKey($0.name, platform: cpuTemperaturePlatform)
         }
-        let preferredNames = Set(preferredCPUKeys.map(\.name))
-        fallbackCPUKeys = TemperatureSensorSelector.hasCPUCoreSet(platform: cpuTemperaturePlatform)
-            ? []
-            : cpuKeys.filter { !preferredNames.contains($0.name) }
+        // A Mac that carries the verified core sensors of its own chip reads
+        // only those. One that carries none of them keeps the compatibility
+        // sweep it had before 3.3.3 instead of showing nothing at all.
+        fallbackCPUKeys = preferredCPUKeys.isEmpty ? cpuKeys : []
         gpuKeys = all.filter { $0.name.hasPrefix("Tg") }
         batteryKeys = all.filter { $0.name.hasPrefix("TB") }
     }
@@ -944,9 +944,9 @@ final class SystemMonitor: ObservableObject {
 
     private func cpuTemperature() -> Double? {
         guard smc != nil else { return nil }
-        // Mapped chips read only their verified core keys. The generic
-        // compatibility path reads the remaining Tp/Te keys when there is
-        // no mapped core set.
+        // Mapped chips read only their verified core keys. The compatibility
+        // path reads the remaining Tp/Te keys when this Mac carries none of
+        // the core sensors its chip generation is mapped to.
         var readings = temperatureReadings(of: preferredCPUKeys)
         if let value = TemperatureSensorSelector.displayedCPUTemperature(readings: readings,
                                                                          platform: cpuTemperaturePlatform) {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1788,7 +1788,7 @@ struct MetricsTests {
                "Apple M5 uses the mapped CPU core sensor set")
         expect(TemperatureSensorSelector.platform(brandString: "Apple M10") == .unmappedAppleSilicon
                && TemperatureSensorSelector.platform(brandString: "Apple A19 Pro") == .unmappedAppleSilicon,
-               "unmapped Apple Silicon never falls through to arbitrary CPU sensors")
+               "an Apple chip with no verified core map is recognised as its own case")
         let a18Platform = TemperatureSensorSelector.platform(brandString: "Apple A18 Pro")
         expect(a18Platform == .generic,
                "A18 Pro preserves the CPU temperature path available before 3.3.3")
@@ -1849,6 +1849,27 @@ struct MetricsTests {
             readings: [("Tp1h", 7.0), ("Tp1t", 6.0)],
             platform: .appleM2Family
         ) == nil, "M2 family rejects a sample made only of broken low readings")
+        // Some Macs of a mapped generation do not carry that generation's core
+        // sensors at all. Before 3.3.3 they showed the hottest CPU-family
+        // reading; the restriction that replaced it left them with nothing.
+        expectClose(TemperatureSensorSelector.displayedCPUTemperature(
+            readings: [("Tp02", 44.0), ("Te04", 51.0)],
+            platform: .appleM1Family
+        ) ?? -1, 51.0, "an M1 without its mapped core sensors reads its CPU family again")
+        expectClose(TemperatureSensorSelector.displayedCPUTemperature(
+            readings: [("Tp02", 44.0), ("Te04", 51.0)],
+            platform: .unmappedAppleSilicon
+        ) ?? -1, 51.0, "an Apple chip with no map at all reads its CPU family again")
+        expect(TemperatureSensorSelector.isCPUTemperatureKey("Tp01", platform: .unmappedAppleSilicon)
+                && TemperatureSensorSelector.isCPUTemperatureKey("Te05", platform: .unmappedAppleSilicon)
+                && !TemperatureSensorSelector.isCPUTemperatureKey("Tg0D", platform: .unmappedAppleSilicon),
+               "an unmapped Apple chip discovers its CPU families and still excludes the GPU")
+        // A mapped sensor that failed this sample is a different matter: it is
+        // never quietly replaced by whatever else the Mac happens to expose.
+        expectClose(TemperatureSensorSelector.displayedCPUTemperature(
+            readings: [("Tp01", 7.0), ("Tp0b", 44.0), ("Tp02", 71.0)],
+            platform: .appleM1Family
+        ) ?? -1, 44.0, "a readable mapped M1 core outranks a hotter sensor outside the map")
         var chipTemperatureCache: CachedSensorReading?
         expectClose(TemperatureSensorSelector.stabilizedTemperature(
             49.25, cache: &chipTemperatureCache, now: 100, maxAge: 30,
@@ -1897,16 +1918,23 @@ struct MetricsTests {
             platform: .appleM4Family
         )
         expectClose(m4InvalidCPU ?? -1, 49.25, "mapped CPU core selection ignores invalid temperatures")
-        let m4FallbackCPU = TemperatureSensorSelector.displayedCPUTemperature(
+        // A mapped core that answers always wins, so an auxiliary hotspot can
+        // never stand in for it. Which sensors are offered here is decided at
+        // discovery: a Mac that carries its chip's core sensors is only ever
+        // asked for those, and a Mac that carries none of them keeps the
+        // compatibility reading it had before 3.3.3 rather than showing nothing.
+        expectClose(TemperatureSensorSelector.displayedCPUTemperature(
+            readings: [("Tp01", 44.5), ("Tp0W", 67.0)],
+            platform: .appleM4Family
+        ) ?? -1, 44.5, "a mapped core outranks a hotter auxiliary sensor")
+        expectClose(TemperatureSensorSelector.displayedCPUTemperature(
             readings: [("Tp00", 44.5), ("Tp0W", 67.0)],
             platform: .appleM4Family
-        )
-        expect(m4FallbackCPU == nil,
-               "mapped Apple Silicon never substitutes an auxiliary hotspot for a missing core sensor")
+        ) ?? -1, 67.0, "an M4 carrying none of its mapped cores reads its CPU family again")
         expect(TemperatureSensorSelector.displayedCPUTemperature(
-            readings: [("Tp00", 44.5), ("Tp0W", 113.0)],
+            readings: [("Tp0W", 130.0)],
             platform: .unmappedAppleSilicon
-        ) == nil, "unmapped Apple Silicon hides unknown sensors instead of reporting an unsafe value")
+        ) == nil, "the compatibility reading still refuses an implausible temperature")
         let genericCPU = TemperatureSensorSelector.displayedCPUTemperature(
             readings: [("Tp00", 44.5), ("Tp01", 51.6)],
             platform: .generic

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -1919,10 +1919,9 @@ struct MetricsTests {
         )
         expectClose(m4InvalidCPU ?? -1, 49.25, "mapped CPU core selection ignores invalid temperatures")
         // A mapped core that answers always wins, so an auxiliary hotspot can
-        // never stand in for it. Which sensors are offered here is decided at
-        // discovery: a Mac that carries its chip's core sensors is only ever
-        // asked for those, and a Mac that carries none of them keeps the
-        // compatibility reading it had before 3.3.3 rather than showing nothing.
+        // never stand in for one while the core set is talking. A tick with no
+        // plausible core reading falls back to the CPU families, exactly as it
+        // did before 3.3.3.
         expectClose(TemperatureSensorSelector.displayedCPUTemperature(
             readings: [("Tp01", 44.5), ("Tp0W", 67.0)],
             platform: .appleM4Family
@@ -1935,6 +1934,43 @@ struct MetricsTests {
             readings: [("Tp0W", 130.0)],
             platform: .unmappedAppleSilicon
         ) == nil, "the compatibility reading still refuses an implausible temperature")
+
+        // Real sensor dumps, so the restored reading is checked against the
+        // machines that lost it rather than against invented keys.
+        //
+        // Mac mini (2020), Macmini9,1, Apple M1, reported on 3.3.2 (issue
+        // #1353): not one of its sensors is in this chip generation's mapped
+        // core set, which is what 3.3.3 then required before showing anything.
+        let macMini9_1M1Sensors: [(key: String, value: Double)] = [
+            ("Te0a", 36.31), ("Te0b", 36.31), ("Te0x", 38.08), ("Te0z", 38.08),
+            ("Te3a", 37.95), ("Te3b", 46.65), ("Te3x", 40.02), ("Te3z", 60.02),
+            ("Tp2a", 38.94), ("Tp2b", 48.04), ("Tp2x", 45.98), ("Tp2z", 60.98),
+            ("Tp3a", 39.62), ("Tp3b", 47.02), ("Tp3x", 48.59), ("Tp3z", 60.59),
+            ("Tp4a", 40.71), ("Tp4b", 50.81), ("Tp4x", 47.61), ("Tp4z", 64.61),
+            ("Tp5a", 38.77), ("Tp5b", 48.97), ("Tp5x", 41.22), ("Tp5z", 57.22),
+            ("Tp7a", 38.84), ("Tp7b", 47.94), ("Tp7x", 43.00), ("Tp7z", 58.00),
+            ("Tp8a", 39.50), ("Tp8b", 46.90), ("Tp8x", 45.34), ("Tp8z", 57.34),
+            ("Tp9a", 40.15), ("Tp9b", 50.25), ("Tp9x", 44.97), ("Tp9z", 61.97),
+        ]
+        expect(macMini9_1M1Sensors.allSatisfy {
+            TemperatureSensorSelector.isCPUTemperatureKey($0.key, platform: .appleM1Family)
+        } && !macMini9_1M1Sensors.contains {
+            TemperatureSensorSelector.isCPUCoreKey($0.key, platform: .appleM1Family)
+        }, "this M1 exposes CPU sensors, none of them in the mapped core set")
+        expectClose(TemperatureSensorSelector.displayedCPUTemperature(
+            readings: macMini9_1M1Sensors, platform: .appleM1Family
+        ) ?? -1, 64.61, "this M1 shows the CPU temperature it showed on 3.3.2 again")
+
+        // This project's own Mac, Apple M4, read with --sensors: its mapped
+        // cores answer and sit well below the hottest auxiliary sensor, so it
+        // is proof that restoring the sweep leaves a mapped Mac untouched.
+        let appleM4Sensors: [(key: String, value: Double)] = [
+            ("Te05", 45.01), ("Te09", 44.70), ("Te0H", 45.29), ("Te0S", 44.84),
+            ("Tp01", 46.12), ("Tp00", 39.02), ("Tp0W", 62.56), ("Tp3X", 69.00),
+        ]
+        expectClose(TemperatureSensorSelector.displayedCPUTemperature(
+            readings: appleM4Sensors, platform: .appleM4Family
+        ) ?? -1, 46.12, "a mapped M4 keeps reading its own cores, not the hotter hotspot")
         let genericCPU = TemperatureSensorSelector.displayedCPUTemperature(
             readings: [("Tp00", 44.5), ("Tp01", 51.6)],
             platform: .generic


### PR DESCRIPTION
3.3.3 made the displayed CPU temperature answer only to the core sensors each Apple chip generation is mapped to, and return nothing otherwise. A Mac that does not carry those exact sensors lost a reading it had shown for years: A18 Pro first (#1445, patched by chip name), then M1 Macs whose layout exposes other Tp/Te keys (#1446). An Apple chip with no map at all also stopped being scanned, so it could not report anything even in principle.

Rather than write a narrower rule, this restores the 3.3.2 code. `displayedCPUTemperature` and `cpuTemperature()` are now identical to the versions that shipped in 3.3.2, line for line. Key discovery differs from 3.3.2 only by staying wider: it keeps the M3 `Tf` family that 3.3.3 added, and scans the CPU families again on an Apple chip with no verified map, which is what the A18 Pro patch on `main` had to work around by name.

Fan control is a separate decision and is untouched: it still requires its own mapped readings and refuses to act on the compatibility reading.

Regression tests use the sensor dumps of the machines involved rather than invented keys:
- Mac mini (2020), Macmini9,1, Apple M1, dumped on 3.3.2 in #1353. Not one of its 36 sensors is in the M1 mapped core set, which is exactly what 3.3.3 began requiring. It reads 64.61 again.
- This project's own M4, read with `--sensors`. Its mapped cores answer at 46.12 while the hottest auxiliary sensor sits at 69.00, so a mapped Mac provably keeps reading its own cores.

Validation: 10,656 unit checks, preference cleanup tests, local Developer build and installation, installed executable selftest, and strict code-signature verification.

Evidence limits: no affected Mac was available, so the restoration is proven by code equivalence with 3.3.2 plus the dumps above, not by running there. The GPU temperature also mentioned in #1446 is not addressed: 3.3.3 changed nothing in GPU discovery or reading, the M1 dump in #1353 shows that model exposing no `Tg` sensors at all on 3.3.2, and a second person on #1446 reports GPU and battery working with only the CPU reading missing.

Refs #1446, #1445.