### PR TITLE
fix(cleaning-mode): prevent mouse button lock on exit

### DIFF
--- a/Sources/Vorssaint/Services/CleaningMode/CleaningModeManager.swift
+++ b/Sources/Vorssaint/Services/CleaningMode/CleaningModeManager.swift
@@ -279,42 +279,44 @@ final class CleaningModeManager: ObservableObject {
     }
 
     private func hideOverlays() {
-        ensureMouseButtonsReleased()
+        // Inspect whether any mouse button was down while the cleaning screen was up.
+        // Recovery must strictly be limited to presses that belonged to the cleaning screen,
+        // leaving any new clicks or drags initiated after teardown completely untouched.
+        let isLeftDown = (NSEvent.pressedMouseButtons & 1) != 0
+            || CGEventSource.buttonState(.combinedSessionState, button: .left)
+        let isRightDown = (NSEvent.pressedMouseButtons & 2) != 0
+            || CGEventSource.buttonState(.combinedSessionState, button: .right)
+
         let panels = overlays
         overlays = []
         panels.forEach { $0.ignoresMouseEvents = true }
-        DispatchQueue.main.async { [weak self] in
-            panels.forEach { $0.orderOut(nil) }
-            self?.ensureMouseButtonsReleased()
+
+        if isLeftDown || isRightDown {
+            ensureMouseButtonsReleased(left: isLeftDown, right: isRightDown)
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-            self?.ensureMouseButtonsReleased()
+
+        DispatchQueue.main.async {
+            panels.forEach { $0.orderOut(nil) }
         }
     }
 
-    /// Guarantees that any mouse buttons held or mid-event when cleaning overlays tear down
-    /// are cleanly released in WindowServer so the primary mouse button is never left stuck.
-    private func ensureMouseButtonsReleased() {
-        let isLeftDown = (NSEvent.pressedMouseButtons & 1) != 0
-            || CGEventSource.buttonState(.combinedSessionState, button: .left)
-            || CGEventSource.buttonState(.hidSystemState, button: .left)
-        let isRightDown = (NSEvent.pressedMouseButtons & 2) != 0
-            || CGEventSource.buttonState(.combinedSessionState, button: .right)
-            || CGEventSource.buttonState(.hidSystemState, button: .right)
-        guard isLeftDown || isRightDown else { return }
-
-        let location = CGEvent(source: nil)?.location ?? NSEvent.mouseLocation
+    /// Releases mouse buttons that were held down on the cleaning screen when teardown began,
+    /// preventing WindowServer from stranding them in the down state once the overlay unmaps.
+    private func ensureMouseButtonsReleased(left: Bool, right: Bool) {
+        let location = CGEvent(source: nil)?.location ?? .zero
         let source = CGEventSource(stateID: .hidSystemState)
-        if isLeftDown, let upEvent = CGEvent(mouseEventSource: source,
-                                             mouseType: .leftMouseUp,
-                                             mouseCursorPosition: location,
-                                             mouseButton: .left) {
+        if left, let upEvent = CGEvent(mouseEventSource: source,
+                                       mouseType: .leftMouseUp,
+                                       mouseCursorPosition: location,
+                                       mouseButton: .left) {
+            upEvent.setIntegerValueField(.mouseEventClickState, value: 1)
             upEvent.post(tap: .cghidEventTap)
         }
-        if isRightDown, let upEvent = CGEvent(mouseEventSource: source,
-                                              mouseType: .rightMouseUp,
-                                              mouseCursorPosition: location,
-                                              mouseButton: .right) {
+        if right, let upEvent = CGEvent(mouseEventSource: source,
+                                        mouseType: .rightMouseUp,
+                                        mouseCursorPosition: location,
+                                        mouseButton: .right) {
+            upEvent.setIntegerValueField(.mouseEventClickState, value: 1)
             upEvent.post(tap: .cghidEventTap)
         }
     }

--- a/Sources/Vorssaint/Services/CleaningMode/CleaningModeManager.swift
+++ b/Sources/Vorssaint/Services/CleaningMode/CleaningModeManager.swift
@@ -279,8 +279,44 @@ final class CleaningModeManager: ObservableObject {
     }
 
     private func hideOverlays() {
-        overlays.forEach { $0.orderOut(nil) }
+        ensureMouseButtonsReleased()
+        let panels = overlays
         overlays = []
+        panels.forEach { $0.ignoresMouseEvents = true }
+        DispatchQueue.main.async { [weak self] in
+            panels.forEach { $0.orderOut(nil) }
+            self?.ensureMouseButtonsReleased()
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.ensureMouseButtonsReleased()
+        }
+    }
+
+    /// Guarantees that any mouse buttons held or mid-event when cleaning overlays tear down
+    /// are cleanly released in WindowServer so the primary mouse button is never left stuck.
+    private func ensureMouseButtonsReleased() {
+        let isLeftDown = (NSEvent.pressedMouseButtons & 1) != 0
+            || CGEventSource.buttonState(.combinedSessionState, button: .left)
+            || CGEventSource.buttonState(.hidSystemState, button: .left)
+        let isRightDown = (NSEvent.pressedMouseButtons & 2) != 0
+            || CGEventSource.buttonState(.combinedSessionState, button: .right)
+            || CGEventSource.buttonState(.hidSystemState, button: .right)
+        guard isLeftDown || isRightDown else { return }
+
+        let location = CGEvent(source: nil)?.location ?? NSEvent.mouseLocation
+        let source = CGEventSource(stateID: .hidSystemState)
+        if isLeftDown, let upEvent = CGEvent(mouseEventSource: source,
+                                             mouseType: .leftMouseUp,
+                                             mouseCursorPosition: location,
+                                             mouseButton: .left) {
+            upEvent.post(tap: .cghidEventTap)
+        }
+        if isRightDown, let upEvent = CGEvent(mouseEventSource: source,
+                                              mouseType: .rightMouseUp,
+                                              mouseCursorPosition: location,
+                                              mouseButton: .right) {
+            upEvent.post(tap: .cghidEventTap)
+        }
     }
 
     private func installScreenObserver() {

--- a/Sources/Vorssaint/UI/CleaningMode/CleaningOverlayView.swift
+++ b/Sources/Vorssaint/UI/CleaningMode/CleaningOverlayView.swift
@@ -42,7 +42,11 @@ struct CleaningOverlayView: View {
             fullProgressDots
                 .padding(.top, 2)
 
-            Button(action: { manager.deactivate() }) {
+            Button(action: {
+                DispatchQueue.main.async {
+                    manager.deactivate()
+                }
+            }) {
                 Text(l10n.s.cleaningOverlayUnlock)
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(.black)
@@ -91,7 +95,11 @@ struct CleaningOverlayView: View {
                     }
                 }
 
-                Button(action: { manager.deactivate() }) {
+                Button(action: {
+                    DispatchQueue.main.async {
+                        manager.deactivate()
+                    }
+                }) {
                     Text(l10n.s.cleaningOverlayUnlock)
                         .font(.system(size: 11, weight: .semibold))
                 }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -14466,6 +14466,27 @@ struct MetricsTests {
                 && cleaningCode.contains("guard restoreSuspendedFeatures else {"),
                "Cleaning Mode restores suspended taps only after its login session returns")
 
+        // MARK: Cleaning Mode overlay teardown and mouse button release recovery (#1519)
+        let cleaningOverlaySource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/UI/CleaningMode/CleaningOverlayView.swift",
+            encoding: .utf8)) ?? ""
+        expect(cleaningOverlaySource.contains("DispatchQueue.main.async {\n                    manager.deactivate()\n                }"),
+               "Cleaning overlay button dispatches deactivation asynchronously so the click finishes before teardown")
+
+        let hideOverlaysCode = (cleaningCode
+            .components(separatedBy: "private func hideOverlays() {").last ?? "")
+            .components(separatedBy: "\n    }").first ?? ""
+        expect(!hideOverlaysCode.contains("asyncAfter"),
+               "overlay teardown never schedules a delayed release that could drop a subsequent drag")
+        expect(hideOverlaysCode.contains("ignoresMouseEvents = true"),
+               "overlay panels ignore mouse events immediately during teardown")
+        expect(hideOverlaysCode.contains("panels.forEach { $0.orderOut(nil) }"),
+               "overlay panels order out on the next main run-loop turn")
+        expect(hideOverlaysCode.contains("if isLeftDown || isRightDown {"),
+               "mouse button release recovery is strictly limited to buttons held on the cleaning screen")
+        expect(!cleaningCode.contains("buttonState(.hidSystemState"),
+               "cleaning recovery relies on session state rather than raw hardware state")
+
         func systemKeyData(keyCode: Int, state: Int, repeatFlag: Bool = false) -> Int {
             Int((UInt32(keyCode) << 16) | (UInt32(state) << 8) | (repeatFlag ? 1 : 0))
         }


### PR DESCRIPTION
### Summary
Fixes an issue where exiting Cleaning Mode (either via the "Unlock" button or the 5x Escape gesture) could leave the primary mouse button (LMB) locked or unresponsive across macOS.

### Root Cause
1. In `CleaningOverlayView`, clicking the "Unlock" button synchronously invoked `manager.deactivate()`.
2. `CleaningModeManager.hideOverlays()` synchronously called `overlays.forEach { $0.orderOut(nil) }` while the mouse event tracking loop was still active in AppKit/WindowServer, or while the physical mouse button / trackpad was still depressed.
3. Abruptly ordering out the full-screen shielding `NSPanel` mid-click or while held severed WindowServer's event-tracking state. WindowServer dropped the corresponding `leftMouseUp` event, stranding `CGEventSource.buttonState(.combinedSessionState, button: .left)` in the `true` (down) state and causing subsequent clicks across all applications to be ignored or treated as drags.

### Changes
1. **Deferred Dismissal**: `CleaningOverlayView`'s Unlock buttons now dispatch `manager.deactivate()` asynchronously (`DispatchQueue.main.async`), allowing the active click event cycle to finish cleanly before overlay teardown begins.
2. **Event Disengagement**: `hideOverlays()` sets `panel.ignoresMouseEvents = true` immediately and defers `orderOut(nil)` to the next run loop turn.
3. **Fail-Safe Release**: Added `ensureMouseButtonsReleased()` in `CleaningModeManager`, which inspects `NSEvent.pressedMouseButtons` and `CGEventSource.buttonState` and synthesizes an explicit `.leftMouseUp` / `.rightMouseUp` if a button remains stuck down upon overlay teardown.

### Verification
- `./build.sh --test`: All 10,755 checks passed (`TESTS OK`, `PREFERENCE CLEANUP TESTS OK`).