### PR TITLE
feat(mouse): short-click shortcuts on Spaces-drag button

### DIFF
--- a/Sources/Vorssaint/Core/MouseButtonStrings.swift
+++ b/Sources/Vorssaint/Core/MouseButtonStrings.swift
@@ -88,12 +88,12 @@ extension MouseButtonFeatureStrings {
         sideWheelLeftName: "Side wheel left",
         sideWheelRightName: "Side wheel right",
         spacesEnableLabel: "Switch Spaces by dragging a button",
-        spacesEnableCaption: "Hold the chosen button and drag: left or right moves one Space over, up opens Mission Control, down opens App Exposé. A short click still does what it always did.",
+        spacesEnableCaption: "Hold the chosen button and drag: left or right moves one Space over, up opens Mission Control, down opens App Exposé. A short click fires that button’s shortcut if you set one; otherwise it does what it always did.",
         spacesPickButton: "Choose a button",
         spacesShortcutsOffNote: "The Mission Control keyboard shortcuts are switched off in System Settings, so this gesture has nothing to ask for.",
         spacesCaptureWaiting: "Now press an extra button.",
         spacesCaptureUnsupported: "That input cannot be held for a drag. Use an extra button.",
-        spacesCaptureExists: "That button already has a shortcut. Pick another one.",
+        spacesCaptureExists: "That button is already being set as a shortcut. Finish or cancel it first.",
         spacesFollowsDragLabel: "Spaces follow the drag",
         spacesFollowsDragCaption: "Dragging right brings the Space on the left, the way a trackpad swipe carries it along with your fingers."
     )
@@ -123,12 +123,12 @@ extension MouseButtonFeatureStrings {
         sideWheelLeftName: "Roda lateral para a esquerda",
         sideWheelRightName: "Roda lateral para a direita",
         spacesEnableLabel: "Trocar de Espaço arrastando um botão",
-        spacesEnableCaption: "Segure o botão escolhido e arraste: para a esquerda ou a direita muda um Espaço, para cima abre o Mission Control, para baixo abre o Exposé do app. Um clique curto continua fazendo o que sempre fez.",
+        spacesEnableCaption: "Segure o botão escolhido e arraste: para a esquerda ou a direita muda um Espaço, para cima abre o Mission Control, para baixo abre o Exposé do app. Um clique curto dispara o atalho desse botão se você configurou um; senão, continua fazendo o que sempre fez.",
         spacesPickButton: "Escolher um botão",
         spacesShortcutsOffNote: "Os atalhos de teclado do Mission Control estão desligados nos Ajustes do Sistema, então este gesto não tem o que pedir.",
         spacesCaptureWaiting: "Agora aperte um botão extra.",
         spacesCaptureUnsupported: "Esse controle não dá para segurar e arrastar. Use um botão extra.",
-        spacesCaptureExists: "Esse botão já tem um atalho. Escolha outro.",
+        spacesCaptureExists: "Esse botão já está sendo definido como atalho. Termine ou cancele antes.",
         spacesFollowsDragLabel: "Espaços acompanham o arrasto",
         spacesFollowsDragCaption: "Arrastar para a direita traz o Espaço da esquerda, como um deslize no trackpad leva o Espaço junto com os dedos."
     )
@@ -158,12 +158,12 @@ extension MouseButtonFeatureStrings {
         sideWheelLeftName: "Yan teker sola",
         sideWheelRightName: "Yan teker sağa",
         spacesEnableLabel: "Düğmeyi sürükleyerek Alanlar arasında geçiş yap",
-        spacesEnableCaption: "Seçtiğiniz düğmeyi basılı tutup sürükleyin: sola veya sağa bir Alan kaydırır, yukarı Mission Control’ü, aşağı Uygulama Exposé’sini açar. Kısa bir tıklama eskiden yaptığını yapmaya devam eder.",
+        spacesEnableCaption: "Seçtiğiniz düğmeyi basılı tutup sürükleyin: sola veya sağa bir Alan kaydırır, yukarı Mission Control’ü, aşağı Uygulama Exposé’sini açar. Kısa bir tıklama, o düğme için kısayol ayarladıysanız onu çalıştırır; yoksa eskiden yaptığını yapmaya devam eder.",
         spacesPickButton: "Bir düğme seç",
         spacesShortcutsOffNote: "Mission Control klavye kısayolları Sistem Ayarları’nda kapalı, bu yüzden bu hareketin isteyeceği bir şey yok.",
         spacesCaptureWaiting: "Şimdi ek bir düğmeye basın.",
         spacesCaptureUnsupported: "Bu giriş basılı tutulup sürüklenemez. Ek bir düğme kullanın.",
-        spacesCaptureExists: "Bu düğmenin zaten bir kısayolu var. Başka bir düğme seçin.",
+        spacesCaptureExists: "Bu düğme zaten bir kısayol olarak ayarlanıyor. Önce bitirin veya iptal edin.",
         spacesFollowsDragLabel: "Alanlar sürüklemeyi izler",
         spacesFollowsDragCaption: "Sağa sürüklemek soldaki Alanı getirir; izleme dörtgeninde kaydırmanın Alanı parmaklarınızla birlikte taşıması gibi."
     )
@@ -193,12 +193,12 @@ extension MouseButtonFeatureStrings {
         sideWheelLeftName: "Боковое колёсико влево",
         sideWheelRightName: "Боковое колёсико вправо",
         spacesEnableLabel: "Переключать рабочие столы перетаскиванием кнопки",
-        spacesEnableCaption: "Удерживайте выбранную кнопку и перетаскивайте: влево или вправо переключает на соседний рабочий стол, вверх открывает Mission Control, вниз открывает Exposé приложения. Короткое нажатие по-прежнему делает то, что делало раньше.",
+        spacesEnableCaption: "Удерживайте выбранную кнопку и перетаскивайте: влево или вправо переключает на соседний рабочий стол, вверх открывает Mission Control, вниз открывает Exposé приложения. Короткое нажатие запускает сочетание этой кнопки, если вы его задали; иначе делает то, что делало раньше.",
         spacesPickButton: "Выбрать кнопку",
         spacesShortcutsOffNote: "Сочетания клавиш Mission Control отключены в Системных настройках, поэтому этому жесту не о чем просить.",
         spacesCaptureWaiting: "Теперь нажмите дополнительную кнопку.",
         spacesCaptureUnsupported: "Этот элемент нельзя удерживать для перетаскивания. Используйте дополнительную кнопку.",
-        spacesCaptureExists: "У этой кнопки уже есть сочетание. Выберите другую.",
+        spacesCaptureExists: "Эта кнопка уже задаётся как сочетание. Сначала завершите или отмените.",
         spacesFollowsDragLabel: "Рабочие столы следуют за перетаскиванием",
         spacesFollowsDragCaption: "Перетаскивание вправо открывает рабочий стол слева, как жест на трекпаде уводит его вместе с пальцами."
     )
@@ -228,12 +228,12 @@ extension MouseButtonFeatureStrings {
         sideWheelLeftName: "Rueda lateral a la izquierda",
         sideWheelRightName: "Rueda lateral a la derecha",
         spacesEnableLabel: "Cambiar de Espacio arrastrando un botón",
-        spacesEnableCaption: "Mantén pulsado el botón elegido y arrastra: a la izquierda o a la derecha cambia un Espacio, hacia arriba abre Mission Control y hacia abajo abre Exposé de apps. Un clic corto sigue haciendo lo de siempre.",
+        spacesEnableCaption: "Mantén pulsado el botón elegido y arrastra: a la izquierda o a la derecha cambia un Espacio, hacia arriba abre Mission Control y hacia abajo abre Exposé de apps. Un clic corto ejecuta el atajo de ese botón si lo configuraste; si no, sigue haciendo lo de siempre.",
         spacesPickButton: "Elegir un botón",
         spacesShortcutsOffNote: "Los atajos de teclado de Mission Control están desactivados en Ajustes del Sistema, así que este gesto no tiene nada que pedir.",
         spacesCaptureWaiting: "Ahora pulsa un botón extra.",
         spacesCaptureUnsupported: "Esa entrada no se puede mantener pulsada para arrastrar. Usa un botón extra.",
-        spacesCaptureExists: "Ese botón ya tiene un atajo. Elige otro.",
+        spacesCaptureExists: "Ese botón ya se está configurando como atajo. Termínalo o cancélalo primero.",
         spacesFollowsDragLabel: "Los Espacios siguen el arrastre",
         spacesFollowsDragCaption: "Arrastrar a la derecha trae el Espacio de la izquierda, igual que un deslizamiento en el trackpad lo lleva con tus dedos."
     )
@@ -263,12 +263,12 @@ extension MouseButtonFeatureStrings {
         sideWheelLeftName: "Seitliches Rad nach links",
         sideWheelRightName: "Seitliches Rad nach rechts",
         spacesEnableLabel: "Spaces durch Ziehen einer Taste wechseln",
-        spacesEnableCaption: "Halte die gewählte Taste gedrückt und ziehe: nach links oder rechts einen Space weiter, nach oben öffnet Mission Control, nach unten App-Exposé. Ein kurzer Klick tut weiterhin, was er immer tat.",
+        spacesEnableCaption: "Halte die gewählte Taste gedrückt und ziehe: nach links oder rechts einen Space weiter, nach oben öffnet Mission Control, nach unten App-Exposé. Ein kurzer Klick löst den Kurzbefehl dieser Taste aus, falls du einen gesetzt hast; sonst tut er weiterhin, was er immer tat.",
         spacesPickButton: "Taste wählen",
         spacesShortcutsOffNote: "Die Tastaturkurzbefehle für Mission Control sind in den Systemeinstellungen ausgeschaltet, also hat diese Geste nichts, worum sie bitten könnte.",
         spacesCaptureWaiting: "Drücke jetzt eine Zusatztaste.",
         spacesCaptureUnsupported: "Diese Eingabe lässt sich nicht gedrückt halten und ziehen. Verwende eine Zusatztaste.",
-        spacesCaptureExists: "Diese Taste hat schon einen Kurzbefehl. Wähle eine andere.",
+        spacesCaptureExists: "Diese Taste wird gerade als Kurzbefehl eingerichtet. Beende oder brich das zuerst ab.",
         spacesFollowsDragLabel: "Spaces folgen der Ziehbewegung",
         spacesFollowsDragCaption: "Nach rechts ziehen holt den Space links daneben, so wie eine Streichbewegung auf dem Trackpad ihn mit den Fingern mitnimmt."
     )
@@ -298,12 +298,12 @@ extension MouseButtonFeatureStrings {
         sideWheelLeftName: "Molette latérale vers la gauche",
         sideWheelRightName: "Molette latérale vers la droite",
         spacesEnableLabel: "Changer d’espace en faisant glisser un bouton",
-        spacesEnableCaption: "Maintenez le bouton choisi et faites glisser\u{00A0}: à gauche ou à droite pour changer d’espace, vers le haut pour Mission Control, vers le bas pour Exposé d’app. Un clic bref fait toujours ce qu’il faisait avant.",
+        spacesEnableCaption: "Maintenez le bouton choisi et faites glisser\u{00A0}: à gauche ou à droite pour changer d’espace, vers le haut pour Mission Control, vers le bas pour Exposé d’app. Un clic bref déclenche le raccourci de ce bouton si vous en avez défini un\u{00A0}; sinon, il fait toujours ce qu’il faisait avant.",
         spacesPickButton: "Choisir un bouton",
         spacesShortcutsOffNote: "Les raccourcis clavier de Mission Control sont désactivés dans Réglages Système, donc ce geste n’a rien à demander.",
         spacesCaptureWaiting: "Appuyez sur un bouton supplémentaire.",
         spacesCaptureUnsupported: "Cette commande ne peut pas être maintenue pour un glissement. Utilisez un bouton supplémentaire.",
-        spacesCaptureExists: "Ce bouton a déjà un raccourci. Choisissez-en un autre.",
+        spacesCaptureExists: "Ce bouton est déjà en cours de définition comme raccourci. Terminez ou annulez d’abord.",
         spacesFollowsDragLabel: "Les espaces suivent le glissement",
         spacesFollowsDragCaption: "Glisser vers la droite amène l’espace de gauche, comme un balayage sur le trackpad qui l’emporte avec les doigts."
     )
@@ -333,12 +333,12 @@ extension MouseButtonFeatureStrings {
         sideWheelLeftName: "Rotella laterale a sinistra",
         sideWheelRightName: "Rotella laterale a destra",
         spacesEnableLabel: "Cambiare Spazio trascinando un pulsante",
-        spacesEnableCaption: "Tieni premuto il pulsante scelto e trascina: a sinistra o a destra cambi Spazio, in alto apri Mission Control, in basso Exposé app. Un clic breve continua a fare quello che ha sempre fatto.",
+        spacesEnableCaption: "Tieni premuto il pulsante scelto e trascina: a sinistra o a destra cambi Spazio, in alto apri Mission Control, in basso Exposé app. Un clic breve attiva la scorciatoia di quel pulsante se ne hai impostata una; altrimenti continua a fare quello che ha sempre fatto.",
         spacesPickButton: "Scegli un pulsante",
         spacesShortcutsOffNote: "Le abbreviazioni da tastiera di Mission Control sono disattivate in Impostazioni di Sistema, quindi questo gesto non ha nulla da chiedere.",
         spacesCaptureWaiting: "Ora premi un pulsante extra.",
         spacesCaptureUnsupported: "Questo comando non si può tenere premuto per trascinare. Usa un pulsante extra.",
-        spacesCaptureExists: "Quel pulsante ha già un’abbreviazione. Scegline un altro.",
+        spacesCaptureExists: "Quel pulsante sta già diventando una scorciatoia. Finisci o annulla prima.",
         spacesFollowsDragLabel: "Gli Spazi seguono il trascinamento",
         spacesFollowsDragCaption: "Trascinare a destra porta lo Spazio di sinistra, come uno scorrimento sul trackpad che lo trascina con le dita."
     )
@@ -368,12 +368,12 @@ extension MouseButtonFeatureStrings {
         sideWheelLeftName: "サイドホイールを左へ",
         sideWheelRightName: "サイドホイールを右へ",
         spacesEnableLabel: "ボタンをドラッグしてスペースを切り替える",
-        spacesEnableCaption: "選んだボタンを押したままドラッグします。左右で1つ隣のスペースへ、上で Mission Control、下で App Exposé が開きます。短いクリックは今までどおりの動きのままです。",
+        spacesEnableCaption: "選んだボタンを押したままドラッグします。左右で1つ隣のスペースへ、上で Mission Control、下で App Exposé が開きます。短いクリックは、そのボタンにショートカットを設定していればそれを実行し、なければ今までどおりの動きのままです。",
         spacesPickButton: "ボタンを選ぶ",
         spacesShortcutsOffNote: "Mission Control のキーボードショートカットがシステム設定でオフになっているため、このジェスチャは何も呼び出せません。",
         spacesCaptureWaiting: "拡張ボタンを押してください。",
         spacesCaptureUnsupported: "この入力は押したままドラッグできません。拡張ボタンを使ってください。",
-        spacesCaptureExists: "そのボタンにはすでにショートカットがあります。別のボタンを選んでください。",
+        spacesCaptureExists: "そのボタンはすでにショートカットとして設定中です。先に完了するか取り消してください。",
         spacesFollowsDragLabel: "スペースがドラッグに追従",
         spacesFollowsDragCaption: "右にドラッグすると左のスペースが現れます。トラックパッドのスワイプが指と一緒にスペースを動かすのと同じ向きです。"
     )
@@ -403,12 +403,12 @@ extension MouseButtonFeatureStrings {
         sideWheelLeftName: "측면 휠 왼쪽",
         sideWheelRightName: "측면 휠 오른쪽",
         spacesEnableLabel: "버튼을 드래그해 스페이스 전환",
-        spacesEnableCaption: "선택한 버튼을 누른 채 드래그하세요. 좌우로는 한 칸 옆 스페이스로, 위로는 미션 컨트롤, 아래로는 앱 엑스포제가 열립니다. 짧게 누르면 원래 하던 동작을 그대로 합니다.",
+        spacesEnableCaption: "선택한 버튼을 누른 채 드래그하세요. 좌우로는 한 칸 옆 스페이스로, 위로는 미션 컨트롤, 아래로는 앱 엑스포제가 열립니다. 짧게 누르면 그 버튼에 단축키를 설정했다면 단축키가 실행되고, 아니면 원래 하던 동작을 그대로 합니다.",
         spacesPickButton: "버튼 선택",
         spacesShortcutsOffNote: "미션 컨트롤 키보드 단축키가 시스템 설정에서 꺼져 있어 이 제스처가 요청할 것이 없습니다.",
         spacesCaptureWaiting: "이제 추가 버튼을 누르세요.",
         spacesCaptureUnsupported: "이 입력은 누른 채 드래그할 수 없습니다. 추가 버튼을 사용하세요.",
-        spacesCaptureExists: "그 버튼에는 이미 단축키가 있습니다. 다른 버튼을 고르세요.",
+        spacesCaptureExists: "그 버튼은 이미 단축키로 설정 중입니다. 먼저 끝내거나 취소하세요.",
         spacesFollowsDragLabel: "스페이스가 드래그를 따라감",
         spacesFollowsDragCaption: "오른쪽으로 드래그하면 왼쪽 스페이스가 나타납니다. 트랙패드 쓸어넘기기가 손가락과 함께 스페이스를 옮기는 방향과 같습니다."
     )
@@ -438,12 +438,12 @@ extension MouseButtonFeatureStrings {
         sideWheelLeftName: "侧滚轮向左",
         sideWheelRightName: "侧滚轮向右",
         spacesEnableLabel: "拖动按键切换桌面",
-        spacesEnableCaption: "按住所选按键并拖动：向左或向右切换一个桌面，向上打开调度中心，向下打开应用程序窗口。短按仍然做它一直做的事。",
+        spacesEnableCaption: "按住所选按键并拖动：向左或向右切换一个桌面，向上打开调度中心，向下打开应用程序窗口。若已为该按键设置快捷键，短按会触发它；否则仍做它一直做的事。",
         spacesPickButton: "选择一个按键",
         spacesShortcutsOffNote: "调度中心的键盘快捷键在系统设置中已关闭，所以这个手势无从调用。",
         spacesCaptureWaiting: "现在请按下额外按键。",
         spacesCaptureUnsupported: "该输入无法按住拖动。请使用额外按键。",
-        spacesCaptureExists: "该按键已设有快捷键。请换一个。",
+        spacesCaptureExists: "该按键正在被设为快捷键。请先完成或取消。",
         spacesFollowsDragLabel: "桌面跟着拖动走",
         spacesFollowsDragCaption: "向右拖动会带来左边的桌面，就像在触控板上滑动时桌面跟着手指移动一样。"
     )
@@ -473,12 +473,12 @@ extension MouseButtonFeatureStrings {
         sideWheelLeftName: "側滾輪向左",
         sideWheelRightName: "側滾輪向右",
         spacesEnableLabel: "拖曳按鍵切換桌面",
-        spacesEnableCaption: "按住所選按鍵並拖曳：向左或向右切換一個桌面，向上開啟指揮中心，向下開啟 App Exposé。短按仍然做它一直做的事。",
+        spacesEnableCaption: "按住所選按鍵並拖曳：向左或向右切換一個桌面，向上開啟指揮中心，向下開啟 App Exposé。若已為該按鍵設定快速鍵，短按會觸發它；否則仍做它一直做的事。",
         spacesPickButton: "選擇一個按鍵",
         spacesShortcutsOffNote: "指揮中心的鍵盤快速鍵在系統設定中已關閉，所以這個手勢無從呼叫。",
         spacesCaptureWaiting: "現在請按下額外按鍵。",
         spacesCaptureUnsupported: "此操作無法按住拖曳。請使用額外按鍵。",
-        spacesCaptureExists: "該按鍵已設有快速鍵。請換一個。",
+        spacesCaptureExists: "該按鍵正在被設為快速鍵。請先完成或取消。",
         spacesFollowsDragLabel: "桌面跟著拖曳走",
         spacesFollowsDragCaption: "向右拖曳會帶來左邊的桌面，就像在觸控式軌跡板上滑動時桌面跟著手指移動一樣。"
     )
@@ -508,12 +508,12 @@ extension MouseButtonFeatureStrings {
         sideWheelLeftName: "側滾輪向左",
         sideWheelRightName: "側滾輪向右",
         spacesEnableLabel: "拖曳按鍵切換桌面",
-        spacesEnableCaption: "按住所選按鍵並拖曳：向左或向右切換一個桌面，向上開啟指揮中心，向下開啟 App Exposé。短按仍然做它一直做的事。",
+        spacesEnableCaption: "按住所選按鍵並拖曳：向左或向右切換一個桌面，向上開啟指揮中心，向下開啟 App Exposé。若已為該按鍵設定快捷鍵，短按會觸發它；否則仍做它一直做的事。",
         spacesPickButton: "選擇一個按鍵",
         spacesShortcutsOffNote: "指揮中心的鍵盤快捷鍵在系統設定中已關閉，所以這個手勢無從呼叫。",
         spacesCaptureWaiting: "現在請按下額外按鍵。",
         spacesCaptureUnsupported: "此操作無法按住拖曳。請使用額外按鍵。",
-        spacesCaptureExists: "該按鍵已設有快捷鍵。請換一個。",
+        spacesCaptureExists: "該按鍵正在被設為快捷鍵。請先完成或取消。",
         spacesFollowsDragLabel: "桌面跟著拖曳走",
         spacesFollowsDragCaption: "向右拖曳會帶來左邊的桌面，就像在觸控式軌跡板上滑動時桌面跟著手指移動一樣。"
     )

--- a/Sources/Vorssaint/Services/MouseButtons/MouseButtonShortcutService.swift
+++ b/Sources/Vorssaint/Services/MouseButtons/MouseButtonShortcutService.swift
@@ -14,10 +14,11 @@ import CoreGraphics
 /// Accessibility for the modifying event tap and the posted keys.
 ///
 /// One button may instead hold and drag for Spaces and Mission Control
-/// (issue #1012). That press is only held back, not taken: it becomes the
-/// app's ordinary click again the moment the release arrives without the
-/// pointer having gone anywhere. Same tap, because the drags it measures are
-/// events this one already receives.
+/// (issue #1012). That press is held back while it may still become a drag.
+/// A still release fires that button's short-click shortcut when one is
+/// active (issue #1507); otherwise the held press is handed back as the
+/// app's ordinary click. Same tap, because the drags it measures are events
+/// this one already receives.
 final class MouseButtonShortcutService: ObservableObject {
     static let shared = MouseButtonShortcutService()
     /// Marks the press this service hands back to the system, so the tap it
@@ -396,12 +397,25 @@ final class MouseButtonShortcutService: ObservableObject {
             case .otherMouseUp:
                 spacesGesture = nil
                 guard gesture.tracker.didFire else {
-                    // The pointer never went far enough to mean anything, so
-                    // the press was only a click: hand it back first and let
-                    // this release close the pair. Below the thresholds this
-                    // feature costs the app nothing at all.
-                    replaySpacesPress(gesture.down, proxy: proxy, at: event.location)
-                    return Unmanaged.passUnretained(event)
+                    // The pointer never went far enough to mean a drag. Prefer
+                    // an active short-click shortcut on this button (issue
+                    // #1507); otherwise hand the press back so this release
+                    // closes an ordinary click.
+                    let shortcut = MouseButtonShortcutSupport.firesShortcut(
+                        for: gesture.button,
+                        isAvailable: AppFeature.mouseButtonShortcuts.isAvailable,
+                        isEnabled: UserDefaults.standard.bool(
+                            forKey: DefaultsKey.mouseButtonShortcutsEnabled),
+                        mappings: mappings,
+                        claimedByWheel: RadialMenuSupport.claimsMouseButton)
+                    switch MouseSpacesGestureSupport.shortClick(activeShortcut: shortcut) {
+                    case .fireShortcut(let shortcut):
+                        post(shortcut)
+                        return nil
+                    case .replayNativeClick:
+                        replaySpacesPress(gesture.down, proxy: proxy, at: event.location)
+                        return Unmanaged.passUnretained(event)
+                    }
                 }
                 // A press that did fire is already held in consumedButtons,
                 // and the release below belongs to it.

--- a/Sources/Vorssaint/Services/MouseButtons/MouseButtonShortcutSupport.swift
+++ b/Sources/Vorssaint/Services/MouseButtons/MouseButtonShortcutSupport.swift
@@ -155,15 +155,14 @@ enum MouseButtonShortcutSupport {
     }
 
     /// The button the Spaces and Mission Control drag is bound to right now,
-    /// or nil when the gesture is off, unbound, or the button already belongs
-    /// to a shortcut or to the radial menu. Defaults reads only, so both taps
-    /// can ask on the hot path.
+    /// or nil when the gesture is off, unbound, or the radial menu already
+    /// owns it. The same button may also carry a short-click shortcut (issue
+    /// #1507). Defaults reads only, so both taps can ask on the hot path.
     static func spacesGestureButton(_ defaults: UserDefaults = .standard) -> Int64? {
         MouseSpacesGestureSupport.boundButton(
             isAvailable: defaults.bool(forKey: AppFeature.mouseButtonShortcuts.availabilityKey),
             isEnabled: defaults.bool(forKey: DefaultsKey.mouseSpacesGestureEnabled),
             button: Int64(defaults.integer(forKey: DefaultsKey.mouseSpacesGestureButton)),
-            hasShortcut: { hasActiveShortcut($0, defaults) },
             claimedByWheel: RadialMenuSupport.claimsMouseButton)
     }
 

--- a/Sources/Vorssaint/Services/MouseButtons/MouseSpacesGestureSupport.swift
+++ b/Sources/Vorssaint/Services/MouseButtons/MouseSpacesGestureSupport.swift
@@ -152,17 +152,28 @@ enum MouseSpacesGestureSupport {
     }
 
     /// The bound button, or nil when the gesture is off, unavailable, has no
-    /// button yet, or the button belongs to another mouse feature. Pure
-    /// defaults reads, so asking never wakes a service; the radial menu keeps
-    /// its summoner and an existing shortcut keeps its button, exactly the way
-    /// the shortcut feature already yields to the wheel.
+    /// button yet, or the radial menu already owns it. A mouse-button shortcut
+    /// on the same button is allowed (issue #1507): the drag arms on press, and
+    /// a still release may fire that shortcut instead of a native click.
     static func boundButton(isAvailable: Bool,
                             isEnabled: Bool,
                             button: Int64,
-                            hasShortcut: (Int64) -> Bool,
                             claimedByWheel: (Int64) -> Bool) -> Int64? {
         guard isAvailable, isEnabled, canBind(button),
-              !hasShortcut(button), !claimedByWheel(button) else { return nil }
+              !claimedByWheel(button) else { return nil }
         return button
+    }
+
+    /// What a Spaces-bound release becomes when the press never fired a drag
+    /// (issue #1507). Movement that crossed a threshold already consumed the
+    /// gesture; only a still press reaches this choice.
+    enum ShortClick: Equatable {
+        case fireShortcut(GlobalShortcut)
+        case replayNativeClick
+    }
+
+    static func shortClick(activeShortcut: GlobalShortcut?) -> ShortClick {
+        if let activeShortcut { return .fireShortcut(activeShortcut) }
+        return .replayNativeClick
     }
 }

--- a/Sources/Vorssaint/UI/Settings/MouseButtonSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/MouseButtonSettings.swift
@@ -280,8 +280,7 @@ struct MouseButtonShortcutsSection: View {
             captureFeedback = text.captureUnsupported
         } else if RadialMenuSupport.claimsMouseButton(seen) {
             captureFeedback = text.captureWheel
-        } else if mappings[seen] != nil || pendingButton == seen
-                    || (spacesEnabled && Int64(spacesButton) == seen) {
+        } else if mappings[seen] != nil || pendingButton == seen {
             captureFeedback = text.captureExists
         } else {
             pendingButton = seen
@@ -307,16 +306,18 @@ struct MouseButtonShortcutsSection: View {
         MouseButtonShortcutService.shared.setCapturing(false)
     }
 
-    /// The drag needs a button that can be held and moved, and one no other
-    /// mouse feature is already answering for. A refusal explains itself
-    /// instead of leaving the press looking ignored.
+    /// The drag needs a button that can be held and moved. The radial menu
+    /// keeps its summoner, and a button mid-way through becoming a shortcut
+    /// stays spoken for; an already-mapped short-click shortcut is fine to
+    /// share (issue #1507). A refusal explains itself instead of leaving the
+    /// press looking ignored.
     private func handleSpacesCapture(_ seen: Int64?) {
         guard spacesCapturing, let seen else { return }
         if !MouseSpacesGestureSupport.canBind(seen) {
             spacesFeedback = text.spacesCaptureUnsupported
         } else if RadialMenuSupport.claimsMouseButton(seen) {
             spacesFeedback = text.captureWheel
-        } else if mappings[seen] != nil || pendingButton == seen {
+        } else if pendingButton == seen {
             spacesFeedback = text.spacesCaptureExists
         } else {
             // Set before the capture ends, so the sync that ends it already

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -19780,25 +19780,25 @@ struct MetricsTests {
                "the drag lives on an extra button, never on a side-wheel tick there is no way to hold")
 
         expect(MouseSpacesGestureSupport.boundButton(isAvailable: true, isEnabled: true, button: 4,
-                                                     hasShortcut: { _ in false },
                                                      claimedByWheel: { _ in false }) == 4,
                "an available, enabled and unclaimed button drives the drag")
         expect(MouseSpacesGestureSupport.boundButton(isAvailable: true, isEnabled: true, button: 4,
-                                                     hasShortcut: { $0 == 4 },
-                                                     claimedByWheel: { _ in false }) == nil
-                && MouseSpacesGestureSupport.boundButton(isAvailable: true, isEnabled: true, button: 4,
-                                                         hasShortcut: { _ in false },
-                                                         claimedByWheel: { $0 == 4 }) == nil
+                                                     claimedByWheel: { _ in false }) == 4,
+               "a button that already has a short-click shortcut can still drive the Spaces drag")
+        expect(MouseSpacesGestureSupport.boundButton(isAvailable: true, isEnabled: true, button: 4,
+                                                     claimedByWheel: { $0 == 4 }) == nil
                 && MouseSpacesGestureSupport.boundButton(isAvailable: false, isEnabled: true, button: 4,
-                                                         hasShortcut: { _ in false },
                                                          claimedByWheel: { _ in false }) == nil
                 && MouseSpacesGestureSupport.boundButton(isAvailable: true, isEnabled: false, button: 4,
-                                                         hasShortcut: { _ in false },
                                                          claimedByWheel: { _ in false }) == nil
                 && MouseSpacesGestureSupport.boundButton(isAvailable: true, isEnabled: true, button: 0,
-                                                         hasShortcut: { _ in false },
                                                          claimedByWheel: { _ in false }) == nil,
-               "the drag never takes a button from a shortcut, from the wheel, or from a switched-off hub")
+               "the drag never takes a button from the wheel, or from a switched-off hub")
+        let sampleShortcut = GlobalShortcut(keyCode: Int64(kVK_ANSI_A), modifiers: [.command])
+        expect(MouseSpacesGestureSupport.shortClick(activeShortcut: sampleShortcut)
+                == .fireShortcut(sampleShortcut)
+                && MouseSpacesGestureSupport.shortClick(activeShortcut: nil) == .replayNativeClick,
+               "a still Spaces press fires its shortcut when one is active, else becomes an ordinary click")
         expect(MouseButtonShortcutSupport.spacesGestureButton() == nil,
                "with nothing configured the drag claims no button away from navigation")
 
@@ -19812,9 +19812,10 @@ struct MetricsTests {
                 && spacesServiceCode.contains("return armSpacesGesture(event, button: button)"),
                "the bound button's press is held back by the tap that already receives its drags")
         expect(spacesServiceCode.contains("guard gesture.tracker.didFire else {")
+                && spacesServiceCode.contains("MouseSpacesGestureSupport.shortClick")
                 && spacesServiceCode.contains(
                     "replaySpacesPress(gesture.down, proxy: proxy, at: event.location)"),
-               "a press that never fired goes back, so a tap on that button keeps its ordinary click")
+               "a press that never fired fires its shortcut when one is active, else goes back as an ordinary click")
         expect(spacesServiceCode.contains("SpaceWindowBridge.spaceShortcut(.left)")
                 && spacesServiceCode.contains("SpaceWindowBridge.overviewShortcut(.missionControl)")
                 && !spacesServiceCode.contains("DockSwipe"),
@@ -20053,6 +20054,26 @@ struct MetricsTests {
         }
         expect(spacesCaptureRefusesPending,
                "the drag capture refuses a button that is mid-way through becoming a shortcut")
+        var shortcutCaptureAllowsSpacesButton = false
+        for (index, line) in mouseSettingsLines.enumerated()
+        where isCodeLine(line) && line.contains("private func handleCapture") {
+            let window = mouseSettingsLines[index...].prefix(20)
+            shortcutCaptureAllowsSpacesButton = !window.contains {
+                isCodeLine($0) && $0.contains("spacesButton")
+            }
+        }
+        expect(shortcutCaptureAllowsSpacesButton,
+               "a Spaces drag button can also be added as a short-click shortcut")
+        var spacesCaptureAllowsShortcutButton = false
+        for (index, line) in mouseSettingsLines.enumerated()
+        where isCodeLine(line) && line.contains("private func handleSpacesCapture") {
+            let window = mouseSettingsLines[index...].prefix(16)
+            spacesCaptureAllowsShortcutButton = !window.contains {
+                isCodeLine($0) && $0.contains("mappings[seen]")
+            }
+        }
+        expect(spacesCaptureAllowsShortcutButton,
+               "a button that already has a shortcut can still be chosen for the Spaces drag")
 
         // A synthesized press has to carry the same flags a finger produces,
         // or the system matches it against no shortcut of its own (issue #401).


### PR DESCRIPTION
## Summary
- Allow the same extra mouse button to be bound to **Switch Spaces by dragging** and a **Mouse button shortcut**.
- On button-down the Spaces gesture still arms; if the pointer moves far enough, drag wins. On a still release, an active shortcut fires (and consumes the click); otherwise the held press is replayed as a native click.
- Settings no longer treats Spaces and shortcut captures as mutually exclusive for the same button; captions updated in all locales.

## Test plan
- [x] `./build.sh --test` — TESTS OK (10759 checks)
- [ ] Bind Spaces drag + a shortcut on the same extra button; short-click fires the shortcut
- [ ] Drag past the threshold still switches Spaces / opens overviews
- [ ] With shortcuts disabled (or no mapping), short-click still replays a native click

Refs #1507