### PR TITLE
feat(switcher): separate apps without open windows

### DIFF
--- a/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
+++ b/Sources/Vorssaint/Services/Switcher/SwitcherSupport.swift
@@ -1000,6 +1000,18 @@ enum SwitcherSupport {
         return groups
     }
 
+    static func windowlessAppDividerPIDs(items: [SwitcherItem]) -> Set<pid_t> {
+        let groups = appGroups(items: items)
+        let windowedPIDs = Set(items.filter { !$0.isAppEntry }.map(\.pid))
+        var dividers: Set<pid_t> = []
+        for (previous, current) in zip(groups, groups.dropFirst()) {
+            if windowedPIDs.contains(previous.pid) != windowedPIDs.contains(current.pid) {
+                dividers.insert(current.pid)
+            }
+        }
+        return dividers
+    }
+
     /// Where a session starts. `pids` is the list in display order, one entry
     /// per position the shortcut steps through: one per window in the grid,
     /// one per app in the icon row.

--- a/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
+++ b/Sources/Vorssaint/UI/Switcher/SwitcherView.swift
@@ -468,6 +468,7 @@ struct SwitcherView: View {
 
     private var appIconRow: some View {
         let groups = appGroups
+        let dividerPIDs = SwitcherSupport.windowlessAppDividerPIDs(items: switcher.windows)
         return overflowingIconRow(
             itemCount: groups.count,
             tileWidth: SwitcherIconRowLayout.appTileWidth
@@ -483,6 +484,17 @@ struct SwitcherView: View {
                                      switcher.select(index: index)
                                      switcher.commitSession()
                                  })
+                    .overlay(alignment: .leading) {
+                        if dividerPIDs.contains(group.pid) {
+                            Rectangle()
+                                .fill(Color(nsColor: .separatorColor))
+                                .frame(width: 1, height: SwitcherIconRowLayout.iconSize)
+                                // Occupy the existing gap so scrolling and hit targets stay aligned.
+                                .offset(x: -(SwitcherIconRowLayout.spacing + 1) / 2)
+                                .allowsHitTesting(false)
+                                .accessibilityHidden(true)
+                        }
+                    }
                     .onHover { hovering in
                         if hovering {
                             switcher.hoverSelectIconRow(index: index)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -11568,6 +11568,31 @@ struct MetricsTests {
                && appGroups[0].windowCount == 2
                && appGroups[1].representativeIndex == 2,
                "App Switcher icon-row mode keeps one row entry per app")
+        let windowlessApps = [SwitcherItem.appOnly(appName: "Gamma", pid: 303),
+                              SwitcherItem.appOnly(appName: "Delta", pid: 404)]
+        expect(SwitcherSupport.windowlessAppDividerPIDs(items: []) == [],
+               "an empty app row has no windowless divider")
+        expect(SwitcherSupport.windowlessAppDividerPIDs(items: groupedSwitcherItems) == []
+               && SwitcherSupport.windowlessAppDividerPIDs(items: windowlessApps) == [],
+               "a row with only one kind of app has no divider")
+        expect(SwitcherSupport.windowlessAppDividerPIDs(items: groupedSwitcherItems + windowlessApps) == [303],
+               "windowless apps are separated once after all windows of the preceding apps")
+        expect(SwitcherSupport.windowlessAppDividerPIDs(items: [groupedSwitcherItems[0],
+                                                               windowlessApps[0],
+                                                               groupedSwitcherItems[2],
+                                                               windowlessApps[1]]) == [303, 202, 404],
+               "dividers follow each windowless boundary without changing recent-use order")
+        expect(SwitcherSupport.windowlessAppDividerPIDs(items: [windowlessApps[0],
+                                                               groupedSwitcherItems[0]]) == [101],
+               "a leading windowless group has a divider after it, never before the first icon")
+        let dividerHiddenWindow = SwitcherItem.window(id: 4, title: "Hidden", appName: "Hidden", pid: 505,
+                                                      isOnScreen: false, isAppHidden: true, frame: .zero)
+        expect(SwitcherSupport.windowlessAppDividerPIDs(items: [groupedSwitcherItems[0].withMinimized(true),
+                                                               dividerHiddenWindow] + windowlessApps) == [303],
+               "minimized and hidden windows still belong to apps with windows")
+        expect(SwitcherSupport.windowlessAppDividerPIDs(items: [SwitcherItem.appOnly(appName: "Alpha", pid: 101)]
+                                                        + groupedSwitcherItems + windowlessApps) == [303],
+               "an app with any real window is never marked windowless by an app-only entry")
         var cappedAppWindows: [SwitcherItem] = []
         var cappedAppRepresentatives: [SwitcherItem] = []
         for appIndex in 1...25 {


### PR DESCRIPTION
Apps with and without open windows currently share an uninterrupted icon row.
Add a thin separator at each boundary between them, including when recent-use order interleaves the groups.
Keep existing app ordering, selection indexes, row dimensions, and overflow offsets.

The separator occupies the existing gap between tiles, follows the system separator color, ignores pointer events, and is hidden from accessibility navigation.
Minimized and hidden windows still count as windows.
The change applies to the grouped app row, including simple mode; individual-window rows are unchanged.

Original implementation validation on a MacBook Air M3 (Mac15,12), macOS 26.6.2 (25G83), English:

- `./build.sh --test`: 10,762 checks passed, including preference cleanup.
- The five new boundary assertions failed against the no-divider behavior and passed with the implementation.
- Rendered the real `SwitcherView` in a temporary native harness with controlled app/window data: light, dark, simple mode, all-windowed, all-windowless, and two overflow positions.
- Before/after images have identical dimensions, and the divider occupies the existing gap.
- `git diff --check` passed.

- `./build.sh` completed with no compiler warnings; the adaptive icon catalog used the script's `AppIcon.icns` fallback.
- `./build/Vorssaint --selftest`: `SELFTEST OK`.
- `codesign --verify --deep --strict build/stage/Vorssaint.app` passed.

Regression tests are included. All 58,669 checks, the build, and self-test passed. Live app testing used an earlier commit. External displays remain untested.

The native rendering harness was removed and is not part of this PR.

**Installed-app validation — 2026-09-19**

Tested PR head 3431d0fb as an installed developer build on macOS 27.0.

* Build, self-test, and code-sign verification passed.
* Command-Tab, arrow navigation, Return, hover, click, and modifier-release activation worked with real running apps.
* Verified separator behavior for No open window apps, including overflow/offscreen cases.
* Cross-Space activation worked in one tested case.
* No divider regression observed.

Not tested: external displays, fullscreen Spaces, dark mode, or physical-keyboard timing.

Refs #776
