### PR TITLE
feat(mouse-buttons): allow unmodified key shortcuts

### DIFF
--- a/Sources/Vorssaint/Core/GlobalShortcut.swift
+++ b/Sources/Vorssaint/Core/GlobalShortcut.swift
@@ -89,6 +89,10 @@ struct GlobalShortcut: Equatable, Hashable {
     }
 
     init?(storageValue: String) {
+        self.init(storageValue: storageValue, allowingUnmodifiedKeys: false)
+    }
+
+    init?(storageValue: String, allowingUnmodifiedKeys: Bool) {
         guard let separator = storageValue.firstIndex(of: ":"),
               let keyCode = Int64(storageValue[storageValue.index(after: separator)...])
         else { return nil }
@@ -103,7 +107,8 @@ struct GlobalShortcut: Equatable, Hashable {
             }
         }
         self.init(keyCode: keyCode, modifiers: modifiers)
-        guard isValid else { return nil }
+        let accepted = allowingUnmodifiedKeys ? isValidForMouseButtonShortcut : isValid
+        guard accepted else { return nil }
     }
 
     /// Delete on its own means "take the shortcut off" while a shortcut field
@@ -244,6 +249,17 @@ struct GlobalShortcut: Equatable, Hashable {
     var isValid: Bool {
         hasUsableKeyCode && keyLabel != nil
             && (modifiers.hasPrimaryModifier || Self.standaloneFunctionKeys.contains(keyCode))
+    }
+
+    /// Mouse-button shortcuts may fire an ordinary key with no modifier
+    /// (Return, a letter, and so on). Global hotkey registration stays
+    /// strict via `isValid`; only the mouse-button recorder and storage
+    /// path opt into this wider rule (issue #1363). Escape alone still
+    /// cancels recording and is never accepted as a binding.
+    var isValidForMouseButtonShortcut: Bool {
+        if isValid { return true }
+        guard hasUsableKeyCode, keyLabel != nil, modifiers.isEmpty else { return false }
+        return keyCode != Int64(kVK_Escape)
     }
 
     var displayString: String {

--- a/Sources/Vorssaint/Services/MouseButtons/MouseButtonShortcutSupport.swift
+++ b/Sources/Vorssaint/Services/MouseButtons/MouseButtonShortcutSupport.swift
@@ -112,7 +112,8 @@ enum MouseButtonShortcutSupport {
         var mappings: [Int64: GlobalShortcut] = [:]
         for (key, value) in raw {
             guard let button = Int64(key), canMap(button),
-                  let shortcut = GlobalShortcut(storageValue: value) else { continue }
+                  let shortcut = GlobalShortcut(storageValue: value,
+                                                allowingUnmodifiedKeys: true) else { continue }
             mappings[button] = shortcut
         }
         return mappings
@@ -173,7 +174,7 @@ enum MouseButtonShortcutSupport {
         guard defaults.bool(forKey: DefaultsKey.mouseButtonShortcutsEnabled) else { return false }
         let raw = defaults.dictionary(forKey: DefaultsKey.mouseButtonShortcuts) as? [String: String]
         guard let stored = raw?[String(button)] else { return false }
-        return GlobalShortcut(storageValue: stored) != nil
+        return GlobalShortcut(storageValue: stored, allowingUnmodifiedKeys: true) != nil
     }
 
     /// The rows in Settings sort by button number so the list never reorders

--- a/Sources/Vorssaint/UI/Settings/MouseButtonSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/MouseButtonSettings.swift
@@ -122,6 +122,7 @@ struct MouseButtonShortcutsSection: View {
                                            recordingButton = recording ? button : nil
                                            if recording { setRecordError(nil, button) }
                                        },
+                                       acceptsUnmodifiedKeys: true,
                                        invalidAction: { setRecordError(l10n.s.shortcutInvalid, button) },
                                        captureAction: { save(button: button, shortcut: $0) })
                     .frame(width: 108)

--- a/Sources/Vorssaint/UI/ShortcutRecorderButton.swift
+++ b/Sources/Vorssaint/UI/ShortcutRecorderButton.swift
@@ -22,6 +22,10 @@ struct ShortcutRecorderButton: NSViewRepresentable {
     var notCapturedAction: (() -> Void)? = nil
     /// Lets the row show its caption exactly while the field is listening.
     var recordingChanged: ((Bool) -> Void)? = nil
+    /// When true, an ordinary key with no modifier (Return, a letter) is
+    /// accepted. Mouse-button shortcuts use this; global hotkey rows do not
+    /// (issue #1363).
+    var acceptsUnmodifiedKeys: Bool = false
     let invalidAction: () -> Void
     let captureAction: (GlobalShortcut) -> Void
 
@@ -72,6 +76,7 @@ struct ShortcutRecorderButton: NSViewRepresentable {
         button.clearAction = clearAction
         button.notCapturedAction = notCapturedAction
         button.recordingChanged = recordingChanged
+        button.acceptsUnmodifiedKeys = acceptsUnmodifiedKeys
         button.invalidAction = invalidAction
         button.captureAction = captureAction
         button.isEnabled = isEnabled
@@ -86,6 +91,7 @@ final class RecorderButton: NSButton {
     var clearAction: (() -> Void)?
     var notCapturedAction: (() -> Void)?
     var recordingChanged: ((Bool) -> Void)?
+    var acceptsUnmodifiedKeys = false
     var invalidAction: (() -> Void)?
     var captureAction: ((GlobalShortcut) -> Void)?
     private var isRecording = false
@@ -222,7 +228,10 @@ final class RecorderButton: NSButton {
             return
         }
         let captured = GlobalShortcut(keyCode: keyCode, modifiers: modifiers)
-        guard captured.isValid else {
+        let accepted = acceptsUnmodifiedKeys
+            ? captured.isValidForMouseButtonShortcut
+            : captured.isValid
+        guard accepted else {
             NSSound.beep()
             invalidAction?()
             return

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -4277,6 +4277,26 @@ struct MetricsTests {
                "a standalone function key records, displays and survives storage")
         expect(!GlobalShortcut(keyCode: Int64(kVK_ANSI_F), modifiers: []).isValid,
                "a bare letter still cannot become a shortcut")
+        // Mouse-button shortcuts may bind an ordinary key with no modifier
+        // (issue #1363). Global hotkeys stay strict; only the opt-in path
+        // accepts a bare Return or letter. Escape alone still cancels
+        // recording and never becomes a binding.
+        let bareReturn = GlobalShortcut(keyCode: Int64(kVK_Return), modifiers: [])
+        let bareLetter = GlobalShortcut(keyCode: Int64(kVK_ANSI_F), modifiers: [])
+        let bareEscape = GlobalShortcut(keyCode: Int64(kVK_Escape), modifiers: [])
+        expect(!bareReturn.isValid && bareReturn.isValidForMouseButtonShortcut,
+               "Return alone is not a global hotkey but is valid for a mouse button")
+        expect(!bareLetter.isValid && bareLetter.isValidForMouseButtonShortcut,
+               "a bare letter stays invalid globally and valid for a mouse button")
+        expect(!bareEscape.isValid && !bareEscape.isValidForMouseButtonShortcut,
+               "Escape alone never becomes a mouse-button shortcut")
+        expect(GlobalShortcut(keyCode: Int64(kVK_Return), modifiers: [.command])
+                .isValidForMouseButtonShortcut,
+               "a modified combination remains valid for mouse buttons through the normal path")
+        expect(!GlobalShortcut(keyCode: -1, modifiers: []).isValidForMouseButtonShortcut,
+               "an unusable key code is never valid for a mouse button either")
+        expect(bareReturn.syntheticEventFlags.isEmpty,
+               "an unmodified mouse-button key posts with empty flags, not leftover modifiers")
         expect(GlobalShortcut.finderRenameDefault.matches(keyCode: Int64(kVK_F2), modifiers: [])
                 && !GlobalShortcut.finderRenameDefault.matches(
                     keyCode: Int64(kVK_F2), modifiers: [.command]),
@@ -19183,7 +19203,7 @@ struct MetricsTests {
             "40": "command:11",
             "junk": "command:11",
             "5": "garbage",
-            "6": ":48",
+            "6": ":53",
         ])
         expect(decodedButtons.count == 3 && decodedButtons[3] == buttonCombo && decodedButtons[4] != nil
                 && decodedButtons[MouseButtonShortcutSupport.sideWheelLeftInput] != nil,
@@ -19191,6 +19211,11 @@ struct MetricsTests {
         expect(MouseButtonShortcutSupport.decode(MouseButtonShortcutSupport.encode(decodedButtons))
                 == decodedButtons,
                "mappings round-trip through their stored form")
+        let bareReturnStored = GlobalShortcut(keyCode: Int64(kVK_Return), modifiers: [])
+        expect(MouseButtonShortcutSupport.decode(["5": bareReturnStored.storageValue])[5]
+                == bareReturnStored
+                && GlobalShortcut(storageValue: bareReturnStored.storageValue) == nil,
+               "mouse-button storage keeps an unmodified key that global hotkey loading still rejects")
         expect(MouseButtonShortcutSupport.decode(nil).isEmpty,
                "no stored mappings decode to none")
         expect(MouseButtonShortcutSupport.sortedButtons([
@@ -19657,6 +19682,25 @@ struct MetricsTests {
                 && GlobalShortcut(keyCode: Int64(kVK_Return), modifiers: [.control, .option])
                 .syntheticEventFlags == [.maskControl, .maskAlternate],
                "the keys beside them are ordinary and stay ordinary")
+        expect(GlobalShortcut(keyCode: Int64(kVK_Return), modifiers: []).syntheticEventFlags.isEmpty,
+               "an unmodified Return for a mouse button posts with flags cleared to empty")
+
+        let recorderSource = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/UI/ShortcutRecorderButton.swift",
+            encoding: .utf8)) ?? "")
+        expect(recorderSource.contains("var acceptsUnmodifiedKeys: Bool = false")
+                && recorderSource.contains("captured.isValidForMouseButtonShortcut"),
+               "the recorder keeps unmodified keys opt-in and validates them on that path")
+        expect(mouseSettingsLines.contains {
+            $0.contains("acceptsUnmodifiedKeys: true")
+        }, "mouse-button shortcut rows opt into unmodified key capture")
+        let mousePostSource = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/MouseButtons/MouseButtonShortcutService.swift",
+            encoding: .utf8)) ?? "")
+        expect(mousePostSource.contains("let flags = shortcut.syntheticEventFlags")
+                && mousePostSource.contains("down.flags = flags")
+                && mousePostSource.contains("up.flags = flags"),
+               "mouse-button posting always assigns synthetic flags, including empty for unmodified keys")
 
         // MARK: Super key (issue #330)
 


### PR DESCRIPTION
## Summary
- Opt-in mouse-button path accepts ordinary keys with empty modifiers (e.g. Return) via `GlobalShortcut.isValidForMouseButtonShortcut`, without loosening global hotkey `isValid`.
- `ShortcutRecorderButton(acceptsUnmodifiedKeys:)` is enabled only in Mouse Button settings; Escape alone still cancels recording.
- Storage decode/claim for mouse mappings allows unmodified keys; posting still assigns `syntheticEventFlags` explicitly (empty for bare keys).

Refs #1363

## Test plan
- [x] `./build.sh --test` — 10647 checks, 0 failures
- [ ] Map an extra mouse button to Return (no modifiers) and confirm it types/activates Return
- [ ] Confirm global hotkey recorders still reject bare letters with beep
- [ ] Confirm Escape while recording still cancels without saving