### PR TITLE
feat(finder): optional cut and paste sounds

### DIFF
--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -122,6 +122,7 @@ enum DefaultsKey {
     static let preferredInputDevice = "preferredInputDevice" // audio input device UID
     static let finderCutPasteEnabled = "finderCutPasteEnabled"
     static let finderCutPasteShowHUD = "finderCutPasteShowHUD"
+    static let finderCutPastePlaySound = "finderCutPastePlaySound"
     static let finderRenameEnabled = "finderRenameEnabled"
     static let finderRenameShortcut = "finderRenameShortcut"
     static let diskImageInstallerTrashesDownload = "diskImageInstallerTrashesDownload"
@@ -1225,6 +1226,8 @@ enum Defaults {
         DefaultsKey.clipboardAutoClearOnDisplaySleep: false,
         DefaultsKey.clipboardAutoClearOnScreenLock: false,
         DefaultsKey.finderCutPasteShowHUD: true,
+        // Opt-in: quieter for existing installs (issue #962).
+        DefaultsKey.finderCutPastePlaySound: false,
         DefaultsKey.finderPasteImageAsFile: false,
         DefaultsKey.windowPreviewExcludedApps: [String](),
         DefaultsKey.diskEjectExcludedVolumes: [String](),

--- a/Sources/Vorssaint/Core/Localization.swift
+++ b/Sources/Vorssaint/Core/Localization.swift
@@ -388,6 +388,8 @@ struct Strings {
     let cutPasteEnableCaption: String
     let cutPasteShowHUD: String
     let cutPasteShowHUDCaption: String
+    let cutPastePlaySound: String
+    let cutPastePlaySoundCaption: String
     let cutPasteHowTitle: String
     let cutPasteStep1: String
     let cutPasteStep2: String
@@ -1429,6 +1431,8 @@ extension Strings {
         cutPasteEnableCaption: "Use ⌘X para recortar e ⌘V para mover arquivos e pastas no Finder.",
         cutPasteShowHUD: "Mostrar painel flutuante",
         cutPasteShowHUDCaption: "Exibe um indicador com os arquivos recortados enquanto o Finder estiver ativo.",
+        cutPastePlaySound: "Reproduzir feedback sonoro",
+        cutPastePlaySoundCaption: "Reproduz o som do sistema Pop do macOS ao recortar ou mover arquivos com sucesso.",
         cutPasteHowTitle: "Como usar",
         cutPasteStep1: "Selecione itens no Finder e pressione ⌘X para recortá-los.",
         cutPasteStep2: "Abra a pasta de destino e pressione ⌘V para movê-los para lá.",
@@ -2439,6 +2443,8 @@ extension Strings {
         cutPasteEnableCaption: "Use ⌘X to cut and ⌘V to move files and folders in Finder.",
         cutPasteShowHUD: "Show floating panel",
         cutPasteShowHUDCaption: "Display a floating indicator with the cut files while Finder is active.",
+        cutPastePlaySound: "Play sound feedback",
+        cutPastePlaySoundCaption: "Play the macOS Pop system sound when files are cut or successfully moved.",
         cutPasteHowTitle: "How to use",
         cutPasteStep1: "Select items in Finder and press ⌘X to cut them.",
         cutPasteStep2: "Open the destination folder and press ⌘V to move them there.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseSimplified.swift
@@ -264,6 +264,8 @@ extension Strings {
         cutPasteEnableCaption: "在访达中用 ⌘X 剪切、用 ⌘V 移动文件和文件夹。",
         cutPasteShowHUD: "显示浮动面板",
         cutPasteShowHUDCaption: "访达处于活跃状态时，显示包含已剪切文件的浮动提示。",
+        cutPastePlaySound: "播放声音反馈",
+        cutPastePlaySoundCaption: "剪切或成功移动文件时播放 macOS 系统声音 Pop。",
         cutPasteHowTitle: "使用方法",
         cutPasteStep1: "在访达中选择项目，按 ⌘X 将其剪切。",
         cutPasteStep2: "打开目标文件夹，按 ⌘V 将其移动到那里。",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalHK.swift
@@ -265,6 +265,8 @@ extension Strings {
         cutPasteEnableCaption: "在 Finder 中用 ⌘X 剪下、用 ⌘V 移動檔案和資料夾。",
         cutPasteShowHUD: "顯示浮動面板",
         cutPasteShowHUDCaption: "Finder 處於啟動狀態時，顯示包含已剪下檔案的浮動提示。",
+        cutPastePlaySound: "播放聲音回饋",
+        cutPastePlaySoundCaption: "剪下或成功移動檔案時播放 macOS 系統聲音 Pop。",
         cutPasteHowTitle: "使用方法",
         cutPasteStep1: "在 Finder 中選取項目，按 ⌘X 剪下。",
         cutPasteStep2: "開啟目的地資料夾，按 ⌘V 移到該處。",

--- a/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+ChineseTraditionalTW.swift
@@ -265,6 +265,8 @@ extension Strings {
         cutPasteEnableCaption: "在 Finder 中用 ⌘X 剪下、用 ⌘V 移動檔案和資料夾。",
         cutPasteShowHUD: "顯示浮動面板",
         cutPasteShowHUDCaption: "Finder 處於啟動狀態時，顯示包含已剪下檔案的浮動提示。",
+        cutPastePlaySound: "播放聲音回饋",
+        cutPastePlaySoundCaption: "剪下或成功移動檔案時播放 macOS 系統聲音 Pop。",
         cutPasteHowTitle: "使用方法",
         cutPasteStep1: "在 Finder 中選擇項目，按 ⌘X 將其剪下。",
         cutPasteStep2: "開啟目標資料夾，按 ⌘V 將其移動到該位置。",

--- a/Sources/Vorssaint/Core/Localizations/Strings+French.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+French.swift
@@ -264,6 +264,8 @@ extension Strings {
         cutPasteEnableCaption: "Utilisez ⌘X pour couper et ⌘V pour déplacer des fichiers et des dossiers dans le Finder.",
         cutPasteShowHUD: "Afficher le panneau flottant",
         cutPasteShowHUDCaption: "Affiche un indicateur flottant avec les fichiers coupés lorsque le Finder est actif.",
+        cutPastePlaySound: "Lire un retour sonore",
+        cutPastePlaySoundCaption: "Joue le son système Pop de macOS lorsque des fichiers sont coupés ou déplacés avec succès.",
         cutPasteHowTitle: "Comment l’utiliser",
         cutPasteStep1: "Sélectionnez des éléments dans le Finder et appuyez sur ⌘X pour les couper.",
         cutPasteStep2: "Ouvrez le dossier de destination et appuyez sur ⌘V pour les y déplacer.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+German.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+German.swift
@@ -264,6 +264,8 @@ extension Strings {
         cutPasteEnableCaption: "Verwende ⌘X zum Ausschneiden und ⌘V, um Dateien und Ordner im Finder zu bewegen.",
         cutPasteShowHUD: "Schwebendes Fenster anzeigen",
         cutPasteShowHUDCaption: "Zeigt eine schwebende Anzeige mit den ausgeschnittenen Dateien, während der Finder aktiv ist.",
+        cutPastePlaySound: "Soundfeedback abspielen",
+        cutPastePlaySoundCaption: "Spielt den macOS-Systemton Pop ab, wenn Dateien ausgeschnitten oder erfolgreich verschoben werden.",
         cutPasteHowTitle: "So geht’s",
         cutPasteStep1: "Wähle Objekte im Finder aus und drücke ⌘X, um sie auszuschneiden.",
         cutPasteStep2: "Öffne den Zielordner und drücke ⌘V, um sie dorthin zu bewegen.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Italian.swift
@@ -264,6 +264,8 @@ extension Strings {
         cutPasteEnableCaption: "Usa ⌘X per tagliare e ⌘V per spostare file e cartelle nel Finder.",
         cutPasteShowHUD: "Mostra pannello mobile",
         cutPasteShowHUDCaption: "Mostra un indicatore mobile con i file tagliati mentre il Finder è attivo.",
+        cutPastePlaySound: "Riproduci feedback sonoro",
+        cutPastePlaySoundCaption: "Riproduce il suono di sistema Pop di macOS quando i file vengono tagliati o spostati correttamente.",
         cutPasteHowTitle: "Come si usa",
         cutPasteStep1: "Seleziona elementi nel Finder e premi ⌘X per tagliarli.",
         cutPasteStep2: "Apri la cartella di destinazione e premi ⌘V per spostarli lì.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Japanese.swift
@@ -264,6 +264,8 @@ extension Strings {
         cutPasteEnableCaption: "⌘X でカット、⌘V で Finder のファイルやフォルダを移動できます。",
         cutPasteShowHUD: "フローティングパネルを表示",
         cutPasteShowHUDCaption: "Finder がアクティブなときに、カットしたファイルのフローティング表示を出します。",
+        cutPastePlaySound: "サウンドフィードバックを再生",
+        cutPastePlaySoundCaption: "ファイルのカットや移動が成功したときに、macOS のシステムサウンド Pop を再生します。",
         cutPasteHowTitle: "使いかた",
         cutPasteStep1: "Finder で項目を選択し、⌘X を押してカットします。",
         cutPasteStep2: "移動先のフォルダを開き、⌘V を押してそこへ移動します。",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Korean.swift
@@ -265,6 +265,8 @@ extension Strings {
         cutPasteEnableCaption: "⌘X로 잘라내고 ⌘V로 Finder의 파일과 폴더를 이동합니다.",
         cutPasteShowHUD: "플로팅 패널 표시",
         cutPasteShowHUDCaption: "Finder가 활성화되어 있는 동안 잘라낸 파일이 담긴 플로팅 표시를 띄웁니다.",
+        cutPastePlaySound: "소리 피드백 재생",
+        cutPastePlaySoundCaption: "파일을 잘라내거나 성공적으로 이동할 때 macOS 시스템 사운드 Pop을 재생합니다.",
         cutPasteHowTitle: "사용 방법",
         cutPasteStep1: "Finder에서 항목을 선택하고 ⌘X를 눌러 잘라냅니다.",
         cutPasteStep2: "대상 폴더를 열고 ⌘V를 눌러 그곳으로 이동합니다.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Russian.swift
@@ -265,6 +265,8 @@ extension Strings {
         cutPasteEnableCaption: "Используйте ⌘X для вырезания и ⌘V для перемещения файлов и папок в Finder.",
         cutPasteShowHUD: "Показывать плавающую панель",
         cutPasteShowHUDCaption: "Отображать плавающий индикатор с вырезанными файлами, пока активен Finder.",
+        cutPastePlaySound: "Звуковая обратная связь",
+        cutPastePlaySoundCaption: "Проигрывать системный звук Pop macOS при вырезании и успешном перемещении файлов.",
         cutPasteHowTitle: "Как использовать",
         cutPasteStep1: "Выберите элементы в Finder и нажмите ⌘X, чтобы вырезать их.",
         cutPasteStep2: "Откройте папку назначения и нажмите ⌘V, чтобы переместить их туда.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Spanish.swift
@@ -264,6 +264,8 @@ extension Strings {
         cutPasteEnableCaption: "Usa ⌘X para cortar y ⌘V para mover archivos y carpetas en el Finder.",
         cutPasteShowHUD: "Mostrar panel flotante",
         cutPasteShowHUDCaption: "Muestra un indicador flotante con los archivos cortados mientras el Finder está activo.",
+        cutPastePlaySound: "Reproducir sonido de confirmación",
+        cutPastePlaySoundCaption: "Reproduce el sonido del sistema Pop de macOS al cortar o mover archivos con éxito.",
         cutPasteHowTitle: "Cómo se usa",
         cutPasteStep1: "Selecciona ítems en el Finder y pulsa ⌘X para cortarlos.",
         cutPasteStep2: "Abre la carpeta de destino y pulsa ⌘V para moverlos allí.",

--- a/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
+++ b/Sources/Vorssaint/Core/Localizations/Strings+Turkish.swift
@@ -264,6 +264,8 @@ extension Strings {
         cutPasteEnableCaption: "Finder’da dosya ve klasörleri kesmek için ⌘X, taşımak için ⌘V kullan.",
         cutPasteShowHUD: "Kayan paneli göster",
         cutPasteShowHUDCaption: "Finder etkinken kesilen dosyaları içeren kayan bir gösterge görüntüler.",
+        cutPastePlaySound: "Ses geri bildirimi çal",
+        cutPastePlaySoundCaption: "Dosyalar kesildiğinde veya başarıyla taşındığında macOS Pop sistem sesini çalar.",
         cutPasteHowTitle: "Nasıl kullanılır",
         cutPasteStep1: "Finder’da öğeleri seç ve kesmek için ⌘X’e bas.",
         cutPasteStep2: "Hedef klasörü aç ve oraya taşımak için ⌘V’ye bas.",

--- a/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderCutPaste.swift
@@ -74,6 +74,7 @@ final class FinderCutPaste: ObservableObject {
     private var moveInProgress = false
     private var cutPasteEnabled = false
     private var showHUD = true
+    private var playSound = false
     private var pasteImageAsFileEnabled = false
     private var imagePasteInProgress = false
     private var appObserver: NSObjectProtocol?
@@ -105,6 +106,8 @@ final class FinderCutPaste: ObservableObject {
         cutPasteEnabled = available
             && UserDefaults.standard.bool(forKey: DefaultsKey.finderCutPasteEnabled)
         showHUD = UserDefaults.standard.object(forKey: DefaultsKey.finderCutPasteShowHUD) as? Bool ?? true
+        playSound = UserDefaults.standard.object(forKey: DefaultsKey.finderCutPastePlaySound) as? Bool
+            ?? FinderCutPasteSoundSupport.defaultEnabled
         pasteImageAsFileEnabled = available
             && UserDefaults.standard.bool(forKey: DefaultsKey.finderPasteImageAsFile)
         if SessionActivitySupport.tapShouldRun(featureWanted: cutPasteEnabled || pasteImageAsFileEnabled,
@@ -478,6 +481,9 @@ final class FinderCutPaste: ObservableObject {
         markedChangeCount = pb.changeCount
         lastResult = nil
         refreshPanel()
+        FinderCutPasteSoundSupport.playIfNeeded(
+            FinderCutPasteSoundSupport.shouldPlayOnCut(preferenceEnabled: playSound,
+                                                       markedCount: marked.count))
     }
 
     // MARK: - Paste (move)
@@ -637,6 +643,9 @@ final class FinderCutPaste: ObservableObject {
         lastResult = MoveResult(moved: moved, failed: failed)
         refreshPanel()
         scheduleResultDismiss()
+        FinderCutPasteSoundSupport.playIfNeeded(
+            FinderCutPasteSoundSupport.shouldPlayOnPaste(preferenceEnabled: playSound,
+                                                         movedCount: moved))
     }
 
     private enum MoveOutcome {

--- a/Sources/Vorssaint/Services/Finder/FinderCutPasteSoundSupport.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderCutPasteSoundSupport.swift
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+
+/// Pure decisions and system-sound playback for Finder cut & paste feedback
+/// (issue #962). Finder has no public dedicated cut/paste UI sound — only
+/// trash effects under CoreAudio `SystemSounds/finder` — so feedback uses the
+/// well-known `Pop` alert from `/System/Library/Sounds`, loadable via
+/// `NSSound(named:)`. Preference defaults off so existing installs stay quiet.
+enum FinderCutPasteSoundSupport {
+    static let systemSoundName = "Pop"
+    static let defaultEnabled = false
+
+    static func shouldPlayOnCut(preferenceEnabled: Bool, markedCount: Int) -> Bool {
+        preferenceEnabled && markedCount > 0
+    }
+
+    static func shouldPlayOnPaste(preferenceEnabled: Bool, movedCount: Int) -> Bool {
+        preferenceEnabled && movedCount > 0
+    }
+
+    static func systemSound() -> NSSound? {
+        NSSound(named: NSSound.Name(systemSoundName))
+    }
+
+    /// Plays `Pop` when `shouldPlay` is true. Returns whether playback started.
+    @discardableResult
+    static func playIfNeeded(_ shouldPlay: Bool) -> Bool {
+        guard shouldPlay, let sound = systemSound() else { return false }
+        return sound.play()
+    }
+}

--- a/Sources/Vorssaint/UI/Settings/CutPasteSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/CutPasteSettings.swift
@@ -9,6 +9,7 @@ struct CutPasteSettings: View {
     @ObservedObject private var service = FinderCutPaste.shared
     @AppStorage(DefaultsKey.finderCutPasteEnabled) private var enabled = false
     @AppStorage(DefaultsKey.finderCutPasteShowHUD) private var showHUD = true
+    @AppStorage(DefaultsKey.finderCutPastePlaySound) private var playSound = false
     @AppStorage(DefaultsKey.finderRenameEnabled) private var renameEnabled = false
     @AppStorage(DefaultsKey.finderRenameShortcut) private var renameShortcutRaw =
         GlobalShortcut.finderRenameDefault.storageValue
@@ -45,6 +46,13 @@ struct CutPasteSettings: View {
                                 FinderCutPaste.shared.syncWithPreferences()
                             }
                         Text(l10n.s.cutPasteShowHUDCaption)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Toggle(l10n.s.cutPastePlaySound, isOn: $playSound)
+                            .onChange(of: playSound) { _, _ in
+                                FinderCutPaste.shared.syncWithPreferences()
+                            }
+                        Text(l10n.s.cutPastePlaySoundCaption)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -3484,6 +3484,10 @@ struct MetricsTests {
                "clipboard history shortcut defaults to Ctrl+Opt+Cmd+V")
         expect(registeredDefaults[DefaultsKey.finderCutPasteShowHUD] as? Bool == true,
                "the Finder cut and paste floating panel starts enabled")
+        expect(registeredDefaults[DefaultsKey.finderCutPastePlaySound] as? Bool == false
+                && registeredDefaults[DefaultsKey.finderCutPastePlaySound] as? Bool
+                    == FinderCutPasteSoundSupport.defaultEnabled,
+               "Finder cut and paste sound feedback is opt-in so existing installs stay quiet")
         expect(registeredDefaults[DefaultsKey.finderRenameEnabled] as? Bool == false,
                "the Finder rename shortcut is opt-in")
         expect(registeredDefaults[DefaultsKey.finderRenameShortcut] as? String == ":120",
@@ -8804,6 +8808,27 @@ struct MetricsTests {
         } catch {
             expect(false, "protected-folder move fixtures: \(error)")
         }
+
+        // MARK: Finder cut & paste sound feedback (issue #962)
+
+        expect(FinderCutPasteSoundSupport.systemSoundName == "Pop",
+               "feedback uses the well-known macOS Pop system alert sound")
+        expect(FinderCutPasteSoundSupport.defaultEnabled == false,
+               "sound feedback stays off until the user opts in")
+        expect(!FinderCutPasteSoundSupport.shouldPlayOnCut(preferenceEnabled: false, markedCount: 3),
+               "a disabled preference never plays on cut")
+        expect(!FinderCutPasteSoundSupport.shouldPlayOnCut(preferenceEnabled: true, markedCount: 0),
+               "an empty cut never plays")
+        expect(FinderCutPasteSoundSupport.shouldPlayOnCut(preferenceEnabled: true, markedCount: 2),
+               "a successful cut plays when the preference is on")
+        expect(!FinderCutPasteSoundSupport.shouldPlayOnPaste(preferenceEnabled: true, movedCount: 0),
+               "a failed paste never plays")
+        expect(FinderCutPasteSoundSupport.shouldPlayOnPaste(preferenceEnabled: true, movedCount: 1),
+               "a successful move plays when the preference is on")
+        expect(!FinderCutPasteSoundSupport.playIfNeeded(false),
+               "playIfNeeded is a no-op when the gate is closed")
+        expect(FinderCutPasteSoundSupport.systemSound() != nil,
+               "Pop resolves from the system sound library")
 
         // MARK: Paste copied image as file (issue #429)
 
@@ -20871,6 +20896,9 @@ struct MetricsTests {
         expect(Defaults.registeredDefaults[DefaultsKey.finderCutPasteShowHUD] as? Bool == true
                 && backupKeys.contains(DefaultsKey.finderCutPasteShowHUD),
                "the Finder cut and paste floating panel default is on and travels with settings backup")
+        expect(Defaults.registeredDefaults[DefaultsKey.finderCutPastePlaySound] as? Bool == false
+                && backupKeys.contains(DefaultsKey.finderCutPastePlaySound),
+               "Finder cut and paste sound feedback is opt-in and travels with settings backup")
         expect(Defaults.registeredDefaults[DefaultsKey.diskImageInstallerTrashesDownload] as? Bool == true
                 && Defaults.registeredDefaults[DefaultsKey.diskImageInstallerRevealsApp] as? Bool == false
                 && backupKeys.contains(DefaultsKey.diskImageInstallerTrashesDownload)

--- a/build.sh
+++ b/build.sh
@@ -346,6 +346,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/DockClick/DockClickSupport.swift \
         Sources/Vorssaint/Services/Finder/CutPasteProgressSupport.swift \
         Sources/Vorssaint/Services/Finder/CutPastePrivilegeSupport.swift \
+        Sources/Vorssaint/Services/Finder/FinderCutPasteSoundSupport.swift \
         Sources/Vorssaint/Services/Finder/FinderPasteImageSupport.swift \
         Sources/Vorssaint/Services/MiddleClick/MiddleClickSupport.swift \
         Sources/Vorssaint/Services/MouseNavigation/MouseNavigationSupport.swift \


### PR DESCRIPTION
## Summary
- Opt-in `finderCutPastePlaySound` (default **false**) plays the macOS **Pop** system sound (`NSSound(named: "Pop")` from `/System/Library/Sounds`) on a successful Finder cut mark and on a successful move (⌘V with `moved > 0`).
- Settings toggle sits next to the HUD toggle in Cut & Paste; strings cover all locales.
- Pure helper `FinderCutPasteSoundSupport` keeps playback decisions out of SwiftUI; `FinderCutPaste` stays AppKit-only for this path.

**Sound choice:** Finder has no public dedicated cut/paste UI asset (only trash effects under CoreAudio `SystemSounds/finder`), so this uses the well-known Pop alert instead of bundling a custom sound.

Refs #962

## Test plan
- [x] `./build.sh --test` — **10647 checks** OK (PreferenceCleanup OK)
- [ ] Enable Cut & Paste + “Play sound feedback”, cut a file in Finder (⌘X) → hear Pop
- [ ] Paste/move successfully (⌘V) → hear Pop
- [ ] Preference off → silent cut/paste
- [ ] Failed paste (0 moved) → no sound