### PR TITLE
feat: turn wi-fi off while sleeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The rest bends the same way: panel sections reorder and hide, the compact layout
 - **Displays.** Adjust brightness or turn individual displays on and off. External screens use their own control channel when available and fall back to dimming the picture, while the keyboard brightness keys can follow the pointer and show the brightness percentage.
 - **Extra brightness.** Pushes the XDR panel of a MacBook Pro past its regular maximum using the display's HDR headroom. Toggle it from the Displays panel or Settings.
 - **Bluetooth on sleep.** Switches Bluetooth off while the Mac sleeps, so a laptop in a bag stops stealing the headphones you are listening to elsewhere. Bluetooth you had already turned off stays off, and only what Vorssaint switched off comes back on wake.
+- **Wi-Fi on sleep.** Switches Wi-Fi off while the Mac sleeps, so a closed laptop goes dark on networks it is not using. Wi-Fi you had already turned off stays off, and only what Vorssaint switched off comes back on wake.
 
 ## Install
 

--- a/Sources/Vorssaint/App/FeatureRuntime.swift
+++ b/Sources/Vorssaint/App/FeatureRuntime.swift
@@ -234,6 +234,7 @@ final class FeatureRuntime: ObservableObject {
         .brightness: { BrightnessService.shared.syncWithPreferences() },
         .extraBrightness: { ExtraBrightnessService.shared.syncWithPreferences() },
         .bluetoothSleep: { BluetoothSleepService.shared.syncWithPreferences() },
+        .wifiSleep: { WiFiSleepService.shared.syncWithPreferences() },
         .quickLauncher: { QuickLauncherService.shared.syncWithPreferences() },
         .colorPicker: {
             ScreenCaptureService.shared.syncWithPreferences()

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -181,6 +181,11 @@ enum DefaultsKey {
     // Set only while Vorssaint owes a Bluetooth restore, so a Mac shut down
     // while asleep still gets it back on the next launch.
     static let bluetoothSleepRestorePending = "bluetoothSleepRestorePending"
+    static let wifiSleepEnabled = "wifiSleepEnabled"
+    static let wifiSleepRestoreOnWake = "wifiSleepRestoreOnWake"
+    // Set only while Vorssaint owes a Wi-Fi restore, so a Mac shut down
+    // while asleep still gets it back on the next launch.
+    static let wifiSleepRestorePending = "wifiSleepRestorePending"
     static let musicBlockEnabled = "musicBlockEnabled"
     static let musicBlockReplacementPath = "musicBlockReplacementPath"  // app bundle path ("" = none)
     static let cleanerScheduleFrequency = "cleanerScheduleFrequency"    // off | daily | weekly
@@ -986,6 +991,9 @@ enum Defaults {
         DefaultsKey.bluetoothSleepEnabled: false,
         DefaultsKey.bluetoothSleepRestoreOnWake: true,
         DefaultsKey.bluetoothSleepRestorePending: false,
+        DefaultsKey.wifiSleepEnabled: false,
+        DefaultsKey.wifiSleepRestoreOnWake: true,
+        DefaultsKey.wifiSleepRestorePending: false,
         DefaultsKey.musicBlockEnabled: false,
         DefaultsKey.musicBlockReplacementPath: "",
         DefaultsKey.cleanerScheduleFrequency: "off",

--- a/Sources/Vorssaint/Core/FeatureCatalog.swift
+++ b/Sources/Vorssaint/Core/FeatureCatalog.swift
@@ -24,7 +24,7 @@ enum AppFeature: String, CaseIterable {
     // Sound
     case mixer, soundOutputSwitcher, micMute, musicBlock
     // Energy and display
-    case keepAwake, brightness, extraBrightness, bluetoothSleep
+    case keepAwake, brightness, extraBrightness, bluetoothSleep, wifiSleep
     // Tools
     case quickLauncher, quickToggles, colorPicker, screenOCR, cleaningMode, mediaTools,
          cleaner, uninstaller, homebrew, appUpdates, screenshot, cameraPreview, radialMenu, scratchpad,
@@ -105,7 +105,7 @@ extension AppFeature {
             return .clipboardFiles
         case .mixer, .soundOutputSwitcher, .micMute, .musicBlock:
             return .sound
-        case .keepAwake, .brightness, .extraBrightness, .bluetoothSleep:
+        case .keepAwake, .brightness, .extraBrightness, .bluetoothSleep, .wifiSleep:
             return .energyDisplay
         case .quickLauncher, .quickToggles, .colorPicker, .screenOCR, .cleaningMode, .mediaTools,
              .cleaner, .uninstaller, .homebrew, .appUpdates, .screenshot, .cameraPreview, .radialMenu,
@@ -155,6 +155,7 @@ extension AppFeature {
         case .brightness: return "display.2"
         case .extraBrightness: return "sun.max.fill"
         case .bluetoothSleep: return "wave.3.right.circle"
+        case .wifiSleep: return "wifi"
         case .quickLauncher: return "wand.and.rays"
         case .quickToggles: return "togglepower"
         case .colorPicker: return "eyedropper"
@@ -233,6 +234,7 @@ extension AppFeature {
         case .brightness: return [DefaultsKey.brightnessControlEnabled]
         case .extraBrightness: return [DefaultsKey.extraBrightnessEnabled]
         case .bluetoothSleep: return [DefaultsKey.bluetoothSleepEnabled]
+        case .wifiSleep: return [DefaultsKey.wifiSleepEnabled]
         case .windowLayout, .diskImageInstaller, .mixer, .micMute, .keepAwake,
              .quickLauncher, .quickToggles, .colorPicker, .screenOCR, .cleaningMode, .mediaTools,
              .cleaner, .uninstaller, .homebrew, .appUpdates, .screenshot, .cameraPreview, .scratchpad,
@@ -284,7 +286,7 @@ extension AppFeature {
         case .monitorCPU, .monitorMemory, .monitorDisk, .monitorPower: return [.notifications]
         case .clipboardHistory, .shelf, .urlCleaner,
              .soundOutputSwitcher, .musicBlock,
-             .extraBrightness, .bluetoothSleep, .quickLauncher, .colorPicker, .micMute, .mediaTools,
+             .extraBrightness, .bluetoothSleep, .wifiSleep, .quickLauncher, .colorPicker, .micMute, .mediaTools,
              .scratchpad, .monitorGPU, .monitorNetwork, .fanControl, .killProcess:
             return []
         }

--- a/Sources/Vorssaint/Core/FeaturePresets.swift
+++ b/Sources/Vorssaint/Core/FeaturePresets.swift
@@ -120,7 +120,7 @@ extension AppFeature {
             return UserDefaults.standard.bool(forKey: DefaultsKey.preciseVolumeRollerEnabled)
                 ? .keyboard : .idle
         case .mouseAcceleration, .pastePlain, .soundOutputSwitcher, .micMute,
-             .musicBlock, .bluetoothSleep, .keepAwake, .brightness, .quickLauncher, .quickToggles, .colorPicker,
+             .musicBlock, .bluetoothSleep, .wifiSleep, .keepAwake, .brightness, .quickLauncher, .quickToggles, .colorPicker,
              .screenOCR, .cleaningMode, .mediaTools, .cleaner, .uninstaller, .homebrew, .screenshot,
              .cameraPreview, .scratchpad, .commandBar, .screenRecorder, .fanControl,
              .diskImageInstaller, .killProcess:

--- a/Sources/Vorssaint/Core/SettingsBackupSupport.swift
+++ b/Sources/Vorssaint/Core/SettingsBackupSupport.swift
@@ -74,6 +74,8 @@ enum SettingsBackupSupport {
     static let machineStateKeys: Set<String> = [
         // A Bluetooth restore owed by one sleeping Mac means nothing on another.
         DefaultsKey.bluetoothSleepRestorePending,
+        // Same for a Wi-Fi restore.
+        DefaultsKey.wifiSleepRestorePending,
         DefaultsKey.micMuteActive,
         DefaultsKey.micMuteSavedVolume,
         // Levels and device ids belong to the microphones of one Mac.

--- a/Sources/Vorssaint/Core/WiFiSleepStrings.swift
+++ b/Sources/Vorssaint/Core/WiFiSleepStrings.swift
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+/// Strings for the Wi-Fi on sleep feature. Same contract as the other
+/// FeatureStrings structs: memberwise init with labeled arguments in
+/// declaration order, one static per language, all in this file.
+struct WiFiSleepStrings {
+    let pageTitle: String
+    let hubDescription: String
+    let enable: String
+    let enableCaption: String
+    let restoreToggle: String
+    let restoreCaption: String
+    let unsupported: String
+}
+
+extension FeatureStrings {
+    static func wifiSleep(_ language: AppLanguage) -> WiFiSleepStrings {
+        switch language {
+        case .enUS: return .enUS
+        case .ptBR: return .ptBR
+        case .tr: return .tr
+        case .ru: return .ru
+        case .es: return .es
+        case .de: return .de
+        case .fr: return .fr
+        case .it: return .it
+        case .ja: return .ja
+        case .ko: return .ko
+        case .zhHans: return .zhHans
+        case .zhTW: return .zhTW
+        case .zhHK: return .zhHK
+        }
+    }
+}
+
+extension WiFiSleepStrings {
+    static let enUS = WiFiSleepStrings(
+        pageTitle: "Wi-Fi on sleep",
+        hubDescription: "Switches Wi-Fi off while the Mac sleeps, so a closed laptop goes dark on networks it is not using.",
+        enable: "Turn Wi-Fi off when the Mac sleeps",
+        enableCaption: "Wi-Fi already off before sleep is left alone and stays off on wake.",
+        restoreToggle: "Turn Wi-Fi back on when the Mac wakes",
+        restoreCaption: "Only when Vorssaint was the one that switched it off.",
+        unsupported: "This Mac has no Wi-Fi adapter."
+    )
+
+    static let ptBR = WiFiSleepStrings(
+        pageTitle: "Wi-Fi ao dormir",
+        hubDescription: "Desliga o Wi-Fi enquanto o Mac dorme, para que um laptop fechado fique invisível nas redes que não usa.",
+        enable: "Desligar o Wi-Fi quando o Mac dormir",
+        enableCaption: "O Wi-Fi que já estava desligado antes do repouso não é tocado e continua desligado ao acordar.",
+        restoreToggle: "Ligar o Wi-Fi de volta quando o Mac acordar",
+        restoreCaption: "Apenas quando foi o Vorssaint que o desligou.",
+        unsupported: "Este Mac não tem adaptador Wi-Fi."
+    )
+
+    static let tr = WiFiSleepStrings(
+        pageTitle: "Uykuda Wi-Fi",
+        hubDescription: "Mac uyurken Wi-Fi’ı kapatır, böylece kapalı dizüstü kullanmadığı ağlarda görünmez olur.",
+        enable: "Mac uykuya girdiğinde Wi-Fi’ı kapat",
+        enableCaption: "Uykudan önce zaten kapalı olan Wi-Fi’a dokunulmaz ve uyanınca da kapalı kalır.",
+        restoreToggle: "Mac uyandığında Wi-Fi’ı yeniden aç",
+        restoreCaption: "Sadece Vorssaint kapatmışsa yeniden açılır.",
+        unsupported: "Bu Mac’te Wi-Fi adaptörü yok."
+    )
+
+    static let ru = WiFiSleepStrings(
+        pageTitle: "Wi-Fi при сне",
+        hubDescription: "Выключает Wi-Fi на время сна Mac, чтобы закрытый ноутбук не светился в сетях, которыми не пользуется.",
+        enable: "Выключать Wi-Fi, когда Mac засыпает",
+        enableCaption: "Wi-Fi, выключенный до сна, не трогается и остаётся выключенным после пробуждения.",
+        restoreToggle: "Включать Wi-Fi обратно, когда Mac просыпается",
+        restoreCaption: "Только если его выключил сам Vorssaint.",
+        unsupported: "На этом Mac нет адаптера Wi-Fi."
+    )
+
+    static let es = WiFiSleepStrings(
+        pageTitle: "Wi-Fi en reposo",
+        hubDescription: "Apaga el Wi-Fi mientras el Mac duerme, para que un portátil cerrado no aparezca en las redes que no usa.",
+        enable: "Apagar el Wi-Fi cuando el Mac entre en reposo",
+        enableCaption: "El Wi-Fi ya apagado antes del reposo no se toca y sigue apagado al despertar.",
+        restoreToggle: "Volver a encender el Wi-Fi cuando el Mac despierte",
+        restoreCaption: "Solo cuando fue Vorssaint el que lo apagó.",
+        unsupported: "Este Mac no tiene adaptador Wi-Fi."
+    )
+
+    static let de = WiFiSleepStrings(
+        pageTitle: "WLAN im Ruhezustand",
+        hubDescription: "Schaltet das WLAN aus, während der Mac schläft, damit ein geschlossenes Laptop in Netzwerken, die es nicht nutzt, unsichtbar bleibt.",
+        enable: "WLAN ausschalten, wenn der Mac schläft",
+        enableCaption: "WLAN, das vor dem Ruhezustand schon aus war, bleibt unberührt und nach dem Aufwachen aus.",
+        restoreToggle: "WLAN wieder einschalten, wenn der Mac aufwacht",
+        restoreCaption: "Nur wenn Vorssaint es ausgeschaltet hat.",
+        unsupported: "Dieser Mac hat kein WLAN-Modul."
+    )
+
+    static let fr = WiFiSleepStrings(
+        pageTitle: "Wi-Fi en veille",
+        hubDescription: "Coupe le Wi-Fi pendant que le Mac dort, pour qu’un ordinateur fermé reste invisible sur les réseaux qu’il n’utilise pas.",
+        enable: "Couper le Wi-Fi quand le Mac se met en veille",
+        enableCaption: "Le Wi-Fi déjà coupé avant la veille n’est pas touché et reste coupé au réveil.",
+        restoreToggle: "Rallumer le Wi-Fi quand le Mac se réveille",
+        restoreCaption: "Seulement si c’est Vorssaint qui l’avait coupé.",
+        unsupported: "Ce Mac n’a pas de carte Wi-Fi."
+    )
+
+    static let it = WiFiSleepStrings(
+        pageTitle: "Wi-Fi in stop",
+        hubDescription: "Spegne il Wi-Fi mentre il Mac dorme, così un laptop chiuso resta invisibile nelle reti che non usa.",
+        enable: "Spegni il Wi-Fi quando il Mac va in stop",
+        enableCaption: "Il Wi-Fi già spento prima dello stop non viene toccato e resta spento al risveglio.",
+        restoreToggle: "Riaccendi il Wi-Fi quando il Mac si sveglia",
+        restoreCaption: "Solo se è stato Vorssaint a spegnerlo.",
+        unsupported: "Questo Mac non ha una scheda Wi-Fi."
+    )
+
+    static let ja = WiFiSleepStrings(
+        pageTitle: "スリープ時のWi-Fi",
+        hubDescription: "Macのスリープ中はWi-Fiを切るので、閉じたノートブックは使っていないネットワークに姿を現しません。",
+        enable: "Macがスリープに入ったらWi-Fiを切る",
+        enableCaption: "スリープ前にすでに切っていたWi-Fiには触れず、目覚めた後も切ったままにします。",
+        restoreToggle: "Macが目覚めたらWi-Fiをもう一度入れる",
+        restoreCaption: "Vorssaintが切ったときだけ入れ直します。",
+        unsupported: "このMacにはWi-Fiアダプタがありません。"
+    )
+
+    static let ko = WiFiSleepStrings(
+        pageTitle: "잠자는 동안의 Wi-Fi",
+        hubDescription: "Mac이 잠자는 동안 Wi-Fi를 꺼서 닫힌 노트북이 쓰지 않는 네트워크에 나타나지 않게 합니다.",
+        enable: "Mac이 잠자기에 들어가면 Wi-Fi 끄기",
+        enableCaption: "잠자기 전에 이미 꺼져 있던 Wi-Fi는 건드리지 않고 깨어난 뒤에도 꺼진 채로 둡니다.",
+        restoreToggle: "Mac이 깨어나면 Wi-Fi 다시 켜기",
+        restoreCaption: "Vorssaint가 껐을 때만 다시 켭니다.",
+        unsupported: "이 Mac에는 Wi-Fi 어댑터가 없습니다."
+    )
+
+    static let zhHans = WiFiSleepStrings(
+        pageTitle: "睡眠时的 Wi-Fi",
+        hubDescription: "Mac 睡眠期间关闭 Wi-Fi，合上的笔记本不会出现在没在使用的网络里。",
+        enable: "Mac 进入睡眠时关闭 Wi-Fi",
+        enableCaption: "睡前已经关闭的 Wi-Fi 不会被改动，醒来后也保持关闭。",
+        restoreToggle: "Mac 唤醒时重新打开 Wi-Fi",
+        restoreCaption: "只有 Vorssaint 关掉的情况下才会重新打开。",
+        unsupported: "这台 Mac 没有 Wi-Fi 适配器。"
+    )
+
+    static let zhTW = WiFiSleepStrings(
+        pageTitle: "睡眠時的 Wi-Fi",
+        hubDescription: "Mac 睡眠期間關閉 Wi-Fi，合上的筆電不會出現在沒在使用的網路裡。",
+        enable: "Mac 進入睡眠時關閉 Wi-Fi",
+        enableCaption: "睡前已經關閉的 Wi-Fi 不會被更動，醒來後也保持關閉。",
+        restoreToggle: "Mac 喚醒時重新開啟 Wi-Fi",
+        restoreCaption: "只有 Vorssaint 關掉的情況下才會重新開啟。",
+        unsupported: "這台 Mac 沒有 Wi-Fi 介面卡。"
+    )
+
+    static let zhHK = WiFiSleepStrings(
+        pageTitle: "睡眠時的 Wi-Fi",
+        hubDescription: "Mac 睡眠期間關閉 Wi-Fi，合上嘅手提電腦唔會喺無用緊嘅網絡出現。",
+        enable: "Mac 進入睡眠時關閉 Wi-Fi",
+        enableCaption: "睡前已經關閉嘅 Wi-Fi 唔會被改動，醒返之後都保持關閉。",
+        restoreToggle: "Mac 醒返時重新開啟 Wi-Fi",
+        restoreCaption: "只有 Vorssaint 關咗嘅情況下先會重新開啟。",
+        unsupported: "呢部 Mac 冇 Wi-Fi 卡。"
+    )
+}

--- a/Sources/Vorssaint/Services/WiFi/WiFiSleepService.swift
+++ b/Sources/Vorssaint/Services/WiFi/WiFiSleepService.swift
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import CoreWLAN
+
+/// Switches Wi-Fi off while the Mac sleeps, so a closed laptop goes dark on
+/// networks it is not using instead of staying joined to them all night.
+///
+/// The restore is honest in exactly the way Bluetooth on sleep is: the state
+/// found before sleep is remembered, so Wi-Fi the user had already turned off
+/// is never switched back on for them. The memory is a preference rather than
+/// a variable, so a Mac shut down while asleep still gets its Wi-Fi back on
+/// the next launch instead of staying dark.
+///
+/// Nothing runs while the feature is off: no observers, no polling, no cost.
+/// Unlike the Bluetooth power switch, the Wi-Fi calls cross to the Wi-Fi
+/// daemon (airportd) and block, so they stay synchronous inside the sleep
+/// handler: the system holds off on the will-sleep reply, and a toggle sent
+/// async could otherwise land after the Mac is already asleep.
+final class WiFiSleepService {
+    static let shared = WiFiSleepService()
+
+    /// A Mac either has a Wi-Fi adapter or it does not; the answer cannot
+    /// change while the Mac is running, so resolve it once. Desktops without
+    /// a card report no interface at all.
+    static let isSupported: Bool = {
+        CWWiFiClient.shared().interface() != nil
+    }()
+
+    private var observers: [NSObjectProtocol] = []
+
+    private init() {}
+
+    func syncWithPreferences() {
+        guard Self.isSupported else { return }
+        // A restore still owed here means an earlier run switched Wi-Fi
+        // off and never saw the wake, because the Mac was shut down (or the
+        // app quit) while it slept. The debt is paid before anything else,
+        // and paid even when the feature has since been switched off, so
+        // nothing Vorssaint took away is ever kept.
+        restoreIfOwed()
+        if AppFeature.wifiSleep.isAvailable,
+           UserDefaults.standard.bool(forKey: DefaultsKey.wifiSleepEnabled) {
+            start()
+        } else {
+            stop()
+        }
+    }
+
+    private func start() {
+        guard observers.isEmpty else { return }
+        let center = NSWorkspace.shared.notificationCenter
+        observers = [
+            center.addObserver(forName: NSWorkspace.willSleepNotification,
+                               object: nil, queue: .main) { [weak self] _ in
+                self?.macWillSleep()
+            },
+            center.addObserver(forName: NSWorkspace.didWakeNotification,
+                               object: nil, queue: .main) { [weak self] _ in
+                self?.restoreIfOwed()
+            },
+        ]
+    }
+
+    func stop() {
+        guard !observers.isEmpty else { return }
+        let center = NSWorkspace.shared.notificationCenter
+        for observer in observers { center.removeObserver(observer) }
+        observers = []
+    }
+
+    private func macWillSleep() {
+        let defaults = UserDefaults.standard
+        let plan = WiFiSleepSupport.sleepPlan(
+            isPoweredOn: Self.isPoweredOn,
+            restoresOnWake: defaults.bool(forKey: DefaultsKey.wifiSleepRestoreOnWake))
+        defaults.set(plan.owesRestore, forKey: DefaultsKey.wifiSleepRestorePending)
+        if plan.powersOff { Self.setPowered(false) }
+    }
+
+    private func restoreIfOwed() {
+        let defaults = UserDefaults.standard
+        let restores = WiFiSleepSupport.restores(
+            owesRestore: defaults.bool(forKey: DefaultsKey.wifiSleepRestorePending),
+            isPoweredOn: Self.isPoweredOn)
+        // The debt is settled either way: Wi-Fi the user switched on
+        // themselves cancels it instead of waiting for the next sleep.
+        defaults.set(false, forKey: DefaultsKey.wifiSleepRestorePending)
+        if restores { Self.setPowered(true) }
+    }
+
+    // MARK: Radio power
+
+    private static var isPoweredOn: Bool {
+        guard let interface = CWWiFiClient.shared().interface() else { return false }
+        return interface.powerOn()
+    }
+
+    private static func setPowered(_ on: Bool) {
+        guard let interface = CWWiFiClient.shared().interface() else { return }
+        try? interface.setPower(on)
+    }
+}

--- a/Sources/Vorssaint/Services/WiFi/WiFiSleepSupport.swift
+++ b/Sources/Vorssaint/Services/WiFi/WiFiSleepSupport.swift
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+/// The decisions behind Wi-Fi on sleep, kept free of AppKit, CoreWLAN and
+/// IOKit so they can be tested directly.
+///
+/// The rule the whole feature turns on is the same one Bluetooth on sleep
+/// uses: Vorssaint only ever puts back what it took away. Wi-Fi already off
+/// when the Mac went to sleep is never switched on for the user, which is the
+/// part a plain sleep-and-wake toggle gets wrong.
+enum WiFiSleepSupport {
+    /// What to do as the Mac goes to sleep.
+    struct SleepPlan: Equatable {
+        /// Whether Wi-Fi should be switched off now.
+        let powersOff: Bool
+        /// Whether a later wake owes the user a restore.
+        let owesRestore: Bool
+    }
+
+    static func sleepPlan(isPoweredOn: Bool, restoresOnWake: Bool) -> SleepPlan {
+        guard isPoweredOn else { return SleepPlan(powersOff: false, owesRestore: false) }
+        return SleepPlan(powersOff: true, owesRestore: restoresOnWake)
+    }
+
+    /// Whether waking (or a launch that finds a restore still owed, because
+    /// the Mac was shut down while asleep) should switch Wi-Fi back on.
+    /// Wi-Fi the user turned on themselves in the meantime is left alone.
+    static func restores(owesRestore: Bool, isPoweredOn: Bool) -> Bool {
+        owesRestore && !isPoweredOn
+    }
+}

--- a/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
@@ -732,6 +732,7 @@ extension AppFeature {
         case .brightness: return FeatureStrings.brightness(L10n.shared.language).pageTitle
         case .extraBrightness: return s.extraBrightnessName
         case .bluetoothSleep: return FeatureStrings.bluetoothSleep(L10n.shared.language).pageTitle
+        case .wifiSleep: return FeatureStrings.wifiSleep(L10n.shared.language).pageTitle
         case .quickLauncher: return s.launcherName
         case .quickToggles: return FeatureStrings.quickToggles(L10n.shared.language).pageTitle
         case .colorPicker: return s.colorPickerName
@@ -796,6 +797,7 @@ extension AppFeature {
         case .brightness: return FeatureStrings.brightness(L10n.shared.language).hubDescription
         case .extraBrightness: return hub.descExtraBrightness
         case .bluetoothSleep: return FeatureStrings.bluetoothSleep(L10n.shared.language).hubDescription
+        case .wifiSleep: return FeatureStrings.wifiSleep(L10n.shared.language).hubDescription
         case .quickLauncher: return hub.descQuickLauncher
         case .quickToggles: return FeatureStrings.quickToggles(L10n.shared.language).hubDescription
         case .colorPicker: return hub.descColorPicker

--- a/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
@@ -22,6 +22,7 @@ enum SettingsSectionAnchor: String, CaseIterable, Hashable {
     case brightness
     case extraBrightness
     case bluetoothSleep
+    case wifiSleep
     case scrollDirection
     case focusFollowsMouse
     case smoothScroll
@@ -53,7 +54,7 @@ enum SettingsSectionAnchor: String, CaseIterable, Hashable {
     var page: SettingsPage {
         switch self {
         case .panelConfiguration, .musicBlocking: return .general
-        case .keepAwake, .brightness, .extraBrightness, .bluetoothSleep: return .energy
+        case .keepAwake, .brightness, .extraBrightness, .bluetoothSleep, .wifiSleep: return .energy
         case .scrollDirection, .focusFollowsMouse, .smoothScroll, .mouseAcceleration, .mouseNavigation, .mouseButtonShortcuts,
              .middleClick, .mouseClickDebounce:
             return .mouse
@@ -217,6 +218,8 @@ extension AppFeature {
             return FeatureSettingsDestination(.energy, sectionAnchor: .extraBrightness)
         case .bluetoothSleep:
             return FeatureSettingsDestination(.energy, sectionAnchor: .bluetoothSleep)
+        case .wifiSleep:
+            return FeatureSettingsDestination(.energy, sectionAnchor: .wifiSleep)
 
         case .quickLauncher:
             return FeatureSettingsDestination(.quickTools, sectionAnchor: .quickLauncher)
@@ -265,7 +268,7 @@ enum FeatureVisibilitySupport {
     /// always shows (General, Shortcuts, About and friends).
     static func features(for page: SettingsPage) -> [AppFeature] {
         switch page {
-        case .energy: return [.keepAwake, .brightness, .extraBrightness, .bluetoothSleep]
+        case .energy: return [.keepAwake, .brightness, .extraBrightness, .bluetoothSleep, .wifiSleep]
         case .monitor: return monitorFeatures
         case .mouse: return [.scrollInverter, .focusFollowsMouse, .smoothScroll, .mouseAcceleration, .mouseNavigation, .mouseButtonShortcuts,
                              .middleClick, .mouseClickDebounce]

--- a/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
@@ -98,6 +98,8 @@ enum SettingsDirectory {
                                         (.extraBrightness, [s.extraBrightnessName]),
                                         (.bluetoothSleep, [FeatureStrings.bluetoothSleep(language).pageTitle,
                                                            FeatureStrings.bluetoothSleep(language).enable]),
+                                        (.wifiSleep, [FeatureStrings.wifiSleep(language).pageTitle,
+                                                      FeatureStrings.wifiSleep(language).enable]),
                                        ]),
                 SettingsDirectoryItem(page: .monitor, title: s.tabMonitor, icon: "chart.line.uptrend.xyaxis",
                                        keywords: [s.menuBarSpacingLabel, s.menuBarHideIconToggle],

--- a/Sources/Vorssaint/UI/Settings/SettingsView.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsView.swift
@@ -642,6 +642,8 @@ struct EnergySettings: View {
     @AppStorage(DefaultsKey.extraBrightnessLevel) private var extraBrightnessLevel = 100
     @AppStorage(DefaultsKey.bluetoothSleepEnabled) private var bluetoothSleepEnabled = false
     @AppStorage(DefaultsKey.bluetoothSleepRestoreOnWake) private var bluetoothSleepRestoreOnWake = true
+    @AppStorage(DefaultsKey.wifiSleepEnabled) private var wifiSleepEnabled = false
+    @AppStorage(DefaultsKey.wifiSleepRestoreOnWake) private var wifiSleepRestoreOnWake = true
     @AppStorage(DefaultsKey.defaultDuration) private var defaultDuration = 0
     @AppStorage(DefaultsKey.batteryLimit) private var batteryLimit = 10
     @AppStorage(DefaultsKey.keepAwakeAutoStart) private var keepAwakeAutoStart = false
@@ -825,6 +827,27 @@ struct EnergySettings: View {
                     }
                 }
                 .settingsSectionAnchor(.bluetoothSleep)
+            }
+            if AppFeature.wifiSleep.isAvailable {
+                let strings = FeatureStrings.wifiSleep(l10n.language)
+                Section(strings.pageTitle) {
+                    if WiFiSleepService.isSupported {
+                        SettingsToggleWithCaption(title: strings.enable,
+                                                  caption: strings.enableCaption,
+                                                  isOn: $wifiSleepEnabled)
+                            .onChange(of: wifiSleepEnabled) { _, _ in
+                                WiFiSleepService.shared.syncWithPreferences()
+                            }
+                        if wifiSleepEnabled {
+                            SettingsToggleWithCaption(title: strings.restoreToggle,
+                                                      caption: strings.restoreCaption,
+                                                      isOn: $wifiSleepRestoreOnWake)
+                        }
+                    } else {
+                        SettingsCaptionText(strings.unsupported)
+                    }
+                }
+                .settingsSectionAnchor(.wifiSleep)
             }
         }
         .formStyle(.grouped)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -4596,6 +4596,14 @@ struct MetricsTests {
                "no Bluetooth restore is owed before the first sleep")
         expect(!SettingsBackupSupport.exportKeys().contains(DefaultsKey.bluetoothSleepRestorePending),
                "a Bluetooth restore owed by one sleeping Mac never travels to another")
+        expect(registeredDefaults[DefaultsKey.wifiSleepEnabled] as? Bool == false,
+               "switching Wi-Fi off on sleep is opt-in")
+        expect(registeredDefaults[DefaultsKey.wifiSleepRestoreOnWake] as? Bool == true,
+               "an enabled Wi-Fi sleep feature puts Wi-Fi back on wake")
+        expect(registeredDefaults[DefaultsKey.wifiSleepRestorePending] as? Bool == false,
+               "no Wi-Fi restore is owed before the first sleep")
+        expect(!SettingsBackupSupport.exportKeys().contains(DefaultsKey.wifiSleepRestorePending),
+               "a Wi-Fi restore owed by one sleeping Mac never travels to another")
         expect(registeredDefaults[DefaultsKey.musicBlockEnabled] as? Bool == false,
                "blocking the music app from launching is opt-in")
         expect(registeredDefaults[DefaultsKey.musicBlockReplacementPath] as? String == "",
@@ -14555,7 +14563,7 @@ struct MetricsTests {
 
         // MARK: Features hub catalog
 
-        expect(AppFeature.allCases.count == 57, "feature catalog has 57 features")
+        expect(AppFeature.allCases.count == 58, "feature catalog has 58 features")
         expect(Set(AppFeature.allCases.map(\.rawValue)).count == AppFeature.allCases.count,
                "feature ids are unique")
         expect(AppFeature.allCases.map(\.rawValue) == [
@@ -14565,7 +14573,7 @@ struct MetricsTests {
             "clipboardHistory", "pastePlain", "finderCutPaste", "finderRename", "shelf", "urlCleaner",
             "diskImageInstaller",
             "mixer", "soundOutputSwitcher", "micMute", "musicBlock",
-            "keepAwake", "brightness", "extraBrightness", "bluetoothSleep",
+            "keepAwake", "brightness", "extraBrightness", "bluetoothSleep", "wifiSleep",
             "quickLauncher", "quickToggles", "colorPicker", "screenOCR", "cleaningMode", "mediaTools",
             "cleaner", "uninstaller", "homebrew", "appUpdates", "screenshot", "cameraPreview",
             "radialMenu", "scratchpad", "commandBar", "screenRecorder", "killProcess",
@@ -14799,6 +14807,19 @@ struct MetricsTests {
                 && AppFeature.bluetoothSleep.settingsDestination.hasValidSectionAnchor
                 && FeatureVisibilitySupport.features(for: .energy).contains(.bluetoothSleep),
                "Bluetooth on sleep owns a section of the Energy page and can keep it alive alone")
+        expect(AppFeature.wifiSleep.group == .energyDisplay
+                && AppFeature.wifiSleep.enabledKeys == [DefaultsKey.wifiSleepEnabled]
+                && AppFeature.wifiSleep.permissions.isEmpty
+                && AppFeature.wifiSleep.energyProfile == .idle
+                && !AppFeature.wifiSleep.isBeta,
+               "Wi-Fi on sleep is an energy feature that costs nothing at rest")
+        expect((AppFeature.availabilityDefaults[AppFeature.wifiSleep.availabilityKey] as? Bool) == true,
+               "Wi-Fi on sleep ships installed, switched off, so its section is findable")
+        expect(AppFeature.wifiSleep.settingsDestination
+                == FeatureSettingsDestination(.energy, sectionAnchor: .wifiSleep)
+                && AppFeature.wifiSleep.settingsDestination.hasValidSectionAnchor
+                && FeatureVisibilitySupport.features(for: .energy).contains(.wifiSleep),
+               "Wi-Fi on sleep owns a section of the Energy page and can keep it alive alone")
         expect(BluetoothSleepSupport.sleepPlan(isPoweredOn: true, restoresOnWake: true)
                 == BluetoothSleepSupport.SleepPlan(powersOff: true, owesRestore: true),
                "Bluetooth on before sleep is switched off and owed back")
@@ -14814,6 +14835,30 @@ struct MetricsTests {
                "a wake owing nothing leaves Bluetooth off")
         expect(!BluetoothSleepSupport.restores(owesRestore: true, isPoweredOn: true),
                "Bluetooth the user switched on first is left alone")
+        expect(WiFiSleepSupport.sleepPlan(isPoweredOn: true, restoresOnWake: true)
+                == WiFiSleepSupport.SleepPlan(powersOff: true, owesRestore: true),
+               "Wi-Fi on before sleep is switched off and owed back")
+        expect(WiFiSleepSupport.sleepPlan(isPoweredOn: true, restoresOnWake: false)
+                == WiFiSleepSupport.SleepPlan(powersOff: true, owesRestore: false),
+               "without the restore option, sleep switches Wi-Fi off for good")
+        expect(WiFiSleepSupport.sleepPlan(isPoweredOn: false, restoresOnWake: true)
+                == WiFiSleepSupport.SleepPlan(powersOff: false, owesRestore: false),
+               "Wi-Fi already off before sleep is left alone, so the wake never turns it on")
+        expect(WiFiSleepSupport.restores(owesRestore: true, isPoweredOn: false),
+               "a wake that still owes a restore switches Wi-Fi back on")
+        expect(!WiFiSleepSupport.restores(owesRestore: false, isPoweredOn: false),
+               "a wake owing nothing leaves Wi-Fi off")
+        expect(!WiFiSleepSupport.restores(owesRestore: true, isPoweredOn: true),
+               "Wi-Fi the user switched on first is left alone")
+
+        for language in AppLanguage.allCases {
+            let strings = FeatureStrings.wifiSleep(language)
+            let values = Mirror(reflecting: strings).children.compactMap { $0.value as? String }
+            expect(values.count == 7 && values.allSatisfy { !$0.isEmpty },
+                   "Wi-Fi on sleep has every localized field for \(language.rawValue)")
+            expect(values.allSatisfy { !$0.contains("—") },
+                   "Wi-Fi on sleep text uses human punctuation for \(language.rawValue)")
+        }
 
         for language in AppLanguage.allCases {
             let strings = FeatureStrings.bluetoothSleep(language)
@@ -15924,8 +15969,9 @@ struct MetricsTests {
                "the mouse page hides only with all eight mouse features off")
         expect(!pageVisible(.energy, available: allFeatures.subtracting([.keepAwake, .brightness,
                                                                          .extraBrightness,
-                                                                         .bluetoothSleep])),
-               "energy hides when all four of its features are off")
+                                                                         .bluetoothSleep,
+                                                                         .wifiSleep])),
+               "energy hides when all five of its features are off")
         expect(pageVisible(.energy, available: [.extraBrightness]), "XDR alone keeps the energy page")
         expect(pageVisible(.energy, available: [.brightness]),
                "brightness control alone keeps the energy page")

--- a/build.sh
+++ b/build.sh
@@ -283,6 +283,7 @@ if (( TEST )); then
         Sources/Vorssaint/Core/BatteryTimeStrings.swift \
         Sources/Vorssaint/Core/KeepAwakeStrings.swift \
         Sources/Vorssaint/Core/BluetoothSleepStrings.swift \
+        Sources/Vorssaint/Core/WiFiSleepStrings.swift \
         Sources/Vorssaint/Core/PermissionGuideStrings.swift \
         Sources/Vorssaint/Core/FanControlStrings.swift \
         Sources/Vorssaint/Services/FanControl/FanControlSupport.swift \
@@ -320,6 +321,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/Audio/MixerRoutingSupport.swift \
         Sources/Vorssaint/Services/Audio/MusicLaunchSupport.swift \
         Sources/Vorssaint/Services/Bluetooth/BluetoothSleepSupport.swift \
+        Sources/Vorssaint/Services/WiFi/WiFiSleepSupport.swift \
         Sources/Vorssaint/UI/MenuPanel/MixerPercentNativeTextField.swift \
         Sources/Vorssaint/Services/Audio/BoostLimiter.swift \
         Sources/Vorssaint/Services/Audio/MixerRender.swift \


### PR DESCRIPTION
## Summary

Adds **Wi-Fi on sleep**, the Wi-Fi sibling of the shipped Bluetooth on sleep feature (#861): an opt-in Energy feature that switches the Wi-Fi radio off when the Mac sleeps and turns it back on wake **only when Vorssaint was the one that switched it off**. Wi-Fi already off before sleep is left alone and stays off on wake, and a Mac shut down while asleep still gets its Wi-Fi back on the next launch — the same "honest restore" debt model the Bluetooth feature uses, persisted in defaults and excluded from settings backup so it never travels between Macs.

Why it belongs here, on the four questions:

- **Built on:** the public CoreWLAN framework, which the app already uses in production for the Command Bar's Wi-Fi row — the exact same `CWInterface.setPower` toggle Control Center flips. No new dependency, nothing to carry when it breaks.
- **Runtime drag:** none. No polling, no observers, no cost while the feature is off; two `NSWorkspace` sleep/wake observers only while enabled.
- **Exposure:** nothing new — the app is unsandboxed and already performs this identical toggle from the Command Bar; no entitlements changed.
- **Surface vs. use:** one toggle on the Energy page next to Bluetooth on sleep, off by default, hidden entirely on Macs without a Wi-Fi adapter. People who already reach for Bluetooth on sleep are the same people who want a laptop fully dark in a bag.

Implementation mirrors the Bluetooth feature file-for-file so the two read as a pair: `WiFiSleepService` (CoreWLAN; calls stay synchronous inside the will-sleep handler since they cross to `airportd`), `WiFiSleepSupport` (pure decision logic), `WiFiSleepStrings` (all 13 languages), plus the catalog, defaults, runtime binding, Settings section, search directory and backup-exclusion wiring. New user-facing text compiles in every supported language; the localization coverage test enforces it.

## Verification

```sh
./build.sh                     # ✓ finished with zero warnings, bundle signed
./build/Vorssaint --selftest   # ✓ SELFTEST OK
./build.sh --test              # ✓ TESTS OK (10794 checks)
```

- `./build.sh --test` includes the new expectations: the catalog count (now 58) with stable feature ids, opt-in registered defaults, the five restore-decision cases (`WiFiSleepSupport`), the 13-language string contract, backup exclusion of the pending-restore key, and Energy-page visibility with the fifth feature.
- Ran on a MacBook Pro (Apple M4 Pro), macOS 27.0 (build 26A5425a), a release build from `./build.sh`, app language English (US). Single built-in display.
- **Could not test:** an actual sleep/wake cycle with the feature enabled — the sleep/wake handlers and the real radio toggle are outside the unit-test harness. The toggle call itself is the same one the Command Bar's Wi-Fi row already makes, but the timing of `setPower` inside the will-sleep window on other hardware (older Intel Macs in particular) deserves the maintainer's local run.

## Anything else

No issue exists for this. Related but distinct: #790 (tracked in the enhancement summary #838) asks for automatic Ethernet/Wi-Fi *switching*; this is the sleep power-off feature, the direct analog of the merged Bluetooth on sleep (#861), not a step toward that.
