### PR TITLE
fix(cleaner): keep Spotify's storage out of the cache list while Spicetify is installed

### DIFF
--- a/Sources/Vorssaint/Services/Cleaner/CleanerPolicy.swift
+++ b/Sources/Vorssaint/Services/Cleaner/CleanerPolicy.swift
@@ -70,6 +70,20 @@ enum CleanerPolicy {
         return hiddenCachePrefixes.contains { lowered.hasPrefix($0.lowercased()) }
     }
 
+    /// Spicetify's configuration folder on macOS, relative to the home
+    /// folder; its command line tool creates it on every run.
+    static let spicetifyConfigFolder = ".config/spicetify"
+
+    /// Spotify keeps its web storage (localStorage, IndexedDB) inside its
+    /// cache folder on macOS, under Browser/, and Spicetify's Marketplace
+    /// records every installed theme, extension and snippet in exactly that
+    /// storage. While Spicetify is installed the folder is the user's setup,
+    /// not a cache, so it never appears; without Spicetify it is offline
+    /// music that downloads again and stays a sensitive cache entry.
+    static func isSpicetifyStorage(_ name: String, spicetifyInstalled: Bool) -> Bool {
+        spicetifyInstalled && name.lowercased().hasPrefix("com.spotify.client")
+    }
+
     /// Plain named cache folders known to be pure downloads or build junk;
     /// anything plain named outside this list stays unchecked because bare
     /// names cannot be attributed (some are the system's own, like the maps

--- a/Sources/Vorssaint/Services/Cleaner/JunkCleaner.swift
+++ b/Sources/Vorssaint/Services/Cleaner/JunkCleaner.swift
@@ -508,9 +508,13 @@ final class JunkCleaner: ObservableObject {
         let fm = FileManager.default
         let dir = NSHomeDirectory() + "/Library/Caches"
         guard let entries = try? fm.contentsOfDirectory(atPath: dir) else { return [] }
+        let spicetifyInstalled = fm.fileExists(
+            atPath: NSHomeDirectory() + "/" + CleanerPolicy.spicetifyConfigFolder)
         var found: [Item] = []
         for entry in entries where !entry.hasPrefix(".") {
-            guard !CleanerPolicy.isExcludedCacheEntry(entry) else { continue }
+            guard !CleanerPolicy.isExcludedCacheEntry(entry),
+                  !CleanerPolicy.isSpicetifyStorage(entry, spicetifyInstalled: spicetifyInstalled)
+            else { continue }
             let url = URL(fileURLWithPath: dir).appendingPathComponent(entry)
             guard !claimed.contains(url.standardizedFileURL.path) else { continue }
             let size = directorySize(of: url, fm: fm)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -5375,6 +5375,19 @@ struct MetricsTests {
                && !CleanerPolicy.precheckCacheEntry("com.spotify.client")
                && !CleanerPolicy.precheckCacheEntry("ms-playwright"),
                "system, sensitive and unattributable caches start unchecked")
+        expect(CleanerPolicy.isSpicetifyStorage("com.spotify.client", spicetifyInstalled: true)
+               && CleanerPolicy.isSpicetifyStorage("com.spotify.client.helper", spicetifyInstalled: true)
+               && !CleanerPolicy.isSpicetifyStorage("com.spotify.client", spicetifyInstalled: false)
+               && !CleanerPolicy.isSpicetifyStorage("com.vendor.editor", spicetifyInstalled: true),
+               "Spotify's cache holds Spicetify's installed themes and extensions, "
+               + "so it leaves the list only while Spicetify is installed")
+        // The cache scan is outside this test binary: pin that it asks about
+        // Spicetify once, at spicetify's own folder, before listing entries.
+        let scanCachesBody = sourceBody(of: junkCleanerSource, from: "private static func scanCaches",
+                                        to: "private static func scanLogs")
+        expect(scanCachesBody.contains("CleanerPolicy.spicetifyConfigFolder")
+               && scanCachesBody.components(separatedBy: "isSpicetifyStorage(").count == 2,
+               "the cache scan keeps Spotify's storage out of the list while Spicetify is installed")
         expect(CleanerSupport.Category.deviceBackups.rawValue == 6
                && CleanerSupport.Category.allCases.count == 7,
                "device backups joined the cleaner with a stable category id")


### PR DESCRIPTION
## Summary

The Cleaner's "Other caches" group lists `~/Library/Caches/com.spotify.client`
(it is on `sensitiveCachePrefixes`, so it is shown but never pre checked, and
the group's caption promises "Safe to remove, nothing breaks"). Ticking the
group checkbox selects every row in it, and for a Spicetify user that folder is
not a cache: Spicetify's Marketplace records every installed theme, extension
and snippet in Spotify's web storage, and Spotify on macOS keeps that storage
inside its cache folder. Trashing it resets Spicetify to a fresh install, which
is what #1522 reports; restoring the folder brings everything back.

Where the data lives, from the sources:

- Marketplace keeps installed items under `marketplace:installed-extensions`,
  `marketplace:installed-themes`, `marketplace:installed-snippets` and the
  per item keys (`src/constants.ts`,
  https://github.com/spicetify/marketplace/blob/main/src/constants.ts), in an
  IndexedDB database `spicetify-marketplace` migrated from `localStorage`
  (`src/logic/Storage.ts`,
  https://github.com/spicetify/marketplace/blob/main/src/logic/Storage.ts).
- On macOS that storage sits at
  `~/Library/Caches/com.spotify.client/Browser/Local Storage`; the Spicetify
  maintainer's answer to the same report was "Not a bug because local storage
  is not a cache" (https://github.com/spicetify/cli/issues/2661) and "this
  data is stored in localstorage"
  (https://github.com/spicetify/marketplace/issues/1159, also #1158 there).
- Spicetify's configuration folder on macOS is `~/.config/spicetify`, created
  by its command line tool on every run (`GetSpicetifyFolder`,
  https://github.com/spicetify/cli/blob/main/src/utils/path-utils.go).
- Spotify's own clean reinstall guide has the user delete
  `~/Library/Caches/com.spotify.client` and `com.spotify.client.helper`
  (https://support.spotify.com/us/article/reinstallation-of-spotify/), so for
  a plain Spotify install the folder really is a cache.

The fix adds one pure rule next to the existing hidden cache list:
`CleanerPolicy.isSpicetifyStorage(name, spicetifyInstalled:)` is true for the
`com.spotify.client` prefix while Spicetify is installed. `scanCaches` checks
for `~/.config/spicetify` once per scan and drops matching entries from the
list, the same treatment `hiddenCachePrefixes` already gives caches that break
things when removed (audio, plugin licensing). Without Spicetify nothing
changes: the folder stays a sensitive, unchecked entry.

Why this shape and not the others:

- Adding `com.spotify.client` to `hiddenCachePrefixes` outright would take the
  entry away from every Spotify user, and for them it is offline music that
  downloads again; the caption is right for them.
- Protecting only `Browser/` inside the folder would need the Cleaner to
  descend into and partially trash another app's cache, which the scan never
  does; every row is a direct child of a root.
- Detecting Spicetify by a marker inside `/Applications/Spotify.app` (the
  extracted `Apps/xpui/` folder `spicetify apply` writes) misses a user who
  ran `spicetify restore` before an update and still expects the Marketplace
  state to survive until the next `apply`; the config folder covers both.

Sibling call sites checked: `scanLogs` reuses `isExcludedCacheEntry` for
`~/Library/Logs` names and is left alone (Spotify's logs are logs). The
scheduled run only cleans pre checked rows, so it never reached this entry;
only the manual group checkbox did. No setting is added and there is no
on-disk state to migrate: the only inputs are the folder names on disk.

## Verification

    Mac15,7 (M3 Pro), macOS 26.7 build 25G227, English
    Local build. Base upstream/main 29bd174.

`./build.sh`, zero warnings, exit 0:

    ▸ Assembling and signing bundle…
      signing with legacy self-signed identity: Vorssaint Utils Signing
    ✓ Bundle ready: build/stage/Vorssaint.app

`./build/Vorssaint --selftest`:

    SELFTEST OK

`./build.sh --test`:

    ▸ Building & running unit tests against MacOSX26.sdk…
    TESTS OK (10757 checks)
    PREFERENCE CLEANUP TESTS OK

Red and green on the new checks (`./build.sh --test`):

    with the fix:                              TESTS OK (10757 checks)
    rule body replaced by `false`:             TESTS FAILED (1 of 10757):
      - Spotify's cache holds Spicetify's installed themes and extensions, so it leaves the list only while Spicetify is installed
    JunkCleaner change reverted, rule kept:    TESTS FAILED (1 of 10757):
      - the cache scan keeps Spotify's storage out of the list while Spicetify is installed

Not tested: on a Mac with Spicetify installed. This machine has neither
Spotify nor Spicetify, so the scan's before and after list was not observed on
screen; the contrast rests on the pure rule and the source pin above. A
`SPICETIFY_CONFIG` override pointing outside `~/.config/spicetify` is not
detected.

## Anything else

What a user notices: with Spicetify installed, `com.spotify.client` no longer
appears under "Other caches", so ticking the group keeps their themes,
extensions and snippets; everyone else sees the same list as before.

Refs #1522


🤖 Generated with [Claude Code](https://claude.com/claude-code)