### PR TITLE
fix(app-updates): stop reporting a catalog version that only adds precision

### DIFF
--- a/Sources/Vorssaint/Services/AppUpdates/AppUpdatesSupport.swift
+++ b/Sources/Vorssaint/Services/AppUpdates/AppUpdatesSupport.swift
@@ -118,6 +118,20 @@ enum AppUpdatesSupport {
         compare(versionCore(candidate), versionCore(installed)) == .orderedDescending
     }
 
+    /// Some app bundles publish a marketing short version with fewer components than the catalog
+    /// records. Android Studio reports 2026.1 for build 2026.1.4.7 (#1465), so a prefix match cannot
+    /// show whether it is genuinely behind; the honest answer is no row, as for an uncomparable `latest`.
+    static func reportsCoarserVersion(installed: String, than catalog: String) -> Bool {
+        let installedParts = parts(of: versionCore(installed))
+        let catalogParts = parts(of: versionCore(catalog))
+        guard installedParts.count < catalogParts.count,
+              (installedParts + catalogParts).allSatisfy({ $0.allSatisfy(\.isNumber) }),
+              zip(installedParts, catalogParts).allSatisfy({
+                  compareDigits($0.0, $0.1) == .orderedSame
+              }) else { return false }
+        return true
+    }
+
     private static func parts(of version: String) -> [String] {
         version
             .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
@@ -469,7 +483,8 @@ enum AppUpdatesSupport {
                   isCompatible(entry,
                                operatingSystemVersion: operatingSystemVersion) else { return nil }
             let latest = versionCore(entry.version)
-            guard isNewer(latest, than: app.version) else { return nil }
+            guard isNewer(latest, than: app.version),
+                  !reportsCoarserVersion(installed: app.version, than: latest) else { return nil }
             return Item(id: "\(Source.onlineCatalog.rawValue):\(app.path)",
                         source: .onlineCatalog,
                         name: app.name,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -21682,6 +21682,19 @@ struct MetricsTests {
             apps: [])
         expect(ownPackageRows.isEmpty,
                "the app update list never offers to replace Vorssaint through its own package")
+        let coarsePackageRows = AppUpdatesSupport.packageUpdates(
+            outdated: [caskUpdate("android-studio", installed: "2026.1",
+                                  current: "2026.1.4.7,quail4")],
+            installed: [HomebrewCaskRecord(token: "android-studio", displayName: "Android Studio",
+                                           installedVersion: "2026.1",
+                                           appFileNames: ["Android Studio.app"])],
+            apps: [AppUpdatesSupport.InstalledApp(
+                name: "Android Studio", bundleID: "com.google.android.studio",
+                path: "/Applications/Android Studio.app", version: "2026.1",
+                isFromAppStore: false)])
+        expect(coarsePackageRows.count == 1
+                && coarsePackageRows.first?.latestVersion == "2026.1.4.7",
+               "a Homebrew-outdated cask still reports when its bundle version is coarser")
 
         let storeApps = [
             AppUpdatesSupport.InstalledApp(name: "Blocker", bundleID: "net.example.blocker",
@@ -21961,6 +21974,39 @@ struct MetricsTests {
                 && AppUpdatesSupport.parseOnlineCatalogResponse(onlineCatalogBody, statusCode: 500) == nil
                 && AppUpdatesSupport.parseOnlineCatalogResponse(Data("broken".utf8), statusCode: 200) == nil,
                "missing, failed and malformed network responses never become successful empty coverage")
+
+        func onlineVersionRows(installed: String, catalog: String) -> [AppUpdatesSupport.Item] {
+            let app = AppUpdatesSupport.InstalledApp(
+                name: "Versioned", bundleID: "com.example.versioned",
+                path: "/Applications/Versioned.app", version: installed,
+                isFromAppStore: false)
+            let entry = AppUpdatesSupport.CatalogEntry(
+                token: "versioned", version: catalog, appNames: ["Versioned.app"],
+                bundleIDs: [], minimumOSVersions: [], exactOSVersions: [],
+                hasUnsupportedOSConstraint: false)
+            return AppUpdatesSupport.onlineCatalogUpdates(
+                apps: [app], catalog: [entry], operatingSystemVersion: "15.7")
+        }
+        expect(onlineVersionRows(installed: "2026.1",
+                                 catalog: "2026.1.4.7,quail4").isEmpty,
+               "Android Studio's coarser bundle version does not create an online catalog update")
+        expect(["2026.1.4-7", "2026.1.4_7", "2026.1.4 7"].allSatisfy {
+            onlineVersionRows(installed: "2026.1", catalog: $0).isEmpty
+        }, "coarser online versions use the same tokenizer as version comparison")
+        expect(onlineVersionRows(installed: "2026.1", catalog: "2026.2").count == 1,
+               "the online catalog still reports a difference in a bundle-reported component")
+        expect(onlineVersionRows(installed: "2026.1", catalog: "2026.2.4").count == 1,
+               "the online catalog still reports when a shared component differs before a longer suffix")
+        expect(onlineVersionRows(installed: "1.12.7", catalog: "1.13.7").count == 1,
+               "the online catalog still reports an Obsidian-shaped full-version difference")
+        expect(onlineVersionRows(installed: "1.2", catalog: "1.2.4beta").count == 1,
+               "a nonnumeric catalog part is a version difference, not coarser precision")
+        expect(onlineVersionRows(installed: "1.2", catalog: "1.2.1").isEmpty,
+               "the online catalog deliberately omits a trailing-only difference when the installed version may be coarser")
+        expect(onlineVersionRows(installed: "02026.01", catalog: "2026.1.4.7").isEmpty,
+               "leading zeros do not hide a coarser online version")
+        expect(!AppUpdatesSupport.reportsCoarserVersion(installed: "1.2.3", than: "1.2"),
+               "a coarser version requires fewer installed components")
 
         let onlineApps = [
             AppUpdatesSupport.InstalledApp(name: "Notes", bundleID: "com.example.notes",


### PR DESCRIPTION
Refs #1465 — the Android Studio row. The online catalog compares the bundle's `CFBundleShortVersionString` with the cask version component by component, and `compare` counts a missing trailing component as zero. Measured today from the current Android Studio DMG (2026.1.4.7): the bundle reports `CFBundleShortVersionString = 2026.1` and `CFBundleVersion = AI-261.26222.65.2614.16204760`; nothing inside the bundle carries the four-component number the catalog records (`2026.1.4.7,quail4`). So every Android Studio install shows `2026.1 → 2026.1.4.7`, and no update can ever clear it — the reporter's screenshot exactly.

When the installed number is a strict numeric prefix of the catalog's — every component the bundle reports is equal, and the catalog only has more of them — the bundle cannot say whether it is behind, so the online source now reports no row, the same choice `isUncomparable` already makes for a package pinned to `latest`. The rule is one pure helper, `AppUpdatesSupport.reportsCoarserVersion(installed:than:)`, applied only in `onlineCatalogUpdates`; it tokenizes with the same `parts(of:)` the comparison uses, so a catalog that separates its extra precision with `-`, `_` or a space is treated the same as a dotted one. A difference inside the components the bundle does report still yields a row (`2026.1` vs `2026.2`, `1.12.7` vs `1.13.7`), a non-numeric part is a difference and not extra precision (`1.2` vs `1.2.4beta` still reports), and `compare`/`isNewer` keep their meaning for every other caller. The package-manager source is untouched: brew's own outdated verdict still produces a row for a bundle that reports `2026.1`, pinned by a check. `AppUpdateFeedSupport.update` (publisher manifests and appcasts) was examined and left alone — a vendor's feed numbers like its own bundle, and the appcast path already substitutes `CFBundleVersion`.

Two things to decide, named rather than hidden. First, this silences `x.y` installed against `x.y.z` catalog for every app, and an otherwise empty list renders as "up to date"; an alternative is to require at least two extra catalog components, which still fixes Android Studio while keeping `1.2 → 1.2.1` visible — not implemented, say the word. Second, the reporter's Obsidian row (`1.12.7 → 1.13.7`) is a different mechanism and is not changed here: Obsidian updates its core under `~/Library/Application Support/obsidian/` (measured on this Mac: bundle 1.12.7, `obsidian-1.13.7.asar` beside it) and leaves the installer bundle at the version first installed, so the row is right about the bundle and wrong about what runs; I told the reporter as much on the issue. The reporter's third symptom, "check incomplete / Antigravity", is a publisher manifest that answers 404; that is a separate small change I'll open next.

Checks: the reporter's case yields no row; a shared component that differs before a longer suffix still reports; the non-numeric suffix still reports; the tokenizer agreement is pinned; the deliberate `1.2` vs `1.2.1` omission is pinned by name; the package path pins `count == 1`. Each clause of the guard has a mutation that turns exactly one named check red (tokenizer swapped for dot-only, count clause dropped, numeric clause dropped, prefix-equality dropped).

Verification: Mac17,9 (M5 Pro), macOS 26.6.2 (25G83), local Developer build. `./build.sh` warning-free; `./build.sh --test` → `TESTS OK`; `./build/Vorssaint --selftest` → `SELFTEST OK`, after rebasing onto current main. Not tested: a real Android Studio installation on this Mac (only its DMG was read), the live catalog fetch through the app, and other macOS releases.
