### PR TITLE
feat(finder): Space on folders opens Get Info

### DIFF
--- a/Sources/Vorssaint/App/FeatureRuntime.swift
+++ b/Sources/Vorssaint/App/FeatureRuntime.swift
@@ -214,7 +214,10 @@ final class FeatureRuntime: ObservableObject {
             ScreenRecorderService.shared.closeEditors(ownedBy: .mediaTools)
         },
         .pastePlain: { PastePlainService.shared.syncWithPreferences() },
-        .finderCutPaste: { FinderCutPaste.shared.syncWithPreferences() },
+        .finderCutPaste: {
+            FinderCutPaste.shared.syncWithPreferences()
+            FinderFolderInfoService.shared.syncWithPreferences()
+        },
         .finderRename: { FinderRenameService.shared.syncWithPreferences() },
         .shelf: { ShelfService.shared.syncWithPreferences() },
         .urlCleaner: { URLCleanerService.shared.syncWithPreferences() },

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -125,6 +125,7 @@ enum DefaultsKey {
     static let finderCutPasteShowHUD = "finderCutPasteShowHUD"
     static let finderRenameEnabled = "finderRenameEnabled"
     static let finderRenameShortcut = "finderRenameShortcut"
+    static let finderFolderSpaceGetInfo = "finderFolderSpaceGetInfo"
     static let diskImageInstallerTrashesDownload = "diskImageInstallerTrashesDownload"
     static let diskImageInstallerRevealsApp = "diskImageInstallerRevealsApp"
     static let finderPasteImageAsFile = "finderPasteImageAsFile"
@@ -1245,6 +1246,7 @@ enum Defaults {
         DefaultsKey.pastePlainShortcut: GlobalShortcut.pastePlainDefault.storageValue,
         DefaultsKey.finderRenameEnabled: false,
         DefaultsKey.finderRenameShortcut: GlobalShortcut.finderRenameDefault.storageValue,
+        DefaultsKey.finderFolderSpaceGetInfo: false,
         DefaultsKey.diskImageInstallerTrashesDownload: true,
         DefaultsKey.diskImageInstallerRevealsApp: false,
         DefaultsKey.colorPickerShortcutEnabled: false,

--- a/Sources/Vorssaint/Core/FeatureCatalog.swift
+++ b/Sources/Vorssaint/Core/FeatureCatalog.swift
@@ -224,7 +224,8 @@ extension AppFeature {
         case .clipboardHistory: return [DefaultsKey.clipboardHistoryEnabled]
         case .pastePlain: return [DefaultsKey.pastePlainEnabled]
         case .finderCutPaste: return [DefaultsKey.finderCutPasteEnabled,
-                                      DefaultsKey.finderPasteImageAsFile]
+                                      DefaultsKey.finderPasteImageAsFile,
+                                      DefaultsKey.finderFolderSpaceGetInfo]
         case .finderRename: return [DefaultsKey.finderRenameEnabled]
         case .shelf: return [DefaultsKey.shelfEnabled]
         case .urlCleaner: return [DefaultsKey.urlCleanerEnabled]

--- a/Sources/Vorssaint/Core/FinderFolderInfoStrings.swift
+++ b/Sources/Vorssaint/Core/FinderFolderInfoStrings.swift
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+struct FinderFolderInfoFeatureStrings {
+    let enableLabel: String
+    let caption: String
+}
+
+extension FeatureStrings {
+    static func finderFolderInfo(_ language: AppLanguage) -> FinderFolderInfoFeatureStrings {
+        switch language {
+        case .enUS: return .enUS
+        case .ptBR: return .ptBR
+        case .tr: return .tr
+        case .ru: return .ru
+        case .es: return .es
+        case .de: return .de
+        case .fr: return .fr
+        case .it: return .it
+        case .ja: return .ja
+        case .ko: return .ko
+        case .zhHans: return .zhHans
+        case .zhTW: return .zhTW
+        case .zhHK: return .zhHK
+        }
+    }
+}
+
+extension FinderFolderInfoFeatureStrings {
+    static let enUS = FinderFolderInfoFeatureStrings(
+        enableLabel: "Space on folders opens Get Info",
+        caption: "In Finder, Space still opens Quick Look for files. When only folders are selected, Space opens Get Info instead. Renaming and other text fields are left alone."
+    )
+
+    static let ptBR = FinderFolderInfoFeatureStrings(
+        enableLabel: "Espaço em pastas abre Obter Informações",
+        caption: "No Finder, Espaço continua abrindo o Quick Look para arquivos. Quando só pastas estão selecionadas, Espaço abre Obter Informações. Renomeação e outros campos de texto ficam intactos."
+    )
+
+    static let tr = FinderFolderInfoFeatureStrings(
+        enableLabel: "Klasörlerde Boşluk, Bilgi Al’ı açar",
+        caption: "Finder’da Boşluk dosyalar için Hızlı Bakış’ı açmaya devam eder. Yalnızca klasörler seçiliyken Boşluk Bilgi Al’ı açar. Yeniden adlandırma ve diğer metin alanlarına dokunulmaz."
+    )
+
+    static let ru = FinderFolderInfoFeatureStrings(
+        enableLabel: "Пробел на папках открывает «Свойства»",
+        caption: "В Finder Пробел по-прежнему открывает Быстрый просмотр для файлов. Если выбраны только папки, Пробел открывает «Свойства». Переименование и другие поля ввода не затрагиваются."
+    )
+
+    static let es = FinderFolderInfoFeatureStrings(
+        enableLabel: "Espacio en carpetas abre Obtener información",
+        caption: "En el Finder, Espacio sigue abriendo Quick Look para archivos. Cuando solo hay carpetas seleccionadas, Espacio abre Obtener información. El renombrado y otros campos de texto no se tocan."
+    )
+
+    static let de = FinderFolderInfoFeatureStrings(
+        enableLabel: "Leertaste bei Ordnern öffnet Informationen",
+        caption: "Im Finder öffnet die Leertaste weiterhin Quick Look für Dateien. Sind nur Ordner ausgewählt, öffnet die Leertaste Informationen. Umbenennen und andere Textfelder bleiben unberührt."
+    )
+
+    static let fr = FinderFolderInfoFeatureStrings(
+        enableLabel: "Espace sur les dossiers ouvre Lire les informations",
+        caption: "Dans le Finder, Espace ouvre toujours Aperçu rapide pour les fichiers. Lorsque seuls des dossiers sont sélectionnés, Espace ouvre Lire les informations. Le renommage et les autres champs de texte restent intacts."
+    )
+
+    static let it = FinderFolderInfoFeatureStrings(
+        enableLabel: "Spazio sulle cartelle apre Ottieni informazioni",
+        caption: "Nel Finder, Spazio continua ad aprire Quick Look per i file. Quando sono selezionate solo cartelle, Spazio apre Ottieni informazioni. Ridenomina e altri campi di testo restano intatti."
+    )
+
+    static let ja = FinderFolderInfoFeatureStrings(
+        enableLabel: "フォルダでスペースを押すと情報を見る",
+        caption: "Finderでは、ファイルのスペースはこれまでどおりクイックルックを開きます。フォルダだけが選択されているときは、スペースで「情報を見る」を開きます。名前の変更やほかのテキスト欄には影響しません。"
+    )
+
+    static let ko = FinderFolderInfoFeatureStrings(
+        enableLabel: "폴더에서 스페이스를 누르면 정보 가져오기",
+        caption: "Finder에서 파일의 스페이스는 계속 Quick Look을 엽니다. 폴더만 선택된 경우 스페이스는 정보 가져오기를 엽니다. 이름 변경과 다른 텍스트 필드는 그대로 둡니다."
+    )
+
+    static let zhHans = FinderFolderInfoFeatureStrings(
+        enableLabel: "在文件夹上按空格打开显示简介",
+        caption: "在访达中，对文件按空格仍会打开快速查看。仅选中文件夹时，空格会打开显示简介。重命名和其他文本栏不受影响。"
+    )
+
+    static let zhTW = FinderFolderInfoFeatureStrings(
+        enableLabel: "在檔案夾上按空白鍵開啟簡介視窗",
+        caption: "在 Finder 中，對檔案按空白鍵仍會開啟快速看。只選取檔案夾時，空白鍵會開啟簡介視窗。重新命名和其他文字欄位不受影響。"
+    )
+
+    static let zhHK = FinderFolderInfoFeatureStrings(
+        enableLabel: "在檔案夾上按空白鍵開啟簡介視窗",
+        caption: "在 Finder 中，對檔案按空白鍵仍會開啟快速睇。只選取檔案夾時，空白鍵會開啟簡介視窗。重新命名和其他文字欄位不受影響。"
+    )
+}

--- a/Sources/Vorssaint/Services/Finder/FinderFolderInfoService.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderFolderInfoService.swift
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import ApplicationServices
+import Carbon.HIToolbox
+import CoreGraphics
+import Foundation
+
+/// In Finder, Space on a folder-only selection opens Get Info; Space on files
+/// still reaches Quick Look. The tap claims Space synchronously from focus and
+/// modifier state, then classifies the selection off the tap thread so Finder
+/// Automation never stalls key delivery (issue #1424).
+final class FinderFolderInfoService {
+    static let shared = FinderFolderInfoService()
+
+    private static let finderBundleID = "com.apple.finder"
+    /// Marks Space events we re-inject for Quick Look so this tap ignores them.
+    private static let syntheticSpaceMarker: Int64 = 0x46494E46 // "FINF"
+
+    private let lifecycleLock = NSLock()
+    private var tap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var tapRunLoop: CFRunLoop?
+    private var tapThread: Thread?
+    private var shouldStopTapThread = false
+    private var pendingStartAfterStop = false
+
+    private let workQueue = DispatchQueue(label: "Vorssaint.FinderFolderInfo", qos: .userInitiated)
+    private let generationLock = NSLock()
+    private var inspectionGeneration = 0
+
+    private init() {
+        SessionActivity.shared.onChange { [weak self] _ in self?.syncWithPreferences() }
+    }
+
+    func syncWithPreferences() {
+        let enabled = AppFeature.finderCutPaste.isAvailable
+            && UserDefaults.standard.bool(forKey: DefaultsKey.finderFolderSpaceGetInfo)
+        if SessionActivitySupport.tapShouldRun(featureWanted: enabled,
+                                               accessibilityGranted: AXIsProcessTrusted(),
+                                               sessionIsActive: SessionActivity.shared.isActive) {
+            installTap()
+        } else {
+            removeTap()
+        }
+    }
+
+    func suspend() {
+        removeTap()
+    }
+
+    private func installTap() {
+        let thread = lifecycleLock.withLock { () -> Thread? in
+            if tapThread != nil {
+                if shouldStopTapThread { pendingStartAfterStop = true }
+                return nil
+            }
+            shouldStopTapThread = false
+            pendingStartAfterStop = false
+            let thread = Thread { [weak self] in self?.runEventTap() }
+            thread.name = "Vorssaint Finder Folder Info"
+            thread.qualityOfService = .userInteractive
+            tapThread = thread
+            return thread
+        }
+        thread?.start()
+    }
+
+    private func removeTap() {
+        let snapshot = lifecycleLock.withLock {
+            () -> (runLoop: CFRunLoop?, tap: CFMachPort?, threadExists: Bool) in
+            shouldStopTapThread = true
+            pendingStartAfterStop = false
+            return (tapRunLoop, tap, tapThread != nil)
+        }
+        if let tap = snapshot.tap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+        }
+        if let runLoop = snapshot.runLoop {
+            CFRunLoopPerformBlock(runLoop, CFRunLoopMode.commonModes.rawValue) {
+                CFRunLoopStop(runLoop)
+            }
+            CFRunLoopWakeUp(runLoop)
+        } else if !snapshot.threadExists {
+            lifecycleLock.withLock {
+                shouldStopTapThread = false
+                tapThread = nil
+            }
+        }
+    }
+
+    private func runEventTap() {
+        autoreleasepool {
+            let runLoop = CFRunLoopGetCurrent()
+            lifecycleLock.withLock { tapRunLoop = runLoop }
+
+            let shouldStop = lifecycleLock.withLock { shouldStopTapThread }
+            guard !shouldStop else {
+                if clearEventTapThread() { installTap() }
+                return
+            }
+
+            let mask = CGEventMask(1 << CGEventType.keyDown.rawValue)
+                | CGEventMask(1 << CGEventType.keyUp.rawValue)
+            guard let tap = CGEvent.tapCreate(
+                tap: .cgSessionEventTap,
+                place: .tailAppendEventTap,
+                options: .defaultTap,
+                eventsOfInterest: mask,
+                callback: { _, type, event, userInfo in
+                    guard let userInfo else { return Unmanaged.passUnretained(event) }
+                    let service = Unmanaged<FinderFolderInfoService>
+                        .fromOpaque(userInfo).takeUnretainedValue()
+                    return service.route(type: type, event: event)
+                },
+                userInfo: Unmanaged.passUnretained(self).toOpaque()
+            ) else {
+                _ = clearEventTapThread()
+                return
+            }
+
+            let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+            lifecycleLock.withLock {
+                self.tap = tap
+                runLoopSource = source
+            }
+            CFRunLoopAddSource(runLoop, source, .commonModes)
+            CGEvent.tapEnable(tap: tap, enable: true)
+
+            if lifecycleLock.withLock({ shouldStopTapThread }) {
+                CGEvent.tapEnable(tap: tap, enable: false)
+            } else {
+                CFRunLoopRun()
+            }
+
+            CGEvent.tapEnable(tap: tap, enable: false)
+            CFRunLoopRemoveSource(runLoop, source, .commonModes)
+            CFMachPortInvalidate(tap)
+            if clearEventTapThread() { installTap() }
+        }
+    }
+
+    private func clearEventTapThread() -> Bool {
+        lifecycleLock.withLock {
+            let shouldRestart = pendingStartAfterStop
+            tap = nil
+            runLoopSource = nil
+            tapRunLoop = nil
+            tapThread = nil
+            shouldStopTapThread = false
+            pendingStartAfterStop = false
+            return shouldRestart
+        }
+    }
+
+    private func route(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            let currentTap = lifecycleLock.withLock { shouldStopTapThread ? nil : tap }
+            if SessionActivity.shared.isActive, AXIsProcessTrusted(), let currentTap {
+                CGEvent.tapEnable(tap: currentTap, enable: true)
+            } else {
+                DispatchQueue.main.async { [weak self] in self?.syncWithPreferences() }
+            }
+            return Unmanaged.passUnretained(event)
+        }
+        guard type == .keyDown || type == .keyUp else {
+            return Unmanaged.passUnretained(event)
+        }
+        guard event.getIntegerValueField(.eventSourceUserData) != Self.syntheticSpaceMarker
+        else { return Unmanaged.passUnretained(event) }
+
+        let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+        guard keyCode == Int64(kVK_Space) else { return Unmanaged.passUnretained(event) }
+
+        let flags = event.flags.intersection([.maskCommand, .maskShift, .maskAlternate, .maskControl])
+        let hasModifiers = !flags.isEmpty
+        guard AXIsProcessTrusted(),
+              let front = NSWorkspace.shared.frontmostApplication,
+              FinderFolderInfoSupport.shouldClaimSpace(
+                  isFinderFrontmost: front.bundleIdentifier == Self.finderBundleID,
+                  hasModifiers: hasModifiers,
+                  acceptsFocusedRole: FinderRenameSupport.acceptsFocusedRole(
+                      focusedRole(for: front.processIdentifier)))
+        else { return Unmanaged.passUnretained(event) }
+
+        // Swallow the matching keyUp so Finder never sees a lone Space release
+        // after we claimed keyDown.
+        if type == .keyUp { return nil }
+
+        let generation = generationLock.withLock { () -> Int in
+            inspectionGeneration += 1
+            return inspectionGeneration
+        }
+        workQueue.async { [weak self] in
+            self?.inspectSelection(generation: generation)
+        }
+        return nil
+    }
+
+    private func inspectSelection(generation: Int) {
+        let urls = selectionURLs()
+        let flags = urls.map(Self.isDirectory)
+        let action = FinderFolderInfoSupport.action(directoryFlags: flags)
+        let current = generationLock.withLock { inspectionGeneration }
+        guard generation == current else { return }
+        switch action {
+        case .openGetInfo:
+            openGetInfo(for: urls)
+        case .forwardQuickLook:
+            postSyntheticSpace()
+        }
+    }
+
+    private func openGetInfo(for urls: [URL]) {
+        guard !urls.isEmpty,
+              AppleScriptRunner.consentToAutomate(bundleID: Self.finderBundleID)
+        else { return }
+        let lines = urls.map { url in
+            "open information window of (POSIX file \(AppleScriptRunner.literal(url.path)) as alias)"
+        }.joined(separator: "\n")
+        let script = """
+        tell application "Finder"
+            \(lines)
+        end tell
+        """
+        _ = AppleScriptRunner.run(script)
+    }
+
+    private func postSyntheticSpace() {
+        let source = CGEventSource(stateID: .combinedSessionState)
+        guard let down = CGEvent(keyboardEventSource: source, virtualKey: CGKeyCode(kVK_Space),
+                                 keyDown: true),
+              let up = CGEvent(keyboardEventSource: source, virtualKey: CGKeyCode(kVK_Space),
+                               keyDown: false)
+        else { return }
+        down.setIntegerValueField(.eventSourceUserData, value: Self.syntheticSpaceMarker)
+        up.setIntegerValueField(.eventSourceUserData, value: Self.syntheticSpaceMarker)
+        down.post(tap: .cgSessionEventTap)
+        up.post(tap: .cgSessionEventTap)
+    }
+
+    private func focusedRole(for pid: pid_t) -> String? {
+        let app = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(app, 0.15)
+        var focused: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(app, kAXFocusedUIElementAttribute as CFString,
+                                            &focused) == .success,
+              let focused, CFGetTypeID(focused) == AXUIElementGetTypeID()
+        else { return nil }
+        let element = focused as! AXUIElement
+        var role: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString,
+                                            &role) == .success,
+              let role, CFGetTypeID(role) == CFStringGetTypeID()
+        else { return nil }
+        return role as? String
+    }
+
+    private static func isDirectory(_ url: URL) -> Bool {
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir) else {
+            return false
+        }
+        return isDir.boolValue
+    }
+
+    private func selectionURLs() -> [URL] {
+        guard AppleScriptRunner.consentToAutomate(bundleID: Self.finderBundleID) else { return [] }
+        let script = """
+        tell application "Finder"
+            set out to ""
+            repeat with f in (get selection)
+                set out to out & (POSIX path of (f as alias)) & linefeed
+            end repeat
+            return out
+        end tell
+        """
+        let result = AppleScriptRunner.run(script)
+        guard result.ok else { return [] }
+        return result.output.split(whereSeparator: \.isNewline)
+            .map { URL(fileURLWithPath: String($0)) }
+    }
+}

--- a/Sources/Vorssaint/Services/Finder/FinderFolderInfoSupport.swift
+++ b/Sources/Vorssaint/Services/Finder/FinderFolderInfoSupport.swift
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+/// Pure decisions for Space → Get Info on Finder folders (issue #1424).
+/// The event tap claims Space only when Finder is frontmost, the focused
+/// role is not a text field, and no modifiers are held; the selection is
+/// inspected off the tap thread afterwards.
+enum FinderFolderInfoSupport {
+    /// What to do once the Finder selection has been classified.
+    enum AfterSelection: Equatable {
+        /// Every selected item is a folder: open Finder's Get Info windows.
+        case openGetInfo
+        /// Empty selection, or any non-folder: re-post Space so Finder's
+        /// Quick Look (or its empty-selection no-op) still runs.
+        case forwardQuickLook
+    }
+
+    /// Whether the tap should swallow Space before reading the selection.
+    static func shouldClaimSpace(isFinderFrontmost: Bool,
+                                 hasModifiers: Bool,
+                                 acceptsFocusedRole: Bool) -> Bool {
+        isFinderFrontmost && !hasModifiers && acceptsFocusedRole
+    }
+
+    /// `directoryFlags[i]` is true when selection item `i` is a directory.
+    static func action(directoryFlags: [Bool]) -> AfterSelection {
+        guard !directoryFlags.isEmpty else { return .forwardQuickLook }
+        if directoryFlags.allSatisfy({ $0 }) { return .openGetInfo }
+        return .forwardQuickLook
+    }
+}

--- a/Sources/Vorssaint/UI/Settings/CutPasteSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/CutPasteSettings.swift
@@ -12,6 +12,7 @@ struct CutPasteSettings: View {
     @AppStorage(DefaultsKey.finderRenameEnabled) private var renameEnabled = false
     @AppStorage(DefaultsKey.finderRenameShortcut) private var renameShortcutRaw =
         GlobalShortcut.finderRenameDefault.storageValue
+    @AppStorage(DefaultsKey.finderFolderSpaceGetInfo) private var folderSpaceGetInfo = false
     @State private var renameError: String?
     @State private var recordingRename = false
 
@@ -19,12 +20,16 @@ struct CutPasteSettings: View {
         FeatureStrings.finderRename(l10n.language)
     }
 
+    private var folderInfoText: FinderFolderInfoFeatureStrings {
+        FeatureStrings.finderFolderInfo(l10n.language)
+    }
+
     private var renameShortcut: GlobalShortcut {
         GlobalShortcut(storageValue: renameShortcutRaw) ?? .finderRenameDefault
     }
 
     private var needsAccessibility: Bool {
-        (AppFeature.finderCutPaste.isAvailable && enabled)
+        (AppFeature.finderCutPaste.isAvailable && (enabled || folderSpaceGetInfo))
             || (AppFeature.finderRename.isAvailable && renameEnabled)
     }
 
@@ -55,6 +60,16 @@ struct CutPasteSettings: View {
                     }
                 }
                 .settingsSectionAnchor(.finderCutPaste)
+
+                Section {
+                    Toggle(folderInfoText.enableLabel, isOn: $folderSpaceGetInfo)
+                        .onChange(of: folderSpaceGetInfo) { _, _ in
+                            FinderFolderInfoService.shared.syncWithPreferences()
+                        }
+                    Text(folderInfoText.caption)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
 
                 Section(l10n.s.cutPasteHowTitle) {
                     howRow(keys: ["⌘", "X"], text: l10n.s.cutPasteStep1)
@@ -116,7 +131,7 @@ struct CutPasteSettings: View {
             if needsAccessibility, !permissions.accessibility {
                 Section(l10n.s.permissionRequired) {
                     PermissionRow(kind: .accessibility)
-                    if AppFeature.finderCutPaste.isAvailable, enabled {
+                    if AppFeature.finderCutPaste.isAvailable, enabled || folderSpaceGetInfo {
                         Text(l10n.s.cutPasteAutomationNote)
                             .font(.caption)
                             .foregroundStyle(.secondary)

--- a/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
+++ b/Sources/Vorssaint/UI/Settings/SettingsDirectory.swift
@@ -177,7 +177,8 @@ enum SettingsDirectory {
                                        title: FeatureStrings.finderRename(language).pageTitle,
                                        icon: "filemenu.and.selection",
                                        featureKeywords: [
-                                        (.finderCutPaste, [s.cutPasteEnable]),
+                                        (.finderCutPaste, [s.cutPasteEnable,
+                                                           FeatureStrings.finderFolderInfo(language).enableLabel]),
                                         (.finderRename,
                                          [FeatureStrings.finderRename(language).enableLabel]),
                                        ]),

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15402,6 +15402,9 @@ struct MetricsTests {
         expect(activeSet(.automationFinder, on: [DefaultsKey.finderPasteImageAsFile])
                 == [.finderCutPaste, .uninstaller, .quickToggles],
                "pasting copied images as files engages the shared Finder feature")
+        expect(activeSet(.automationFinder, on: [DefaultsKey.finderFolderSpaceGetInfo])
+                == [.finderCutPaste, .uninstaller, .quickToggles],
+               "Space on folders for Get Info engages the shared Finder feature")
         expect(AppFeature.quickToggles.permissions == [.automationFinder],
                "the quick toggles need no permission beyond the Trash's Finder ask")
         expect(activeSet(.automationTerminal) == [.homebrew], "homebrew drives the Terminal")
@@ -21169,6 +21172,40 @@ struct MetricsTests {
                 && !FinderRenameSupport.acceptsFocusedRole(nil),
                "Finder rename only acts outside editable fields with a known focus")
 
+        expect(FinderFolderInfoSupport.shouldClaimSpace(isFinderFrontmost: true,
+                                                         hasModifiers: false,
+                                                         acceptsFocusedRole: true),
+               "Space is claimed in Finder outside text fields with no modifiers")
+        expect(!FinderFolderInfoSupport.shouldClaimSpace(isFinderFrontmost: false,
+                                                          hasModifiers: false,
+                                                          acceptsFocusedRole: true),
+               "Space is left alone when Finder is not frontmost")
+        expect(!FinderFolderInfoSupport.shouldClaimSpace(isFinderFrontmost: true,
+                                                          hasModifiers: true,
+                                                          acceptsFocusedRole: true),
+               "modified Space is left for Finder / the system")
+        expect(!FinderFolderInfoSupport.shouldClaimSpace(isFinderFrontmost: true,
+                                                          hasModifiers: false,
+                                                          acceptsFocusedRole: false),
+               "Space stays with the focused text field while renaming")
+        expect(FinderFolderInfoSupport.action(directoryFlags: [true, true]) == .openGetInfo,
+               "a folder-only selection opens Get Info")
+        expect(FinderFolderInfoSupport.action(directoryFlags: [true, false]) == .forwardQuickLook,
+               "a mixed selection keeps Quick Look")
+        expect(FinderFolderInfoSupport.action(directoryFlags: [false]) == .forwardQuickLook,
+               "a file selection keeps Quick Look")
+        expect(FinderFolderInfoSupport.action(directoryFlags: []) == .forwardQuickLook,
+               "an empty selection re-posts Space instead of swallowing it")
+
+        for language in AppLanguage.allCases {
+            let strings = FeatureStrings.finderFolderInfo(language)
+            let values = Mirror(reflecting: strings).children.compactMap { $0.value as? String }
+            expect(values.count == 2 && values.allSatisfy { !$0.isEmpty },
+                   "every Finder folder Space Get Info string is set for \(language.rawValue)")
+            expect(values.allSatisfy { !$0.contains("—") },
+                   "no em-dash in Finder folder Space Get Info strings (\(language.rawValue))")
+        }
+
         for language in AppLanguage.allCases {
             let strings = FeatureStrings.windowPreviewExclusions(language)
             let values = Mirror(reflecting: strings).children.compactMap { $0.value as? String }
@@ -21337,6 +21374,9 @@ struct MetricsTests {
         expect(Defaults.registeredDefaults[DefaultsKey.finderPasteImageAsFile] as? Bool == false
                 && backupKeys.contains(DefaultsKey.finderPasteImageAsFile),
                "pasting copied images as files is opt-in and travels with settings backup")
+        expect(Defaults.registeredDefaults[DefaultsKey.finderFolderSpaceGetInfo] as? Bool == false
+                && backupKeys.contains(DefaultsKey.finderFolderSpaceGetInfo),
+               "Space on folders for Get Info is opt-in and travels with settings backup")
         expect(Defaults.registeredDefaults[DefaultsKey.finderCutPasteShowHUD] as? Bool == true
                 && backupKeys.contains(DefaultsKey.finderCutPasteShowHUD),
                "the Finder cut and paste floating panel default is on and travels with settings backup")
@@ -25654,6 +25694,7 @@ struct MetricsTests {
                          "Sources/Vorssaint/Services/WindowMaximizer.swift",
                          "Sources/Vorssaint/Services/Finder/FinderCutPaste.swift",
                          "Sources/Vorssaint/Services/Finder/FinderRenameService.swift",
+                         "Sources/Vorssaint/Services/Finder/FinderFolderInfoService.swift",
                          "Sources/Vorssaint/Services/KeyboardDebounce/KeyboardDebounceService.swift",
                          "Sources/Vorssaint/Services/SuperKey/SuperKeyService.swift",
                          "Sources/Vorssaint/Services/ShortcutRecordingTap.swift",

--- a/build.sh
+++ b/build.sh
@@ -274,6 +274,7 @@ if (( TEST )); then
         Sources/Vorssaint/Core/CameraPreviewStrings.swift \
         Sources/Vorssaint/Core/ScratchpadStrings.swift \
         Sources/Vorssaint/Core/FinderRenameStrings.swift \
+        Sources/Vorssaint/Core/FinderFolderInfoStrings.swift \
         Sources/Vorssaint/Core/CommandBarStrings.swift \
         Sources/Vorssaint/Core/FeedbackStrings.swift \
         Sources/Vorssaint/Core/RadialMenuStrings.swift \
@@ -336,6 +337,7 @@ if (( TEST )); then
         Sources/Vorssaint/Services/AutoQuit/AutoQuitSupport.swift \
         Sources/Vorssaint/Services/Shelf/ShelfSupport.swift \
         Sources/Vorssaint/Services/Finder/FinderRenameSupport.swift \
+        Sources/Vorssaint/Services/Finder/FinderFolderInfoSupport.swift \
         Sources/Vorssaint/Services/Update/UpdateInstallerSupport.swift \
         Sources/Vorssaint/Services/Update/UpdateServiceSupport.swift \
         Sources/Vorssaint/Services/InstalledApps.swift \


### PR DESCRIPTION
## Summary
- Opt-in under Finder shortcuts: Space on a folder-only selection opens Get Info; files still get Quick Look
- Event tap claims Space only in Finder outside text fields, then classifies the selection off the tap thread
- Covers decision logic, defaults/backup, permissions engagement, and localized settings copy in MetricsTests

Refs #1424

## Test plan
- [x] `./build.sh --test` → TESTS OK (10841 checks)
- [ ] Settings → Finder shortcuts: enable “Space on folders opens Get Info”
- [ ] In Finder, select a folder and press Space → Get Info opens
- [ ] Select a file and press Space → Quick Look still opens
- [ ] Rename a folder (text field focused) and press Space → typing is unaffected