### PR TITLE
fix(recorder): preserve raw recording track synchronization

### DIFF
--- a/Sources/Vorssaint/Core/AppInfo.swift
+++ b/Sources/Vorssaint/Core/AppInfo.swift
@@ -19,7 +19,7 @@ enum AppInfo {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "dev"
     }
 
-    /// True for the local "Vorssaint (Developer)" build (bundle id ends in `.dev`).
+    /// True for the local "Vorssaint Developer" build (bundle id ends in `.dev`).
     /// It is never published and never auto-updates; all work is tested here first.
     static var isDeveloperBuild: Bool {
         (Bundle.main.bundleIdentifier ?? "").hasSuffix(".dev")

--- a/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift
@@ -26,7 +26,7 @@ protocol RecorderCaptureEngineDelegate: AnyObject {
 }
 
 /// Owns the ScreenCaptureKit stream and nothing else: it acquires pixels and
-/// system audio and hands them over untouched. No compositing happens here,
+/// system audio and maps their timestamps to the host clock. No compositing happens here,
 /// because everything the editor can change has to stay changeable after the
 /// recording ends.
 final class RecorderCaptureEngine: NSObject {
@@ -45,13 +45,6 @@ final class RecorderCaptureEngine: NSObject {
     private var lifecycle = RecorderCaptureLifecycle()
     private var stream: SCStream?
 
-    /// The clock the stream timestamps against, so a source that is not
-    /// ScreenCaptureKit (the microphone) can be lined up with the video.
-    private var storedSynchronizationClock: CMClock?
-    var synchronizationClock: CMClock? {
-        lifecycleLock.withLock { storedSynchronizationClock }
-    }
-
     /// True while pixels are being delivered. Read from the main thread.
     var isRunning: Bool {
         lifecycleLock.withLock { lifecycle.isRunning }
@@ -65,6 +58,7 @@ final class RecorderCaptureEngine: NSObject {
                frameRate: Int,
                capturesSystemAudio: Bool,
                excludedWindowNumbers: [Int],
+               willStartCapture: (CMTime) -> Void,
                isCancelled: @escaping () -> Bool) async -> RecorderFailure? {
         guard lifecycleLock.withLock({ self.stream == nil }), !isCancelled() else {
             return .streamFailed
@@ -134,13 +128,13 @@ final class RecorderCaptureEngine: NSObject {
                 return true
             }
             guard willStart else { return .streamFailed }
+            willStartCapture(CMClockGetTime(CMClockGetHostTimeClock()))
             try await stream.startCapture()
         } catch {
             let failure = Self.failure(for: error)
             lifecycleLock.withLock {
                 lifecycle.stop()
                 if self.stream === stream { self.stream = nil }
-                storedSynchronizationClock = nil
             }
             await stopAndDrain(stream)
             return failure
@@ -150,7 +144,6 @@ final class RecorderCaptureEngine: NSObject {
             lifecycleLock.withLock {
                 lifecycle.stop()
                 if self.stream === stream { self.stream = nil }
-                storedSynchronizationClock = nil
             }
             await stopAndDrain(stream)
             return .streamFailed
@@ -158,7 +151,6 @@ final class RecorderCaptureEngine: NSObject {
 
         let didStart = lifecycleLock.withLock { () -> Bool in
             guard self.stream === stream, lifecycle.didStart() else { return false }
-            storedSynchronizationClock = stream.synchronizationClock
             return true
         }
         guard didStart else {
@@ -175,7 +167,6 @@ final class RecorderCaptureEngine: NSObject {
             lifecycle.stop()
             let stream = self.stream
             self.stream = nil
-            storedSynchronizationClock = nil
             return stream
         }
         if let stream { try? await stream.stopCapture() }
@@ -245,7 +236,7 @@ final class RecorderCaptureEngine: NSObject {
 }
 
 /// Captures the default microphone only while a recording asks for it. Its
-/// sample timestamps are converted onto ScreenCaptureKit's clock before the
+/// sample timestamps are converted onto the recording's host clock before the
 /// writer sees them, so system sound, voice and picture keep one timeline.
 final class RecorderMicrophoneCapture: NSObject,
                                        AVCaptureAudioDataOutputSampleBufferDelegate,
@@ -306,28 +297,12 @@ final class RecorderMicrophoneCapture: NSObject,
               let targetClock,
               CMSampleBufferIsValid(sampleBuffer)
         else { return }
-        let sourceTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
-        let targetTime = CMSyncConvertTime(sourceTime, from: sourceClock, to: targetClock)
-        guard targetTime.isValid,
-              let synchronized = Self.retimed(sampleBuffer, to: targetTime)
+        guard let synchronized = RecorderSampleTiming.converted(sampleBuffer,
+            from: sourceClock, to: targetClock)
         else { return }
         onSample?(synchronized)
     }
 
-    private static func retimed(_ sampleBuffer: CMSampleBuffer,
-                                to time: CMTime) -> CMSampleBuffer? {
-        var timing = CMSampleTimingInfo(duration: CMSampleBufferGetDuration(sampleBuffer),
-                                        presentationTimeStamp: time,
-                                        decodeTimeStamp: .invalid)
-        var copy: CMSampleBuffer?
-        let status = CMSampleBufferCreateCopyWithNewTiming(
-            allocator: kCFAllocatorDefault,
-            sampleBuffer: sampleBuffer,
-            sampleTimingEntryCount: 1,
-            sampleTimingArray: &timing,
-            sampleBufferOut: &copy)
-        return status == noErr ? copy : nil
-    }
 }
 
 // MARK: - Stream callbacks
@@ -339,16 +314,21 @@ extension RecorderCaptureEngine: SCStreamOutput {
         guard lifecycleLock.withLock({
             lifecycle.acceptsSamples && self.stream === stream
         }),
-              CMSampleBufferIsValid(sampleBuffer) else { return }
+              CMSampleBufferIsValid(sampleBuffer),
+              let clock = stream.synchronizationClock else { return }
+        let kind: Kind
         switch type {
         case .screen:
             guard Self.carriesPixels(sampleBuffer) else { return }
-            delegate?.captureEngine(self, didOutput: sampleBuffer, of: .video)
+            kind = .video
         case .audio:
-            delegate?.captureEngine(self, didOutput: sampleBuffer, of: .systemAudio)
+            kind = .systemAudio
         default:
-            break
+            return
         }
+        guard let synchronized = RecorderSampleTiming.converted(sampleBuffer,
+            from: clock, to: CMClockGetHostTimeClock()) else { return }
+        delegate?.captureEngine(self, didOutput: synchronized, of: kind)
     }
 
     /// A screen buffer only counts when the display actually changed and the
@@ -372,7 +352,6 @@ extension RecorderCaptureEngine: SCStreamDelegate {
             guard lifecycle.acceptsSamples, self.stream === stream else { return false }
             lifecycle.stop()
             self.stream = nil
-            storedSynchronizationClock = nil
             return true
         }
         guard shouldReport else { return }

--- a/Sources/Vorssaint/Services/Recorder/RecorderSampleTiming.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderSampleTiming.swift
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import CoreMedia
+
+enum RecorderSampleTiming {
+    static func converted(_ sampleBuffer: CMSampleBuffer,
+                          from sourceClock: CMClockOrTimebase,
+                          to targetClock: CMClockOrTimebase) -> CMSampleBuffer? {
+        let presentation = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        let target = CMSyncConvertTime(presentation, from: sourceClock, to: targetClock)
+        return retimed(sampleBuffer, to: target)
+    }
+
+    /// Shift timestamps without changing the cadence. A timing entry's duration
+    /// is per sample, even when that entry describes an entire PCM buffer.
+    static func retimed(_ sampleBuffer: CMSampleBuffer, to time: CMTime) -> CMSampleBuffer? {
+        let presentation = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        guard presentation.isNumeric, time.isNumeric else { return nil }
+        var count = 0
+        guard CMSampleBufferGetSampleTimingInfoArray(sampleBuffer, entryCount: 0,
+            arrayToFill: nil, entriesNeededOut: &count) == noErr, count > 0 else { return nil }
+        var timing = Array(repeating: CMSampleTimingInfo(), count: count)
+        guard CMSampleBufferGetSampleTimingInfoArray(sampleBuffer, entryCount: count,
+            arrayToFill: &timing, entriesNeededOut: nil) == noErr else { return nil }
+        let offset = time - presentation
+        for index in timing.indices {
+            if timing[index].presentationTimeStamp.isNumeric {
+                timing[index].presentationTimeStamp = timing[index].presentationTimeStamp + offset
+            }
+            if timing[index].decodeTimeStamp.isNumeric {
+                timing[index].decodeTimeStamp = timing[index].decodeTimeStamp + offset
+            }
+        }
+        var copy: CMSampleBuffer?
+        let status = CMSampleBufferCreateCopyWithNewTiming(
+            allocator: kCFAllocatorDefault,
+            sampleBuffer: sampleBuffer,
+            sampleTimingEntryCount: count,
+            sampleTimingArray: &timing,
+            sampleBufferOut: &copy)
+        return status == noErr ? copy : nil
+    }
+}

--- a/Sources/Vorssaint/Services/Recorder/RecorderWriter.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderWriter.swift
@@ -165,13 +165,16 @@ final class RecorderWriter {
 
         switch kind {
         case .video:
+            // Hold the first captured image over startup latency. Keep the
+            // shared origin and every later timestamp so audio stays aligned.
+            let videoTime: CMTime = videoFrameCount == 0 ? .zero : shifted
             guard videoInput.isReadyForMoreMediaData,
-                  let retimed = RecorderSampleTiming.retimed(sampleBuffer, to: shifted)
+                  let retimed = RecorderSampleTiming.retimed(sampleBuffer, to: videoTime)
             else { return }
             if videoInput.append(retimed) {
                 videoFrameCount += 1
                 lastVideoSample = sampleBuffer
-                lastVideoTime = shifted
+                lastVideoTime = videoTime
             } else {
                 failed = true
             }

--- a/Sources/Vorssaint/Services/Recorder/RecorderWriter.swift
+++ b/Sources/Vorssaint/Services/Recorder/RecorderWriter.swift
@@ -21,8 +21,7 @@ final class RecorderWriter {
     private let microphoneInput: AVAssetWriterInput?
     private let pauseClock: RecorderPauseClock
 
-    /// Everything is re-timed against the first sample that arrives, so the
-    /// file starts at zero instead of at the machine's uptime.
+    /// Chosen before capture starts, in the host clock shared by every source.
     private var origin: CMTime?
     private var lastVideoSample: CMSampleBuffer?
     private var lastVideoTime: CMTime = .zero
@@ -144,18 +143,18 @@ final class RecorderWriter {
         return true
     }
 
+    func beginSession(at time: CMTime) {
+        guard !started, time.isNumeric else { return }
+        origin = time
+        writer.startSession(atSourceTime: .zero)
+        started = true
+    }
+
     func append(_ sampleBuffer: CMSampleBuffer, kind: RecorderCaptureEngine.Kind) {
         guard !failed else { return }
         let presentation = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
         guard presentation.isValid else { return }
 
-        if origin == nil {
-            // The session opens on the first sample of any source, so the two
-            // tracks share one zero and stay aligned without a second clock.
-            origin = presentation
-            writer.startSession(atSourceTime: .zero)
-            started = true
-        }
         guard let origin, started else { return }
         let duration = CMSampleBufferGetDuration(sampleBuffer)
         let seconds = duration.isValid && !duration.isIndefinite ? max(0, duration.seconds) : 0
@@ -167,7 +166,7 @@ final class RecorderWriter {
         switch kind {
         case .video:
             guard videoInput.isReadyForMoreMediaData,
-                  let retimed = Self.retimed(sampleBuffer, to: shifted)
+                  let retimed = RecorderSampleTiming.retimed(sampleBuffer, to: shifted)
             else { return }
             if videoInput.append(retimed) {
                 videoFrameCount += 1
@@ -178,14 +177,14 @@ final class RecorderWriter {
             }
         case .systemAudio:
             guard let systemAudioInput, systemAudioInput.isReadyForMoreMediaData,
-                  let retimed = Self.retimed(sampleBuffer, to: shifted)
+                  let retimed = RecorderSampleTiming.retimed(sampleBuffer, to: shifted)
             else { return }
             if !systemAudioInput.append(retimed) {
                 failed = true
             }
         case .microphone:
             guard let microphoneInput, microphoneInput.isReadyForMoreMediaData,
-                  let retimed = Self.retimed(sampleBuffer, to: shifted)
+                  let retimed = RecorderSampleTiming.retimed(sampleBuffer, to: shifted)
             else { return }
             if !microphoneInput.append(retimed) {
                 failed = true
@@ -206,9 +205,10 @@ final class RecorderWriter {
                 seconds: pauseClock.elapsed(since: origin.seconds, at: wallClockEnd.seconds),
                 preferredTimescale: 600_000_000)
             if end > lastVideoTime, videoInput.isReadyForMoreMediaData,
-               let tail = Self.retimed(lastVideoSample, to: end) {
+               let tail = RecorderSampleTiming.retimed(lastVideoSample, to: end) {
                 videoInput.append(tail)
             }
+            writer.endSession(atSourceTime: end)
         }
         lastVideoSample = nil
         videoInput.markAsFinished()
@@ -222,22 +222,5 @@ final class RecorderWriter {
         lastVideoSample = nil
         guard writer.status == .writing else { return }
         writer.cancelWriting()
-    }
-
-    /// A copy of the buffer carrying a new presentation time. The pixels are
-    /// shared, not duplicated.
-    private static func retimed(_ sampleBuffer: CMSampleBuffer, to time: CMTime) -> CMSampleBuffer? {
-        var timing = CMSampleTimingInfo(
-            duration: CMSampleBufferGetDuration(sampleBuffer),
-            presentationTimeStamp: time,
-            decodeTimeStamp: .invalid)
-        var copy: CMSampleBuffer?
-        let status = CMSampleBufferCreateCopyWithNewTiming(
-            allocator: kCFAllocatorDefault,
-            sampleBuffer: sampleBuffer,
-            sampleTimingEntryCount: 1,
-            sampleTimingArray: &timing,
-            sampleBufferOut: &copy)
-        return status == noErr ? copy : nil
     }
 }

--- a/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
+++ b/Sources/Vorssaint/Services/Recorder/ScreenRecorderService.swift
@@ -105,6 +105,9 @@ private final class RecorderSession: NSObject, RecorderCaptureEngineDelegate {
                                             frameRate: frameRate,
                                             capturesSystemAudio: capturesSystemAudio,
                                             excludedWindowNumbers: excludedWindowNumbers,
+                                            willStartCapture: { [writerQueue, writer] time in
+                                                writerQueue.sync { writer.beginSession(at: time) }
+                                            },
                                             isCancelled: { [weak self] in
                                                 self?.startGate.isAuthorized != true
                                             }) {
@@ -119,7 +122,8 @@ private final class RecorderSession: NSObject, RecorderCaptureEngineDelegate {
         }
         // The tap starts before the microphone so the Mac's sound has the
         // shortest possible gap at the head of the file while it comes up.
-        if let tap, let clock = engine.synchronizationClock {
+        let clock = CMClockGetHostTimeClock()
+        if let tap {
             let started = await tap.start(synchronizingTo: clock)
             // A trusted tap that could not build a reader this time (no output
             // device, or a permission just revoked) would otherwise leave the
@@ -131,7 +135,7 @@ private final class RecorderSession: NSObject, RecorderCaptureEngineDelegate {
             await engine.stop()
             return .streamFailed
         }
-        if let microphone, let clock = engine.synchronizationClock {
+        if let microphone {
             if await microphone.start(synchronizingTo: clock) == false {
                 onMicrophoneUnavailable?()
             }
@@ -170,6 +174,7 @@ private final class RecorderSession: NSObject, RecorderCaptureEngineDelegate {
     /// Stops the stream first and waits for it, so the file is closed knowing
     /// no further frame can arrive.
     func stop() async -> Bool {
+        let end = CMClockGetTime(CMClockGetHostTimeClock())
         let ownsFinalization = startGate.cancelAndClaimStop()
         await startGate.waitUntilFinished()
         guard ownsFinalization else { return false }
@@ -193,7 +198,6 @@ private final class RecorderSession: NSObject, RecorderCaptureEngineDelegate {
                 forKey: DefaultsKey.recorderSystemAudioTapVerified)
         }
         let (track, typingTrack) = await MainActor.run { (pointer.stop(), typing.stop()) }
-        let end = CMClockGetTime(CMClockGetHostTimeClock())
         writerQueue.sync {}
         let written = await writer.finish(at: end)
         if written, !track.isEmpty {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -22902,6 +22902,8 @@ struct MetricsTests {
                 && SettingsBackupSupport.exportKeys().contains(DefaultsKey.recorderSystemAudio),
                "the tap grant this Mac gave stays out of the backup while the sound choice travels")
         var pauseTimeline = RecorderPauseTimeline()
+        RecorderSampleTimingTests.run { expect($0, $1) }
+        RecorderWriterTests.run { expect($0, $1) }
         expect(pauseTimeline.pause(at: 3) && !pauseTimeline.pause(at: 4),
                "a recording enters one pause only once")
         expect(pauseTimeline.elapsed(since: 0, at: 7) == 3

--- a/Tests/RecorderSampleTimingTests.swift
+++ b/Tests/RecorderSampleTimingTests.swift
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AVFoundation
+
+enum RecorderSampleTimingTests {
+    static func run(expect: (Bool, String) -> Void) {
+        for rate: CMTimeScale in [44_100, 48_000] {
+            for count in [1, 480, 1024] {
+                let original = audio(count: count, rate: rate, time: CMTime(value: 100, timescale: 1))
+                let target = CMTime(value: 3, timescale: 2)
+                guard let system = RecorderSampleTiming.retimed(original, to: target),
+                      let converted = RecorderSampleTiming.retimed(original, to: CMTime(value: 200, timescale: 1)),
+                      let microphone = RecorderSampleTiming.retimed(converted, to: target) else {
+                    expect(false, "audio retiming succeeds")
+                    continue
+                }
+                for shifted in [system, microphone] {
+                    expect(CMSampleBufferGetDuration(shifted) == CMSampleBufferGetDuration(original),
+                           "retiming preserves \(count) audio sample durations at \(rate) Hz")
+                    var last = CMSampleTimingInfo()
+                    expect(CMSampleBufferGetSampleTimingInfo(shifted, at: count - 1, timingInfoOut: &last) == noErr
+                        && last.presentationTimeStamp == target + CMTime(value: Int64(count - 1), timescale: rate),
+                           "the last audio sample stays on its original cadence after either capture path")
+                    expect(CMSampleBufferGetDataBuffer(shifted) === CMSampleBufferGetDataBuffer(original),
+                           "retiming shares the captured audio data")
+                }
+                expect(CMSampleBufferGetPresentationTimeStamp(original) == CMTime(value: 100, timescale: 1),
+                       "retiming leaves the captured buffer unchanged")
+            }
+        }
+
+        var entries = [
+            CMSampleTimingInfo(duration: CMTime(value: 1, timescale: 30),
+                               presentationTimeStamp: CMTime(value: 10, timescale: 1),
+                               decodeTimeStamp: CMTime(value: 9, timescale: 1)),
+            CMSampleTimingInfo(duration: .invalid,
+                               presentationTimeStamp: CMTime(value: 21, timescale: 2),
+                               decodeTimeStamp: .invalid),
+        ]
+        var sample: CMSampleBuffer?
+        precondition(CMSampleBufferCreateReady(allocator: kCFAllocatorDefault, dataBuffer: nil,
+            formatDescription: nil, sampleCount: 2, sampleTimingEntryCount: entries.count,
+            sampleTimingArray: &entries, sampleSizeEntryCount: 0, sampleSizeArray: nil,
+            sampleBufferOut: &sample) == noErr)
+        if let shifted = RecorderSampleTiming.retimed(sample!, to: .zero) {
+            for index in entries.indices {
+                var actual = CMSampleTimingInfo()
+                let status = CMSampleBufferGetSampleTimingInfo(shifted, at: index, timingInfoOut: &actual)
+                expect(status == noErr && actual.duration == entries[index].duration,
+                       "retiming preserves each timing entry, including an unknown video duration")
+                expect(actual.presentationTimeStamp == entries[index].presentationTimeStamp - CMTime(value: 10, timescale: 1),
+                       "retiming preserves relative presentation timestamps")
+                expect(entries[index].decodeTimeStamp.isValid
+                    ? actual.decodeTimeStamp == CMTime(value: -1, timescale: 1)
+                    : !actual.decodeTimeStamp.isValid,
+                       "retiming shifts valid decode timestamps and preserves invalid ones")
+            }
+        } else {
+            expect(false, "buffers with multiple timing entries can be retimed")
+        }
+        expect(RecorderSampleTiming.retimed(sample!, to: .invalid) == nil,
+               "an invalid destination timestamp is rejected")
+
+        let clock = offsetClock()
+        let microphone = audio(count: 480, time: CMTime(value: 500, timescale: 1))
+        if let converted = RecorderSampleTiming.converted(microphone, from: clock, to: CMClockGetHostTimeClock()) {
+            expect(CMSampleBufferGetPresentationTimeStamp(converted) == CMTime(value: 100, timescale: 1)
+                && CMSampleBufferGetDuration(converted) == CMTime(value: 1, timescale: 100),
+                   "clock conversion changes the epoch without stretching audio samples")
+        } else {
+            expect(false, "audio converts between clocks with different epochs")
+        }
+    }
+
+    static func offsetClock() -> CMTimebase {
+        var clock: CMTimebase?
+        precondition(CMTimebaseCreateWithSourceClock(allocator: kCFAllocatorDefault,
+            sourceClock: CMClockGetHostTimeClock(), timebaseOut: &clock) == noErr)
+        precondition(CMTimebaseSetRateAndAnchorTime(clock!, rate: 1,
+            anchorTime: CMTime(value: 500, timescale: 1),
+            immediateSourceTime: CMTime(value: 100, timescale: 1)) == noErr)
+        return clock!
+    }
+
+    static func audio(count: Int, rate: CMTimeScale = 48_000, time: CMTime) -> CMSampleBuffer {
+        var format = AudioStreamBasicDescription(mSampleRate: Double(rate), mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked,
+            mBytesPerPacket: 4, mFramesPerPacket: 1, mBytesPerFrame: 4,
+            mChannelsPerFrame: 2, mBitsPerChannel: 16, mReserved: 0)
+        var description: CMAudioFormatDescription?
+        precondition(CMAudioFormatDescriptionCreate(allocator: kCFAllocatorDefault, asbd: &format,
+            layoutSize: 0, layout: nil, magicCookieSize: 0, magicCookie: nil,
+            extensions: nil, formatDescriptionOut: &description) == noErr)
+        var block: CMBlockBuffer?
+        precondition(CMBlockBufferCreateWithMemoryBlock(allocator: kCFAllocatorDefault,
+            memoryBlock: nil, blockLength: count * 4, blockAllocator: kCFAllocatorDefault,
+            customBlockSource: nil, offsetToData: 0, dataLength: count * 4, flags: 0,
+            blockBufferOut: &block) == noErr)
+        precondition(CMBlockBufferFillDataBytes(with: 0, blockBuffer: block!, offsetIntoDestination: 0,
+            dataLength: count * 4) == noErr)
+        var timing = CMSampleTimingInfo(duration: CMTime(value: 1, timescale: rate),
+                                       presentationTimeStamp: time, decodeTimeStamp: .invalid)
+        var size = 4
+        var buffer: CMSampleBuffer?
+        precondition(CMSampleBufferCreateReady(allocator: kCFAllocatorDefault, dataBuffer: block,
+            formatDescription: description, sampleCount: count, sampleTimingEntryCount: 1,
+            sampleTimingArray: &timing, sampleSizeEntryCount: 1, sampleSizeArray: &size,
+            sampleBufferOut: &buffer) == noErr)
+        return buffer!
+    }
+}

--- a/Tests/RecorderWriterTests.swift
+++ b/Tests/RecorderWriterTests.swift
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AVFoundation
+
+enum RecorderWriterTests {
+    static func run(expect: @escaping (Bool, String) -> Void) {
+        let finished = DispatchSemaphore(value: 0)
+        Task.detached {
+            do { try await check(expect: expect) }
+            catch { expect(false, "recorder writer fixture failed: \(error)") }
+            finished.signal()
+        }
+        finished.wait()
+    }
+
+    private static func check(expect: (Bool, String) -> Void) async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("recorder-sync-\(UUID()).mov")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let pause = RecorderPauseClock()
+        let origin = CMTime(value: 100, timescale: 1)
+        let microphoneClock = RecorderSampleTimingTests.offsetClock()
+        let writer = RecorderWriter(url: url, pixelSize: CGSize(width: 64, height: 64), frameRate: 30,
+            capturesSystemAudio: true, capturesMicrophone: true, pauseClock: pause)!
+        precondition(writer.start())
+        writer.beginSession(at: origin)
+
+        // The microphone callback arrives first but its capture starts later.
+        // Video and system audio must retain their earlier timestamps.
+        writer.append(RecorderSampleTimingTests.audio(count: 480, time: origin + time(0.1)), kind: .microphone)
+        for index in 0..<100 {
+            if index == 50 {
+                pause.pause(at: 100.5)
+                pause.resume(at: 101)
+            }
+            let source = origin + time(Double(index) / 100 + (index >= 50 ? 0.5 : 0))
+            if [0, 40, 80].contains(index) {
+                writer.append(video(at: source), kind: .video)
+            }
+            let audio = RecorderSampleTimingTests.audio(count: 480, time: source)
+            if index == 40 || index == 80 {
+                let block = CMSampleBufferGetDataBuffer(audio)!
+                precondition(CMBlockBufferFillDataBytes(with: 0x30, blockBuffer: block,
+                    offsetIntoDestination: 0, dataLength: 480 * 4) == noErr)
+            }
+            writer.append(audio, kind: .systemAudio)
+            if index > 10 {
+                // Exercise the additional clock-conversion pass the microphone uses.
+                let microphone = RecorderSampleTiming.retimed(audio, to: source + time(400))!
+                let converted = RecorderSampleTiming.converted(microphone,
+                    from: microphoneClock, to: CMClockGetHostTimeClock())!
+                writer.append(converted, kind: .microphone)
+            }
+            // Real-time writer inputs apply backpressure; give the encoders time.
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        let finished = await writer.finish(at: origin + time(1.5))
+        expect(finished, "the raw multitrack MOV finishes")
+        expect(writer.videoFrameCount == 3, "late-arriving video at the recording origin is retained")
+        guard finished else { return }
+        let asset = AVURLAsset(url: url)
+        let tracks = try await asset.load(.tracks)
+        expect(tracks.count == 3, "the raw MOV contains video, system audio and microphone")
+        for track in tracks {
+            let type = track.mediaType
+            let range = try await track.load(.timeRange)
+            expect(abs(range.end.seconds - 1) < 0.05, "\(type.rawValue) ends on the shared timeline after the pause")
+            if type == .video {
+                expect(abs(range.start.seconds) < 0.001, "video begins at the explicit recording origin")
+                let reader = try AVAssetReader(asset: asset)
+                let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
+                reader.add(output)
+                precondition(reader.startReading())
+                var timestamps: [Double] = []
+                while let sample = output.copyNextSampleBuffer() {
+                    timestamps.append(CMSampleBufferGetPresentationTimeStamp(sample).seconds)
+                }
+                expect([0.4, 0.8].allSatisfy { expected in timestamps.contains { abs($0 - expected) < 0.001 } },
+                       "the raw MOV preserves video marker timestamps across pause/resume")
+                continue
+            }
+            let reader = try AVAssetReader(asset: asset)
+            let output = AVAssetReaderTrackOutput(track: track, outputSettings: [
+                AVFormatIDKey: kAudioFormatLinearPCM, AVLinearPCMBitDepthKey: 32,
+                AVLinearPCMIsFloatKey: true, AVLinearPCMIsNonInterleaved: false,
+            ])
+            reader.add(output)
+            precondition(reader.startReading())
+            var markers: [Double] = []
+            while let sample = output.copyNextSampleBuffer() {
+                let block = CMSampleBufferGetDataBuffer(sample)!
+                let frames = CMSampleBufferGetNumSamples(sample)
+                var values = [Float](repeating: 0, count: frames * 2)
+                precondition(CMBlockBufferCopyDataBytes(block, atOffset: 0, dataLength: values.count * 4,
+                    destination: &values) == noErr)
+                let start = CMSampleBufferGetPresentationTimeStamp(sample).seconds
+                for frame in 0..<frames where abs(values[frame * 2]) > 0.1 {
+                    let marker = start + Double(frame) / 48_000
+                    if markers.last.map({ marker - $0 > 0.1 }) ?? true { markers.append(marker) }
+                }
+            }
+            expect(reader.status == .completed, "the saved audio decodes fully")
+            expect(markers.count == 2 && abs(markers[0] - 0.4) < 0.025 && abs(markers[1] - 0.8) < 0.025,
+                   "audio markers align with video before and after the pause")
+        }
+    }
+
+    private static func time(_ seconds: Double) -> CMTime {
+        CMTime(seconds: seconds, preferredTimescale: 48_000)
+    }
+
+    private static func video(at time: CMTime) -> CMSampleBuffer {
+        var pixels: CVPixelBuffer?
+        precondition(CVPixelBufferCreate(kCFAllocatorDefault, 64, 64, kCVPixelFormatType_32BGRA,
+            nil, &pixels) == kCVReturnSuccess)
+        CVPixelBufferLockBaseAddress(pixels!, [])
+        memset(CVPixelBufferGetBaseAddress(pixels!), 0, CVPixelBufferGetDataSize(pixels!))
+        CVPixelBufferUnlockBaseAddress(pixels!, [])
+        var format: CMVideoFormatDescription?
+        precondition(CMVideoFormatDescriptionCreateForImageBuffer(allocator: kCFAllocatorDefault,
+            imageBuffer: pixels!, formatDescriptionOut: &format) == noErr)
+        var timing = CMSampleTimingInfo(duration: .invalid, presentationTimeStamp: time, decodeTimeStamp: .invalid)
+        var sample: CMSampleBuffer?
+        precondition(CMSampleBufferCreateReadyWithImageBuffer(allocator: kCFAllocatorDefault, imageBuffer: pixels!,
+            formatDescription: format!, sampleTiming: &timing, sampleBufferOut: &sample) == noErr)
+        return sample!
+    }
+}

--- a/Tests/RecorderWriterTests.swift
+++ b/Tests/RecorderWriterTests.swift
@@ -7,21 +7,26 @@ enum RecorderWriterTests {
     static func run(expect: @escaping (Bool, String) -> Void) {
         let finished = DispatchSemaphore(value: 0)
         Task.detached {
-            do { try await check(expect: expect) }
+            do {
+                try await check(expect: expect)
+                try await check(expect: expect, delayedVideo: true)
+                try await check(expect: expect, delayedVideo: true, capturesAudio: false)
+            }
             catch { expect(false, "recorder writer fixture failed: \(error)") }
             finished.signal()
         }
         finished.wait()
     }
 
-    private static func check(expect: (Bool, String) -> Void) async throws {
+    private static func check(expect: (Bool, String) -> Void,
+                              delayedVideo: Bool = false, capturesAudio: Bool = true) async throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("recorder-sync-\(UUID()).mov")
         defer { try? FileManager.default.removeItem(at: url) }
         let pause = RecorderPauseClock()
         let origin = CMTime(value: 100, timescale: 1)
         let microphoneClock = RecorderSampleTimingTests.offsetClock()
         let writer = RecorderWriter(url: url, pixelSize: CGSize(width: 64, height: 64), frameRate: 30,
-            capturesSystemAudio: true, capturesMicrophone: true, pauseClock: pause)!
+            capturesSystemAudio: capturesAudio, capturesMicrophone: capturesAudio, pauseClock: pause)!
         precondition(writer.start())
         writer.beginSession(at: origin)
 
@@ -34,7 +39,7 @@ enum RecorderWriterTests {
                 pause.resume(at: 101)
             }
             let source = origin + time(Double(index) / 100 + (index >= 50 ? 0.5 : 0))
-            if [0, 40, 80].contains(index) {
+            if [delayedVideo ? 20 : 0, 40, 80].contains(index) {
                 writer.append(video(at: source), kind: .video)
             }
             let audio = RecorderSampleTimingTests.audio(count: 480, time: source)
@@ -56,25 +61,33 @@ enum RecorderWriterTests {
         }
         let finished = await writer.finish(at: origin + time(1.5))
         expect(finished, "the raw multitrack MOV finishes")
-        expect(writer.videoFrameCount == 3, "late-arriving video at the recording origin is retained")
+        expect(writer.videoFrameCount == 3, "all three captured video frames are retained")
         guard finished else { return }
         let asset = AVURLAsset(url: url)
         let tracks = try await asset.load(.tracks)
-        expect(tracks.count == 3, "the raw MOV contains video, system audio and microphone")
+        expect(tracks.count == (capturesAudio ? 3 : 1), "the raw MOV contains exactly the enabled tracks")
         for track in tracks {
             let type = track.mediaType
             let range = try await track.load(.timeRange)
             expect(abs(range.end.seconds - 1) < 0.05, "\(type.rawValue) ends on the shared timeline after the pause")
             if type == .video {
+                let segments = try await track.load(.segments)
+                expect(!segments.contains { $0.isEmpty && $0.timeMapping.target.start.seconds < 0.001 },
+                       "video has no empty opening edit when the first capture is delayed")
                 expect(abs(range.start.seconds) < 0.001, "video begins at the explicit recording origin")
                 let reader = try AVAssetReader(asset: asset)
-                let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
+                let output = AVAssetReaderTrackOutput(track: track, outputSettings: [
+                    kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+                ])
                 reader.add(output)
                 precondition(reader.startReading())
                 var timestamps: [Double] = []
                 while let sample = output.copyNextSampleBuffer() {
                     timestamps.append(CMSampleBufferGetPresentationTimeStamp(sample).seconds)
                 }
+                expect(timestamps.first.map { abs($0) < 0.001 } ?? false,
+                       "the first decoded image starts at zero, including delayed capture with sound off")
+                expect(reader.status == .completed, "the saved video decodes fully")
                 expect([0.4, 0.8].allSatisfy { expected in timestamps.contains { abs($0 - expected) < 0.001 } },
                        "the raw MOV preserves video marker timestamps across pause/resume")
                 continue

--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ trap cleanup EXIT
 # into the build sweeps like any other ending.
 trap 'exit 1' INT TERM HUP
 
-# Flags: --dev builds the local-only "Vorssaint Developer" variant (its own
+# Flags: --dev builds the local-only "Vorssaint (Developer)" variant (its own
 # bundle id, so it coexists with the official app); --install puts it in /Applications.
 DEV=0
 INSTALL=0
@@ -40,7 +40,7 @@ for arg in "$@"; do
 done
 
 if (( DEV )); then
-    APP_NAME="Vorssaint Developer"
+    APP_NAME="Vorssaint (Developer)"
     EXECUTABLE="VorssaintDeveloper"
     APP_BUNDLE_ID="com.vorssaint.utils.dev"
     BUILD_VARIANT_FLAGS=(-D VORSSAINT_DEVELOPMENT)

--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ trap cleanup EXIT
 # into the build sweeps like any other ending.
 trap 'exit 1' INT TERM HUP
 
-# Flags: --dev builds the local-only "Vorssaint (Developer)" variant (its own
+# Flags: --dev builds the local-only "Vorssaint Developer" variant (its own
 # bundle id, so it coexists with the official app); --install puts it in /Applications.
 DEV=0
 INSTALL=0
@@ -40,7 +40,7 @@ for arg in "$@"; do
 done
 
 if (( DEV )); then
-    APP_NAME="Vorssaint (Developer)"
+    APP_NAME="Vorssaint Developer"
     EXECUTABLE="VorssaintDeveloper"
     APP_BUNDLE_ID="com.vorssaint.utils.dev"
     BUILD_VARIANT_FLAGS=(-D VORSSAINT_DEVELOPMENT)
@@ -292,6 +292,10 @@ if (( TEST )); then
         Sources/Vorssaint/Services/QuickTools/ScratchpadStore.swift \
         Sources/Vorssaint/Services/KillProcess/KillProcessSupport.swift \
         Sources/Vorssaint/Services/Recorder/RecorderSupport.swift \
+        Sources/Vorssaint/Services/Recorder/RecorderSampleTiming.swift \
+        Sources/Vorssaint/Services/Recorder/RecorderWriter.swift \
+        Sources/Vorssaint/Services/Recorder/RecorderCaptureEngine.swift \
+        Sources/Vorssaint/Services/Recorder/RecorderComposition.swift \
         Sources/Vorssaint/Services/Recorder/RecordingSharingSupport.swift \
         Sources/Vorssaint/Services/PrivateFileStore.swift \
         Sources/Vorssaint/Services/Recorder/RecorderTakeStore.swift \
@@ -428,6 +432,8 @@ if (( TEST )); then
         Tests/MetricsTests.swift \
         Tests/RecentCaptureStoreTests.swift \
         Tests/RecorderPresetImageStoreTests.swift \
+        Tests/RecorderSampleTimingTests.swift \
+        Tests/RecorderWriterTests.swift \
         Tests/SpeedTestTests.swift \
         -o build/metrics-tests
     # `set -e` would end the script on a failing run before the sweep below.
@@ -527,9 +533,9 @@ done
 if (( DEV )); then
     # A distinct identity so the Developer build installs and runs next to the
     # official app, with its own permissions, preferences and login item.
-    /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier com.vorssaint.utils.dev" "$STAGE/Contents/Info.plist"
-    /usr/libexec/PlistBuddy -c "Set :CFBundleName Vorssaint (Developer)" "$STAGE/Contents/Info.plist"
-    /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName Vorssaint (Developer)" "$STAGE/Contents/Info.plist"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $APP_BUNDLE_ID" "$STAGE/Contents/Info.plist"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleName $APP_NAME" "$STAGE/Contents/Info.plist"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName $APP_NAME" "$STAGE/Contents/Info.plist"
     /usr/libexec/PlistBuddy -c "Set :CFBundleExecutable $EXECUTABLE" "$STAGE/Contents/Info.plist"
     FAN_PLIST="$STAGE/Contents/Library/LaunchDaemons/$FAN_HELPER_ID.plist"
     /usr/libexec/PlistBuddy -c "Set :Label $FAN_HELPER_ID" "$FAN_PLIST"


### PR DESCRIPTION
## Summary

Preserve per-sample durations and relative timestamps when retiming captured media. Previously, a 10 ms PCM buffer containing 480 samples became 4.8 seconds after writer retiming and 2,304 seconds after the microphone's two retiming passes.

Map ScreenCaptureKit, microphone, and system-audio tap timestamps onto the host clock used by pause and stop. Choose the recording origin immediately before capture starts so callback arrival order cannot discard earlier video or audio, and end the MOV at the captured stop time.

Both retiming call sites now use the shared helper. The local Developer build is named `Vorssaint Developer` and retains its separate `com.vorssaint.utils.dev` identity.

## Verification

Tested on Mac17,9, Apple Silicon, macOS 26.5, build 25F71, with Swift 6.3.3 and the macOS 26 SDK.

- `./build.sh --test`: 10,760 checks passed, including preference cleanup.
- Timing regression tests cover 44.1/48 kHz PCM, repeated retiming, multiple timing entries, decode timestamps, and conversion between clock epochs. They fail 22 checks against the original helper.
- The real MOV writer test saves and decodes video plus separate system/microphone tracks, checking callback reordering, pause/resume, stop duration, and audio/video markers.
- `./build.sh --dev --install` compiled without warnings. The installed app passed `--selftest` and strict code-signature verification.
- Local testing of the installed Developer build was also confirmed by the contributor before opening this PR.

The reporter's M1 Mac mini/macOS 26.6.2 combination and Swift 6.0.3 compatibility were not tested locally. This change addresses the raw master timeline; edited multitrack export in #1478 is separate.

Refs #1483
