### PR TITLE
fix(switcher): let every delayed focus pass stop for a window opened after the switch

### DIFF
--- a/Sources/Vorssaint/Services/Switcher/SpaceHop.swift
+++ b/Sources/Vorssaint/Services/Switcher/SpaceHop.swift
@@ -47,12 +47,20 @@ final class SpaceHop {
     static func beginIfNeeded(windowID: CGWindowID,
                               appPID: pid_t,
                               windowOwnerPID: pid_t,
+                              sourcePID: pid_t?,
                               app: NSRunningApplication) -> Bool {
         guard let topology = SpaceWindowBridge.topology(),
               SpaceWindowBridge.isParkedOnHiddenSpace(windowID, visibleSpaces: topology.visibleSpaces)
         else { return false }
         cancelPending()
-        let hop = SpaceHop(windowID: windowID, appPID: appPID, windowOwnerPID: windowOwnerPID, app: app)
+        // The app's windows before anything moves: a window it opens during the
+        // hop is the user's, and the arrival pulses must leave it in front.
+        let focusState = SwitcherWindowFocusRetryState(
+            targetWindowID: windowID,
+            targetStartedMinimized: false,
+            knownWindowIDs: WindowActivator.focusSnapshot(ownerPID: windowOwnerPID))
+        let hop = SpaceHop(windowID: windowID, appPID: appPID, windowOwnerPID: windowOwnerPID,
+                           sourcePID: sourcePID, focusState: focusState, app: app)
         current = hop
         hop.start()
         return true
@@ -67,16 +75,22 @@ final class SpaceHop {
     private let windowID: CGWindowID
     private let appPID: pid_t
     private let windowOwnerPID: pid_t
+    private let sourcePID: pid_t?
+    private let focusState: SwitcherWindowFocusRetryState
     private let app: NSRunningApplication
     private var cancelled = false
     private var arrowPressesLeft = SpaceHopSupport.maximumArrowSteps
     private var originalCursorLocation: CGPoint?
     private var warpedCursorLocation: CGPoint?
 
-    private init(windowID: CGWindowID, appPID: pid_t, windowOwnerPID: pid_t, app: NSRunningApplication) {
+    private init(windowID: CGWindowID, appPID: pid_t, windowOwnerPID: pid_t,
+                 sourcePID: pid_t?, focusState: SwitcherWindowFocusRetryState,
+                 app: NSRunningApplication) {
         self.windowID = windowID
         self.appPID = appPID
         self.windowOwnerPID = windowOwnerPID
+        self.sourcePID = sourcePID
+        self.focusState = focusState
         self.app = app
     }
 
@@ -223,7 +237,9 @@ final class SpaceHop {
                 guard !self.cancelled, !self.app.isTerminated else { return }
                 WindowActivator.focusAfterSpaceHop(windowID: self.windowID,
                                                    appPID: self.appPID,
-                                                   windowOwnerPID: self.windowOwnerPID)
+                                                   windowOwnerPID: self.windowOwnerPID,
+                                                   sourcePID: self.sourcePID,
+                                                   state: self.focusState)
             }
         }
         schedule(after: 1.0) { self.finish() }

--- a/Sources/Vorssaint/Services/Switcher/WindowActivator.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowActivator.swift
@@ -504,7 +504,13 @@ enum WindowActivator {
             sourcePID: sourcePID,
             frontmostPID: currentFrontmostPID(),
             targetMinimizedState: minimizedState,
-            targetAppWindowIDs: windowIDs(ownerPID: targetWindowOwnerPID, options: .optionOnScreenOnly),
+            // The same scope the snapshot used. The on-screen list lags: a
+            // window the app has just opened is focused, and answered as
+            // focused by Accessibility, before the window server composites
+            // it — so comparing on-screen windows against an all-windows
+            // snapshot reported nothing new in exactly the race this guard
+            // exists for, and the focus reading below was never taken.
+            targetAppWindowIDs: windowIDs(ownerPID: targetWindowOwnerPID, options: .optionAll),
             targetAppFocusedWindowID: focusedWindowID(for: targetWindowOwnerPID)
         )
     }

--- a/Sources/Vorssaint/Services/Switcher/WindowActivator.swift
+++ b/Sources/Vorssaint/Services/Switcher/WindowActivator.swift
@@ -74,6 +74,7 @@ enum WindowActivator {
            SpaceHop.beginIfNeeded(windowID: windowID,
                                   appPID: item.pid,
                                   windowOwnerPID: windowOwnerPID,
+                                  sourcePID: sourcePID,
                                   app: app) {
             return
         }
@@ -704,10 +705,31 @@ enum WindowActivator {
         return true
     }
 
+    /// Every window the owner has right now, in the scope the retry guard
+    /// compares against. Taken by a hop at the moment it begins.
+    static func focusSnapshot(ownerPID: pid_t) -> Set<CGWindowID> {
+        windowIDs(ownerPID: ownerPID, options: .optionAll)
+    }
+
     /// Focus pass run by SpaceHop once the target window's Space became
     /// visible and Accessibility can finally describe the window.
-    static func focusAfterSpaceHop(windowID: CGWindowID, appPID: pid_t, windowOwnerPID: pid_t) {
+    ///
+    /// Its pulses run up to a second after the switch, long enough for the
+    /// user to open a window in the app they just reached — Command-N right
+    /// after switching away from a fullscreen app lands here. They consult the
+    /// same guard as every other delayed pass, so a window the app did not
+    /// have when the hop began ends them instead of being covered.
+    static func focusAfterSpaceHop(windowID: CGWindowID,
+                                   appPID: pid_t,
+                                   windowOwnerPID: pid_t,
+                                   sourcePID: pid_t?,
+                                   state: SwitcherWindowFocusRetryState) {
         guard let app = NSRunningApplication(processIdentifier: appPID), !app.isTerminated else { return }
+        guard shouldContinueFocusRetry(windowID: windowID,
+                                       targetPID: appPID,
+                                       targetWindowOwnerPID: windowOwnerPID,
+                                       sourcePID: sourcePID,
+                                       state: state) else { return }
         prepareWindowForActivation(windowID: windowID, pid: windowOwnerPID)
         activateApp(app, allWindows: false)
         focusWindow(windowID: windowID, pid: windowOwnerPID)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -12281,6 +12281,26 @@ struct MetricsTests {
                                                          targetAppFocusedWindowID: 777,
                                                          ownPID: 99),
                "App Switcher focus retries let go of a window the app opened after the switch")
+        // The guard only reads Accessibility once the cheap window-server list
+        // shows the app gained something. Both lists must therefore be taken
+        // in the same scope: the on-screen list lags a newly opened window,
+        // and comparing it against an all-windows snapshot reported nothing
+        // new in exactly the race the guard exists for. Comments are stripped
+        // first, so the one explaining that lag cannot satisfy the check.
+        let activatorSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Switcher/WindowActivator.swift",
+            encoding: .utf8)) ?? ""
+        let activatorCode = activatorSource
+            .components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        let windowScopes = activatorCode
+            .components(separatedBy: "windowIDs(ownerPID:")
+            .dropFirst()
+            .compactMap { $0.components(separatedBy: ")").first }
+            .filter { $0.contains("options: .") }
+        expect(windowScopes.count >= 2 && windowScopes.allSatisfy { $0.contains(".optionAll") },
+               "the retry's live window list is gathered in the same scope as the snapshot it is compared against")
         expect(SwitcherSupport.shouldContinueFocusRetry(targetPID: 10,
                                                         sourcePID: 20,
                                                         frontmostPID: 10,

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -12301,6 +12301,30 @@ struct MetricsTests {
             .filter { $0.contains("options: .") }
         expect(windowScopes.count >= 2 && windowScopes.allSatisfy { $0.contains(".optionAll") },
                "the retry's live window list is gathered in the same scope as the snapshot it is compared against")
+        // A switch away from a fullscreen app reaches its target through a hop,
+        // whose arrival pulses raise it for up to a second. They must ask the
+        // same guard before raising, or Command-N in the app just reached is
+        // covered by the target on the next pulse. Comments are stripped, so a
+        // doc comment naming the guard cannot stand in for the call.
+        let hopFocusBody: String = {
+            guard let start = activatorCode.range(of: "static func focusAfterSpaceHop(") else { return "" }
+            let rest = activatorCode[start.upperBound...]
+            let end = rest.range(of: "static func ")?.lowerBound ?? rest.endIndex
+            return String(rest[..<end])
+        }()
+        let hopGuard = hopFocusBody.range(of: "shouldContinueFocusRetry(")
+        let hopRaise = hopFocusBody.range(of: "focusWindow(")
+        expect(hopGuard != nil && hopRaise != nil && hopGuard!.lowerBound < hopRaise!.lowerBound,
+               "the hop's arrival pass consults the retry guard before it raises the target")
+        let spaceHopCode = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Switcher/SpaceHop.swift",
+            encoding: .utf8)) ?? "")
+            .components(separatedBy: "\n")
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(spaceHopCode.contains("state: self.focusState")
+               && spaceHopCode.contains("knownWindowIDs: WindowActivator.focusSnapshot(ownerPID:"),
+               "a hop snapshots the app's windows when it begins and hands that state to every pulse")
         expect(SwitcherSupport.shouldContinueFocusRetry(targetPID: 10,
                                                         sourcePID: 20,
                                                         frontmostPID: 10,


### PR DESCRIPTION
## Summary

Two cases #1541 left open, both traced on a diagnostic build that logged every delayed focus pass with its inputs.

**The guard compared two different window lists.** It reads Accessibility only once the window server shows the app gained a window, but took that list on screen only while the snapshot covers all windows. A window the app has just opened is focused before the window server composites it, so the guard saw nothing new and never took the focus reading. Logged in Finder: `onScreen=[77,39507]` against the snapshot, while Accessibility already answered 44049 and the all-windows list contained it. The live list now uses the snapshot's scope. Two passes seconds later showed the all-windows list unchanged, so this keeps the reading rare.

**A space hop's arrival pulses never asked the guard.** A switch away from a fullscreen app goes through `SpaceHop`, which raises the target in three pulses up to a second later — and started before the activation took its snapshot. Logged: fullscreen source to Mail, Command-N, three raises of the old Mail window and not one pass through the guard. The hop now snapshots the app's windows when it begins and every pulse asks the same guard before raising.

## Verification

```sh
./build.sh                     # finished, no warnings
./build/Vorssaint --selftest   # SELFTEST OK
./build.sh --test              # TESTS OK (31446 checks)
```

Each fix checked in both directions: the scope test goes red with the on-screen list restored, the hop test goes red with the guard removed from `focusAfterSpaceHop`. After the change, the same fullscreen-to-Mail sequence logged the first pulse stopping at the new window (`allNew=[48625] focused=48625 → stop`) and the two remaining pulses raising nothing.

Confirmed by hand on a MacBook Pro (M4 Max, Mac16,5), macOS 26.6.2 (25G83), built-in Liquid Retina XDR plus one external display, English, own build with a stable self-signed identity: from a windowed source and from a fullscreen app, Command-N right after switching keeps the new window in front.

Not tested: other Macs and macOS versions; Spaces layouts beyond one Space per display plus fullscreen apps; apps other than Safari, Mail and Finder.

## Anything else

Refs #1540
