### PR TITLE
feat(command-bar): optional ASCII layout while open

### DIFF
--- a/Sources/Vorssaint/Core/CommandBarStrings.swift
+++ b/Sources/Vorssaint/Core/CommandBarStrings.swift
@@ -165,6 +165,8 @@ struct CommandBarFeatureStrings {
     let filesIgnoreAdd: String
     let compactModeToggle: String
     let compactModeCaption: String
+    let asciiLayoutToggle: String
+    let asciiLayoutCaption: String
 }
 
 extension FeatureStrings {
@@ -346,7 +348,9 @@ extension CommandBarFeatureStrings {
         filesIgnorePlaceholder: "A folder or file name",
         filesIgnoreAdd: "Add",
         compactModeToggle: "Compact mode",
-        compactModeCaption: "Bar opens without suggestions. Results appear as you type.")
+        compactModeCaption: "Bar opens without suggestions. Results appear as you type.",
+        asciiLayoutToggle: "Use Latin keyboard while open",
+        asciiLayoutCaption: "Switch to the first Latin layout among your enabled keyboards when the bar opens, and restore the previous one when it closes.")
 
     static let ptBR = CommandBarFeatureStrings(
         pageTitle: "Barra de comando",
@@ -506,7 +510,9 @@ extension CommandBarFeatureStrings {
         filesIgnorePlaceholder: "Nome de pasta ou arquivo",
         filesIgnoreAdd: "Adicionar",
         compactModeToggle: "Modo compacto",
-        compactModeCaption: "A barra abre sem sugestões. Os resultados aparecem conforme você digita.")
+        compactModeCaption: "A barra abre sem sugestões. Os resultados aparecem conforme você digita.",
+        asciiLayoutToggle: "Usar teclado latino enquanto aberta",
+        asciiLayoutCaption: "Ao abrir, troca para o primeiro layout latino entre os teclados ativos e restaura o anterior ao fechar.")
 
     static let tr = CommandBarFeatureStrings(
         pageTitle: "Komut çubuğu",
@@ -666,7 +672,9 @@ extension CommandBarFeatureStrings {
         filesIgnorePlaceholder: "Klasör veya dosya adı",
         filesIgnoreAdd: "Ekle",
         compactModeToggle: "Kompakt mod",
-        compactModeCaption: "Çubuk önerilmeden açılır. Sonuçlar siz yazdıkça görünür.")
+        compactModeCaption: "Çubuk önerilmeden açılır. Sonuçlar siz yazdıkça görünür.",
+        asciiLayoutToggle: "Açıkken Latin klavye kullan",
+        asciiLayoutCaption: "Çubuk açılınca etkin klavyelerinizdeki ilk Latin düzene geçer; kapanınca öncekinin üzerine döner.")
 
     static let ru = CommandBarFeatureStrings(
         pageTitle: "Командная панель",
@@ -826,7 +834,9 @@ extension CommandBarFeatureStrings {
         filesIgnorePlaceholder: "Имя папки или файла",
         filesIgnoreAdd: "Добавить",
         compactModeToggle: "Компактный режим",
-        compactModeCaption: "Строка открывается без подсказок. Результаты появляются по мере ввода.")
+        compactModeCaption: "Строка открывается без подсказок. Результаты появляются по мере ввода.",
+        asciiLayoutToggle: "Латинская раскладка, пока строка открыта",
+        asciiLayoutCaption: "При открытии переключается на первую латинскую раскладку среди включённых и возвращает прежнюю при закрытии.")
 
     static let es = CommandBarFeatureStrings(
         pageTitle: "Barra de comandos",
@@ -986,7 +996,9 @@ extension CommandBarFeatureStrings {
         filesIgnorePlaceholder: "Nombre de carpeta o archivo",
         filesIgnoreAdd: "Añadir",
         compactModeToggle: "Modo compacto",
-        compactModeCaption: "La barra se abre sin sugerencias. Los resultados aparecen mientras escribes.")
+        compactModeCaption: "La barra se abre sin sugerencias. Los resultados aparecen mientras escribes.",
+        asciiLayoutToggle: "Usar teclado latino mientras está abierta",
+        asciiLayoutCaption: "Al abrir, cambia al primer diseño latino de tus teclados activos y restaura el anterior al cerrar.")
 
     static let de = CommandBarFeatureStrings(
         pageTitle: "Befehlsleiste",
@@ -1146,7 +1158,9 @@ extension CommandBarFeatureStrings {
         filesIgnorePlaceholder: "Ordner- oder Dateiname",
         filesIgnoreAdd: "Hinzufügen",
         compactModeToggle: "Kompaktmodus",
-        compactModeCaption: "Die Leiste öffnet sich ohne Vorschläge. Die Ergebnisse erscheinen beim Tippen.")
+        compactModeCaption: "Die Leiste öffnet sich ohne Vorschläge. Die Ergebnisse erscheinen beim Tippen.",
+        asciiLayoutToggle: "Lateinische Tastatur während geöffnet",
+        asciiLayoutCaption: "Wechselt beim Öffnen zur ersten lateinischen Belegung unter den aktiven Tastaturen und stellt die vorherige beim Schließen wieder her.")
 
     static let fr = CommandBarFeatureStrings(
         pageTitle: "Barre de commande",
@@ -1306,7 +1320,9 @@ extension CommandBarFeatureStrings {
         filesIgnorePlaceholder: "Nom de dossier ou de fichier",
         filesIgnoreAdd: "Ajouter",
         compactModeToggle: "Mode compact",
-        compactModeCaption: "La barre s’ouvre sans suggestions. Les résultats apparaissent à mesure que vous tapez.")
+        compactModeCaption: "La barre s’ouvre sans suggestions. Les résultats apparaissent à mesure que vous tapez.",
+        asciiLayoutToggle: "Clavier latin tant qu’elle est ouverte",
+        asciiLayoutCaption: "À l’ouverture, passe à la première disposition latine parmi vos claviers actifs, et restaure la précédente à la fermeture.")
 
     static let it = CommandBarFeatureStrings(
         pageTitle: "Barra dei comandi",
@@ -1466,7 +1482,9 @@ extension CommandBarFeatureStrings {
         filesIgnorePlaceholder: "Nome di cartella o file",
         filesIgnoreAdd: "Aggiungi",
         compactModeToggle: "Modalità compatta",
-        compactModeCaption: "La barra si apre senza suggerimenti. I risultati appaiono mentre scrivi.")
+        compactModeCaption: "La barra si apre senza suggerimenti. I risultati appaiono mentre scrivi.",
+        asciiLayoutToggle: "Tastiera latina mentre è aperta",
+        asciiLayoutCaption: "All’apertura passa al primo layout latino tra le tastiere attive e ripristina il precedente alla chiusura.")
 
     static let ja = CommandBarFeatureStrings(
         pageTitle: "コマンドバー",
@@ -1626,7 +1644,9 @@ extension CommandBarFeatureStrings {
         filesIgnorePlaceholder: "フォルダまたはファイルの名前",
         filesIgnoreAdd: "追加",
         compactModeToggle: "コンパクトモード",
-        compactModeCaption: "バーは候補なしで開きます。入力すると結果が現れます。")
+        compactModeCaption: "バーは候補なしで開きます。入力すると結果が現れます。",
+        asciiLayoutToggle: "表示中はラテン配列を使う",
+        asciiLayoutCaption: "バーを開くと、有効なキーボードのうち最初のラテン配列に切り替え、閉じると元の入力ソースに戻します。")
 
     static let ko = CommandBarFeatureStrings(
         pageTitle: "명령 막대",
@@ -1786,7 +1806,9 @@ extension CommandBarFeatureStrings {
         filesIgnorePlaceholder: "폴더 또는 파일 이름",
         filesIgnoreAdd: "추가",
         compactModeToggle: "컴팩트 모드",
-        compactModeCaption: "막대가 추천 없이 열립니다. 입력하면 결과가 나타납니다.")
+        compactModeCaption: "막대가 추천 없이 열립니다. 입력하면 결과가 나타납니다.",
+        asciiLayoutToggle: "열려 있는 동안 라틴 키보드 사용",
+        asciiLayoutCaption: "막대가 열리면 사용 중인 키보드 중 첫 라틴 배열로 바꾸고, 닫히면 이전 입력 소스로 되돌립니다.")
 
     static let zhHans = CommandBarFeatureStrings(
         pageTitle: "命令栏",
@@ -1946,7 +1968,9 @@ extension CommandBarFeatureStrings {
         filesIgnorePlaceholder: "文件夹或文件名",
         filesIgnoreAdd: "添加",
         compactModeToggle: "紧凑模式",
-        compactModeCaption: "命令栏打开时不显示建议，输入时才显示结果。")
+        compactModeCaption: "命令栏打开时不显示建议，输入时才显示结果。",
+        asciiLayoutToggle: "打开时使用拉丁键盘",
+        asciiLayoutCaption: "打开命令栏时切换到已启用键盘中的第一个拉丁布局，关闭时恢复之前的输入法。")
 
     static let zhTW = CommandBarFeatureStrings(
         pageTitle: "指令列",
@@ -2106,7 +2130,9 @@ extension CommandBarFeatureStrings {
         filesIgnorePlaceholder: "檔案夾或檔案名稱",
         filesIgnoreAdd: "加入",
         compactModeToggle: "精簡模式",
-        compactModeCaption: "命令列打開時不顯示建議，輸入時才顯示結果。")
+        compactModeCaption: "命令列打開時不顯示建議，輸入時才顯示結果。",
+        asciiLayoutToggle: "開啟時使用拉丁鍵盤",
+        asciiLayoutCaption: "開啟命令列時切換到已啟用鍵盤中的第一個拉丁配置，關閉時還原先前的輸入法。")
 
     static let zhHK = CommandBarFeatureStrings(
         pageTitle: "指令列",
@@ -2266,5 +2292,7 @@ extension CommandBarFeatureStrings {
         filesIgnorePlaceholder: "檔案夾或檔案名稱",
         filesIgnoreAdd: "加入",
         compactModeToggle: "精簡模式",
-        compactModeCaption: "命令列打開時不顯示建議，輸入時才顯示結果。")
+        compactModeCaption: "命令列打開時不顯示建議，輸入時才顯示結果。",
+        asciiLayoutToggle: "開啟時使用拉丁鍵盤",
+        asciiLayoutCaption: "開啟命令列時切換到已啟用鍵盤中嘅第一個拉丁配置，關閉時還原先前嘅輸入法。")
 }

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -492,6 +492,9 @@ enum DefaultsKey {
     static let commandBarShortcut = "commandBarShortcut"
     /// Compact mode: an empty field shows nothing but itself. Off by default
     static let commandBarCompactMode = "commandBarCompactMode"
+    /// While the bar is open, switch to the first ASCII-capable keyboard layout.
+    /// Off by default; restores the previous input source on close.
+    static let commandBarSwitchToASCIILayout = "commandBarSwitchToASCIILayout"
     static let commandBarUsage = "commandBarUsage"           // per-command run counts, never queries
     static let commandBarQueryHabits = "commandBarQueryHabits" // keyed query digests → app row ids
     static let commandBarDisabledSources = "commandBarDisabledSources" // kinds of result switched off
@@ -1250,6 +1253,7 @@ enum Defaults {
         DefaultsKey.scratchpadShortcut: GlobalShortcut.scratchpadDefault.storageValue,
         DefaultsKey.commandBarShortcutEnabled: false,
         DefaultsKey.commandBarCompactMode: false,
+        DefaultsKey.commandBarSwitchToASCIILayout: false,
         DefaultsKey.commandBarDisabledSources: "",
         DefaultsKey.commandBarAliases: "",
         DefaultsKey.commandBarPins: "",

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarASCIILayout.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarASCIILayout.swift
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Carbon
+import Foundation
+
+/// One-shot Text Input Services switch around Command Bar show/hide. Remembers
+/// the previous source only after a successful switch so a close with no open
+/// change leaves the Mac alone.
+enum CommandBarASCIILayout {
+    private static var previousSourceID: String?
+
+    static func applyOnShow(enabled: Bool) {
+        guard enabled, previousSourceID == nil else { return }
+        let apply = {
+            let sources = selectableKeyboardLayouts()
+            let descriptors = sources.map(descriptor(for:))
+            let currentID = currentKeyboardSourceID()
+            guard let targetID = CommandBarASCIILayoutSupport.openSelection(
+                    currentID: currentID, sources: descriptors),
+                  let target = sources.first(where: { sourceID($0) == targetID })
+            else { return }
+            previousSourceID = currentID
+            _ = TISSelectInputSource(target)
+        }
+        runOnMain(apply)
+    }
+
+    static func restoreOnHide() {
+        let restore = {
+            let previousID = previousSourceID
+            previousSourceID = nil
+            guard let previousID else { return }
+            let currentID = currentKeyboardSourceID()
+            guard let restoreID = CommandBarASCIILayoutSupport.closeSelection(
+                    previousID: previousID, currentID: currentID),
+                  let source = selectableKeyboardLayouts().first(where: { sourceID($0) == restoreID })
+            else { return }
+            _ = TISSelectInputSource(source)
+        }
+        runOnMain(restore)
+    }
+
+    private static func runOnMain(_ work: @escaping () -> Void) {
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.sync(execute: work)
+        }
+    }
+
+    private static func currentKeyboardSourceID() -> String? {
+        guard let current = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else {
+            return nil
+        }
+        return sourceID(current)
+    }
+
+    private static func selectableKeyboardLayouts() -> [TISInputSource] {
+        guard let list = TISCreateInputSourceList(nil, false) else { return [] }
+        let values = list.takeRetainedValue() as NSArray
+        return (values as! [TISInputSource]).filter {
+            stringProperty($0, kTISPropertyInputSourceCategory)
+                == kTISCategoryKeyboardInputSource as String
+                && boolProperty($0, kTISPropertyInputSourceIsSelectCapable)
+                && stringProperty($0, kTISPropertyInputSourceType)
+                    == kTISTypeKeyboardLayout as String
+        }
+    }
+
+    private static func descriptor(for source: TISInputSource) -> CommandBarASCIILayoutSupport.Source {
+        CommandBarASCIILayoutSupport.Source(
+            id: sourceID(source) ?? "",
+            isASCIICapable: boolProperty(source, kTISPropertyInputSourceIsASCIICapable),
+            isSelectCapable: boolProperty(source, kTISPropertyInputSourceIsSelectCapable),
+            isKeyboardLayout: stringProperty(source, kTISPropertyInputSourceType)
+                == kTISTypeKeyboardLayout as String)
+    }
+
+    private static func sourceID(_ source: TISInputSource) -> String? {
+        stringProperty(source, kTISPropertyInputSourceID)
+    }
+
+    private static func stringProperty(_ source: TISInputSource, _ property: CFString) -> String? {
+        guard let pointer = TISGetInputSourceProperty(source, property) else { return nil }
+        return Unmanaged<CFString>.fromOpaque(pointer).takeUnretainedValue() as String
+    }
+
+    private static func boolProperty(_ source: TISInputSource, _ property: CFString) -> Bool {
+        guard let pointer = TISGetInputSourceProperty(source, property) else { return false }
+        return CFBooleanGetValue(Unmanaged<CFBoolean>.fromOpaque(pointer).takeUnretainedValue())
+    }
+}

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarASCIILayoutSupport.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarASCIILayoutSupport.swift
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+/// Pure selection rules for the optional Command Bar Latin-layout switch.
+/// Callers inject source ids and flags so the harness can pin behavior without
+/// talking to Text Input Services.
+enum CommandBarASCIILayoutSupport {
+    struct Source: Equatable {
+        let id: String
+        let isASCIICapable: Bool
+        let isSelectCapable: Bool
+        /// Keyboard layouts only — input methods and palettes stay out even
+        /// when they happen to be ASCII-capable.
+        let isKeyboardLayout: Bool
+    }
+
+    static func isEligible(_ source: Source) -> Bool {
+        source.isKeyboardLayout && source.isSelectCapable && source.isASCIICapable
+    }
+
+    static func firstEligibleID(in sources: [Source]) -> String? {
+        sources.first(where: isEligible)?.id
+    }
+
+    /// The layout to select when the bar opens, or `nil` when nothing should
+    /// change. Without a known current id there is nothing safe to restore, so
+    /// the bar leaves the input source alone.
+    static func openSelection(currentID: String?, sources: [Source]) -> String? {
+        guard let currentID else { return nil }
+        guard let target = firstEligibleID(in: sources), target != currentID else { return nil }
+        return target
+    }
+
+    /// The layout to select when the bar closes, or `nil` when there is nothing
+    /// to put back.
+    static func closeSelection(previousID: String?, currentID: String?) -> String? {
+        guard let previousID, previousID != currentID else { return nil }
+        return previousID
+    }
+}

--- a/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
+++ b/Sources/Vorssaint/Services/CommandBar/CommandBarService.swift
@@ -291,6 +291,8 @@ final class CommandBarService: ObservableObject {
             }
         }
         present(panel)
+        CommandBarASCIILayout.applyOnShow(
+            enabled: UserDefaults.standard.bool(forKey: DefaultsKey.commandBarSwitchToASCIILayout))
         // Ordering the prepared panel is the keystroke path. Home is filled on
         // the next main-loop turn, when a close or newer opening can supersede it.
         DispatchQueue.main.async { [weak self] in
@@ -408,6 +410,7 @@ final class CommandBarService: ObservableObject {
         query = ""
         presentationLifecycle.hide()
         clearIndex()
+        CommandBarASCIILayout.restoreOnHide()
     }
 
     /// Re-fits the panel to its content as the result list grows and

--- a/Sources/Vorssaint/UI/Settings/CommandBarSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/CommandBarSettings.swift
@@ -9,6 +9,7 @@ struct CommandBarSettings: View {
     @ObservedObject private var service = CommandBarService.shared
     @AppStorage(DefaultsKey.commandBarShortcutEnabled) private var shortcutEnabled = false
     @AppStorage(DefaultsKey.commandBarCompactMode) private var compactMode = false
+    @AppStorage(DefaultsKey.commandBarSwitchToASCIILayout) private var switchToASCIILayout = false
     @AppStorage(DefaultsKey.commandBarDisabledSources) private var disabledSources = ""
     @AppStorage(DefaultsKey.commandBarAliases) private var aliasesRaw = ""
     @AppStorage(DefaultsKey.commandBarPins) private var pinsRaw = ""
@@ -78,6 +79,10 @@ struct CommandBarSettings: View {
                 // screen with a stale value between them.
                 Toggle(text.compactModeToggle, isOn: $compactMode)
                 Text(text.compactModeCaption)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Toggle(text.asciiLayoutToggle, isOn: $switchToASCIILayout)
+                Text(text.asciiLayoutCaption)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 // Not the shared "Global shortcut" label the other feature

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21979,6 +21979,60 @@ struct MetricsTests {
                 && !SettingsBackupSupport.valueLooksRight(DefaultsKey.commandBarCompactMode, "yes"),
                "a restored compact mode has to be a switch, not text that looks like one")
 
+        // Optional Latin layout while the bar is open: pick the first
+        // ASCII-capable keyboard layout from an injected list, without talking
+        // to Text Input Services. Off by default; restores only after a switch.
+        expect(Defaults.registeredDefaults[DefaultsKey.commandBarSwitchToASCIILayout] as? Bool == false,
+               "ASCII layout switching ships off so existing layouts stay put")
+        expect(SettingsBackupSupport.exportKeys().contains(DefaultsKey.commandBarSwitchToASCIILayout),
+               "ASCII layout switching is configuration and travels with a backup")
+        expect(SettingsBackupSupport.valueLooksRight(DefaultsKey.commandBarSwitchToASCIILayout, true)
+                && !SettingsBackupSupport.valueLooksRight(DefaultsKey.commandBarSwitchToASCIILayout, "yes"),
+               "a restored ASCII layout switch has to be a bool")
+        let russian = CommandBarASCIILayoutSupport.Source(
+            id: "com.apple.keylayout.Russian",
+            isASCIICapable: false, isSelectCapable: true, isKeyboardLayout: true)
+        let us = CommandBarASCIILayoutSupport.Source(
+            id: "com.apple.keylayout.US",
+            isASCIICapable: true, isSelectCapable: true, isKeyboardLayout: true)
+        let abc = CommandBarASCIILayoutSupport.Source(
+            id: "com.apple.keylayout.ABC",
+            isASCIICapable: true, isSelectCapable: true, isKeyboardLayout: true)
+        let pinyin = CommandBarASCIILayoutSupport.Source(
+            id: "com.apple.inputmethod.SCIM.ITABC",
+            isASCIICapable: false, isSelectCapable: true, isKeyboardLayout: false)
+        let palette = CommandBarASCIILayoutSupport.Source(
+            id: "com.apple.CharacterPaletteIM",
+            isASCIICapable: true, isSelectCapable: false, isKeyboardLayout: false)
+        expect(!CommandBarASCIILayoutSupport.isEligible(russian)
+                && CommandBarASCIILayoutSupport.isEligible(us)
+                && !CommandBarASCIILayoutSupport.isEligible(pinyin)
+                && !CommandBarASCIILayoutSupport.isEligible(palette),
+               "only a select-capable ASCII keyboard layout counts")
+        expect(CommandBarASCIILayoutSupport.firstEligibleID(in: [russian, pinyin, us, abc])
+                == "com.apple.keylayout.US",
+               "the first eligible layout in the enabled list wins")
+        expect(CommandBarASCIILayoutSupport.firstEligibleID(in: [russian, pinyin]) == nil,
+               "no eligible layout means the bar leaves the input source alone")
+        expect(CommandBarASCIILayoutSupport.openSelection(currentID: "com.apple.keylayout.Russian",
+                                                         sources: [russian, us])
+                == "com.apple.keylayout.US"
+                && CommandBarASCIILayoutSupport.openSelection(currentID: "com.apple.keylayout.US",
+                                                             sources: [russian, us]) == nil
+                && CommandBarASCIILayoutSupport.openSelection(currentID: nil,
+                                                             sources: [us]) == nil,
+               "opening switches only when the current source is not already the first Latin layout")
+        expect(CommandBarASCIILayoutSupport.closeSelection(
+                    previousID: "com.apple.keylayout.Russian",
+                    currentID: "com.apple.keylayout.US")
+                == "com.apple.keylayout.Russian"
+                && CommandBarASCIILayoutSupport.closeSelection(
+                    previousID: "com.apple.keylayout.Russian",
+                    currentID: "com.apple.keylayout.Russian") == nil
+                && CommandBarASCIILayoutSupport.closeSelection(
+                    previousID: nil, currentID: "com.apple.keylayout.US") == nil,
+               "closing restores the remembered source only when it still differs")
+
         // MARK: What the bar noticed about this session
         expect(CommandBarQueryMemory.prefixes(of: "wha") == ["w", "wh", "wha"],
                "choosing a row for what was typed also answers every shorter piece of it")
@@ -23829,7 +23883,7 @@ struct MetricsTests {
         for language in AppLanguage.allCases {
             let commandBarValues = Mirror(reflecting: FeatureStrings.commandBar(language)).children
                 .compactMap { $0.value as? String }
-            expect(commandBarValues.count == 158 && commandBarValues.allSatisfy { !$0.isEmpty },
+            expect(commandBarValues.count == 160 && commandBarValues.allSatisfy { !$0.isEmpty },
                    "every command bar string is set for \(language.rawValue)")
             expect(commandBarValues.allSatisfy { !$0.contains("—") },
                    "no em-dash in visible command bar strings (\(language.rawValue))")
@@ -23930,6 +23984,21 @@ struct MetricsTests {
         expect(commandBarSettingsSource.contains("Toggle(text.shortcutToggle,")
                 && !commandBarSettingsSource.contains("l10n.s.quickToolShortcutToggle"),
                "the command bar shortcut toggle says what the shortcut opens")
+        expect(commandBarSettingsSource.contains("Toggle(text.asciiLayoutToggle,")
+                && commandBarSettingsSource.contains("DefaultsKey.commandBarSwitchToASCIILayout")
+                && commandBarSettingsSource.contains("text.asciiLayoutCaption"),
+               "Command Bar settings expose the optional ASCII layout switch")
+        let commandBarServiceSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/CommandBar/CommandBarService.swift",
+            encoding: .utf8)) ?? ""
+        let commandBarServiceCode = commandBarServiceSource
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(commandBarServiceCode.contains("CommandBarASCIILayout.applyOnShow")
+                && commandBarServiceCode.contains("CommandBarASCIILayout.restoreOnHide")
+                && commandBarServiceCode.contains("DefaultsKey.commandBarSwitchToASCIILayout"),
+               "the Command Bar switches and restores the input source around show and hide")
         for language in AppLanguage.allCases {
             let recordingShareValues = Mirror(
                 reflecting: FeatureStrings.recorderShare(language)).children

--- a/build.sh
+++ b/build.sh
@@ -364,6 +364,7 @@ if (( TEST )); then
         Sources/Vorssaint/Core/SwitcherAppRulesStrings.swift \
         Sources/Vorssaint/Services/QuickTools/QuickToolsSupport.swift \
         Sources/Vorssaint/Services/CommandBar/CommandBarSupport.swift \
+        Sources/Vorssaint/Services/CommandBar/CommandBarASCIILayoutSupport.swift \
         Sources/Vorssaint/Services/CommandBar/CommandBarPreferences.swift \
         Sources/Vorssaint/Services/CommandBar/CommandBarMath.swift \
         Sources/Vorssaint/Services/CommandBar/CommandBarUnits.swift \


### PR DESCRIPTION
## Summary
- Adds optional `commandBarSwitchToASCIILayout` (default off): on Command Bar show, select the first ASCII-capable keyboard layout among enabled sources via TIS; on hide, restore the previous input source.
- Pure helpers (`CommandBarASCIILayoutSupport`) are unit-tested without live TIS; settings toggle + all locales.

## Test plan
- [x] `./build.sh --test` — TESTS OK (10670 checks)
- [ ] Enable the toggle in Command Bar settings; open the bar on a non-Latin layout and confirm Latin input; close and confirm restore
- [ ] Leave the toggle off and confirm layout is unchanged

Refs #1327