### PR TITLE
fix(recorder): keep recording when capture shortcuts fire

### DIFF
--- a/Sources/Vorssaint/Services/QuickTools/ScreenCaptureService.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenCaptureService.swift
@@ -62,7 +62,16 @@ final class ScreenCaptureService: ObservableObject {
 
     private init() {
         for (tool, hotkey) in toolHotkeys {
-            hotkey.onPress = { [weak self] in self?.capture(initial: tool, fromShortcut: true) }
+            hotkey.onPress = { [weak self] in
+                // Recording's dedicated shortcut is a start/stop control; route
+                // it through the recorder toggle so other capture shortcuts
+                // never inherit that abort.
+                if tool == .recording {
+                    ScreenRecorderService.shared.toggle(fromShortcut: true)
+                } else {
+                    self?.capture(initial: tool, fromShortcut: true)
+                }
+            }
         }
     }
 
@@ -108,10 +117,8 @@ final class ScreenCaptureService: ObservableObject {
     /// selecting anything.
     func capture(initial preferred: ScreenCaptureTool? = nil, fromShortcut: Bool = false) {
         let recorder = ScreenRecorderService.shared
-        if preferred == .recording, AppFeature.screenRecorder.isAvailable,
-           recorder.stopOrCancelActiveCapture() {
-            return
-        }
+        // Do not stop an active recording here. Only ScreenRecorderService.toggle
+        // is the stop path; capture shortcuts refuse to open over a take.
         guard !recorder.hasActiveCapture else { return }
         if countdown != nil {
             cancelSelection()

--- a/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
+++ b/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
@@ -329,9 +329,9 @@ final class ScreenRecorderService: ObservableObject {
 
     /// The one control the shortcut, the panel tile and the command bar all
     /// use: it starts when nothing is running and stops when something is.
-    func toggle() {
+    func toggle(fromShortcut: Bool = false) {
         if stopOrCancelActiveCapture() { return }
-        ScreenCaptureService.shared.capture(initial: .recording)
+        ScreenCaptureService.shared.capture(initial: .recording, fromShortcut: fromShortcut)
     }
 
     var hasActiveCapture: Bool {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -17837,6 +17837,25 @@ struct MetricsTests {
             encoding: .utf8)) ?? ""
         expect(!captureServiceSource.contains("replaceSelection"),
                "the capture service does not cancel and recreate selection controllers when changing modes")
+        // Screenshot, screen text, color and the capture palette all enter
+        // through capture(initial:). Stopping an active recording belongs only
+        // on the recorder's own toggle; a capture shortcut must leave the take
+        // running (and refuse to open over it).
+        expect(!captureServiceSource.contains("stopOrCancelActiveCapture"),
+               "capture shortcuts must not stop an active recording; only the recorder toggle may")
+        expect(captureServiceSource.contains("guard !recorder.hasActiveCapture else { return }"),
+               "capture entry refuses to open while a recording is already active")
+        expect(captureServiceSource.contains(
+            "ScreenRecorderService.shared.toggle(fromShortcut: true)"),
+               "the recorder shortcut stops and starts through toggle, not capture abort")
+        let recorderToggleSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift",
+            encoding: .utf8)) ?? ""
+        expect(recorderToggleSource.contains("func toggle(fromShortcut: Bool = false)")
+                && recorderToggleSource.contains("if stopOrCancelActiveCapture() { return }")
+                && recorderToggleSource.contains(
+                    "ScreenCaptureService.shared.capture(initial: .recording, fromShortcut: fromShortcut)"),
+               "recorder toggle remains the stop path and still opens capture when idle")
         // The preview appears unasked for, so presenting it must not take the
         // keyboard away from whatever the person is typing into. Its shortcuts
         // read a local monitor, which is delivered nothing until the panel is


### PR DESCRIPTION
## Summary
- Screen capture shortcuts (screenshot, screen text, color picker, palette) no longer call `stopOrCancelActiveCapture` at the start of `ScreenCaptureService.capture`.
- Active takes stay running; capture entry refuses to open over them via `hasActiveCapture`.
- The recorder dedicated shortcut routes through `ScreenRecorderService.toggle(fromShortcut:)`, which remains the only stop path.
- MetricsTests source-shape regression locks the separation.

## Test plan
- [x] `./build.sh --test` → TESTS OK (10640 checks)
- [ ] Start a screen recording, press screenshot / screen text / color / capture palette shortcuts → recording continues
- [ ] Press the recorder shortcut / panel toggle while recording → recording stops as before
- [ ] Start recording via the recorder shortcut when idle → chooser still respects “show capture menu on shortcut”

Refs #1338