### PR TITLE
fix(cleaner): preserve Spotify cache containing Spicetify state

### DIFF
--- a/Sources/Vorssaint/Services/Cleaner/CleanerPolicy.swift
+++ b/Sources/Vorssaint/Services/Cleaner/CleanerPolicy.swift
@@ -55,13 +55,14 @@ enum CleanerPolicy {
         "com.apple.FontRegistry", "com.apple.ATS",
         "com.apple.akd", "com.apple.AuthKit",
         "com.paceap.", "com.native-instruments", "com.fabfilter",
+        // Spotify stores Spicetify Marketplace state alongside its cache.
+        "com.spotify.client",
     ]
 
     /// Third party caches whose content the user paid bandwidth or setup
     /// for (offline media, model and browser downloads): shown, never pre
     /// checked.
     private static let sensitiveCachePrefixes = [
-        "com.spotify.client",
         "ms-playwright",
     ]
 
@@ -85,6 +86,7 @@ enum CleanerPolicy {
     /// checked unless they hold content worth keeping, and plain named
     /// folders only when they are known download or build caches.
     static func precheckCacheEntry(_ name: String) -> Bool {
+        guard !isExcludedCacheEntry(name) else { return false }
         let lowered = name.lowercased()
         if sensitiveCachePrefixes.contains(where: { lowered.hasPrefix($0.lowercased()) }) { return false }
         if CleanerSupport.looksLikeBundleID(name) {

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -5375,6 +5375,13 @@ struct MetricsTests {
                && !CleanerPolicy.precheckCacheEntry("com.spotify.client")
                && !CleanerPolicy.precheckCacheEntry("ms-playwright"),
                "system, sensitive and unattributable caches start unchecked")
+        expect(CleanerPolicy.isExcludedCacheEntry("com.spotify.client")
+               && CleanerPolicy.isExcludedCacheEntry("COM.SPOTIFY.CLIENT")
+               && CleanerPolicy.isExcludedCacheEntry("com.spotify.client.helper"),
+               "Spotify caches holding Spicetify state are excluded even when all caches are selected")
+        expect(!CleanerPolicy.isExcludedCacheEntry("com.vendor.editor")
+               && !CleanerPolicy.isExcludedCacheEntry("ms-playwright"),
+               "ordinary and downloadable sensitive caches remain available for review")
         expect(CleanerSupport.Category.deviceBackups.rawValue == 6
                && CleanerSupport.Category.allCases.count == 7,
                "device backups joined the cleaner with a stable category id")


### PR DESCRIPTION
## Summary

Selecting "Other caches" could trash `~/Library/Caches/com.spotify.client`, removing installed Spicetify Marketplace customizations. Move Spotify from the unchecked list to the existing cache exclusion list, and keep excluded entries from being recommended.

The shared policy covers cache and log scans. Regression checks cover Spotify's case-insensitive prefix exclusion and confirm ordinary caches remain available.

## Verification

Verified on Apple Silicon, macOS 26.5, build 25F71:

- `./build.sh` passed without compiler warnings.
- Bundled `--selftest` passed.
- `./build.sh --test` passed all 10,757 checks and preference cleanup tests.
- Strict code-signature verification and `git diff --check` passed.
- The focused exclusion check failed before the fix and passed afterward.

An installed Spotify/Spicetify setup was not tested.

Refs #1522
