### PR TITLE
fix(AudioMixer): using exponential instead of linear gain scaling

### DIFF
--- a/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
+++ b/Sources/Vorssaint/Services/Audio/AppVolumeMixer.swift
@@ -1902,7 +1902,7 @@ private final class TapGainEngine: GainEngine {
             // here on leaves the output written.
             let frames = MixerRender.render(source: inputBuffers[tapIndex],
                                             into: outputBuffers,
-                                            gain: gain)
+                                            gain: pow(gain, 2))
             // Keep the tiny delay filled for every live engine. Crossing from
             // attenuation into boost then changes level without inserting a
             // fresh block of silence into audio that is already playing.

--- a/Sources/Vorssaint/Services/Audio/MixerRender.swift
+++ b/Sources/Vorssaint/Services/Audio/MixerRender.swift
@@ -101,9 +101,7 @@ enum MixerRender {
                                              channels: buffer.mNumberChannels))
         }
         guard frames > 0, outputChannels > 0, hasWritableOutput else { return 0 }
-        // Converting from linear to exponential gain for perceptually smooth gain adjustments.
-        // This is due to the non-linear perception of human hearing.
-        var gain = pow(gain, 2)
+        var gain = gain
 
         // The usual shape: one interleaved buffer wanting exactly what the
         // tap produced. One pass, nothing to map.

--- a/Sources/Vorssaint/Services/Audio/MixerRender.swift
+++ b/Sources/Vorssaint/Services/Audio/MixerRender.swift
@@ -101,7 +101,9 @@ enum MixerRender {
                                              channels: buffer.mNumberChannels))
         }
         guard frames > 0, outputChannels > 0, hasWritableOutput else { return 0 }
-        var gain = gain
+        // Converting from linear to exponential gain for perceptually smooth gain adjustments.
+        // This is due to the non-linear perception of human hearing.
+        var gain = pow(gain, 2)
 
         // The usual shape: one interleaved buffer wanting exactly what the
         // tap produced. One pass, nothing to map.


### PR DESCRIPTION
## Summary

Now the audio mixer uses exponential gain scaling instead of linear scaling.
Linear scaling is not intuitive because humans hear changes in volume in
a logarithmic way.

## Verification

Device: MacBook Air M1 8GB 256GB

I ran the routine verifications:
```sh
./build.sh                     # must finish without warnings
./build/Vorssaint --selftest
./build.sh --test
```
No warnings, no failed tests.
No issues related to this PR.