### PR TITLE
feat(screenshot): zoom pinned captures with the wheel

### DIFF
--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotPinController.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotPinController.swift
@@ -6,10 +6,10 @@ import Carbon.HIToolbox
 import UniformTypeIdentifiers
 
 /// Floating pinned screenshots keep a capture visible while working.
-/// Drag anywhere to move, resize from the edges keeping proportions, arrows
-/// nudge, double click or Esc closes, right click offers copy, save, opacity
-/// and click-through. A monitor exists only while a click-through pin needs
-/// its Option-click escape hatch.
+/// Drag anywhere to move, resize from the edges keeping proportions, scroll
+/// or pinch to zoom, arrows nudge, double click or Esc closes, right click
+/// offers copy, save, opacity and click-through. A monitor exists only while
+/// a click-through pin needs its Option-click escape hatch.
 final class ScreenshotPinController {
     static let shared = ScreenshotPinController()
 
@@ -85,7 +85,9 @@ private final class ScreenshotPinWindow: NSPanel {
                           height: CGFloat(image.height) / scale)
         let cap = min(screen.width, screen.height) * 0.55
         let ratio = min(1, min(cap / max(size.width, 1), cap / max(size.height, 1)))
-        size = CGSize(width: max(90, size.width * ratio), height: max(60, size.height * ratio))
+        let floorSize = ScreenshotSupport.pinMinSize
+        size = CGSize(width: max(floorSize.width, size.width * ratio),
+                      height: max(floorSize.height, size.height * ratio))
         let rect = CGRect(x: screen.midX - size.width / 2,
                           y: screen.midY - size.height / 2,
                           width: size.width,
@@ -105,13 +107,30 @@ private final class ScreenshotPinWindow: NSPanel {
         hidesOnDeactivate = false
         contentAspectRatio = CGSize(width: CGFloat(max(1, image.width)),
                                     height: CGFloat(max(1, image.height)))
-        minSize = CGSize(width: 90, height: 60)
+        minSize = ScreenshotSupport.pinMinSize
 
         let view = PinContentView(image: image, window: self)
         contentView = view
     }
 
     override var canBecomeKey: Bool { true }
+
+    /// Grows or shrinks the pin around `anchor`, staying on the display that
+    /// holds that point. A factor of 1, or a frame already at its floor or
+    /// ceiling, is a no-op so coasting packets do not keep rewriting the
+    /// window.
+    func applyZoom(factor: CGFloat, anchor: CGPoint) {
+        guard factor != 1 else { return }
+        let limits = NSScreen.screens.first { $0.frame.contains(anchor) }?.visibleFrame
+            ?? screen?.visibleFrame
+            ?? NSScreen.pointerVisibleFrame
+        let next = ScreenshotSupport.pinZoomedFrame(frame,
+                                                    factor: factor,
+                                                    anchor: anchor,
+                                                    limits: limits)
+        guard next != frame else { return }
+        setFrame(next, display: true)
+    }
 
     // MARK: Actions
 
@@ -216,6 +235,32 @@ private final class ScreenshotPinWindow: NSPanel {
             }
             pinWindow.makeKey()
             super.mouseDown(with: event)
+        }
+
+        override func scrollWheel(with event: NSEvent) {
+            guard let pinWindow else { return }
+            // Trackpad coasting would keep zooming after the fingers left.
+            guard event.momentumPhase == .none else { return }
+            let delta: CGFloat
+            if let cgEvent = event.cgEvent {
+                delta = ScreenshotSupport.captureLoupeWheelDelta(
+                    scrollingDelta: event.scrollingDeltaY,
+                    lineDelta: cgEvent.getIntegerValueField(.scrollWheelEventDeltaAxis1),
+                    fixedPointDelta: cgEvent.getDoubleValueField(
+                        .scrollWheelEventFixedPtDeltaAxis1))
+            } else {
+                delta = event.scrollingDeltaY
+            }
+            let factor = ScreenshotSupport.pinZoomFactor(
+                wheelDelta: delta,
+                precise: event.hasPreciseScrollingDeltas)
+            pinWindow.applyZoom(factor: factor, anchor: NSEvent.mouseLocation)
+        }
+
+        override func magnify(with event: NSEvent) {
+            guard let pinWindow else { return }
+            let factor = ScreenshotSupport.pinZoomFactor(magnification: event.magnification)
+            pinWindow.applyZoom(factor: factor, anchor: NSEvent.mouseLocation)
         }
 
         override func menu(for event: NSEvent) -> NSMenu? {

--- a/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
+++ b/Sources/Vorssaint/Services/QuickTools/ScreenshotSupport.swift
@@ -1912,6 +1912,64 @@ enum ScreenshotSupport {
         else { return "[]" }
         return String(data: data, encoding: .utf8) ?? "[]"
     }
+
+    /// Smallest a pinned capture can be. The window's resize floor and wheel
+    /// zoom share this so shrinking by either path cannot disagree.
+    static let pinMinSize = CGSize(width: 90, height: 60)
+
+    /// One discrete mouse-wheel notch grows the pin by this fraction.
+    static let pinZoomWheelStep: CGFloat = 0.03
+
+    /// Same gain as Control-scroll in the screenshot editor. Precise trackpad
+    /// packets would jump if each one took a full mouse notch.
+    static let pinZoomPreciseGain: CGFloat = 0.014
+
+    /// How much a pinned capture should grow or shrink for one wheel event.
+    /// Positive `wheelDelta` zooms in, matching the capture loupe.
+    static func pinZoomFactor(wheelDelta: CGFloat, precise: Bool) -> CGFloat {
+        guard wheelDelta.isFinite, wheelDelta != 0 else { return 1 }
+        if precise {
+            let clamped = min(24, max(-24, wheelDelta))
+            return max(0.2, 1 + clamped * pinZoomPreciseGain)
+        }
+        return wheelDelta > 0 ? 1 + pinZoomWheelStep : 1 / (1 + pinZoomWheelStep)
+    }
+
+    /// Trackpad pinch. `magnification` is AppKit's relative change for one
+    /// event in the gesture, already signed so a pinch-out grows the pin.
+    static func pinZoomFactor(magnification: CGFloat) -> CGFloat {
+        guard magnification.isFinite, magnification != 0 else { return 1 }
+        return max(0.2, 1 + magnification)
+    }
+
+    /// Scales `frame` around `anchor` (screen coordinates), keeping aspect
+    /// ratio, then slides it back onto `limits` so a corner zoom cannot run
+    /// the pin off the display.
+    static func pinZoomedFrame(_ frame: CGRect,
+                               factor: CGFloat,
+                               anchor: CGPoint,
+                               minSize: CGSize = pinMinSize,
+                               limits: CGRect) -> CGRect {
+        guard factor.isFinite, factor > 0,
+              frame.width > 0, frame.height > 0,
+              limits.width > 0, limits.height > 0
+        else { return frame }
+
+        let minFactor = max(minSize.width / frame.width, minSize.height / frame.height)
+        let maxFactor = min(limits.width / frame.width, limits.height / frame.height)
+        guard maxFactor > 0 else { return frame }
+        let clampedFactor = min(max(factor, minFactor), max(minFactor, maxFactor))
+        let width = frame.width * clampedFactor
+        let height = frame.height * clampedFactor
+        let tX = (anchor.x - frame.minX) / frame.width
+        let tY = (anchor.y - frame.minY) / frame.height
+        let next = CGRect(x: anchor.x - tX * width,
+                          y: anchor.y - tY * height,
+                          width: width,
+                          height: height)
+        guard next.width <= limits.width, next.height <= limits.height else { return next }
+        return movedRect(next, by: .zero, within: limits)
+    }
 }
 
 /// The action to run automatically right after a capture, chosen in

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -18947,6 +18947,74 @@ struct MetricsTests {
         expectClose(ScreenshotSupport.captureLoupeZoom(4, adjustedBy: 1),
                     ScreenshotSupport.captureLoupeMaxZoom,
                     "zoom reaches the three-pixel sample without a dead range above it")
+        expectClose(ScreenshotSupport.pinZoomFactor(wheelDelta: 1, precise: false),
+                    1 + ScreenshotSupport.pinZoomWheelStep,
+                    "a mouse notch zooms a pinned capture in by Flameshot's step")
+        expectClose(ScreenshotSupport.pinZoomFactor(wheelDelta: -1, precise: false),
+                    1 / (1 + ScreenshotSupport.pinZoomWheelStep),
+                    "a mouse notch zooms a pinned capture out by the same step")
+        expectClose(ScreenshotSupport.pinZoomFactor(wheelDelta: 0, precise: false), 1,
+                    "a still wheel leaves a pinned capture unchanged")
+        expectClose(ScreenshotSupport.pinZoomFactor(wheelDelta: .nan, precise: false), 1,
+                    "a broken wheel delta leaves a pinned capture unchanged")
+        expect(ScreenshotSupport.pinZoomFactor(wheelDelta: 1, precise: true)
+                < ScreenshotSupport.pinZoomFactor(wheelDelta: 1, precise: false),
+               "a precise trackpad packet zooms a pin more gently than a mouse notch")
+        expectClose(ScreenshotSupport.pinZoomFactor(magnification: 0.2), 1.2,
+                    "pinching out grows a pinned capture")
+        expectClose(ScreenshotSupport.pinZoomFactor(magnification: 0), 1,
+                    "a pinch event with no change leaves a pinned capture unchanged")
+        let pinFrame = CGRect(x: 100, y: 80, width: 200, height: 100)
+        let pinLimits = CGRect(x: 0, y: 0, width: 1000, height: 800)
+        let pinGrown = ScreenshotSupport.pinZoomedFrame(
+            pinFrame, factor: 2, anchor: CGPoint(x: 100, y: 80), limits: pinLimits)
+        expect(pinGrown.origin == pinFrame.origin
+                && pinGrown.size == CGSize(width: 400, height: 200),
+               "zooming a pin from a corner keeps that corner still")
+        let pinCentered = ScreenshotSupport.pinZoomedFrame(
+            pinFrame, factor: 2, anchor: CGPoint(x: 200, y: 130), limits: pinLimits)
+        expect(abs(pinCentered.midX - pinFrame.midX) < 0.001
+                && abs(pinCentered.midY - pinFrame.midY) < 0.001
+                && pinCentered.size == CGSize(width: 400, height: 200),
+               "zooming a pin from its centre keeps the centre still")
+        let pinCenter = CGPoint(x: pinFrame.midX, y: pinFrame.midY)
+        let pinMin = ScreenshotSupport.pinZoomedFrame(
+            pinFrame, factor: 0.01, anchor: pinCenter, limits: pinLimits)
+        expect(pinMin.height == ScreenshotSupport.pinMinSize.height
+                && abs(pinMin.width / pinMin.height - pinFrame.width / pinFrame.height) < 0.001,
+               "zooming a pin out stops at the shared minimum size")
+        let pinMax = ScreenshotSupport.pinZoomedFrame(
+            pinFrame, factor: 100, anchor: pinCenter, limits: pinLimits)
+        expect(pinMax.width == pinLimits.width
+                && pinMax.minX == pinLimits.minX
+                && pinMax.maxX == pinLimits.maxX,
+               "zooming a pin in cannot grow past the display")
+        let pinOffscreen = ScreenshotSupport.pinZoomedFrame(
+            pinFrame, factor: 2, anchor: CGPoint(x: 100, y: 80),
+            limits: CGRect(x: 0, y: 0, width: 300, height: 200))
+        expect(pinOffscreen.minX >= 0 && pinOffscreen.minY >= 0
+                && pinOffscreen.maxX <= 300 && pinOffscreen.maxY <= 200,
+               "a corner zoom that would leave the display is slid back onto it")
+        expect(ScreenshotSupport.pinZoomedFrame(
+            pinFrame, factor: .nan, anchor: pinCenter, limits: pinLimits) == pinFrame,
+               "a broken zoom amount leaves a pinned capture where it was")
+        let pinControllerSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/QuickTools/ScreenshotPinController.swift",
+            encoding: .utf8)) ?? ""
+        let pinControllerCode = pinControllerSource
+            .components(separatedBy: "\n")
+            .map { line -> String in
+                guard let comment = line.range(of: "//") else { return line }
+                return String(line[..<comment.lowerBound])
+            }
+            .joined()
+        expect(!pinControllerSource.isEmpty
+                && pinControllerCode.contains("scrollWheel(with")
+                && pinControllerCode.contains("magnify(with")
+                && pinControllerCode.contains("pinZoomedFrame")
+                && pinControllerCode.contains("pinZoomFactor")
+                && pinControllerCode.contains("momentumPhase"),
+               "a pinned capture zooms from the wheel and pinch, ignoring trackpad coasting")
         expectClose(ScreenshotSupport.captureLoupeSampleSide(zoom: 2), 7,
                     "higher capture loupe zoom samples fewer source pixels")
         expectClose(ScreenshotSupport.captureLoupeSampleSide(zoom: 0.5), 27,


### PR DESCRIPTION
## Summary

Pinned captures could already be resized from the edges, but there was no Flameshot-style zoom: the mouse wheel and trackpad pinch did nothing.

Scroll and pinch now scale the pin around the pointer. A mouse notch grows or shrinks by 3% (Flameshot's step). Precise trackpad packets use the same gain as Control-scroll in the screenshot editor, so a flick does not jump. Coasting momentum is ignored. The pin stays on the display and cannot shrink below the existing 90×60 floor.

This belongs here because it is the missing half of a feature Vorssaint already ships. Flameshot, PixPin and Snipaste all zoom a pinned screenshot with the wheel; the pin is already an `NSPanel`, so this is that interaction, not a new subsystem. No settings, no new strings, no dependencies.

Open PRs and issues were searched for pin zoom before writing. #1015 requested pin-to-screen and has shipped. Nothing open covers wheel zoom on a pin.

## Verification

This change was written on a Linux cloud agent. I could not run:

```sh
./build.sh
./build/Vorssaint --selftest
./build.sh --test
```

those require macOS. Unit checks for the zoom math and a source-shape check that the pin window actually calls them were added in `Tests/MetricsTests.swift`.

**What I could not test:** a real pinned capture on a Mac — mouse wheel, Magic Mouse / trackpad pinch, edge-resize still working after a zoom, click-through pins (they should ignore the wheel, as they ignore other mouse events), and a second display.

## Anything else

No issue to reference. The branch is `cursor/screenshot-pin-zoom-fac8` on `zec4o/vorssaint-utils`.