### PR TITLE
feat(window-layout): snap to top half before maximizing on upward drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. The format follows
 
 ## [Unreleased]
 
+### Changed
+- Dragging a window to the top edge first previews the upper half; pushing farther upward fills the screen.
+
 ## [3.3.5] - 2026-09-06
 
 ### Summary

--- a/Sources/Vorssaint/Services/WindowLayout/WindowGestureSupport.swift
+++ b/Sources/Vorssaint/Services/WindowLayout/WindowGestureSupport.swift
@@ -354,7 +354,7 @@ enum WindowEdgeSnapZone: String, CaseIterable {
     var action: WindowLayoutAction {
         switch self {
         case .topLeft: return .topLeft
-        case .top: return .maximize
+        case .top: return .topHalf
         case .topRight: return .topRight
         case .left: return .leftHalf
         case .right: return .rightHalf
@@ -387,7 +387,7 @@ struct WindowEdgeSnapTarget: Equatable {
     let frame: CGRect
     let visibleFrame: CGRect
 
-    var action: WindowLayoutAction { zone.action }
+    let action: WindowLayoutAction
 }
 
 enum WindowEdgeSnapSupport {
@@ -502,7 +502,8 @@ enum WindowEdgeSnapSupport {
     /// Resolves the hot zone under an AppKit-coordinate pointer. Screen frames
     /// choose the reachable edge; visible frames keep the result clear of the
     /// menu bar and Dock. A seam shared by two displays is not an edge, so a
-    /// window can cross it without being caught halfway through.
+    /// window can cross it without being caught halfway through. Top-center
+    /// contact selects the upper half; pushing farther upward maximizes.
     static func target(at point: CGPoint,
                        screens: [WindowEdgeSnapScreen],
                        distance: CGFloat = activationDistance,
@@ -579,7 +580,9 @@ enum WindowEdgeSnapSupport {
             }
             guard enabledZones.contains(zone) else { return nil }
 
-            let action = zone.action
+            let action = zone == .top
+                ? topCenterAction(pointY: point.y, visibleTop: visibleTop, physicalTop: frame.maxY)
+                : zone.action
             let targetFrame = WindowLayoutGeometry.rect(for: action,
                                                         current: screen.visibleFrame,
                                                         visibleFrame: screen.visibleFrame,
@@ -587,9 +590,23 @@ enum WindowEdgeSnapSupport {
                                                         screenGap: WindowLayoutGaps.screenGap)
             return WindowEdgeSnapTarget(zone: zone,
                                         frame: targetFrame.integral,
-                                        visibleFrame: screen.visibleFrame)
+                                        visibleFrame: screen.visibleFrame,
+                                        action: action)
         }
         return nil
+    }
+
+    /// Split the menu bar into a top-half band and a maximize band. Without
+    /// a visible menu bar, maximize only at the physical edge so the approach
+    /// still offers the upper half. Corner zones never use this split.
+    static func topCenterAction(pointY: CGFloat,
+                                visibleTop: CGFloat,
+                                physicalTop: CGFloat) -> WindowLayoutAction {
+        let menuBar = max(physicalTop - visibleTop, 0)
+        let promoteFrom = menuBar >= activationDistance
+            ? physicalTop - menuBar / 2
+            : physicalTop
+        return pointY >= promoteFrom ? .maximize : .topHalf
     }
 
     private enum Edge {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -5743,16 +5743,38 @@ struct MetricsTests {
                                          screens: screens,
                                          enabledZones: enabledZones)
         }
-        let topSnapFrame = WindowLayoutGeometry.rect(for: .maximize,
+        let topSnapFrame = WindowLayoutGeometry.rect(for: .topHalf,
                                                      current: snapVisibleFrame,
                                                      visibleFrame: snapVisibleFrame)
         expect(snapTarget(CGPoint(x: 720, y: snapVisibleFrame.maxY))
                == WindowEdgeSnapTarget(zone: .top,
                                        frame: topSnapFrame,
-                                       visibleFrame: snapVisibleFrame),
-               "touching the lower edge of the menu bar previews maximize")
+                                       visibleFrame: snapVisibleFrame,
+                                       action: .topHalf),
+               "touching the lower edge of the menu bar previews the upper half")
         expect(snapTarget(CGPoint(x: 720, y: 900))?.action == .maximize,
-               "the full menu bar band remains a top snap target for maximize")
+               "pushing to the physical top promotes the target to maximize")
+        let maximizeSnapFrame = WindowLayoutGeometry.rect(for: .maximize,
+                                                          current: snapVisibleFrame,
+                                                          visibleFrame: snapVisibleFrame)
+        expect(snapTarget(CGPoint(x: 720, y: 900))?.frame == maximizeSnapFrame,
+               "the promoted preview matches the maximize placement")
+        expect(snapTarget(CGPoint(x: 720, y: 887))?.action == .topHalf
+               && snapTarget(CGPoint(x: 720, y: 887.5))?.action == .maximize
+               && snapTarget(CGPoint(x: 720, y: 875))?.action == .topHalf,
+               "crossing the menu bar midpoint promotes and retreating restores the upper half")
+        expect(snapTarget(CGPoint(x: 0, y: 900))?.action == .topLeft
+               && snapTarget(CGPoint(x: 1440, y: 900))?.action == .topRight,
+               "pushing to the physical top keeps corner placements")
+        for menuBarHeight in [CGFloat(0), 8, 25, 38] {
+            let screen = WindowEdgeSnapScreen(
+                frame: CGRect(x: -1440, y: -900, width: 1440, height: 900),
+                visibleFrame: CGRect(x: -1440, y: -900, width: 1440, height: 900 - menuBarHeight)
+            )
+            expect(snapTarget(CGPoint(x: -720, y: -menuBarHeight - 1), screens: [screen])?.action == .topHalf
+                   && snapTarget(CGPoint(x: -720, y: 0), screens: [screen])?.action == .maximize,
+                   "top snapping supports hidden, short and tall menu bars on offset displays")
+        }
         expect(snapTarget(CGPoint(x: 720, y: snapVisibleFrame.maxY - 13)) == nil,
                "the top target does not reach below its activation band")
         expect(snapTarget(CGPoint(x: 0, y: 450))?.action == .leftHalf
@@ -5776,6 +5798,7 @@ struct MetricsTests {
         let withoutTop = WindowEdgeSnapZone.enabledZones(from: disabledZoneStorage)
         expect(snapTarget(CGPoint(x: 720, y: snapVisibleFrame.maxY),
                           enabledZones: withoutTop) == nil
+               && snapTarget(CGPoint(x: 720, y: 900), enabledZones: withoutTop) == nil
                && snapTarget(CGPoint(x: 0, y: 450),
                              enabledZones: withoutTop)?.zone == .left,
                "turning off the top zone leaves the other visual snap areas active")


### PR DESCRIPTION
Dragging a window into the top-center snap area now previews and applies the upper half. Continuing upward through the menu bar promotes the target to maximize; retreating selects the upper half again. With a hidden menu bar, maximize activates at the physical top edge.

The selected action is stored with the target so preview and release agree. Existing corner targets, disabled-zone preferences, display seams, and system top-drag protection are preserved. The top-zone settings icon now reflects its initial upper-half placement.

Regression coverage includes the promotion boundary, placement geometry, retreat, corners, disabled top zones, and hidden/short/tall menu bars on offset displays. Validation passed: local unit tests (10,705 checks) and preference-cleanup tests; CI Build & selftest (including DMG packaging and unit tests); and CI Swift 6.0.3 compatibility (build, self-test, and unit tests).
