### PR TITLE
feat(homebrew): pass the login shell's proxy and mirror settings to brew

### DIFF
--- a/Sources/Vorssaint/Services/AppUpdates/AppUpdatesService.swift
+++ b/Sources/Vorssaint/Services/AppUpdates/AppUpdatesService.swift
@@ -315,7 +315,8 @@ final class AppUpdatesService: ObservableObject {
             return PackageResult(items: [], coveredPaths: [], available: !includeUpdates,
                                  onlineCoverageAvailable: true)
         }
-        let installedOutput = Self.runCommand(HomebrewCommandBuilder.installed(brewPath: brewPath))
+        let installedOutput = Self.runCommand(HomebrewCommandBuilder.installed(brewPath: brewPath),
+                                              environment: HomebrewEnvironment.forBrew)
         let records = installedOutput.status == 0
             ? HomebrewParser.parseInstalledCaskRecords(installedOutput.output)
             : []
@@ -327,7 +328,8 @@ final class AppUpdatesService: ObservableObject {
                                  onlineCoverageAvailable: installedOutput.status == 0)
         }
         let outdatedOutput = Self.runCommand(
-            HomebrewCommandBuilder.outdatedCasksIncludingSelfUpdating(brewPath: brewPath))
+            HomebrewCommandBuilder.outdatedCasksIncludingSelfUpdating(brewPath: brewPath),
+            environment: HomebrewEnvironment.forBrew)
         guard installedOutput.status == 0, outdatedOutput.status == 0 else {
             let failure = [outdatedOutput, installedOutput].first { $0.status != 0 }
             let message = failure.map { HomebrewProgressParser.visibleError(from: $0.output) } ?? ""
@@ -753,10 +755,12 @@ final class AppUpdatesService: ObservableObject {
     private static let commandTimeout: TimeInterval = 120
     private static let commandOutputLimit = 32 * 1_024 * 1_024
 
-    private static func runCommand(_ command: HomebrewCommand) -> (status: Int32, output: String) {
+    private static func runCommand(_ command: HomebrewCommand,
+                                   environment: [String: String]? = nil) -> (status: Int32, output: String) {
         let result = BoundedProcessRunner.run(command.executable, command.arguments,
                                               timeout: commandTimeout,
-                                              maxOutputBytes: commandOutputLimit)
+                                              maxOutputBytes: commandOutputLimit,
+                                              environment: environment)
         return (result.status, String(decoding: result.output, as: UTF8.self))
     }
 }

--- a/Sources/Vorssaint/Services/BoundedProcessRunner.swift
+++ b/Sources/Vorssaint/Services/BoundedProcessRunner.swift
@@ -37,10 +37,12 @@ enum BoundedProcessRunner {
     static func run(_ path: String,
                     _ arguments: [String],
                     timeout: TimeInterval,
-                    maxOutputBytes: Int) -> Result {
+                    maxOutputBytes: Int,
+                    environment: [String: String]? = nil) -> Result {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: path)
         process.arguments = arguments
+        process.environment = environment
         let pipe = Pipe()
         process.standardOutput = pipe
         process.standardError = pipe

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewEnvironment.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewEnvironment.swift
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+/// The environment `brew` runs with. An app launched from Finder gets launchd's
+/// environment, not the one a Terminal has after `~/.zprofile`, so a proxy or a
+/// mirror exported there never reached the brew this app runs (issue #1290).
+/// The login shell is asked once per launch for its exports, and only the names
+/// brew itself keeps (the filter in `bin/brew`) are handed on.
+enum HomebrewEnvironment {
+    /// The app's own environment plus the login shell's proxy and HOMEBREW_*
+    /// exports. The first read runs the login shell and may take up to
+    /// `loginShellTimeout`, so it belongs on a work queue; a shell that fails
+    /// or stalls contributes nothing and brew runs as before.
+    static let forBrew: [String: String] = ProcessInfo.processInfo.environment
+        .merging(exportsFromLoginShell(shellPath: HomebrewCommandBuilder.currentShellPath)) { _, shell in shell }
+
+    static let loginShellTimeout: TimeInterval = 10
+
+    /// brew's own list: the lowercase proxy names curl and git read, the
+    /// uppercase ones brew forwards, and every HOMEBREW_* setting.
+    static let passedThroughNames: Set<String> = [
+        "http_proxy", "https_proxy", "ftp_proxy", "no_proxy", "all_proxy",
+        "HTTPS_PROXY", "FTP_PROXY", "ALL_PROXY",
+    ]
+
+    static func isPassedThrough(_ name: String) -> Bool {
+        passedThroughNames.contains(name) || name.hasPrefix("HOMEBREW_")
+    }
+
+    static func passthrough(_ environment: [String: String]) -> [String: String] {
+        environment.filter { isPassedThrough($0.key) }
+    }
+
+    /// A login shell reads the profile files a Terminal window reads, without
+    /// the interactive startup; `env -0` ends each entry with NUL so a value
+    /// may contain anything, newlines included.
+    static func loginShellCommand(shellPath: String) -> HomebrewCommand {
+        HomebrewCommand(executable: shellPath, arguments: ["-l", "-c", "/usr/bin/env -0"])
+    }
+
+    static func exportsFromLoginShell(shellPath: String,
+                                      timeout: TimeInterval = loginShellTimeout) -> [String: String] {
+        guard !shellPath.isEmpty else { return [:] }
+        let command = loginShellCommand(shellPath: shellPath)
+        let result = BoundedProcessRunner.run(command.executable, command.arguments,
+                                              timeout: timeout, maxOutputBytes: 1024 * 1024)
+        guard result.status == 0, !result.timedOut else { return [:] }
+        return passthrough(parse(nullSeparated: result.output))
+    }
+
+    /// An entry whose name is not an identifier is dropped: that is what a
+    /// startup file's greeting looks like once it is glued to the entry behind
+    /// it, and stdout and stderr arrive on the one pipe.
+    static func parse(nullSeparated data: Data) -> [String: String] {
+        var environment: [String: String] = [:]
+        for entry in data.split(separator: 0) {
+            guard let separator = entry.firstIndex(of: UInt8(ascii: "=")) else { continue }
+            let name = String(decoding: entry[entry.startIndex..<separator], as: UTF8.self)
+            guard name.range(of: "^[A-Za-z_][A-Za-z0-9_]*$", options: .regularExpression) != nil else { continue }
+            environment[name] = String(decoding: entry[entry.index(after: separator)...], as: UTF8.self)
+        }
+        return environment
+    }
+}

--- a/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
+++ b/Sources/Vorssaint/Services/Homebrew/HomebrewManager.swift
@@ -708,12 +708,20 @@ final class HomebrewManager: ObservableObject {
         }
     }
 
+    /// Called on `workQueue` only: the first `HomebrewEnvironment.forBrew` read
+    /// waits on the login shell.
+    private static func makeProcess(_ command: HomebrewCommand) -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: command.executable)
+        process.arguments = command.arguments
+        process.environment = HomebrewEnvironment.forBrew
+        return process
+    }
+
     private func run(_ command: HomebrewCommand,
                      completion: @escaping (_ status: Int32, _ output: String) -> Void) {
         workQueue.async {
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: command.executable)
-            process.arguments = command.arguments
+            let process = Self.makeProcess(command)
             let pipe = Pipe()
             process.standardOutput = pipe
             process.standardError = pipe
@@ -756,9 +764,7 @@ final class HomebrewManager: ObservableObject {
                               onOutput: @escaping (String) -> Void,
                               completion: @escaping (_ status: Int32, _ output: String) -> Void) {
         workQueue.async { [weak self] in
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: command.executable)
-            process.arguments = command.arguments
+            let process = Self.makeProcess(command)
             let pipe = Pipe()
             process.standardOutput = pipe
             process.standardError = pipe

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -12998,6 +12998,43 @@ struct MetricsTests {
                 && alternateShellSetupCommand.contains("/bin/mkdir -p /Users/test/.config/fish")
                 && alternateShellSetupCommand.hasSuffix("; eval (/opt/homebrew/bin/brew shellenv fish); brew --version"),
                "Homebrew shell setup creates and activates the interactive shell config")
+
+        // The login shell's exports reach brew through an allowlist (issue #1290).
+        let loginShell = HomebrewEnvironment.loginShellCommand(shellPath: "/bin/zsh")
+        expect(loginShell.executable == "/bin/zsh"
+                && loginShell.arguments.contains("-l")
+                && loginShell.arguments.last == "/usr/bin/env -0",
+               "Homebrew asks the user's shell as a login shell for a NUL-separated environment")
+        let envDump = Data(("HOME=/Users/test\0https_proxy=http://127.0.0.1:7890\0MULTI=a\nb\0"
+                            + "EQUALS=x=y\0EMPTY=\0noequals\0Welcome back\nHOMEBREW_API_DOMAIN=https://mirror.example/api\0").utf8)
+        let parsedEnvironment = HomebrewEnvironment.parse(nullSeparated: envDump)
+        expectEqual(parsedEnvironment["https_proxy"] ?? "", "http://127.0.0.1:7890",
+                    "Homebrew environment parser reads a NAME=value entry")
+        expectEqual(parsedEnvironment["MULTI"] ?? "", "a\nb",
+                    "Homebrew environment parser keeps a newline inside a value; NUL is the only separator")
+        expectEqual(parsedEnvironment["EQUALS"] ?? "", "x=y",
+                    "Homebrew environment parser splits on the first equals sign only")
+        expect(parsedEnvironment["EMPTY"] == "" && parsedEnvironment["noequals"] == nil,
+               "Homebrew environment parser keeps an empty value and drops an entry without one")
+        expect(!parsedEnvironment.keys.contains { $0.contains("Welcome") || $0.hasPrefix("HOMEBREW_") },
+               "Homebrew environment parser drops an entry whose name is not an identifier, "
+               + "such as startup output glued to the variable behind it")
+        let passedThrough = HomebrewEnvironment.passthrough([
+            "PATH": "/tmp/evil:/usr/bin", "DYLD_INSERT_LIBRARIES": "/tmp/evil.dylib", "HOME": "/Users/test",
+            "SHELL": "/bin/zsh", "HTTP_PROXY": "http://127.0.0.1:7890", "https_proxy": "http://127.0.0.1:7890",
+            "ALL_PROXY": "socks5://127.0.0.1:7891", "no_proxy": "localhost", "HOMEBREW_API_DOMAIN": "https://mirror.example/api",
+            "HOMEBREW_BOTTLE_DOMAIN": "https://mirror.example", "HOMEBREWX": "no", "homebrew_lower": "no",
+        ])
+        expect(Set(passedThrough.keys) == ["https_proxy", "ALL_PROXY", "no_proxy",
+                                           "HOMEBREW_API_DOMAIN", "HOMEBREW_BOTTLE_DOMAIN"],
+               "Homebrew passes through only the proxy names brew itself keeps and HOMEBREW_* settings, "
+               + "found \(passedThrough.keys.sorted())")
+        expect(HomebrewEnvironment.exportsFromLoginShell(shellPath: "").isEmpty
+                && HomebrewEnvironment.exportsFromLoginShell(shellPath: "/nonexistent/shell", timeout: 1).isEmpty,
+               "Homebrew contributes nothing when there is no login shell or it cannot start")
+        expect(HomebrewEnvironment.exportsFromLoginShell(shellPath: "/bin/sh").keys
+                .allSatisfy(HomebrewEnvironment.isPassedThrough),
+               "Homebrew never hands a login shell's whole environment to brew")
         expectClose(HomebrewProgressParser.progressFraction(in: "######## 42.5%") ?? -1,
                     0.425,
                     "Homebrew progress parser reads percentage output")

--- a/build.sh
+++ b/build.sh
@@ -326,6 +326,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/Audio/PreciseVolumeRollerSupport.swift \
         Sources/Vorssaint/Services/DockPreview/DockPreviewSupport.swift \
         Sources/Vorssaint/Services/Homebrew/HomebrewSupport.swift \
+        Sources/Vorssaint/Services/Homebrew/HomebrewEnvironment.swift \
         Sources/Vorssaint/Services/AppUpdates/AppUpdatesSupport.swift \
         Sources/Vorssaint/Services/AppUpdates/AppUpdateFeedSupport.swift \
         Sources/Vorssaint/Core/AppUpdateStrings.swift \


### PR DESCRIPTION
## Summary

`HomebrewManager.run` and `runStreaming` set only `executableURL` and
`arguments`, so `brew` inherits the app's own environment. An app launched from
Finder gets launchd's environment, not the one a Terminal has after
`~/.zprofile`, so `HTTPS_PROXY` / `ALL_PROXY` / `NO_PROXY` and mirror settings
like `HOMEBREW_API_DOMAIN` / `HOMEBREW_BOTTLE_DOMAIN` are absent from both
sides. `brew update` then goes to `formulae.brew.sh` and hangs for anyone
behind a proxy or on a mirror.

This asks the user's login shell for its exports once per app launch and hands
brew only the names brew itself keeps:

    HomebrewCommand(executable: shellPath, arguments: ["-l", "-c", "/usr/bin/env -0"])

**The direction is a maintainer call, and this is offered as the smallest
workable shape.** Three were on the table:

- **(a) Read the login shell environment, implemented here.** This is what the
  mainstream Mac developer tools do with the same problem: VS Code has shipped
  `resolveShellEnv` for years (it runs the user's `$SHELL` as a login shell and
  reads the environment back), and Nova, Tower and Fork all resolve the login
  shell rather than asking the user to restate their setup. It is the only one
  of the three that covers proxies and mirrors together, and it needs no new
  setting, because the values are already in the file the user edited.
- **(b) `CFNetworkCopySystemProxySettings`, rejected.** It synthesises
  `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` correctly, but it cannot see
  `HOMEBREW_API_DOMAIN`, which is the half the reporter actually needs. It also
  answers a question the user did not ask, since a system proxy is not
  necessarily the one they want brew on.
- **(c) A Homebrew settings screen, rejected as the first move.** It is
  permanent surface in thirteen languages, and it asks the user to type in
  values that already exist in `~/.zprofile`, so the two can then disagree.
  Worth doing later as an override if (a) turns out not to be enough; not worth
  doing before it.

Security bounds, since this reads a file the app does not control:

- **Allowlist, not passthrough.** `HomebrewEnvironment.passthrough` keeps the
  proxy names in brew's own filter (`bin/brew`, the `ENV_VAR_NAMES` list) plus
  `HOMEBREW_*`, and drops everything else. The whole login environment is never
  handed over, so a startup file that exports `DYLD_INSERT_LIBRARIES` or `PATH`
  changes nothing about the process this app spawns. brew filters its own
  environment too, but that is brew's guarantee to keep, not one to lean on.
  One consequence is worth flagging, because it looks like an omission: the
  uppercase `HTTP_PROXY` and `NO_PROXY` the issue names are deliberately not in
  the list, because brew's own filter does not carry them either. Passing them
  would change nothing, and matching brew's list exactly is what makes the app
  behave the way the reporter's Terminal already behaves. If a maintainer would
  rather they were forwarded anyway, that is a one-line change to
  `passedThroughNames`.
- **Bounded.** The login shell runs through the existing
  `BoundedProcessRunner` with a 10 second timeout and a 1 MB output cap, so a
  shell that asks a question or waits on a dead mount cannot hang the app.
- **Resolved once, off the main thread.** `HomebrewEnvironment.forBrew` is a
  `static let`, so the shell runs on the first brew command of the session and
  never again. Both call sites are already on a work queue
  (`HomebrewManager.workQueue`, `AppUpdatesService.workQueue`).
- **Silent fallback.** A shell that fails, times out or is not set contributes
  nothing and brew runs exactly as it does today. Nothing about this is
  visible to a user who has no proxy.

Following rule 10, the other callers were checked rather than only the one the
report named. `AppUpdatesService` spawns the same brew commands through
`BoundedProcessRunner` for the app update list and had the identical gap; it is
fixed in the same pass. There was no shared "environment for child processes"
mechanism to join: no `.environment =` assignment existed anywhere under
`Sources/`, and every spawner answered the question by not answering it.
`BoundedProcessRunner.run` gains an optional `environment:` parameter that
defaults to `nil`, which is the inherit-the-parent behaviour every existing
caller already had, so no other spawner changes.

`build.sh` is modified by one line, and it is load-bearing rather than
incidental: `--test` compiles a hand-written source list, and a new file is
invisible to the test binary until it is on that list. Without it the tests
below do not compile.

Deliberately not included: no new dependency, no new setting, no new string, no
user-visible surface.

## Verification

    Mac15,7 (M3 Pro), macOS 26.7 build 25G227, Homebrew 6.0.22, /opt/homebrew
    Local self-signed build, English. Swift 6.3.3, Xcode CLT.

The three CI commands, in order:

    $ ./build.sh
    ✓ Bundle ready: build/stage/Vorssaint.app
    build.sh exit=0, warnings: 0

    $ ./build/Vorssaint --selftest
    SELFTEST OK
    selftest exit=0

    $ ./build.sh --test
    ▸ Building & running unit tests against MacOSX26.sdk…
    TESTS OK (10757 checks)
    PREFERENCE CLEANUP TESTS OK

Nine checks were added, on the two pure functions:
`HomebrewEnvironment.parse(nullSeparated:)` and
`HomebrewEnvironment.passthrough(_:)`, plus the login shell command shape and
the two fallback paths. They cover a `NAME=value` entry, a value containing a
newline (NUL is the only separator, which is why `env -0` is used rather than
`env`), a value containing a further `=`, an empty value, an entry with no `=`,
and an entry whose name is not an identifier, which is what a startup file's
greeting looks like once stdout and stderr arrive glued together on one pipe.

Checked in both directions. With the allowlist reduced to `environment` and the
identifier check replaced by `_ = name`, three go red:

    TESTS FAILED (3 of 10757):
      - Homebrew environment parser drops an entry whose name is not an identifier, such as startup output glued to the variable behind it
      - Homebrew passes through only the proxy names brew itself keeps and HOMEBREW_* settings, found ["ALL_PROXY", "DYLD_INSERT_LIBRARIES", "HOME", "HOMEBREWX", "HOMEBREW_API_DOMAIN", "HOMEBREW_BOTTLE_DOMAIN", "HTTP_PROXY", "PATH", "SHELL", "homebrew_lower", "https_proxy", "no_proxy"]
      - Homebrew never hands a login shell's whole environment to brew

The second failure is the one worth reading: with the filter gone, `PATH` and
`DYLD_INSERT_LIBRARIES` from a startup file reach the child. That is the case
the allowlist exists for.

The resolver's real output on this machine, values redacted, is the shape the
code parses:

    $ $SHELL -l -c 'env -0' | tr '\0' '\n' | grep -E '^(HOMEBREW_|HTTPS?_PROXY|ALL_PROXY|NO_PROXY|...)'
    HOMEBREW_PREFIX=<redacted>
    HOMEBREW_CELLAR=<redacted>
    HOMEBREW_REPOSITORY=<redacted>

70 entries come back from the login shell; the allowlist keeps 3 of them here,
all written by `brew shellenv`, and no proxy variable, which is the expected
result on a machine with no proxy.

Not tested: I have no proxy and no mirror available here, so the end to end
case the issue reports, `brew update` succeeding through
`HOMEBREW_API_DOMAIN` where it previously hung, is unverified on real hardware
and is the part most worth a second pair of eyes. Also untested: `fish` and
`bash` as the login shell (only `zsh` here), a shell whose startup file prompts
for input, and the sudo-via-Terminal fallback path, which does not go through
`Process` and is unchanged. No brew command that modifies anything was run.

## Anything else

What a user notices: nothing at all unless they have a proxy or a mirror
exported in their shell profile, in which case Homebrew inside Vorssaint starts
reaching the same servers their Terminal already reaches, with no setting to
turn on.

Refs #1290


🤖 Generated with [Claude Code](https://claude.com/claude-code)