### PR TITLE
fix(menu-panel): carry the panel's glass surface out to the popover arrow

### DIFF
--- a/Sources/Vorssaint/App/AppDelegate.swift
+++ b/Sources/Vorssaint/App/AppDelegate.swift
@@ -365,6 +365,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
         // We animate the underlying popover window ourselves so applicationDefined
         // dismissal, right-click menus and live Settings previews stay predictable.
         popover.animates = false
+        // The panel paints its own glass surface, or the arrow tip would show plain
+        // system material where the surface stops, the seam users see. The visible
+        // content stays inset either way, before through the content view's frame
+        // and now through the safe area the popover publishes, so only the surface
+        // reaches the arrow.
+        popover.hasFullSizeContent = true
         popover.delegate = self
         let host = NSHostingController(rootView: MenuPanelView())
         host.sizingOptions = .preferredContentSize

--- a/Sources/Vorssaint/UI/Theme.swift
+++ b/Sources/Vorssaint/UI/Theme.swift
@@ -113,8 +113,9 @@ extension View {
 
     /// A restrained glass base for the menu panel: still translucent, but with a
     /// stable tint so text and controls do not depend too much on the wallpaper.
-    func panelGlassSurface(cornerRadius: CGFloat = 18) -> some View {
-        background(PanelGlassSurface(cornerRadius: cornerRadius))
+    /// It reaches the popover's arrow; see PanelGlassSurface.
+    func panelGlassSurface() -> some View {
+        background(PanelGlassSurface())
     }
 }
 
@@ -139,21 +140,28 @@ private struct PanelGlassSurface: View {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @AppStorage(DefaultsKey.liquidGlassEnabled) private var liquidGlassEnabled = false
-    let cornerRadius: CGFloat
 
     var body: some View {
+        // AppKit hands the hosted panel a safe area for the popover's border and
+        // arrow, so a surface that stopped at the panel would leave the tip in the
+        // plain system material. The panel content keeps that inset and never sits
+        // under the arrow; only this background bleeds into it. The popover clips
+        // it to its own balloon, so the surface is a plain rectangle: rounding would
+        // expose the system material at the corners, while stroking would duplicate
+        // the outline AppKit already draws.
+        surface.ignoresSafeArea()
+    }
+
+    @ViewBuilder
+    private var surface: some View {
 #if compiler(>=6.2)
         if #available(macOS 26.0, *), liquidGlassEnabled, !reduceTransparency {
-            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            Rectangle()
                 .fill(Color.clear)
-                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+                .glassEffect(.regular, in: Rectangle())
                 .overlay(
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    Rectangle()
                         .fill(PanelSurface.baseFill(for: colorScheme).opacity(colorScheme == .light ? 0.35 : 0.45))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        .strokeBorder(PanelSurface.border(for: colorScheme), lineWidth: 0.8)
                 )
         } else {
             standardSurface
@@ -165,16 +173,9 @@ private struct PanelGlassSurface: View {
 
     @ViewBuilder
     private var standardSurface: some View {
-        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        Rectangle()
             .fill(.regularMaterial)
-            .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .fill(PanelSurface.baseFill(for: colorScheme))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .strokeBorder(PanelSurface.border(for: colorScheme), lineWidth: 0.8)
-            )
+            .overlay(Rectangle().fill(PanelSurface.baseFill(for: colorScheme)))
     }
 }
 

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -3914,6 +3914,44 @@ struct MetricsTests {
         expect(statusHitTestCode.contains(statusFrameCall) && statusHitTestCode.contains("return false"),
                "status-item hit testing rejects an untrustworthy frame")
 
+        // MARK: The panel surface reaches the popover arrow (issue #1030)
+
+        // AppKit hands the hosted panel a safe area for the popover's border and
+        // draws the arrow on the frame itself, so a surface that stopped at the
+        // panel would leave the tip in the plain system material. None of these
+        // owners compiles into this binary, so pin the three pieces that together
+        // carry the panel's own surface out to the tip.
+        let popoverSetUpCode = stripCommentLines((statusAnchorAppDelegateSource
+            .components(separatedBy: "private func setUpPopover() {").last ?? "")
+            .components(separatedBy: "\n    }").first ?? "")
+        expect(popoverSetUpCode.contains("popover.hasFullSizeContent = true"),
+               "the panel is hosted across the whole popover, arrow band included")
+        let panelThemeSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/UI/Theme.swift",
+            encoding: .utf8)) ?? ""
+        let panelGlassCode = stripCommentLines((panelThemeSource
+            .components(separatedBy: "private struct PanelGlassSurface: View {").last ?? "")
+            .components(separatedBy: "\n}").first ?? "")
+        expect(panelGlassCode.contains("surface.ignoresSafeArea()"),
+               "the panel surface paints past the safe area, up into the arrow")
+        expect(!panelGlassCode.isEmpty
+                   && !panelGlassCode.contains("RoundedRectangle")
+                   && !panelGlassCode.contains("cornerRadius"),
+               "the panel surface leaves the rounding to the popover balloon that clips it")
+        expect(panelGlassCode.contains(".glassEffect(.regular, in: Rectangle())")
+                   && panelGlassCode.contains("Rectangle()\n            .fill(.regularMaterial)"),
+               "both the standard and the Liquid Glass surface fill the whole balloon, no shape of their own")
+        let panelViewSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/UI/MenuPanel/MenuPanelView.swift",
+            encoding: .utf8)) ?? ""
+        let panelBodyCode: (String) -> String = { header in
+            stripCommentLines((panelViewSource.components(separatedBy: header).last ?? "")
+                .components(separatedBy: "\n    }").first ?? "")
+        }
+        expect(panelBodyCode("private var navigablePanel: some View {").contains(".panelGlassSurface()")
+                   && panelBodyCode("private var metricPanel: some View {").contains(".panelGlassSurface()"),
+               "both the navigable panel and the metric panel wear that surface")
+
         // The panel keeps its top edge and its center while its content resizes.
         let panelArea = CGRect(x: 0, y: 0, width: 1470, height: 932)
         let shortPanel = StatusItemAnchorSupport.pinnedPanelFrame(size: CGSize(width: 332, height: 375),


### PR DESCRIPTION
Refs #1030. The menu panel paints its own glass surface (`panelGlassSurface()`, a material plus a stable tint) as a rounded card inside the popover's content, and AppKit insets that content 13 pt inside the popover frame and draws the arrow on the frame itself. So the surface stopped at the card and the arrow tip, plus the ring around the card, kept the plain system popover material — the seam the reporter points at, most visible in dark mode. Measured on this Mac over a constant white backdrop, sampling down the arrow's apex column: tip versus body differed by up to 51 (of 255) per channel in dark mode and 24 in light.

Two documented pieces carry the surface out to the tip. `popover.hasFullSizeContent = true` (NSPopover, macOS 14+) hands the hosting view the whole popover window instead of the inset rectangle; the hosting view then publishes a 13 pt safe area on every side, and SwiftUI honours it — so a plain background still starts 13 pt down, which is why the earlier attempt on this branch did not close the gap. `PanelGlassSurface` therefore applies `.ignoresSafeArea()` to itself: the background bleeds into the safe area up to the arrow while the panel content keeps its inset and never sits under the arrow. The popover clips the content to its own balloon, so the surface is now a plain `Rectangle` with no corner radius and no outer stroke — rounding it would expose the system material at the corners and stroking it would duplicate the outline AppKit already draws. `PanelSurface.border` still governs the card outlines through `panelCard()`, so the increase-contrast behaviour is unchanged where it was ever visible. The `cornerRadius` parameter went away with nothing passing one. Both the standard path and the Liquid Glass path (`glassEffect(.regular, in: Rectangle())`) changed the same way; `MenuPanelView` is untouched.

After: dark-mode tip versus body 1, light 0, Liquid Glass on 3 (captures linked below). The popover window is 358×375 at the same origin before and after, the first control sits at the same absolute position, and the Accessibility tree is identical (one AXGroup, thirteen children, twelve buttons); the only AX change is the group's own frame, which now spans the balloon. `popover.contentSize` reads 332×260 before and 358×286 after with the window frame byte-identical; nothing in the app reads `contentSize`. The alternative `safeAreaRegions = []` on the hosting view was measured and rejected: the window shrinks to the content and the content lands under the arrow.

Checks: five source-shape pins, since none of the three owners compiles into the test binary — `setUpPopover` sets `hasFullSizeContent`; `PanelGlassSurface` applies `surface.ignoresSafeArea()` itself; both its branches use `Rectangle()` (the Liquid Glass shape and the material fill); it contains no `RoundedRectangle`/`cornerRadius`; and both panel bodies still call `.panelGlassSurface()`. Each was reverted alone (including swapping either `Rectangle()` for a `Capsule()`) and turned exactly its named check red.

Verification: Mac17,9 (M5 Pro), macOS 26.6.2 (25G83), Swift 6.3.3, local Developer build. `./build.sh` warning-free; `./build.sh --test` → `TESTS OK`; `./build/Vorssaint --selftest` → `SELFTEST OK`. Not tested: macOS 14 and 15 (hasFullSizeContent is documented from 14.0; behaviour there is from the docs, not measured), reduce-transparency on, a multi-display anchor.

Captures (developer build, white backdrop, 2x):

| | before | after |
|---|---|---|
| dark | ![before dark](https://raw.githubusercontent.com/iltonandrew/vorssaint-utils/captures/1030/panel-before-dark.png) | ![after dark](https://raw.githubusercontent.com/iltonandrew/vorssaint-utils/captures/1030/panel-after-dark.png) |
| light | ![before light](https://raw.githubusercontent.com/iltonandrew/vorssaint-utils/captures/1030/panel-before-light.png) | ![after light](https://raw.githubusercontent.com/iltonandrew/vorssaint-utils/captures/1030/panel-after-light.png) |

Liquid Glass on, dark: ![after dark liquid glass](https://raw.githubusercontent.com/iltonandrew/vorssaint-utils/captures/1030/panel-after-dark-liquidglass.png)
