### PR TITLE
feat(monitor): Add connected devices and disk count to menu bar metrics

### DIFF
--- a/Sources/Vorssaint/App/FeatureRuntime.swift
+++ b/Sources/Vorssaint/App/FeatureRuntime.swift
@@ -271,6 +271,7 @@ final class FeatureRuntime: ObservableObject {
         .monitorMemory: { FeatureRuntime.syncMonitor() },
         .monitorNetwork: { FeatureRuntime.syncMonitor() },
         .monitorDisk: { FeatureRuntime.syncMonitor() },
+        .monitorUSB: { FeatureRuntime.syncMonitor() },
         .monitorPower: { FeatureRuntime.syncMonitor() },
         .fanControl: {
             SystemMonitor.shared.planDidChange()

--- a/Sources/Vorssaint/App/MenuBarRenderer.swift
+++ b/Sources/Vorssaint/App/MenuBarRenderer.swift
@@ -5,7 +5,7 @@ import AppKit
 
 /// A live reading the user can pin next to the menu bar icon.
 enum MenuBarMetric: String, CaseIterable, Identifiable {
-    case cpu, gpu, memory, cpuTemperature, gpuTemperature, batteryTemperature, network, diskUsage, diskActivity, battery, batteryTime, peripheralBattery, power, fanSpeed
+    case cpu, gpu, memory, cpuTemperature, gpuTemperature, batteryTemperature, network, diskUsage, diskActivity, diskCount, connectedDevices, battery, batteryTime, peripheralBattery, power, fanSpeed
 
     var id: String { rawValue }
 
@@ -20,6 +20,8 @@ enum MenuBarMetric: String, CaseIterable, Identifiable {
         case .network: return DefaultsKey.menuBarNetwork
         case .diskUsage: return DefaultsKey.menuBarDiskUsage
         case .diskActivity: return DefaultsKey.menuBarDiskActivity
+        case .diskCount: return DefaultsKey.menuBarDiskCount
+        case .connectedDevices: return DefaultsKey.menuBarConnectedDevices
         case .battery: return DefaultsKey.menuBarBattery
         case .batteryTime: return DefaultsKey.menuBarBatteryTime
         case .peripheralBattery: return DefaultsKey.menuBarPeripheralBattery
@@ -39,6 +41,8 @@ enum MenuBarMetric: String, CaseIterable, Identifiable {
         case .network: return "network"
         case .diskUsage: return "internaldrive"
         case .diskActivity: return "internaldrive.fill"
+        case .diskCount: return "externaldrive"
+        case .connectedDevices: return "cable.connector"
         case .battery: return "battery.100"
         case .batteryTime: return "clock"
         case .peripheralBattery: return "keyboard"
@@ -58,6 +62,8 @@ enum MenuBarMetric: String, CaseIterable, Identifiable {
         case .network: return strings.monitorShowNetwork
         case .diskUsage: return strings.monitorItemDiskUsage
         case .diskActivity: return strings.monitorItemDiskActivity
+        case .diskCount: return strings.monitorShowDiskCount
+        case .connectedDevices: return strings.monitorShowConnectedDevices
         case .battery: return strings.batteryLabel
         case .batteryTime: return FeatureStrings.batteryTime(L10n.shared.language).title
         case .peripheralBattery: return strings.monitorShowPeripheralBattery
@@ -71,7 +77,7 @@ enum MenuBarMetric: String, CaseIterable, Identifiable {
         .gpu, .gpuTemperature,
         .memory,
         .battery, .batteryTime, .batteryTemperature, .peripheralBattery,
-        .network, .diskUsage, .diskActivity, .power, .fanSpeed,
+        .network, .diskUsage, .diskActivity, .diskCount, .connectedDevices, .power, .fanSpeed,
     ]
 
     static func order(in defaults: UserDefaults) -> [MenuBarMetric] {
@@ -93,7 +99,8 @@ enum MenuBarMetric: String, CaseIterable, Identifiable {
         case .gpu, .gpuTemperature: return .monitorGPU
         case .memory: return .monitorMemory
         case .network: return .monitorNetwork
-        case .diskUsage, .diskActivity: return .monitorDisk
+        case .diskUsage, .diskActivity, .diskCount: return .monitorDisk
+        case .connectedDevices: return .monitorUSB
         case .battery, .batteryTime, .batteryTemperature, .peripheralBattery, .power: return .monitorPower
         case .fanSpeed: return .fanControl
         }
@@ -414,6 +421,16 @@ enum MenuBarRenderer {
                                             segments: [.symbol(metric.symbolName), .text(" " + text)],
                                             width: reservedWidth(for: metric, preset: preset)))
                 }
+            case .diskCount:
+                let count = snapshot.disk?.externalDisksCount ?? 0
+                items.append(MetricItem(metric: metric,
+                                        segments: [.symbol(metric.symbolName), .text(" \(count)")],
+                                        width: reservedWidth(for: metric, preset: preset)))
+            case .connectedDevices:
+                let count = USBMonitorService.shared.menuBarDeviceCount
+                items.append(MetricItem(metric: metric,
+                                        segments: [.symbol(metric.symbolName), .text(" \(count)")],
+                                        width: reservedWidth(for: metric, preset: preset)))
             case .battery:
                 if let charge = snapshot.power?.chargePercent {
                     let symbol = (snapshot.power?.isCharging ?? false) ? "battery.100.bolt" : metric.symbolName
@@ -454,6 +471,16 @@ enum MenuBarRenderer {
                     items.append(MetricItem(metric: metric,
                                             segments: [.symbol(metric.symbolName), .text(" " + value + " RPM")],
                                             width: reservedWidth(for: metric, preset: preset)))
+                } else {
+                    let rpms = snapshot.fans.compactMap(\.rpm)
+                    if !rpms.isEmpty {
+                        let averageRPM = rpms.reduce(0.0, +) / Double(rpms.count)
+                        let rpmString = averageRPM == 0 ? L10n.shared.s.monitorOff : String(format: "%.0f RPM", locale: Locale.current, averageRPM)
+                        let text = "FAN \(rpmString)"
+                        items.append(MetricItem(metric: metric,
+                                                segments: [.symbol(metric.symbolName), .text(" " + text)],
+                                                width: reservedWidth(for: metric, preset: preset)))
+                    }
                 }
             }
         }
@@ -619,6 +646,20 @@ enum MenuBarRenderer {
                                                       write: MetricFormat.bytesPerSecCompact(activity.write),
                                                       style: style)])
                 }
+            case .diskCount:
+                let count = snapshot.disk?.externalDisksCount ?? 0
+                groups.append([.metricBlock(label: "EXT",
+                                            value: "\(count)",
+                                            minimumValue: "0",
+                                            style: style,
+                                            pressure: nil)])
+            case .connectedDevices:
+                let count = USBMonitorService.shared.menuBarDeviceCount
+                groups.append([.metricBlock(label: "USB",
+                                            value: "\(count)",
+                                            minimumValue: "0",
+                                            style: style,
+                                            pressure: nil)])
             case .battery, .batteryTemperature:
                 if combineTemperatures {
                     guard !renderedBattery else { break }
@@ -706,6 +747,22 @@ enum MenuBarRenderer {
                                                 minimumValue: minimumValue,
                                                 style: style,
                                                 pressure: nil)])
+                } else {
+                    let rpms = snapshot.fans.compactMap(\.rpm)
+                    if !rpms.isEmpty {
+                        let averageRPM = rpms.reduce(0.0, +) / Double(rpms.count)
+                        var fraction = 0.0
+                        if averageRPM > 0 {
+                            let percents = snapshot.fans.compactMap(\.percent)
+                            if !percents.isEmpty {
+                                fraction = Double(percents.reduce(0, +)) / Double(percents.count) / 100.0
+                            }
+                        }
+                        groups.append([.usageBarBlock(label: "FAN",
+                                                      fraction: fraction,
+                                                      style: style,
+                                                      pressure: nil)])
+                    }
                 }
             }
         }
@@ -780,6 +837,8 @@ enum MenuBarRenderer {
             return 11      // symbol + " DSK 100%"
         case (_, .diskActivity):
             return 15      // R1.0G + W1.0G
+        case (_, .diskCount), (_, .connectedDevices):
+            return 6       // symbol + " 99"
         case (_, .battery), (_, .power):
             return 11      // symbol + " BAT 100%" / " PWR 99W"
         case (_, .batteryTime):
@@ -1028,10 +1087,88 @@ enum MenuBarRenderer {
         return image
     }
 
+    private static func fanCircleBlockImage(label: String,
+                                            fraction: Double?,
+                                            style: MenuBarBlockStyle) -> NSImage {
+        let fractionKey = fraction.map { String(format: "%.3f", locale: Locale.current, $0) } ?? "none"
+        let cacheKey = "fanCircle|\(label)|\(fractionKey)|\(style)" as NSString
+        if let cached = blockImageCache.object(forKey: cacheKey) { return cached }
+
+        let labelFont = NSFont.systemFont(ofSize: style == .readable ? 7.2 : 6.6, weight: .medium)
+        let sizingLabelAttrs: [NSAttributedString.Key: Any] = [.font: labelFont]
+        let labelSize = (label as NSString).size(withAttributes: sizingLabelAttrs)
+        
+        let circleDiameter: CGFloat = style == .readable ? 11.5 : 10.5
+        let width = ceil(max(labelSize.width, circleDiameter) + (style == .readable ? 2 : 0.5))
+        let height: CGFloat = style == .readable ? 23 : 21
+
+        let image = NSImage(size: NSSize(width: width, height: height), flipped: false) { rect in
+            NSColor.clear.setFill()
+            rect.fill()
+
+            let labelAttrs = dynamicTextAttributes(font: labelFont)
+            let labelX = (width - labelSize.width) / 2
+            let labelY = style == .readable ? 12.9 : 12.0
+            (label as NSString).draw(at: NSPoint(x: labelX, y: labelY), withAttributes: labelAttrs)
+
+            let circleX = (width - circleDiameter) / 2
+            let circleY = style == .readable ? 1.0 : 0.8
+            let circleRect = NSRect(x: circleX,
+                                    y: circleY,
+                                    width: circleDiameter,
+                                    height: circleDiameter)
+            
+            // Draw background circle
+            let bgPath = NSBezierPath(ovalIn: circleRect)
+            NSColor.labelColor.withAlphaComponent(0.12).setStroke()
+            bgPath.lineWidth = 1.6
+            bgPath.stroke()
+
+            if let fraction, fraction > 0 {
+                // Draw circular progress arc starting from 12 o'clock (90 degrees) clockwise
+                let center = NSPoint(x: circleRect.midX, y: circleRect.midY)
+                let radius = circleRect.width / 2
+                let arcPath = NSBezierPath()
+                let endAngle = 90 - 360 * CGFloat(min(1.0, max(0.0, fraction)))
+                arcPath.appendArc(withCenter: center, radius: radius, startAngle: 90, endAngle: endAngle, clockwise: true)
+                
+                // Color dynamically based on speed fraction
+                let tint: NSColor
+                switch fraction {
+                case ..<0.6:
+                    tint = NSColor.controlAccentColor
+                case ..<0.85:
+                    tint = nsColor(for: .warning) // yellow
+                default:
+                    tint = nsColor(for: .critical) // red
+                }
+                tint.setStroke()
+                arcPath.lineWidth = 1.6
+                arcPath.lineCapStyle = .round
+                arcPath.stroke()
+            } else if fraction == nil {
+                // Stale/undefined state: draw a small dash
+                NSColor.secondaryLabelColor.setStroke()
+                let dash = NSBezierPath()
+                dash.move(to: NSPoint(x: circleRect.midX - 2, y: circleRect.midY))
+                dash.line(to: NSPoint(x: circleRect.midX + 2, y: circleRect.midY))
+                dash.lineWidth = 1.0
+                dash.stroke()
+            }
+            return true
+        }
+        image.isTemplate = false
+        blockImageCache.setObject(image, forKey: cacheKey, cost: blockImageCost(image))
+        return image
+    }
+
     private static func usageBarBlockImage(label: String,
                                            fraction: Double?,
                                            style: MenuBarBlockStyle,
                                            pressure: MemoryPressure?) -> NSImage {
+        if label == "FAN" {
+            return fanCircleBlockImage(label: label, fraction: fraction, style: style)
+        }
         let innerSteps = style == .readable ? 17 : 15
         let fillLevel = fraction.map { MenuBarUsageBarSupport.fillLevel(for: $0, steps: innerSteps) }
         let fillColorHex = fraction.map {

--- a/Sources/Vorssaint/App/StatusItemController.swift
+++ b/Sources/Vorssaint/App/StatusItemController.swift
@@ -174,6 +174,31 @@ final class StatusItemController {
             }
             .store(in: &cancellables)
 
+        USBMonitorService.shared.$devices
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard MenuBarMetric.anyEnabled(in: .standard) else { return }
+                self?.refresh()
+            }
+            .store(in: &cancellables)
+
+        USBMonitorService.shared.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard MenuBarMetric.anyEnabled(in: .standard) else { return }
+                self?.refresh()
+            }
+            .store(in: &cancellables)
+
+        NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didMountNotification)
+            .merge(with: NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didUnmountNotification))
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard MenuBarMetric.anyEnabled(in: .standard) else { return }
+                self?.refresh()
+            }
+            .store(in: &cancellables)
+
         defaultsObserver = NotificationCenter.default.addObserver(forName: UserDefaults.didChangeNotification,
                                                                   object: nil,
                                                                   queue: .main) { [weak self] _ in
@@ -586,7 +611,7 @@ final class StatusItemController {
                                      primary: .battery,
                                      temperature: .batteryTemperature,
                                      primaryTitle: strings.batteryLabel)
-            case .memory, .network, .diskUsage, .diskActivity, .batteryTime, .peripheralBattery, .power,
+            case .memory, .network, .diskUsage, .diskActivity, .diskCount, .connectedDevices, .batteryTime, .peripheralBattery, .power,
                  .fanSpeed:
                 let id = metric.rawValue
                 guard emittedIDs.insert(id).inserted else { continue }

--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -316,6 +316,8 @@ enum DefaultsKey {
     static let menuBarPeripheralBattery = "menuBarPeripheralBattery"
     static let menuBarPower = "menuBarPower"
     static let menuBarFanSpeed = "menuBarFanSpeed"
+    static let menuBarConnectedDevices = "menuBarConnectedDevices"
+    static let menuBarDiskCount = "menuBarDiskCount"
     static let menuBarPreset = "menuBarPreset"           // dense
     static let menuBarMetricSpacing = "menuBarMetricSpacing" // standard | compact
     static let menuBarMetricAppearance = "menuBarMetricAppearance" // values | bars
@@ -338,6 +340,14 @@ enum DefaultsKey {
     static let monitorShowSystem = "monitorShowSystem"
     static let monitorShowNetwork = "monitorShowNetwork"
     static let monitorShowDisk = "monitorShowDisk"
+    static let monitorShowUSB = "monitorShowUSB"
+    static let usbShowTechnicalDetails = "usbShowTechnicalDetails"
+    static let usbShowEthernet = "usbShowEthernet"
+    static let usbShowPowerCable = "usbShowPowerCable"
+    static let usbExcludeChargersFromCount = "usbExcludeChargersFromCount"
+    static let usbExcludeHubsFromCount = "usbExcludeHubsFromCount"
+    static let usbExcludeEthernetFromCount = "usbExcludeEthernetFromCount"
+    static let usbExcludeStorageFromCount = "usbExcludeStorageFromCount"
     static let monitorShowPower = "monitorShowPower"
     static let monitorShowMixer = "monitorShowMixer"
     static let panelShowFanControl = "panelShowFanControl"
@@ -366,6 +376,9 @@ enum DefaultsKey {
     static let monitorSysMemory = "monitorSysMemory"
     static let monitorSysAlerts = "monitorSysAlerts"
     static let monitorSysUptime = "monitorSysUptime"
+    static let monitorSysFanSpeeds = "monitorSysFanSpeeds"
+    static let monitorSysDetailedTemps = "monitorSysDetailedTemps"
+    static let monitorSysDetailedTempsExpanded = "monitorSysDetailedTempsExpanded"
     static let monitorNetSpeed = "monitorNetSpeed"
     static let monitorNetApps = "monitorNetApps"
     static let monitorNetTotals = "monitorNetTotals"
@@ -851,7 +864,7 @@ enum Defaults {
         "gpu", "gpuTemperature",
         "memory",
         "battery", "batteryTime", "batteryTemperature", "peripheralBattery",
-        "network", "diskUsage", "diskActivity", "power", "fanSpeed",
+        "network", "diskUsage", "diskActivity", "diskCount", "connectedDevices", "power", "fanSpeed",
     ]
     static let allowedMenuBarLabelStyles = ["compact", "classic"]
     static let allowedMenuBarMemoryStyles = ["dot", "percent", "both"]
@@ -1123,11 +1136,14 @@ enum Defaults {
         DefaultsKey.menuBarCPUTemperature: false,
         DefaultsKey.menuBarGPUTemperature: false,
         DefaultsKey.menuBarBatteryTemperature: false,
+        DefaultsKey.menuBarFanSpeed: false,
+        DefaultsKey.menuBarConnectedDevices: false,
+        DefaultsKey.menuBarDiskCount: false,
+        DefaultsKey.monitorSysDetailedTempsExpanded: false,
         DefaultsKey.menuBarBatteryTime: false,
         DefaultsKey.menuBarDiskUsage: false,
         DefaultsKey.menuBarDiskActivity: false,
         DefaultsKey.menuBarPeripheralBattery: false,
-        DefaultsKey.menuBarFanSpeed: false,
         DefaultsKey.menuBarPreset: "dense",
         DefaultsKey.menuBarMetricSpacing: "compact",  // owner's call: compact by default in 3.1.8
         DefaultsKey.menuBarMetricAppearance: "values",
@@ -1150,6 +1166,14 @@ enum Defaults {
         DefaultsKey.monitorShowSystem: true,
         DefaultsKey.monitorShowNetwork: true,
         DefaultsKey.monitorShowDisk: true,
+        DefaultsKey.monitorShowUSB: true,
+        DefaultsKey.usbShowTechnicalDetails: false,
+        DefaultsKey.usbShowEthernet: false,
+        DefaultsKey.usbShowPowerCable: false,
+        DefaultsKey.usbExcludeChargersFromCount: false,
+        DefaultsKey.usbExcludeHubsFromCount: false,
+        DefaultsKey.usbExcludeEthernetFromCount: false,
+        DefaultsKey.usbExcludeStorageFromCount: false,
         DefaultsKey.monitorShowPower: true,
         DefaultsKey.monitorShowMixer: true,
         DefaultsKey.panelShowFanControl: true,
@@ -1174,6 +1198,8 @@ enum Defaults {
         DefaultsKey.monitorSysMemory: true,
         DefaultsKey.monitorSysAlerts: true,
         DefaultsKey.monitorSysUptime: true,
+        DefaultsKey.monitorSysFanSpeeds: true,
+        DefaultsKey.monitorSysDetailedTemps: false,
         DefaultsKey.monitorNetSpeed: true,
         DefaultsKey.monitorNetApps: true,
         DefaultsKey.monitorNetTotals: true,

--- a/Sources/Vorssaint/Core/FeatureCatalog.swift
+++ b/Sources/Vorssaint/Core/FeatureCatalog.swift
@@ -31,7 +31,7 @@ enum AppFeature: String, CaseIterable {
          commandBar, screenRecorder, killProcess
     // System monitor, one entry per metric family (temperatures live with
     // their parent metric: CPU temp with CPU, battery temp with power).
-    case monitorCPU, monitorGPU, monitorMemory, monitorNetwork, monitorDisk, monitorPower, fanControl
+    case monitorCPU, monitorGPU, monitorMemory, monitorNetwork, monitorDisk, monitorUSB, monitorPower, fanControl
 }
 
 /// Hub sections, in display order.
@@ -111,7 +111,7 @@ extension AppFeature {
              .cleaner, .uninstaller, .homebrew, .appUpdates, .screenshot, .cameraPreview, .radialMenu,
              .scratchpad, .commandBar, .screenRecorder, .killProcess:
             return .tools
-        case .monitorCPU, .monitorGPU, .monitorMemory, .monitorNetwork, .monitorDisk, .monitorPower,
+        case .monitorCPU, .monitorGPU, .monitorMemory, .monitorNetwork, .monitorDisk, .monitorUSB, .monitorPower,
              .fanControl:
             return .monitor
         }
@@ -177,6 +177,7 @@ extension AppFeature {
         case .monitorMemory: return "memorychip"
         case .monitorNetwork: return "network"
         case .monitorDisk: return "internaldrive"
+        case .monitorUSB: return "cable.connector"
         case .monitorPower: return "bolt.fill"
         case .fanControl: return "fanblades.fill"
         }
@@ -237,7 +238,7 @@ extension AppFeature {
              .quickLauncher, .quickToggles, .colorPicker, .screenOCR, .cleaningMode, .mediaTools,
              .cleaner, .uninstaller, .homebrew, .appUpdates, .screenshot, .cameraPreview, .scratchpad,
              .commandBar, .screenRecorder, .killProcess,
-             .monitorCPU, .monitorGPU, .monitorMemory, .monitorNetwork, .monitorDisk, .monitorPower,
+             .monitorCPU, .monitorGPU, .monitorMemory, .monitorNetwork, .monitorDisk, .monitorUSB, .monitorPower,
              .fanControl:
             return []
         }
@@ -285,7 +286,7 @@ extension AppFeature {
         case .clipboardHistory, .shelf, .urlCleaner,
              .soundOutputSwitcher, .musicBlock,
              .extraBrightness, .bluetoothSleep, .quickLauncher, .colorPicker, .micMute, .mediaTools,
-             .scratchpad, .monitorGPU, .monitorNetwork, .fanControl, .killProcess:
+             .scratchpad, .monitorGPU, .monitorNetwork, .monitorUSB, .fanControl, .killProcess:
             return []
         }
     }

--- a/Sources/Vorssaint/Core/FeaturePresets.swift
+++ b/Sources/Vorssaint/Core/FeaturePresets.swift
@@ -114,7 +114,7 @@ extension AppFeature {
                 ? .idle : .mouse
         case .clipboardHistory, .urlCleaner, .extraBrightness,
              .monitorCPU, .monitorGPU, .monitorMemory,
-             .monitorNetwork, .monitorDisk, .monitorPower:
+             .monitorNetwork, .monitorDisk, .monitorUSB, .monitorPower:
             return .periodic
         case .mixer:
             return UserDefaults.standard.bool(forKey: DefaultsKey.preciseVolumeRollerEnabled)

--- a/Sources/Vorssaint/Core/Localization.swift
+++ b/Sources/Vorssaint/Core/Localization.swift
@@ -1113,6 +1113,39 @@ struct Strings {
     let switcherCurrentSpaceOnly: String
     let switcherCurrentSpaceOnlyCaption: String
     let shelfFileMissing: String
+    var usbSection: String = "USB Devices"
+    var usbConnectedDevices: String = "Connected USB Devices"
+    var usbNoDevices: String = "No USB devices connected"
+    var usbEject: String = "Eject USB Device"
+    var usbShowTechDetails: String = "Show Technical Details (VID:PID, Serial, BCD)"
+    var usbShowEthernet: String = "Show Ethernet / LAN Adapter"
+    var usbShowPowerCable: String = "Show Charger / Power Supply"
+    var monitorShowConnectedDevices: String = "Connected Devices"
+    var monitorShowDiskCount: String = "External Disks"
+    var usbExcludeChargers: String = "Exclude Power Supplies / Chargers"
+    var usbExcludeHubs: String = "Exclude USB Hubs & Docks"
+    var usbExcludeEthernet: String = "Exclude Network & Ethernet Adapters"
+    var usbExcludeStorage: String = "Exclude External Storage"
+
+    var monitorSysFanSpeeds: String = "Fan speeds"
+    var monitorSysDetailedTemps: String = "Detailed temperatures"
+    var monitorOff: String = "Off"
+    var monitorRPM: String = "RPM"
+    var monitorFansTitle: String = "Fans"
+
+    var tempCPUPerformanceCores: String = "CPU Performance Cores"
+    var tempCPUEfficiencyCores: String = "CPU Efficiency Cores"
+    var tempGraphics: String = "Graphics"
+    var tempSSD: String = "SSD"
+    var tempPalmRest: String = "Palm Rest"
+    var tempAirflow: String = "Airflow"
+    var tempAirPort: String = "AirPort"
+
+    var fanFallbackName: String = "Fan"
+    var fanLeftFallbackName: String = "Left Fan"
+    var fanRightFallbackName: String = "Right Fan"
+    var fanNumberedFallbackNamePattern: String = "Fan %d"
+
     let previewSizeSmall: String
     let mixerSoundEffectsOutputTitle: String
     let mixerSoundEffectsOutputTooltip: String
@@ -2124,6 +2157,22 @@ extension Strings {
         switcherCurrentSpaceOnly: "Mostrar só a Mesa atual",
         switcherCurrentSpaceOnlyCaption: "Mostra no alternador apenas as janelas da Mesa em que você está. Escolher uma janela nunca leva você para outra Mesa.",
         shelfFileMissing: "O arquivo não existe mais",
+        monitorSysFanSpeeds: "Velocidade das ventoinhas",
+        monitorSysDetailedTemps: "Temperaturas detalhadas",
+        monitorOff: "Desligado",
+        monitorRPM: "RPM",
+        monitorFansTitle: "Ventoinhas",
+        tempCPUPerformanceCores: "Núcleos de Performance do CPU",
+        tempCPUEfficiencyCores: "Núcleos de Eficiência do CPU",
+        tempGraphics: "Gráficos",
+        tempSSD: "SSD",
+        tempPalmRest: "Apoio de mãos",
+        tempAirflow: "Fluxo de ar",
+        tempAirPort: "AirPort",
+        fanFallbackName: "Ventoinha",
+        fanLeftFallbackName: "Ventoinha Esquerda",
+        fanRightFallbackName: "Ventoinha Direita",
+        fanNumberedFallbackNamePattern: "Ventoinha %d",
         previewSizeSmall: "Pequeno",
         mixerSoundEffectsOutputTitle: "Sons do sistema",
         mixerSoundEffectsOutputTooltip: "Escolher onde alertas e efeitos sonoros tocam",
@@ -3136,6 +3185,22 @@ extension Strings {
         switcherCurrentSpaceOnly: "Show only the current desktop",
         switcherCurrentSpaceOnlyCaption: "Lists only windows from the desktop you are on. Picking a window never moves you to another desktop.",
         shelfFileMissing: "The file no longer exists",
+        monitorSysFanSpeeds: "Fan speeds",
+        monitorSysDetailedTemps: "Detailed temperatures",
+        monitorOff: "Off",
+        monitorRPM: "RPM",
+        monitorFansTitle: "Fans",
+        tempCPUPerformanceCores: "CPU Performance Cores",
+        tempCPUEfficiencyCores: "CPU Efficiency Cores",
+        tempGraphics: "Graphics",
+        tempSSD: "SSD",
+        tempPalmRest: "Palm Rest",
+        tempAirflow: "Airflow",
+        tempAirPort: "AirPort",
+        fanFallbackName: "Fan",
+        fanLeftFallbackName: "Left Fan",
+        fanRightFallbackName: "Right Fan",
+        fanNumberedFallbackNamePattern: "Fan %d",
         previewSizeSmall: "Small",
         mixerSoundEffectsOutputTitle: "System sounds",
         mixerSoundEffectsOutputTooltip: "Choose where alerts and sound effects play",

--- a/Sources/Vorssaint/Services/Metrics/DiskSampler.swift
+++ b/Sources/Vorssaint/Services/Metrics/DiskSampler.swift
@@ -37,6 +37,10 @@ final class DiskSampler {
     /// minutes long and still fall outside.
     private static let maxGap: TimeInterval = 15
 
+    func invalidateCache() {
+        metadataCache.removeAll()
+    }
+
     func sample(now: TimeInterval, refreshMetadata: Bool = true) -> DiskReading {
         let counters = Self.readCounters()
         let devices = Self.mountedVolumes().map { volume -> DiskDeviceReading in

--- a/Sources/Vorssaint/Services/Metrics/DiskSupport.swift
+++ b/Sources/Vorssaint/Services/Metrics/DiskSupport.swift
@@ -72,6 +72,15 @@ struct DiskReading: Equatable {
             return seen.insert(key).inserted
         }
     }
+
+    var externalDisksCount: Int {
+        let external = devices.filter { !$0.isInternal }
+        var seen = Set<String>()
+        return external.filter { dev in
+            let key = dev.wholeDisk ?? dev.bsdName ?? dev.id
+            return seen.insert(key).inserted
+        }.count
+    }
 }
 
 enum DiskSupport {

--- a/Sources/Vorssaint/Services/Metrics/MonitorSamplingPolicy.swift
+++ b/Sources/Vorssaint/Services/Metrics/MonitorSamplingPolicy.swift
@@ -13,6 +13,7 @@ enum MonitorSamplingKind: String {
     case gpuUsage
     case temperature
     case fanSpeed
+    static var fanSpeeds: MonitorSamplingKind { .fanSpeed }
 }
 
 enum MonitorSamplingPolicy {

--- a/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
+++ b/Sources/Vorssaint/Services/Metrics/TemperatureSensorSelector.swift
@@ -4,6 +4,43 @@
 import Darwin
 import Foundation
 
+public enum TemperatureLabelType: String, CaseIterable, Codable, Equatable {
+    case cpuPerformanceCores
+    case cpuEfficiencyCores
+    case cpu
+    case graphics
+    case battery
+    case ssd
+    case palmRest
+    case airflow
+    case airport
+}
+
+public struct TemperatureReading: Identifiable, Equatable {
+    public var id: String { key }
+    public let key: String
+    public let labelType: TemperatureLabelType
+    public var valueCelsius: Double
+    public var group: TemperatureGroup
+
+    public init(key: String, labelType: TemperatureLabelType, valueCelsius: Double, group: TemperatureGroup) {
+        self.key = key
+        self.labelType = labelType
+        self.valueCelsius = valueCelsius
+        self.group = group
+    }
+}
+
+public enum TemperatureGroup: String, Equatable {
+    case cpu
+    case gpu
+    case battery
+    case storage
+    case enclosure
+    case wireless
+    case other
+}
+
 enum CPUTemperaturePlatform: Equatable {
     case appleM1Family
     case appleM2Family
@@ -163,5 +200,58 @@ enum TemperatureSensorSelector {
 
     private static func isPlausibleTemperature(_ value: Double) -> Bool {
         value >= minimumChipTemperature && value < 125
+    }
+}
+
+enum TemperatureSensorClassifier {
+    static func classify(key: String, value: Double, platform: CPUTemperaturePlatform) -> TemperatureReading? {
+        guard value > 1 && value < 125 else { return nil }
+
+        let group: TemperatureGroup
+        let labelType: TemperatureLabelType
+
+        if TemperatureSensorSelector.isCPUCoreKey(key, platform: platform) {
+            group = .cpu
+            let isEfficiency: Bool
+            if key.hasPrefix("Te") {
+                isEfficiency = true
+            } else if platform == .appleM1Family && (key == "Tp09" || key == "Tp0T") {
+                isEfficiency = true
+            } else if platform == .appleM2Family && (key == "Tp1h" || key == "Tp1t" || key == "Tp1p" || key == "Tp1l") {
+                isEfficiency = true
+            } else {
+                isEfficiency = false
+            }
+            labelType = isEfficiency ? .cpuEfficiencyCores : .cpuPerformanceCores
+        } else if key.hasPrefix("Tp") || key.hasPrefix("Te") || key.hasPrefix("Tf") {
+            group = .cpu
+            labelType = .cpu
+        } else if key.hasPrefix("Tg") {
+            group = .gpu
+            labelType = .graphics
+        } else if key.hasPrefix("TB") || key.hasPrefix("Tb") {
+            group = .battery
+            labelType = .battery
+        } else if key.hasPrefix("Ts") {
+            group = .storage
+            labelType = .ssd
+        } else if key.hasPrefix("Th") {
+            group = .enclosure
+            if key.lowercased() == "th0f" {
+                labelType = .palmRest
+            } else {
+                labelType = .airflow
+            }
+        } else if key.hasPrefix("TW") || key.hasPrefix("Tw") {
+            group = .wireless
+            labelType = .airport
+        } else if key.hasPrefix("Ta") {
+            group = .enclosure
+            labelType = .airflow
+        } else {
+            return nil
+        }
+
+        return TemperatureReading(key: key, labelType: labelType, valueCelsius: value, group: group)
     }
 }

--- a/Sources/Vorssaint/Services/SystemMonitor/SMCClient.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/SMCClient.swift
@@ -112,6 +112,30 @@ final class SMCClient {
         guard output.result == 0 else { throw WriteError.controller(output.result) }
     }
 
+    /// Reads a string value from SMC, e.g. for fan labels (F0ID).
+    func readStringValue(_ key: Key) -> String? {
+        var input = SMCParamStruct()
+        input.key = key.code
+        input.keyInfo.dataSize = key.dataSize
+        input.data8 = Self.cmdReadKey
+        guard let out = call(&input), out.result == 0 else { return nil }
+
+        let bytes = withUnsafeBytes(of: out.bytes) { Array($0.prefix(Int(key.dataSize))) }
+        guard bytes.count > 2 else {
+            let printable = bytes.filter { $0 >= 32 && $0 <= 126 }
+            return String(bytes: printable, encoding: .ascii)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let stringBytes = bytes[2...]
+        let printable = stringBytes.prefix(while: { $0 >= 32 && $0 <= 126 })
+        if let decoded = String(bytes: printable, encoding: .ascii) {
+            let trimmed = decoded.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return nil
+    }
+
     /// Looks up a single key by its 4-character code, returning its size and type
     /// so `readValue` can decode it. Cheaper than enumerating every key — used to
     /// resolve the power sensors directly.

--- a/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
+++ b/Sources/Vorssaint/Services/SystemMonitor/SystemMonitor.swift
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2026 Vorssaint
 
+import AppKit
 import Combine
 import Darwin
 import Foundation
@@ -21,6 +22,22 @@ enum MemoryPressure {
         }
     }
 }
+
+struct FanReading: Identifiable, Equatable {
+    let id: Int
+    var name: String
+    var rpm: Double?
+    var minRPM: Double?
+    var maxRPM: Double?
+
+    var percent: Int? {
+        guard let rpm, let minRPM, let maxRPM, maxRPM > minRPM else { return nil }
+        let value = (rpm - minRPM) / (maxRPM - minRPM) * 100.0
+        return min(max(Int(value.rounded()), 0), 100)
+    }
+}
+
+
 
 /// One refresh tick of the system monitor. Optionals stay nil when a reading
 /// is unavailable on the current hardware, and the UI hides those rows.
@@ -49,6 +66,9 @@ struct SystemSnapshot {
     var memoryCached: UInt64?
     var memorySwapUsed: UInt64?
     var memoryPressure: MemoryPressure = .unknown
+    var fans: [FanReading] = []
+    var detailedTemperatures: [TemperatureReading] = []
+    var hasFans: Bool = false
     var fanSpeeds: [Double] = []
 
     // Network
@@ -122,12 +142,18 @@ final class SystemMonitor: ObservableObject {
     private var refreshInFlight = false
     private var pendingRefresh = false
     private var pendingRefreshSuppressesGPU = false
+    private var pendingForceSampleKinds: Set<MonitorSamplingKind> = []
     private var suppressGPUReadsUntil: TimeInterval = 0
 
     // SMC sensors
     private var smc: SMCClient?
     private var smcTried = false
     private var cpuKeys: [SMCClient.Key] = []
+    private var allDiscoveredTempKeys: [SMCClient.Key] = []
+    private var fanKeysPrepared = false
+    private var fanKeys: [Int: (ac: SMCClient.Key, mn: SMCClient.Key?, mx: SMCClient.Key?, idKey: SMCClient.Key?)] = [:]
+    private var fanCount = 0
+    private var hasFans = false
     /// The platform's known CPU core sensors (what the displayed value is
     /// actually computed from) and everything else, split once at discovery:
     /// each SMC read is a kernel call, so the per-tick read sticks to the
@@ -136,9 +162,7 @@ final class SystemMonitor: ObservableObject {
     private var fallbackCPUKeys: [SMCClient.Key] = []
     private var gpuKeys: [SMCClient.Key] = []
     private var batteryKeys: [SMCClient.Key] = []
-    private var fanKeys: [SMCClient.Key] = []
     private var tempKeysPrepared = false
-    private var fanKeysPrepared = false
     private var cpuTemperaturePlatform: CPUTemperaturePlatform = .generic
 
     // Samplers
@@ -166,6 +190,12 @@ final class SystemMonitor: ObservableObject {
     private var cpuTemperatureCache: CachedSensorReading?
     private var gpuTemperatureCache: CachedSensorReading?
     private var batteryTemperatureCache: CachedSensorReading?
+    private var fanReadingsCache: [FanReading]?
+    private var lastFanReadingsTime: TimeInterval = 0
+    private var missedFanSamples = 0
+    private var detailedTempsCache: [TemperatureReading]?
+    private var lastDetailedTempsTime: TimeInterval = 0
+    private var missedDetailedTempsSamples = 0
     private var lastFanSpeeds: [Double] = []
     private var missedFanSpeedSamples = 0
     private var lastDiskReading: DiskReading?
@@ -202,15 +232,44 @@ final class SystemMonitor: ObservableObject {
         if PowerSampler.hasInternalBattery {
             installPowerSourceObserver()
         }
+        installDiskObservers()
     }
 
     deinit {
         if let powerSourceRunLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), powerSourceRunLoopSource, .defaultMode)
         }
+        for obs in diskObservers {
+            NSWorkspace.shared.notificationCenter.removeObserver(obs)
+        }
+        diskObservers.removeAll()
     }
 
     // MARK: - Lifecycle
+
+    private var diskObservers: [NSObjectProtocol] = []
+
+    private func installDiskObservers() {
+        let center = NSWorkspace.shared.notificationCenter
+        let mountObs = center.addObserver(forName: NSWorkspace.didMountNotification, object: nil, queue: .main) { [weak self] _ in
+            self?.handleDiskStorageChanged()
+        }
+        let unmountObs = center.addObserver(forName: NSWorkspace.didUnmountNotification, object: nil, queue: .main) { [weak self] _ in
+            self?.handleDiskStorageChanged()
+        }
+        diskObservers = [mountObs, unmountObs]
+    }
+
+    private func handleDiskStorageChanged() {
+        runOnMain { [weak self] in
+            guard let self else { return }
+            guard self.shouldRun else { return }
+            let plan = self.currentPlan(defaults: .standard)
+            guard plan.needDisk else { return }
+            self.diskSampler.invalidateCache()
+            self.refresh(forceSampleKinds: [.disk])
+        }
+    }
 
     /// The same system notification used by the reference battery monitor.
     /// It removes the normal background sampling delay after unplugging,
@@ -409,17 +468,19 @@ final class SystemMonitor: ObservableObject {
         var needCPUTemperature = false
         var needGPUTemperature = false
         var needBatteryTemperature = false
-        var needFanSpeed = false
+        var needFanSpeeds = false
+        var needFanSpeed: Bool { get { needFanSpeeds } set { needFanSpeeds = newValue } }
+        var needDetailedTemperatures = false
 
-        var needSMC: Bool { needPower || needTemperature || needFanSpeed }
+        var needSMC: Bool { needPower || needTemperature || needFanSpeeds }
 
         var needTemperature: Bool {
-            needCPUTemperature || needGPUTemperature || needBatteryTemperature
+            needCPUTemperature || needGPUTemperature || needBatteryTemperature || needDetailedTemperatures
         }
 
         var any: Bool {
             needCPU || needMemory || needNetwork || needDisk || needPower ||
-                needPeripheralBattery || needGPUUsage || needTemperature || needFanSpeed
+                needPeripheralBattery || needGPUUsage || needTemperature || needFanSpeeds
         }
     }
 
@@ -449,6 +510,8 @@ final class SystemMonitor: ObservableObject {
         let panelBattery = hasInternalBattery
             && ((panelNeedsPower && defaults.bool(forKey: DefaultsKey.monitorSysBattery)) || menuPanelNeeds.battery)
         let panelTemps = panelNeedsSystem && defaults.bool(forKey: DefaultsKey.monitorSysTemps)
+        let panelFans = panelNeedsSystem && defaults.bool(forKey: DefaultsKey.monitorSysFanSpeeds)
+        let panelDetailedTemps = panelNeedsSystem && defaults.bool(forKey: DefaultsKey.monitorSysTemps) && defaults.bool(forKey: DefaultsKey.monitorSysDetailedTemps)
         let alertCPU = defaults.bool(forKey: DefaultsKey.monitorAlertCPU)
         let alertCPUTemperature = defaults.bool(forKey: DefaultsKey.monitorAlertCPUTemperature)
         let alertBatteryTemperature = hasInternalBattery
@@ -463,6 +526,7 @@ final class SystemMonitor: ObservableObject {
         plan.needDisk = panelNeedsDisk
             || defaults.bool(forKey: DefaultsKey.menuBarDiskUsage)
             || defaults.bool(forKey: DefaultsKey.menuBarDiskActivity)
+            || defaults.bool(forKey: DefaultsKey.menuBarDiskCount)
             || alertDisk
         plan.needPower = panelNeedsPower || panelBattery
             || defaults.bool(forKey: DefaultsKey.menuBarPower)
@@ -478,11 +542,14 @@ final class SystemMonitor: ObservableObject {
             defaults.bool(forKey: DefaultsKey.menuBarGPUTemperature)
         plan.needBatteryTemperature = hasInternalBattery && (
             (panelNeedsPower && defaults.bool(forKey: DefaultsKey.monitorPwrTemperature))
+                || panelTemps
                 || menuPanelNeeds.batteryTemperature
                 || defaults.bool(forKey: DefaultsKey.menuBarBatteryTemperature) || alertBatteryTemperature)
+        plan.needFanSpeeds = panelFans || defaults.bool(forKey: DefaultsKey.menuBarFanSpeed)
+        plan.needDetailedTemperatures = panelDetailedTemps
         if defaults.bool(forKey: AppFeature.fanControl.availabilityKey),
            Self.fanTelemetryAvailable {
-            plan.needFanSpeed = fullMonitorVisible || menuPanelNeeds.fanSpeed
+            plan.needFanSpeeds = plan.needFanSpeeds || fullMonitorVisible || menuPanelNeeds.fanSpeed
                 || defaults.bool(forKey: DefaultsKey.menuBarFanSpeed)
         }
 
@@ -552,7 +619,7 @@ final class SystemMonitor: ObservableObject {
         if plan.needPeripheralBattery { kinds.append(.peripheralBattery) }
         if plan.needGPUUsage { kinds.append(.gpuUsage) }
         if plan.needTemperature { kinds.append(.temperature) }
-        if plan.needFanSpeed { kinds.append(.fanSpeed) }
+        if plan.needFanSpeeds { kinds.append(.fanSpeed) }
         return kinds
     }
 
@@ -574,9 +641,9 @@ final class SystemMonitor: ObservableObject {
 
     // MARK: - Refresh
 
-    private func refresh(suppressImmediateGPU: Bool = false) {
+    private func refresh(suppressImmediateGPU: Bool = false, forceSampleKinds: Set<MonitorSamplingKind> = []) {
         if !Thread.isMainThread {
-            DispatchQueue.main.async { [weak self] in self?.refresh(suppressImmediateGPU: suppressImmediateGPU) }
+            DispatchQueue.main.async { [weak self] in self?.refresh(suppressImmediateGPU: suppressImmediateGPU, forceSampleKinds: forceSampleKinds) }
             return
         }
         let defaults = UserDefaults.standard
@@ -588,10 +655,13 @@ final class SystemMonitor: ObservableObject {
         if refreshInFlight {
             pendingRefresh = true
             pendingRefreshSuppressesGPU = pendingRefreshSuppressesGPU || suppressImmediateGPU
+            pendingForceSampleKinds.formUnion(forceSampleKinds)
             return
         }
         syncTimerCadence(plan: plan)
         refreshInFlight = true
+        let currentForceKinds = forceSampleKinds.union(pendingForceSampleKinds)
+        pendingForceSampleKinds.removeAll()
         let suppressGPUReadsUntil = self.suppressGPUReadsUntil
         let foregroundSampling = fullMonitorVisible || menuPanelNeeds.any
         let intervalSeconds = self.intervalSeconds
@@ -600,11 +670,12 @@ final class SystemMonitor: ObservableObject {
         // through the captured value.
         let tick = tickCount
         tickCount &+= scheduledWakeTicks
+        let strings = L10n.shared.s
         queue.async { [weak self] in
             guard let self else { return }
             self.prepareIfNeeded(needSMC: plan.needSMC,
                                  needTemperature: plan.needTemperature,
-                                 needFanSpeed: plan.needFanSpeed)
+                                 needFanSpeed: plan.needFanSpeeds)
             let now = ProcessInfo.processInfo.systemUptime
 
             var next = SystemSnapshot()
@@ -615,6 +686,10 @@ final class SystemMonitor: ObservableObject {
             // is skipped below to save that work.
             var sampledAnything = false
             func take(_ kind: MonitorSamplingKind) -> Bool {
+                if currentForceKinds.contains(kind) {
+                    sampledAnything = true
+                    return true
+                }
                 let sample = MonitorSamplingPolicy.shouldSample(kind,
                                                                 tick: tick,
                                                                 intervalSeconds: intervalSeconds,
@@ -671,7 +746,8 @@ final class SystemMonitor: ObservableObject {
 
             if plan.needDisk {
                 if take(.disk) {
-                    let disk = self.diskSampler.sample(now: now, refreshMetadata: foregroundSampling)
+                    let refreshMeta = foregroundSampling || currentForceKinds.contains(.disk)
+                    let disk = self.diskSampler.sample(now: now, refreshMetadata: refreshMeta)
                     self.lastDiskReading = disk
                     next.disk = disk
                     let ioDevices = disk.uniqueIODevices
@@ -788,6 +864,67 @@ final class SystemMonitor: ObservableObject {
                 next.fanSpeeds = self.lastFanSpeeds
             }
 
+            if plan.needFanSpeeds {
+                if take(.fanSpeed) {
+                    let rawFans = self.readFans(strings: strings)
+                    if !rawFans.isEmpty {
+                        self.fanReadingsCache = rawFans
+                        self.lastFanReadingsTime = now
+                        self.missedFanSamples = 0
+                    } else if self.missedFanSamples < 4 && now - self.lastFanReadingsTime <= temperatureBridge {
+                        self.missedFanSamples += 1
+                    } else {
+                        self.fanReadingsCache = nil
+                    }
+                }
+                next.fans = self.fanReadingsCache ?? []
+            }
+
+            if plan.needDetailedTemperatures {
+                if take(.temperature) {
+                    var dict: [TemperatureLabelType: TemperatureReading] = [:]
+                    for key in self.allDiscoveredTempKeys {
+                        guard let v = self.smc?.readValue(key) else { continue }
+                        if let reading = TemperatureSensorClassifier.classify(key: key.name, value: v, platform: self.cpuTemperaturePlatform) {
+                            if let existing = dict[reading.labelType] {
+                                if reading.valueCelsius > existing.valueCelsius {
+                                    dict[reading.labelType] = reading
+                                }
+                            } else {
+                                dict[reading.labelType] = reading
+                            }
+                        }
+                    }
+                    let order: [TemperatureLabelType] = [
+                        .cpuPerformanceCores,
+                        .cpuEfficiencyCores,
+                        .cpu,
+                        .graphics,
+                        .battery,
+                        .ssd,
+                        .palmRest,
+                        .airflow,
+                        .airport
+                    ]
+                    let sorted = dict.values.sorted { lhs, rhs in
+                        let idxL = order.firstIndex(of: lhs.labelType) ?? order.count
+                        let idxR = order.firstIndex(of: rhs.labelType) ?? order.count
+                        if idxL != idxR {
+                            return idxL < idxR
+                        }
+                        return lhs.labelType.rawValue < rhs.labelType.rawValue
+                    }
+                    self.detailedTempsCache = sorted
+                    self.lastDetailedTempsTime = now
+                    self.missedDetailedTempsSamples = 0
+                } else if self.missedDetailedTempsSamples < 4 && now - self.lastDetailedTempsTime <= temperatureBridge {
+                    self.missedDetailedTempsSamples += 1
+                } else {
+                    self.detailedTempsCache = nil
+                }
+                next.detailedTemperatures = self.detailedTempsCache ?? []
+            }
+
             next.cpuHistory = plan.needCPU
                 ? self.cpuHistory.publishedValues(whileVisible: foregroundSampling) : []
             next.gpuHistory = plan.needGPUUsage
@@ -808,6 +945,7 @@ final class SystemMonitor: ObservableObject {
                 ? self.powerHistory.publishedValues(whileVisible: foregroundSampling) : []
             next.batteryHistory = plan.needPower
                 ? self.batteryHistory.publishedValues(whileVisible: foregroundSampling) : []
+            next.hasFans = self.hasFans
 
             DispatchQueue.main.async {
                 // Skip pure carry-over publishes (nothing sampled, same plan,
@@ -825,7 +963,9 @@ final class SystemMonitor: ObservableObject {
                 self.pendingRefresh = false
                 self.pendingRefreshSuppressesGPU = false
                 if shouldRunPendingRefresh, self.shouldRun {
-                    self.refresh(suppressImmediateGPU: suppressGPU)
+                    let pendingKinds = self.pendingForceSampleKinds
+                    self.pendingForceSampleKinds.removeAll()
+                    self.refresh(suppressImmediateGPU: suppressGPU, forceSampleKinds: pendingKinds)
                 }
             }
         }
@@ -885,41 +1025,95 @@ final class SystemMonitor: ObservableObject {
             smc = SMCClient()
             cpuTemperaturePlatform = TemperatureSensorSelector.currentPlatform()
             powerSampler = PowerSampler(smc: smc)
-        }
-        guard let client = smc else { return }
-
-        if needFanSpeed, !fanKeysPrepared {
-            fanKeysPrepared = true
-            let count = Self.fanTelemetryCount
-            if count > 0 {
-                let keys = (0..<count).compactMap { client.key(named: "F\($0)Ac") }
-                if keys.count == count { fanKeys = keys }
+            if let client = smc {
+                var count = 0
+                if let fNumKey = client.key(named: "FNum"),
+                   let fNum = client.readValue(fNumKey) {
+                    count = Int(fNum)
+                } else {
+                    // Fallback scan up to 10 fans in case FNum is missing or unreadable
+                    for i in 0..<10 {
+                        if client.key(named: "F\(i)Ac") != nil {
+                            count = i + 1
+                        } else {
+                            break
+                        }
+                    }
+                }
+                fanCount = count
+                hasFans = fanCount > 0
             }
         }
+        if needTemperature, !tempKeysPrepared {
+            tempKeysPrepared = true
+            if let client = smc {
+                let all = client.keys { name in
+                    TemperatureSensorSelector.isCPUTemperatureKey(name, platform: cpuTemperaturePlatform)
+                        || name.hasPrefix("Tg")
+                        || name.range(of: "^TB[0-9]T$", options: .regularExpression) != nil
+                        || name.hasPrefix("Ts") || name.hasPrefix("Th") || name.hasPrefix("Ta")
+                        || name.hasPrefix("Tw") || name.hasPrefix("TW")
+                }
+                cpuKeys = all.filter {
+                    TemperatureSensorSelector.isCPUTemperatureKey($0.name, platform: cpuTemperaturePlatform)
+                }
+                preferredCPUKeys = cpuKeys.filter {
+                    TemperatureSensorSelector.isCPUCoreKey($0.name, platform: cpuTemperaturePlatform)
+                }
+                let preferredNames = Set(preferredCPUKeys.map(\.name))
+                fallbackCPUKeys = cpuKeys.filter { !preferredNames.contains($0.name) }
+                gpuKeys = all.filter { $0.name.hasPrefix("Tg") }
+                batteryKeys = all.filter { $0.name.hasPrefix("TB") }
+                allDiscoveredTempKeys = all
+            }
+        }
+        if needFanSpeed, !fanKeysPrepared {
+            fanKeysPrepared = true
+            if let client = smc {
+                for i in 0..<fanCount {
+                    let acKey = client.key(named: "F\(i)Ac")
+                    let mnKey = client.key(named: "F\(i)Mn")
+                    let mxKey = client.key(named: "F\(i)Mx")
+                    let idKey = client.key(named: "F\(i)ID")
+                    if let ac = acKey {
+                        fanKeys[i] = (ac: ac, mn: mnKey, mx: mxKey, idKey: idKey)
+                    }
+                }
+            }
+        }
+    }
 
-        guard needTemperature, !tempKeysPrepared else { return }
-        tempKeysPrepared = true
+    private func readFans(strings: Strings) -> [FanReading] {
+        guard let client = smc, fanKeysPrepared else { return [] }
+        var readings: [FanReading] = []
+        for i in 0..<fanCount {
+            guard let keys = fanKeys[i] else { continue }
+            let rpm = client.readValue(keys.ac)
+            let minRPM = keys.mn.flatMap { client.readValue($0) }
+            let maxRPM = keys.mx.flatMap { client.readValue($0) }
 
-        let all = client.keys { name in
-            TemperatureSensorSelector.isCPUTemperatureKey(name, platform: cpuTemperaturePlatform)
-                || name.hasPrefix("Tg")
-                || name.range(of: "^TB[0-9]T$", options: .regularExpression) != nil
+            var name = ""
+            if let idK = keys.idKey, let label = client.readStringValue(idK) {
+                name = label
+            } else {
+                if fanCount == 1 {
+                    name = strings.fanFallbackName
+                } else if fanCount == 2 {
+                    name = i == 0 ? strings.fanLeftFallbackName : strings.fanRightFallbackName
+                } else {
+                    name = String(format: strings.fanNumberedFallbackNamePattern, i + 1)
+                }
+            }
+
+            readings.append(FanReading(
+                id: i,
+                name: name,
+                rpm: rpm,
+                minRPM: minRPM,
+                maxRPM: maxRPM
+            ))
         }
-        cpuKeys = all.filter {
-            TemperatureSensorSelector.isCPUTemperatureKey($0.name,
-                                                          platform: cpuTemperaturePlatform)
-        }
-        preferredCPUKeys = cpuKeys.filter {
-            TemperatureSensorSelector.isCPUCoreKey($0.name, platform: cpuTemperaturePlatform)
-        }
-        // Everything that is not a verified core of this chip, swept only when
-        // the core set goes silent. 3.3.3 emptied this list for every mapped
-        // chip, which is what left a Mac carrying none of its generation's
-        // core sensors with no reading at all.
-        let preferredNames = Set(preferredCPUKeys.map(\.name))
-        fallbackCPUKeys = cpuKeys.filter { !preferredNames.contains($0.name) }
-        gpuKeys = all.filter { $0.name.hasPrefix("Tg") }
-        batteryKeys = all.filter { $0.name.hasPrefix("TB") }
+        return readings
     }
 
     static let fanTelemetryCount: Int = {
@@ -940,8 +1134,9 @@ final class SystemMonitor: ObservableObject {
 
     private func readFanSpeeds() -> [Double]? {
         guard let smc, !fanKeys.isEmpty else { return nil }
-        return FanControlPolicy.telemetryReadings(expectedCount: fanKeys.count,
-                                                  readings: fanKeys.map { smc.readValue($0) })
+        let readings = (0..<fanCount).compactMap { fanKeys[$0]?.ac }.map { smc.readValue($0) }
+        return FanControlPolicy.telemetryReadings(expectedCount: fanCount,
+                                                  readings: readings)
     }
 
     private func cpuTemperature() -> Double? {

--- a/Sources/Vorssaint/Services/USB/USBMonitorService.swift
+++ b/Sources/Vorssaint/Services/USB/USBMonitorService.swift
@@ -1,0 +1,692 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import Foundation
+import IOKit
+import IOKit.ps
+import IOKit.usb
+import SystemConfiguration
+
+enum USBItemCategory: String, Codable {
+    case usbDevice
+    case ethernet
+    case charger
+}
+
+struct USBDeviceItem: Identifiable, Hashable, Codable {
+    let id: String // Unique ID: vendorId-productId-serial
+    var parentId: String? = nil
+    let name: String
+    let vendor: String?
+    let vendorId: Int
+    let productId: Int
+    let serialNumber: String?
+    let speedMbps: Int?
+    let portMaxSpeedMbps: Int?
+    let usbVersionBCD: Int?
+    var isExternalStorage: Bool
+    var isHub: Bool = false
+    var bsdName: String?
+    var category: USBItemCategory = .usbDevice
+    var customSubtitle: String? = nil
+    var volumeCapacity: String? = nil
+    var volumeName: String? = nil
+
+    var hexVIDPID: String {
+        guard vendorId > 0 || productId > 0 else { return "" }
+        return String(format: "%04X:%04X", vendorId, productId)
+    }
+
+    var bcdHexLabel: String {
+        guard let bcd = usbVersionBCD else { return "" }
+        return String(format: "USB Version: %@ (0x%04X)", versionLabel, bcd)
+    }
+
+    var serialFormatted: String? {
+        guard let sn = serialNumber, !sn.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
+        return "SN: \(sn)"
+    }
+
+    var cleanVendor: String? {
+        guard let v = vendor?.trimmingCharacters(in: .whitespacesAndNewlines), !v.isEmpty, v != name else { return nil }
+        var cleaned = v
+        cleaned = cleaned.replacingOccurrences(of: ", Inc.", with: "")
+        cleaned = cleaned.replacingOccurrences(of: " Inc.", with: "")
+        cleaned = cleaned.replacingOccurrences(of: " Inc", with: "")
+        cleaned = cleaned.replacingOccurrences(of: " Corp.", with: "")
+        cleaned = cleaned.replacingOccurrences(of: " Corporation", with: "")
+        cleaned = cleaned.replacingOccurrences(of: " Ltd.", with: "")
+        cleaned = cleaned.replacingOccurrences(of: " Co., Ltd.", with: "")
+        cleaned = cleaned.replacingOccurrences(of: " Technology", with: "")
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
+    var iconName: String {
+        switch category {
+        case .charger: return "bolt.fill"
+        case .ethernet: return "network"
+        case .usbDevice:
+            let combined = "\(name) \(vendor ?? "")".lowercased()
+            if combined.contains("ax88") || combined.contains("rtl81") || combined.contains("ethernet") || combined.contains("lan adapter") || combined.contains("asix") {
+                return "network"
+            }
+            if combined.contains("wlan") || combined.contains("wifi") || combined.contains("802.11") || combined.contains("wireless") {
+                return "wifi"
+            }
+            if combined.contains("logitech") || combined.contains("insta360") || combined.contains("opal") || combined.contains("razer") || combined.contains("facecam") || combined.contains("c920") || combined.contains("brio") || combined.contains("camera") || combined.contains("webcam") || combined.contains("isight") || combined.contains("uvc") {
+                return "web.camera"
+            }
+            if combined.contains("display") || combined.contains("monitor") || combined.contains("hdmi") || combined.contains("billboard") || combined.contains("displaylink") || combined.contains("dp ") || combined.contains("video") {
+                return "display"
+            }
+            if combined.contains("card reader") || combined.contains("sd reader") || combined.contains("sdcard") || combined.contains("sd/mmc") || combined.contains("rts5") || combined.contains("gl32") {
+                return "sdcard"
+            }
+            if combined.contains("wacom") || combined.contains("tablet") || combined.contains("cintiq") || combined.contains("intuos") {
+                return "applepencil"
+            }
+            if combined.contains("capture") || combined.contains("elgato") || combined.contains("avermedia") || combined.contains("cam link") {
+                return "video.fill"
+            }
+            if combined.contains("keyboard") || combined.contains("keypad") { return "keyboard" }
+            if combined.contains("mouse") || combined.contains("trackpad") || combined.contains("pointing") { return "mouse" }
+            if combined.contains("audio") || combined.contains("sound") || combined.contains("mic") || combined.contains("headset") || combined.contains("dac") || combined.contains("focusrite") || combined.contains("scarlett") {
+                return "headphones"
+            }
+            if combined.contains("hub") || combined.contains("dock") || combined.contains("genesys") || combined.contains("vli") || combined.contains("rts54") || isHub {
+                return "rectangle.grid.2x2"
+            }
+            if isExternalStorage { return "externaldrive" }
+            return "cable.connector"
+        }
+    }
+
+    var speedLabel: String {
+        if let subtitle = customSubtitle { return subtitle }
+        guard let mbps = speedMbps else { return "Unknown Speed" }
+        switch mbps {
+        case 1, 2: return "1.5 Mbps"
+        case 12: return "12 Mbps"
+        case 480: return "480 Mbps"
+        case 5000: return "5 Gbps"
+        case 10000: return "10 Gbps"
+        case 20000: return "20 Gbps"
+        case 40000: return "⚡ TB4 40 Gbps"
+        case 80000: return "⚡ TB5 80 Gbps"
+        default:
+            if mbps >= 1000 {
+                return String(format: "%.1f Gbps", locale: Locale.current, Double(mbps) / 1000.0)
+            }
+            return "\(mbps) Mbps"
+        }
+    }
+
+    var versionLabel: String {
+        if let cap = volumeCapacity { return cap }
+        guard let bcd = usbVersionBCD else { return "USB" }
+        let major = (bcd >> 8) & 0xFF
+        let minorHigh = (bcd >> 4) & 0x0F
+        let minorLow = bcd & 0x0F
+        let minor = minorHigh * 10 + minorLow
+
+        switch major {
+        case 1:
+            if bcd == 0x0100 { return "USB 1.0" }
+            if bcd == 0x0110 { return "USB 1.1" }
+            return "USB 1.\(minor)"
+        case 2:
+            return "USB 2.0"
+        case 3:
+            if bcd >= 0x0320 { return "USB 3.2" }
+            if bcd >= 0x0310 { return "USB 3.1" }
+            return "USB 3.0"
+        case 4:
+            if bcd >= 0x0420 { return "USB4 2.0" }
+            return "USB4"
+        default:
+            return minor == 0 ? "USB \(major)" : "USB \(major).\(minor)"
+        }
+    }
+}
+
+final class USBMonitorService: ObservableObject {
+    static let shared = USBMonitorService()
+
+    @Published private(set) var devices: [USBDeviceItem] = []
+    @Published private(set) var isScanning = false
+
+    var menuBarDeviceCount: Int {
+        filteredDevicesForMenuBar.count
+    }
+
+    var filteredDevicesForMenuBar: [USBDeviceItem] {
+        let excludeChargers = UserDefaults.standard.bool(forKey: DefaultsKey.usbExcludeChargersFromCount)
+        let excludeHubs = UserDefaults.standard.bool(forKey: DefaultsKey.usbExcludeHubsFromCount)
+        let excludeEthernet = UserDefaults.standard.bool(forKey: DefaultsKey.usbExcludeEthernetFromCount)
+        let excludeStorage = UserDefaults.standard.bool(forKey: DefaultsKey.usbExcludeStorageFromCount)
+
+        return devices.filter { item in
+            if excludeChargers && item.category == .charger {
+                return false
+            }
+            if excludeHubs && item.isHub {
+                return false
+            }
+            if excludeEthernet && item.category == .ethernet {
+                return false
+            }
+            if excludeStorage && item.isExternalStorage {
+                return false
+            }
+            return true
+        }
+    }
+
+    private var notifyPort: IONotificationPortRef?
+    private var addedIterator: io_iterator_t = 0
+    private var removedIterator: io_iterator_t = 0
+    private var addedLegacyIterator: io_iterator_t = 0
+    private var removedLegacyIterator: io_iterator_t = 0
+    private var powerSourceRunLoopSource: CFRunLoopSource?
+    private var workspaceObservers: [NSObjectProtocol] = []
+    private var defaultsObserver: NSObjectProtocol?
+
+    private init() {
+        startMonitoring()
+        refresh()
+    }
+
+    deinit {
+        stopMonitoring()
+    }
+
+    func refresh(retryLateDescriptors: Bool = true) {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
+            let scanned = self.scanUSBDevices()
+            DispatchQueue.main.async {
+                self.devices = scanned
+            }
+        }
+        if retryLateDescriptors {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
+                self?.refresh(retryLateDescriptors: false)
+            }
+        }
+    }
+
+    private func startMonitoring() {
+        notifyPort = IONotificationPortCreate(kIOMainPortDefault)
+        guard let notifyPort = notifyPort else { return }
+
+        let runLoopSource = IONotificationPortGetRunLoopSource(notifyPort).takeUnretainedValue()
+        CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+
+        let callback: IOServiceMatchingCallback = { context, iterator in
+            guard let context = context else { return }
+            let service = Unmanaged<USBMonitorService>.fromOpaque(context).takeUnretainedValue()
+            while case let entry = IOIteratorNext(iterator), entry != 0 {
+                IOObjectRelease(entry)
+            }
+            service.refresh()
+        }
+
+        let refCon = Unmanaged.passUnretained(self).toOpaque()
+
+        let matchingAdded = IOServiceMatching("IOUSBHostDevice")
+        IOServiceAddMatchingNotification(
+            notifyPort,
+            kIOFirstMatchNotification,
+            matchingAdded,
+            callback,
+            refCon,
+            &addedIterator
+        )
+        // Consume iterator to arm notification
+        while case let entry = IOIteratorNext(addedIterator), entry != 0 {
+            IOObjectRelease(entry)
+        }
+
+        let matchingRemoved = IOServiceMatching("IOUSBHostDevice")
+        IOServiceAddMatchingNotification(
+            notifyPort,
+            kIOTerminatedNotification,
+            matchingRemoved,
+            callback,
+            refCon,
+            &removedIterator
+        )
+        // Consume iterator to arm notification
+        while case let entry = IOIteratorNext(removedIterator), entry != 0 {
+            IOObjectRelease(entry)
+        }
+
+        if let matchingLegacyAdded = IOServiceMatching(kIOUSBDeviceClassName) {
+            IOServiceAddMatchingNotification(
+                notifyPort,
+                kIOFirstMatchNotification,
+                matchingLegacyAdded,
+                callback,
+                refCon,
+                &addedLegacyIterator
+            )
+            while case let entry = IOIteratorNext(addedLegacyIterator), entry != 0 {
+                IOObjectRelease(entry)
+            }
+        }
+
+        if let matchingLegacyRemoved = IOServiceMatching(kIOUSBDeviceClassName) {
+            IOServiceAddMatchingNotification(
+                notifyPort,
+                kIOTerminatedNotification,
+                matchingLegacyRemoved,
+                callback,
+                refCon,
+                &removedLegacyIterator
+            )
+            while case let entry = IOIteratorNext(removedLegacyIterator), entry != 0 {
+                IOObjectRelease(entry)
+            }
+        }
+
+        // Power Source changes (charger connected / disconnected)
+        powerSourceRunLoopSource = IOPSNotificationCreateRunLoopSource({ context in
+            guard let context else { return }
+            let service = Unmanaged<USBMonitorService>.fromOpaque(context).takeUnretainedValue()
+            service.refresh()
+        }, refCon)?.takeRetainedValue()
+        if let powerSourceRunLoopSource {
+            CFRunLoopAddSource(CFRunLoopGetMain(), powerSourceRunLoopSource, .commonModes)
+        }
+
+        // Observe Volume Mount/Unmount for SD Cards and External Media on NSWorkspace
+        let center = NSWorkspace.shared.notificationCenter
+        let m1 = center.addObserver(forName: NSWorkspace.didMountNotification, object: nil, queue: .main) { [weak self] _ in
+            self?.refresh()
+        }
+        let m2 = center.addObserver(forName: NSWorkspace.didUnmountNotification, object: nil, queue: .main) { [weak self] _ in
+            self?.refresh()
+        }
+        workspaceObservers = [m1, m2]
+
+        // Observe Defaults changes (category exclusions / display options)
+        defaultsObserver = NotificationCenter.default.addObserver(forName: UserDefaults.didChangeNotification, object: nil, queue: .main) { [weak self] _ in
+            guard let self else { return }
+            self.objectWillChange.send()
+            self.refresh(retryLateDescriptors: false)
+        }
+    }
+
+    private func stopMonitoring() {
+        if addedIterator != 0 { IOObjectRelease(addedIterator); addedIterator = 0 }
+        if removedIterator != 0 { IOObjectRelease(removedIterator); removedIterator = 0 }
+        if addedLegacyIterator != 0 { IOObjectRelease(addedLegacyIterator); addedLegacyIterator = 0 }
+        if removedLegacyIterator != 0 { IOObjectRelease(removedLegacyIterator); removedLegacyIterator = 0 }
+        if let powerSourceRunLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), powerSourceRunLoopSource, .commonModes)
+            self.powerSourceRunLoopSource = nil
+        }
+        for obs in workspaceObservers {
+            NSWorkspace.shared.notificationCenter.removeObserver(obs)
+        }
+        workspaceObservers.removeAll()
+        if let defaultsObserver {
+            NotificationCenter.default.removeObserver(defaultsObserver)
+            self.defaultsObserver = nil
+        }
+        if let notifyPort = notifyPort {
+            IONotificationPortDestroy(notifyPort)
+            self.notifyPort = nil
+        }
+    }
+
+    private func scanUSBDevices() -> [USBDeviceItem] {
+        var items: [USBDeviceItem] = []
+        var seenIds = Set<String>()
+
+        let showEthernet = UserDefaults.standard.bool(forKey: DefaultsKey.usbShowEthernet)
+        let showPower = UserDefaults.standard.bool(forKey: DefaultsKey.usbShowPowerCable)
+
+        if showPower, let charger = scanPowerSource() {
+            items.append(charger)
+        }
+
+        if showEthernet {
+            items.append(contentsOf: scanEthernetAdapters())
+        }
+
+        func scanMatching(name: String) {
+            guard let matching = IOServiceMatching(name) else { return }
+            var iterator: io_iterator_t = 0
+            let kr = IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iterator)
+            guard kr == KERN_SUCCESS else { return }
+            defer { IOObjectRelease(iterator) }
+
+            while case let entry = IOIteratorNext(iterator), entry != 0 {
+                if let dev = parseDevice(from: entry) {
+                    if !seenIds.contains(dev.id) {
+                        seenIds.insert(dev.id)
+                        items.append(dev)
+                    }
+                }
+                IOObjectRelease(entry)
+            }
+        }
+
+        scanMatching(name: "IOUSBHostDevice")
+        scanMatching(name: kIOUSBDeviceClassName)
+
+        // Scan Mounted Removable External Volumes (SD Cards, Flash Drives, External Media)
+        let externalVolumes = scanMountedExternalVolumes()
+        for vol in externalVolumes {
+            if !seenIds.contains(vol.id) {
+                let matchedIndex = items.firstIndex(where: { dev in
+                    if let devBsd = dev.bsdName, !devBsd.isEmpty, let volBsd = vol.bsdName, !volBsd.isEmpty {
+                        if volBsd.contains(devBsd) || devBsd.contains(volBsd) { return true }
+                    }
+                    if dev.isExternalStorage && dev.name.lowercased() == vol.name.lowercased() { return true }
+                    return false
+                })
+
+                if let idx = matchedIndex {
+                    items[idx].isExternalStorage = true
+                    if items[idx].volumeCapacity == nil, let cap = vol.volumeCapacity {
+                        items[idx].volumeCapacity = cap
+                    }
+                    if items[idx].volumeName == nil {
+                        items[idx].volumeName = vol.name
+                    }
+                } else {
+                    seenIds.insert(vol.id)
+                    items.append(vol)
+                }
+            }
+        }
+
+        return items.sorted {
+            if $0.category != $1.category {
+                return $0.category.rawValue < $1.category.rawValue
+            }
+            return ($0.vendor ?? "") < ($1.vendor ?? "") ||
+            ($0.vendor == $1.vendor && $0.name < $1.name)
+        }
+    }
+
+    private func scanMountedExternalVolumes() -> [USBDeviceItem] {
+        var items: [USBDeviceItem] = []
+        guard let volumeURLs = FileManager.default.mountedVolumeURLs(
+            includingResourceValuesForKeys: [.volumeIsRemovableKey, .volumeIsEjectableKey, .volumeLocalizedNameKey, .volumeNameKey, .volumeTotalCapacityKey],
+            options: [.skipHiddenVolumes]
+        ) else {
+            return items
+        }
+
+        for url in volumeURLs {
+            guard let values = try? url.resourceValues(forKeys: [.volumeIsRemovableKey, .volumeIsEjectableKey, .volumeLocalizedNameKey, .volumeNameKey, .volumeTotalCapacityKey]) else { continue }
+            let isRemovable = values.volumeIsRemovable ?? false
+            let isEjectable = values.volumeIsEjectable ?? false
+
+            if url.path == "/" || url.path == "/System/Volumes/Data" || url.path.hasPrefix("/System/") { continue }
+
+            if isRemovable || isEjectable {
+                let name = values.volumeLocalizedName ?? values.volumeName ?? url.lastPathComponent
+                let capacityBytes = values.volumeTotalCapacity ?? 0
+                let capacityString = capacityBytes > 0 ? ByteCountFormatter.string(fromByteCount: Int64(capacityBytes), countStyle: .file) : ""
+
+                var volBSD: String? = nil
+                var stat = statfs()
+                if statfs(url.path, &stat) == 0 {
+                    withUnsafePointer(to: &stat.f_mntfromname) { ptr in
+                        let path = String(cString: UnsafeRawPointer(ptr).assumingMemoryBound(to: CChar.self))
+                        volBSD = path.replacingOccurrences(of: "/dev/", with: "")
+                    }
+                }
+
+                let volId = "vol-\(url.path)"
+
+                items.append(USBDeviceItem(
+                    id: volId,
+                    parentId: nil,
+                    name: name,
+                    vendor: nil,
+                    vendorId: 0,
+                    productId: 0,
+                    serialNumber: nil,
+                    speedMbps: 5000,
+                    portMaxSpeedMbps: nil,
+                    usbVersionBCD: nil,
+                    isExternalStorage: true,
+                    isHub: false,
+                    bsdName: volBSD ?? url.lastPathComponent,
+                    category: .usbDevice,
+                    customSubtitle: nil,
+                    volumeCapacity: capacityString.isEmpty ? nil : capacityString,
+                    volumeName: name
+                ))
+            }
+        }
+        return items
+    }
+
+    private func scanPowerSource() -> USBDeviceItem? {
+        guard let snapshot = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
+              let sources = IOPSCopyPowerSourcesList(snapshot)?.takeRetainedValue() as? [CFTypeRef] else {
+            return nil
+        }
+
+        var pct = 0
+        var isACConnected = false
+
+        for ps in sources {
+            guard let desc = IOPSGetPowerSourceDescription(snapshot, ps)?.takeUnretainedValue() as? [String: Any] else { continue }
+            if let state = desc[kIOPSPowerSourceStateKey as String] as? String,
+               state == (kIOPSACPowerValue as String) {
+                isACConnected = true
+                pct = desc[kIOPSCurrentCapacityKey as String] as? Int ?? 0
+                break
+            }
+        }
+
+        guard isACConnected else { return nil }
+
+        let displayName = "Power supply"
+        var tag: String = "MagSafe"
+
+        if let adapterDetails = IOPSCopyExternalPowerAdapterDetails()?.takeRetainedValue() as? [String: Any] {
+            let watts = adapterDetails["Watts"] as? Int ?? (adapterDetails["Watts"] as? Double).map(Int.init)
+            let name = (adapterDetails["Name"] as? String ?? "").lowercased()
+            let desc = (adapterDetails["Description"] as? String ?? "").lowercased()
+            let combined = "\(name) \(desc)"
+
+            if combined.contains("usb-c") && !combined.contains("magsafe") {
+                tag = watts != nil && watts! > 0 ? "USB-C \(watts!)W" : "USB-C"
+            } else if let w = watts, w > 0 {
+                tag = "MagSafe \(w)W"
+            } else {
+                tag = "MagSafe"
+            }
+        } else {
+            tag = "MagSafe"
+        }
+
+        let rightStatus = "⚡ \(pct)%"
+
+        return USBDeviceItem(
+            id: "power-charger-adapter",
+            name: displayName,
+            vendor: tag,
+            vendorId: 0,
+            productId: 0,
+            serialNumber: nil,
+            speedMbps: nil,
+            portMaxSpeedMbps: nil,
+            usbVersionBCD: nil,
+            isExternalStorage: false,
+            bsdName: nil,
+            category: .charger,
+            customSubtitle: rightStatus
+        )
+    }
+
+    private func scanEthernetAdapters() -> [USBDeviceItem] {
+        var items: [USBDeviceItem] = []
+        guard let store = SCDynamicStoreCreate(nil, "VorssaintEthernet" as CFString, nil, nil),
+              let interfaces = SCNetworkInterfaceCopyAll() as? [SCNetworkInterface] else {
+            return items
+        }
+        for iface in interfaces {
+            let type = SCNetworkInterfaceGetInterfaceType(iface) as String?
+            if type == (kSCNetworkInterfaceTypeEthernet as String) {
+                guard let bsd = SCNetworkInterfaceGetBSDName(iface) as String? else { continue }
+                let key = "State:/Network/Interface/\(bsd)/Link" as CFString
+                let isLinkActive = (SCDynamicStoreCopyValue(store, key) as? [String: Any])?["Active"] as? Bool ?? false
+                if isLinkActive {
+                    let displayName = SCNetworkInterfaceGetLocalizedDisplayName(iface) as String? ?? "Ethernet Adapter (\(bsd))"
+                    items.append(USBDeviceItem(
+                        id: "ethernet-\(bsd)",
+                        name: displayName,
+                        vendor: "LAN Cable",
+                        vendorId: 0,
+                        productId: 0,
+                        serialNumber: nil,
+                        speedMbps: 1000,
+                        portMaxSpeedMbps: nil,
+                        usbVersionBCD: nil,
+                        isExternalStorage: false,
+                        bsdName: bsd,
+                        category: .ethernet,
+                        customSubtitle: "Active Link (\(bsd))"
+                    ))
+                }
+            }
+        }
+        return items
+    }
+
+    private func parseDevice(from entry: io_registry_entry_t) -> USBDeviceItem? {
+        var props: Unmanaged<CFMutableDictionary>?
+        guard IORegistryEntryCreateCFProperties(entry, &props, kCFAllocatorDefault, 0) == KERN_SUCCESS,
+              let dict = props?.takeRetainedValue() as? [String: Any] else { return nil }
+
+        func num(_ key: String) -> NSNumber? { dict[key] as? NSNumber }
+        func intValue(_ key: String) -> Int? { num(key)?.intValue }
+        func uint32Value(_ key: String) -> UInt32? { num(key)?.uint32Value }
+        func doubleValue(_ key: String) -> Double? { num(key)?.doubleValue }
+        func stringValue(_ key: String) -> String? { dict[key] as? String }
+
+        let vendorId = intValue(kUSBVendorID as String) ?? 0
+        let productId = intValue(kUSBProductID as String) ?? 0
+        let productString = stringValue(kUSBProductString as String)
+        let vendorString = stringValue(kUSBVendorString as String)
+        let serial = stringValue(kUSBSerialNumberString as String)
+        let registryName = tryGetIORegistryName(entry) ?? "USB Device"
+
+        let bcdUSBCandidates = ["bcdUSB", "kUSBDevicePropertyUSBReleaseNumber", "USB-bcdUSB"]
+        let usbVersionBCD = bcdUSBCandidates.compactMap { intValue($0) }.first
+
+        let linkSpeedBpsCandidates = ["kUSBDevicePropertyLinkSpeed", "LinkSpeed", "DeviceLinkSpeed", "link-speed"]
+        let linkSpeedBps: Double? = linkSpeedBpsCandidates.compactMap { doubleValue($0) ?? intValue($0).map(Double.init) }.first
+        let speedMbpsFromDevice = linkSpeedBps.map { Int($0 / 1_000_000.0) }
+
+        let speedCode = intValue(kUSBDevicePropertySpeed as String)
+        let speedMbpsFromCode: Int? = speedCode.flatMap {
+            switch $0 {
+            case 0: return 2
+            case 1: return 12
+            case 2: return 480
+            case 3: return 5000
+            case 4: return 10000
+            default: return nil
+            }
+        }
+        let speedMbps = speedMbpsFromDevice ?? speedMbpsFromCode
+        let directBsdName = stringValue("BSD Name")
+        let searchedBsdName: String? = {
+            if let searched = IORegistryEntrySearchCFProperty(
+                entry,
+                kIOServicePlane,
+                "BSD Name" as CFString,
+                kCFAllocatorDefault,
+                IOOptionBits(kIORegistryIterateRecursively)
+            ) as? String {
+                let trimmed = searched.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty ? nil : trimmed
+            }
+            return nil
+        }()
+        let bsdName = directBsdName ?? searchedBsdName
+        let isStorage = (bsdName != nil)
+
+        let serialClean = serial?.trimmingCharacters(in: .whitespaces) ?? ""
+        let idString = !serialClean.isEmpty ? "\(vendorId)-\(productId)-\(serialClean)" : "\(vendorId)-\(productId)-\(registryName)"
+
+        let deviceName = productString ?? registryName
+        let isHubDevice = deviceName.lowercased().contains("hub") || registryName.lowercased().contains("hub") || intValue("bDeviceClass") == 9
+
+        var parentId: String? = nil
+        var parentEntry: io_registry_entry_t = 0
+        if IORegistryEntryGetParentEntry(entry, kIOServicePlane, &parentEntry) == KERN_SUCCESS, parentEntry != 0 {
+            defer { IOObjectRelease(parentEntry) }
+            var pProps: Unmanaged<CFMutableDictionary>?
+            if IORegistryEntryCreateCFProperties(parentEntry, &pProps, kCFAllocatorDefault, 0) == KERN_SUCCESS,
+               let pDict = pProps?.takeRetainedValue() as? [String: Any] {
+                let pVid = (pDict["idVendor"] as? NSNumber)?.intValue ?? 0
+                let pPid = (pDict["idProduct"] as? NSNumber)?.intValue ?? 0
+                let pSerial = (pDict["USB Serial Number"] as? String ?? "").trimmingCharacters(in: .whitespaces)
+                let pName = pDict["USB Product Name"] as? String ?? (pDict["kUSBProductString"] as? String ?? "")
+                let pRegName = tryGetIORegistryName(parentEntry) ?? ""
+                if pVid > 0 || pPid > 0 {
+                    let pCleanSerial = pSerial
+                    let pIdentifier = !pCleanSerial.isEmpty ? "\(pVid)-\(pPid)-\(pCleanSerial)" : "\(pVid)-\(pPid)-\(pName.isEmpty ? pRegName : pName)"
+                    if pIdentifier != idString {
+                        parentId = pIdentifier
+                    }
+                }
+            }
+        }
+
+        return USBDeviceItem(
+            id: idString,
+            parentId: parentId,
+            name: deviceName,
+            vendor: vendorString,
+            vendorId: vendorId,
+            productId: productId,
+            serialNumber: serial,
+            speedMbps: speedMbps,
+            portMaxSpeedMbps: nil,
+            usbVersionBCD: usbVersionBCD,
+            isExternalStorage: isStorage,
+            isHub: isHubDevice,
+            bsdName: bsdName
+        )
+    }
+
+    private func tryGetIORegistryName(_ entry: io_registry_entry_t) -> String? {
+        var cName = [CChar](repeating: 0, count: 128)
+        if IORegistryEntryGetName(entry, &cName) == KERN_SUCCESS {
+            let name = String(cString: cName)
+            if !name.isEmpty && name != "IOUSBHostDevice" && name != kIOUSBDeviceClassName {
+                return name
+            }
+        }
+        return nil
+    }
+
+    func eject(_ device: USBDeviceItem) {
+        let url: URL
+        if device.id.hasPrefix("vol-") {
+            let path = device.id.replacingOccurrences(of: "vol-", with: "")
+            url = URL(fileURLWithPath: path)
+        } else if let bsdName = device.bsdName {
+            url = URL(fileURLWithPath: "/dev/\(bsdName)")
+        } else {
+            return
+        }
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            try? NSWorkspace.shared.unmountAndEjectDevice(at: url)
+            self?.refresh()
+        }
+    }
+}

--- a/Sources/Vorssaint/UI/MenuBarMetricsPreview.swift
+++ b/Sources/Vorssaint/UI/MenuBarMetricsPreview.swift
@@ -21,6 +21,9 @@ struct MenuBarMetricsPreview: View {
     @AppStorage(DefaultsKey.menuBarBatteryTime) private var batteryTime = false
     @AppStorage(DefaultsKey.menuBarPeripheralBattery) private var peripheralBattery = false
     @AppStorage(DefaultsKey.menuBarPower) private var power = false
+    @AppStorage(DefaultsKey.menuBarFanSpeed) private var fanSpeed = false
+    @AppStorage(DefaultsKey.menuBarConnectedDevices) private var connectedDevices = false
+    @AppStorage(DefaultsKey.menuBarDiskCount) private var diskCount = false
     @AppStorage(DefaultsKey.menuBarMetricOrder) private var metricOrder = ""
     @AppStorage(DefaultsKey.menuBarCombineTemperatures) private var combineTemperatures = true
     @AppStorage(DefaultsKey.menuBarMetricAppearance) private var metricAppearance = "values"
@@ -33,11 +36,14 @@ struct MenuBarMetricsPreview: View {
     @AppStorage(DefaultsKey.menuBarNetworkUploadFirst) private var networkUploadFirst = false
     @AppStorage(DefaultsKey.menuBarMemoryStyle) private var memoryStyle = "percent"
     @AppStorage(DefaultsKey.temperatureUnit) private var temperatureUnit = TemperatureUnit.celsius.rawValue
-
+ 
     var body: some View {
         let _ = metricOrder
         let _ = combineTemperatures
         let _ = metricAppearance
+        let _ = fanSpeed
+        let _ = connectedDevices
+        let _ = diskCount
         let _ = usageBarNormalColor
         let _ = usageBarElevatedColor
         let _ = usageBarCriticalColor
@@ -100,6 +106,9 @@ struct MenuBarMetricsPreview: View {
         let _ = batteryTime
         let _ = peripheralBattery
         let _ = power
+        let _ = fanSpeed
+        let _ = connectedDevices
+        let _ = diskCount
         return MenuBarMetric.enabled(in: .standard)
     }
 
@@ -219,6 +228,7 @@ struct MenuBarMetricsPreview: View {
         .fixedSize(horizontal: true, vertical: true)
     }
 
+    @ViewBuilder
     private func usageBarBlock(label: String,
                                fraction: Double?,
                                style: MenuBarBlockStyle,
@@ -229,45 +239,77 @@ struct MenuBarMetricsPreview: View {
         let innerHeight = barHeight - 4.2
         let clamped = fraction.map(MenuBarUsageBarSupport.clampedFraction)
 
-        return HStack(spacing: 2) {
-            VStack(spacing: -1.8) {
-                ForEach(Array(label.prefix(3).enumerated()), id: \.offset) { _, character in
-                    Text(String(character))
-                        .font(.system(size: style == .readable ? 6.5 : 6.1,
-                                      weight: .semibold))
-                        .frame(height: (size.height - 2) / 3)
+        if label == "FAN" {
+            VStack(spacing: 0) {
+                Text(label)
+                    .font(.system(size: style == .readable ? 7.2 : 6.6, weight: .medium))
+                    .frame(height: style == .readable ? 10 : 9)
+                
+                ZStack {
+                    Circle()
+                        .stroke(Color.white.opacity(0.12), lineWidth: 1.6)
+                    if let clamped, clamped > 0 {
+                        Circle()
+                            .trim(from: 0, to: CGFloat(min(1.0, max(0.0, clamped))))
+                            .stroke(
+                                clamped < 0.6 ? Color.accentColor :
+                                clamped < 0.85 ? Color.yellow : Color.red,
+                                style: StrokeStyle(lineWidth: 1.6, lineCap: .round)
+                            )
+                            .rotationEffect(.degrees(-90))
+                    } else if clamped == nil {
+                        Rectangle()
+                            .fill(Color.white.opacity(0.55))
+                            .frame(width: 4, height: 1.0)
+                    }
                 }
+                .frame(width: style == .readable ? 11.5 : 10.5, height: style == .readable ? 11.5 : 10.5)
+                .padding(.top, style == .readable ? 1 : 0.5)
             }
-            .frame(width: style == .readable ? 6.5 : 6)
-
-            if let pressure {
-                Circle()
-                    .fill(dotColor(pressure))
-                    .frame(width: style == .readable ? 4.8 : 4.4,
-                           height: style == .readable ? 4.8 : 4.4)
-                    .padding(.trailing, 0.2)
-            }
-
-            ZStack(alignment: .bottom) {
-                RoundedRectangle(cornerRadius: 2.2, style: .continuous)
-                    .stroke(Color.white, lineWidth: 1.15)
-                if let clamped, clamped > 0 {
-                    RoundedRectangle(cornerRadius: 1.2, style: .continuous)
-                        .fill(usageBarColor(for: clamped))
-                        .frame(width: barWidth - 4.2,
-                               height: max(1, innerHeight * clamped))
-                        .padding(.bottom, 2.1)
-                } else if clamped == nil {
-                    Rectangle()
-                        .fill(Color.white.opacity(0.55))
-                        .frame(width: barWidth - 4.8, height: 1)
+            .foregroundStyle(.white)
+            .frame(width: style == .readable ? 21 : 19, height: style == .readable ? 23 : 21)
+            .fixedSize(horizontal: true, vertical: true)
+        } else {
+            HStack(spacing: 2) {
+                VStack(spacing: -1.8) {
+                    ForEach(Array(label.prefix(3).enumerated()), id: \.offset) { _, character in
+                        Text(String(character))
+                            .font(.system(size: style == .readable ? 6.5 : 6.1,
+                                          weight: .semibold))
+                            .frame(height: (size.height - 2) / 3)
+                    }
                 }
+                .frame(width: style == .readable ? 6.5 : 6)
+
+                if let pressure {
+                    Circle()
+                        .fill(dotColor(pressure))
+                        .frame(width: style == .readable ? 4.8 : 4.4,
+                               height: style == .readable ? 4.8 : 4.4)
+                        .padding(.trailing, 0.2)
+                }
+
+                ZStack(alignment: .bottom) {
+                    RoundedRectangle(cornerRadius: 2.2, style: .continuous)
+                        .stroke(Color.white, lineWidth: 1.15)
+                    if let clamped, clamped > 0 {
+                        RoundedRectangle(cornerRadius: 1.2, style: .continuous)
+                            .fill(usageBarColor(for: clamped))
+                            .frame(width: barWidth - 4.2,
+                                   height: max(1, innerHeight * clamped))
+                            .padding(.bottom, 2.1)
+                    } else if clamped == nil {
+                        Rectangle()
+                            .fill(Color.white.opacity(0.55))
+                            .frame(width: barWidth - 4.8, height: 1)
+                    }
+                }
+                .frame(width: barWidth, height: barHeight)
             }
-            .frame(width: barWidth, height: barHeight)
+            .foregroundStyle(.white)
+            .frame(width: size.width, height: size.height)
+            .fixedSize(horizontal: true, vertical: true)
         }
-        .foregroundStyle(.white)
-        .frame(width: size.width, height: size.height)
-        .fixedSize(horizontal: true, vertical: true)
     }
 
     private func usageBarColor(for fraction: Double) -> Color {

--- a/Sources/Vorssaint/UI/MenuPanel/MenuPanelView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/MenuPanelView.swift
@@ -69,6 +69,7 @@ struct MenuPanelView: View {
     @AppStorage(DefaultsKey.monitorShowSystem) private var showSystem = true
     @AppStorage(DefaultsKey.monitorShowNetwork) private var showNetwork = true
     @AppStorage(DefaultsKey.monitorShowDisk) private var showDisk = true
+    @AppStorage(DefaultsKey.monitorShowUSB) private var showUSB = true
     @AppStorage(DefaultsKey.monitorShowPower) private var showPower = true
     @AppStorage(DefaultsKey.panelShowFanControl) private var showFanControl = true
     @AppStorage(DefaultsKey.panelShowKeepAwake) private var showKeepAwake = true
@@ -259,6 +260,7 @@ struct MenuPanelView: View {
         case .system: return 460
         case .network: return 190
         case .disk: return 360
+        case .usb: return 220
         case .power: return 170
         case .fanControl: return 220
         case .utilities: return 500
@@ -275,6 +277,7 @@ struct MenuPanelView: View {
         case .disk: return 360
         case .battery, .power: return 360
         case .fan: return 240
+        case .usb: return 320
         }
     }
 
@@ -290,6 +293,7 @@ struct MenuPanelView: View {
         case .system: if showSystem { SystemSection(collapsible: collapsible) }
         case .network: if showNetwork { NetworkSection(collapsible: collapsible) }
         case .disk: if showDisk { DiskSection(collapsible: collapsible) }
+        case .usb: if showUSB { USBSection(collapsible: collapsible) }
         case .power: if showPower { PowerSection(collapsible: collapsible) }
         case .fanControl: if showFanControl { FanControlSection(collapsible: collapsible) }
         case .utilities: UtilitiesSection(collapsible: collapsible, startCleaning: startCleaning)
@@ -309,6 +313,7 @@ struct MenuPanelView: View {
         case .system: return showSystem
         case .network: return showNetwork
         case .disk: return showDisk
+        case .usb: return showUSB
         case .power: return showPower
         case .fanControl: return showFanControl
         case .utilities: return showUtilities

--- a/Sources/Vorssaint/UI/MenuPanel/MetricDetailView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/MetricDetailView.swift
@@ -5,7 +5,7 @@ import AppKit
 import SwiftUI
 
 enum MetricDetailKind: String, Equatable, Identifiable {
-    case cpu, gpu, memory, network, disk, battery, power, fan
+    case cpu, gpu, memory, network, disk, battery, power, fan, usb
 
     var id: String { rawValue }
 
@@ -21,6 +21,8 @@ enum MetricDetailKind: String, Equatable, Identifiable {
             return .power
         case .fan:
             return .fanControl
+        case .usb:
+            return .usb
         }
     }
 
@@ -34,6 +36,7 @@ enum MetricDetailKind: String, Equatable, Identifiable {
         case .battery: return "battery.100"
         case .power: return "powerplug.fill"
         case .fan: return "fanblades"
+        case .usb: return "cable.connector"
         }
     }
 
@@ -61,6 +64,8 @@ enum MetricDetailKind: String, Equatable, Identifiable {
             return SystemMonitorPanelNeeds(power: true)
         case .fan:
             return SystemMonitorPanelNeeds(fanSpeed: true)
+        case .usb:
+            return .none
         }
     }
 
@@ -74,6 +79,7 @@ enum MetricDetailKind: String, Equatable, Identifiable {
         case .battery: return s.batteryLabel
         case .power: return s.powerSection
         case .fan: return FeatureStrings.fanControl(L10n.shared.language).menuBarTitle
+        case .usb: return s.usbSection
         }
     }
 
@@ -84,7 +90,7 @@ enum MetricDetailKind: String, Equatable, Identifiable {
         case .memory: return .memory
         case .power: return .energy
         case .network: return .network
-        case .disk, .battery, .fan: return nil
+        case .disk, .battery, .fan, .usb: return nil
         }
     }
 }
@@ -100,7 +106,7 @@ extension MenuBarMetric {
             return .memory
         case .network:
             return .network
-        case .diskUsage, .diskActivity:
+        case .diskUsage, .diskActivity, .diskCount:
             return .disk
         case .battery, .batteryTemperature, .peripheralBattery:
             return .battery
@@ -108,6 +114,8 @@ extension MenuBarMetric {
             return .power
         case .fanSpeed:
             return .fan
+        case .connectedDevices:
+            return .usb
         }
     }
 }
@@ -141,6 +149,7 @@ struct ActivityMonitorButton: View {
 struct MetricDetailView: View {
     @ObservedObject private var l10n = L10n.shared
     @ObservedObject private var monitor = SystemMonitor.shared
+    @ObservedObject private var usbMonitor = USBMonitorService.shared
     @ObservedObject private var speed = SpeedTest.shared
     @Environment(\.colorScheme) private var colorScheme
     @AppStorage(DefaultsKey.temperatureUnit) private var temperatureUnit = TemperatureUnit.celsius.rawValue
@@ -231,7 +240,7 @@ struct MetricDetailView: View {
             }
         case .power:
             historyGraph(monitor.snapshot.systemPowerHistory, color: summaryColor)
-        case .fan:
+        case .fan, .usb:
             EmptyView()
         }
     }
@@ -457,6 +466,24 @@ struct MetricDetailView: View {
                 row(String(format: strings.fanNameFormat, index + 1),
                     String(format: strings.rpmFormat, Int(rpm.rounded())))
             }
+        case .usb:
+            var rows: [MetricDetailRow] = []
+            let devices = USBMonitorService.shared.filteredDevicesForMenuBar
+            if devices.isEmpty {
+                rows.append(row(l10n.s.usbConnectedDevices, l10n.s.usbNoDevices))
+            } else {
+                for dev in devices {
+                    let subtitle: String
+                    if dev.isExternalStorage, let volName = dev.volumeName, !volName.isEmpty, volName != dev.name {
+                        let cap = dev.volumeCapacity.map { " (\($0))" } ?? ""
+                        subtitle = "\(volName)\(cap)"
+                    } else {
+                        subtitle = dev.cleanVendor ?? dev.vendor ?? dev.volumeCapacity ?? dev.speedLabel
+                    }
+                    rows.append(row(dev.name, subtitle))
+                }
+            }
+            return rows
         }
     }
 
@@ -487,6 +514,8 @@ struct MetricDetailView: View {
             let strings = FeatureStrings.fanControl(l10n.language)
             guard let rpm = snapshot.fanSpeeds.first else { return "-" }
             return String(format: strings.rpmFormat, Int(rpm.rounded()))
+        case .usb:
+            return "\(USBMonitorService.shared.menuBarDeviceCount)"
         }
     }
 
@@ -519,6 +548,9 @@ struct MetricDetailView: View {
             return snapshot.fanSpeeds.isEmpty
                 ? strings.menuBarTitle
                 : String(format: strings.fanNameFormat, 1)
+        case .usb:
+            let count = USBMonitorService.shared.menuBarDeviceCount
+            return count == 1 ? "1 connected device" : "\(count) connected devices"
         }
     }
 
@@ -538,6 +570,8 @@ struct MetricDetailView: View {
             return PanelMetricColor.orange(for: colorScheme)
         case .fan:
             return PanelMetricColor.cyan(for: colorScheme)
+        case .usb:
+            return .accentColor
         }
     }
 

--- a/Sources/Vorssaint/UI/MenuPanel/PanelLayout.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/PanelLayout.swift
@@ -10,7 +10,7 @@ protocol PanelOrderItem: RawRepresentable, CaseIterable, Hashable where RawValue
 /// stable identifiers persisted in the saved order and the collapsed set, so
 /// renaming a case would orphan a user's stored layout — keep them stable.
 enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
-    case keepAwake, brightness, mixer, system, network, disk, power, fanControl, utilities, controls,
+    case keepAwake, brightness, mixer, system, network, disk, usb, power, fanControl, utilities, controls,
          toggles
 
     var id: String { rawValue }
@@ -24,6 +24,7 @@ enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
         case .system: return s.systemSection
         case .network: return s.networkSection
         case .disk: return s.diskSection
+        case .usb: return s.usbSection
         case .power: return s.powerSection
         case .fanControl: return FeatureStrings.fanControl(L10n.shared.language).title
         case .utilities: return s.utilitiesSection
@@ -40,6 +41,7 @@ enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
         case .system: return "cpu"
         case .network: return "network"
         case .disk: return "internaldrive"
+        case .usb: return "cable.connector"
         case .power: return "bolt.fill"
         case .fanControl: return "fanblades.fill"
         case .utilities: return "wrench.and.screwdriver.fill"
@@ -59,6 +61,7 @@ enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
         case .system: return DefaultsKey.monitorShowSystem
         case .network: return DefaultsKey.monitorShowNetwork
         case .disk: return DefaultsKey.monitorShowDisk
+        case .usb: return DefaultsKey.monitorShowUSB
         case .power: return DefaultsKey.monitorShowPower
         case .fanControl: return DefaultsKey.panelShowFanControl
         case .utilities: return DefaultsKey.panelShowUtilities
@@ -82,6 +85,7 @@ enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
         case .system: return [.monitorCPU, .monitorGPU, .monitorMemory]
         case .network: return [.monitorNetwork]
         case .disk: return [.monitorDisk]
+        case .usb: return [.monitorUSB]
         case .power: return [.monitorPower]
         case .fanControl: return [.fanControl]
         case .utilities: return [.quickLauncher, .cleaner, .homebrew, .appUpdates, .mediaTools,
@@ -120,6 +124,8 @@ enum PanelLayout {
         for id in PanelSectionID.allCases where seen.insert(id).inserted {
             if id == .disk, let networkIndex = result.firstIndex(of: .network) {
                 result.insert(id, at: networkIndex + 1)
+            } else if id == .usb, let diskIndex = result.firstIndex(of: .disk) {
+                result.insert(id, at: diskIndex + 1)
             } else if id == .controls, let utilitiesIndex = result.firstIndex(of: .utilities) {
                 result.insert(id, at: utilitiesIndex + 1)
             } else if id == .brightness, let keepAwakeIndex = result.firstIndex(of: .keepAwake) {

--- a/Sources/Vorssaint/UI/MenuPanel/SystemSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/SystemSection.swift
@@ -37,6 +37,9 @@ struct SystemSection: View {
     @AppStorage(DefaultsKey.monitorGraphMemory) private var graphMemory = true
     @AppStorage(DefaultsKey.temperatureUnit) private var temperatureUnit = TemperatureUnit.celsius.rawValue
     @AppStorage(DefaultsKey.monitorSysTemps) private var sysTemps = true
+    @AppStorage(DefaultsKey.monitorSysFanSpeeds) private var sysFanSpeeds = true
+    @AppStorage(DefaultsKey.monitorSysDetailedTemps) private var sysDetailedTemps = false
+    @AppStorage(DefaultsKey.monitorSysDetailedTempsExpanded) private var detailedTempsExpanded = false
     @AppStorage(DefaultsKey.monitorSysCPU) private var sysCPU = true
     @AppStorage(DefaultsKey.monitorSysGPU) private var sysGPU = true
     @AppStorage(DefaultsKey.monitorSysMemory) private var sysMemory = true
@@ -86,13 +89,17 @@ struct SystemSection: View {
 
     /// Card subsections, in order, filtered by the per-item toggles (and whether a
     /// battery exists). Drives divider interleaving so only rendered blocks get one.
-    private enum Block: String, PanelOrderItem { case temps, usage, memory, alerts, uptime }
+    private enum Block: String, PanelOrderItem { case temps, fanSpeeds, usage, memory, alerts, uptime }
 
     // Hub availability per metric family: an unavailable metric leaves the
     // card entirely, including the edit-mode hidden rows.
     private var cpuAvailable: Bool { AppFeature.monitorCPU.isAvailable }
     private var gpuAvailable: Bool { AppFeature.monitorGPU.isAvailable }
     private var memoryAvailable: Bool { AppFeature.monitorMemory.isAvailable }
+    private var powerAvailable: Bool { AppFeature.monitorPower.isAvailable }
+    private var batteryAvailable: Bool {
+        powerAvailable && PowerSampler.hasInternalBattery
+    }
 
     private var usageVisible: Bool {
         (sysCPU && cpuAvailable) || (sysGPU && gpuAvailable)
@@ -108,7 +115,8 @@ struct SystemSection: View {
 
     private func isBlockAvailable(_ block: Block) -> Bool {
         switch block {
-        case .temps, .usage: return cpuAvailable || gpuAvailable
+        case .temps, .usage: return cpuAvailable || gpuAvailable || batteryAvailable || powerAvailable
+        case .fanSpeeds: return monitor.snapshot.hasFans
         case .memory: return memoryAvailable
         case .alerts, .uptime: return true
         }
@@ -132,6 +140,7 @@ struct SystemSection: View {
     private func isVisible(_ block: Block) -> Bool {
         switch block {
         case .temps: return sysTemps
+        case .fanSpeeds: return sysFanSpeeds
         case .usage: return usageVisible
         case .memory: return sysMemory
         case .alerts: return sysAlerts
@@ -143,6 +152,8 @@ struct SystemSection: View {
         PanelLayout.resetItemOrder(key: DefaultsKey.panelSystemOrder)
         systemOrderRaw = ""
         sysTemps = true
+        sysFanSpeeds = true
+        sysDetailedTemps = false
         sysCPU = true
         sysGPU = true
         sysMemory = true
@@ -154,6 +165,7 @@ struct SystemSection: View {
     private func blockContent(_ block: Block, editing: Bool) -> some View {
         switch block {
         case .temps: temperatureGrid(editing: editing)
+        case .fanSpeeds: fanSpeedsRow(editing: editing)
         case .usage: usageRows(editing: editing)
         case .memory: memoryRows(editing: editing)
         case .alerts: alertRows(editing: editing)
@@ -265,8 +277,152 @@ struct SystemSection: View {
                         .font(.system(size: 10))
                         .foregroundStyle(.tertiary)
                 }
+
+                if sysDetailedTemps, !monitor.snapshot.detailedTemperatures.isEmpty {
+                    Button {
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                            detailedTempsExpanded.toggle()
+                        }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Text(l10n.s.monitorSysDetailedTemps)
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(.secondary)
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 8, weight: .bold))
+                                .foregroundStyle(.tertiary)
+                                .rotationEffect(.degrees(detailedTempsExpanded ? 90 : 0))
+                            Spacer()
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.top, 4)
+
+                    if detailedTempsExpanded {
+                        VStack(alignment: .leading, spacing: 4) {
+                            ForEach(monitor.snapshot.detailedTemperatures) { reading in
+                                HStack {
+                                    Text(localizedLabel(for: reading.labelType))
+                                        .font(.system(size: 11))
+                                        .foregroundStyle(.secondary)
+                                    Spacer()
+                                    Text(MetricFormat.temperature(reading.valueCelsius, unit: displayTemperatureUnit))
+                                        .font(.system(size: 11, weight: .medium, design: .rounded))
+                                        .monospacedDigit()
+                                }
+                                .padding(.horizontal, 4)
+                            }
+                        }
+                        .padding(.top, 2)
+                    }
+                }
             }
         }
+    }
+
+    private func localizedLabel(for type: TemperatureLabelType) -> String {
+        switch type {
+        case .cpuPerformanceCores: return l10n.s.tempCPUPerformanceCores
+        case .cpuEfficiencyCores: return l10n.s.tempCPUEfficiencyCores
+        case .cpu: return l10n.s.cpuLabel
+        case .graphics: return l10n.s.tempGraphics
+        case .battery: return l10n.s.batteryLabel
+        case .ssd: return l10n.s.tempSSD
+        case .palmRest: return l10n.s.tempPalmRest
+        case .airflow: return l10n.s.tempAirflow
+        case .airport: return l10n.s.tempAirPort
+        }
+    }
+
+    @ViewBuilder
+    private func fanSpeedsRow(editing: Bool) -> some View {
+        if !sysFanSpeeds {
+            PanelHiddenItemRow(title: l10n.s.monitorSysFanSpeeds,
+                               systemImage: "fanblades",
+                               isVisible: $sysFanSpeeds)
+        } else {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 6) {
+                    subsectionLabel(l10n.s.monitorFansTitle)
+                    Spacer(minLength: 0)
+                    if editing {
+                        PanelInlineHideButton(isVisible: $sysFanSpeeds)
+                    }
+                }
+                if monitor.snapshot.fans.isEmpty {
+                    Text(l10n.s.monitorUnavailable)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
+                } else {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(monitor.snapshot.fans) { fan in
+                            fanRowContent(name: fan.name, rpm: fan.rpm, percent: fan.percent)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func fanRowContent(name: String, rpm: Double?, percent: Int?) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "fanblades")
+                .font(.system(size: 9))
+                .foregroundStyle(.secondary)
+                .frame(width: 12)
+            
+            Text(name)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+                .frame(width: 58, alignment: .leading)
+            
+            if let rpm {
+                if rpm == 0 {
+                    UsageBar(fraction: 0)
+                    Text(l10n.s.monitorOff)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 60, alignment: .trailing)
+                    Text("")
+                        .frame(width: 30)
+                } else {
+                    let fraction = percent.map { Double($0) / 100.0 } ?? 0.0
+                    UsageBar(fraction: fraction, tint: .accentColor)
+                    
+                    Text(String(format: "%.0f %@", locale: Locale.current, rpm, l10n.s.monitorRPM))
+                        .font(.system(size: 11, weight: .medium, design: .rounded))
+                        .monospacedDigit()
+                        .frame(width: 60, alignment: .trailing)
+                    
+                    if let percent {
+                        Text("\(percent)%")
+                            .font(.system(size: 11, weight: .semibold, design: .rounded))
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                            .frame(width: 30, alignment: .trailing)
+                    } else {
+                        Text("-")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 30, alignment: .trailing)
+                    }
+                }
+            } else {
+                UsageBar(fraction: 0)
+                Text("-")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 60, alignment: .trailing)
+                Text("-")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 30, alignment: .trailing)
+            }
+        }
+        .padding(.horizontal, 4)
     }
 
     private func temperatureCell(icon: String, label: String, value: Double?) -> some View {

--- a/Sources/Vorssaint/UI/MenuPanel/USBSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/USBSection.swift
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import SwiftUI
+
+struct USBSection: View {
+    @ObservedObject private var l10n = L10n.shared
+    @ObservedObject private var usbMonitor = USBMonitorService.shared
+    @Environment(\.colorScheme) private var colorScheme
+    @AppStorage(DefaultsKey.usbShowTechnicalDetails) private var showTechDetails = false
+    var collapsible = true
+
+    private var chargers: [USBDeviceItem] { usbMonitor.devices.filter { $0.category == .charger } }
+    private var ethernetAdapters: [USBDeviceItem] { usbMonitor.devices.filter { $0.category == .ethernet } }
+    private var usbDevices: [USBDeviceItem] { usbMonitor.devices.filter { $0.category == .usbDevice } }
+
+    var body: some View {
+        PanelSection(.usb, title: l10n.s.usbSection, collapsible: collapsible) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text(l10n.s.usbConnectedDevices)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            showTechDetails.toggle()
+                        }
+                    } label: {
+                        Image(systemName: showTechDetails ? "info.circle.fill" : "info.circle")
+                            .font(.system(size: 11))
+                            .foregroundStyle(showTechDetails ? Color.accentColor : .secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help(l10n.s.usbShowTechDetails)
+
+                    Button {
+                        usbMonitor.refresh()
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help(l10n.s.homebrewRefresh)
+                }
+
+                if usbMonitor.devices.isEmpty {
+                    HStack(spacing: 8) {
+                        Image(systemName: "cable.connector.slash")
+                            .font(.system(size: 14))
+                            .foregroundStyle(.tertiary)
+                        Text(l10n.s.usbNoDevices)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.tertiary)
+                    }
+                    .padding(.vertical, 6)
+                } else {
+                    VStack(spacing: 8) {
+                        ForEach(chargers) { device in
+                            powerSupplyRow(device)
+                        }
+
+                        ForEach(ethernetAdapters) { device in
+                            usbDeviceRow(device)
+                        }
+
+                        if !usbDevices.isEmpty {
+                            renderUSBDevicesList(usbDevices)
+                        }
+                    }
+                }
+            }
+            .panelCard()
+        }
+    }
+
+    private func usbDeviceRow(_ device: USBDeviceItem) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            // Header Row: Icon + Name + Vendor + Eject
+            let devColor = deviceColor(for: device)
+
+            // Header Row: Icon + Name + Vendor + Eject
+            HStack(spacing: 8) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(devColor.opacity(0.14))
+                        .frame(width: 24, height: 24)
+
+                    Image(systemName: device.iconName)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(devColor)
+                }
+
+                Text(device.name)
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+                    .layoutPriority(1)
+
+                Spacer(minLength: 4)
+
+                if let vendor = device.cleanVendor {
+                    Text(vendor)
+                        .font(.system(size: 10.5, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.65)
+                }
+            }
+
+            // Line 2: Speed Badge + VID:PID Chip
+            HStack(alignment: .center, spacing: 6) {
+                Text(device.speedLabel)
+                    .font(.system(size: 10, weight: .semibold))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule()
+                            .fill(devColor.opacity(0.12))
+                    )
+                    .foregroundStyle(devColor)
+
+                Spacer(minLength: 4)
+
+                if showTechDetails && !device.hexVIDPID.isEmpty {
+                    Text(device.hexVIDPID)
+                        .font(.system(size: 10, weight: .bold, design: .monospaced))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                                .fill(Color.primary.opacity(0.06))
+                        )
+                        .foregroundStyle(.secondary)
+                } else if !showTechDetails {
+                    Text(device.versionLabel)
+                        .font(.system(size: 9.5, weight: .medium))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule()
+                                .fill(Color.primary.opacity(0.06))
+                        )
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            // Line 3 & 4: Version (BCD) + Serial Number (Stacked for full line width)
+            if showTechDetails && (device.usbVersionBCD != nil || device.serialFormatted != nil) {
+                VStack(alignment: .leading, spacing: 3) {
+                    if device.usbVersionBCD != nil {
+                        Text(device.bcdHexLabel)
+                            .font(.system(size: 9.5, weight: .regular))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
+                    }
+
+                    if let sn = device.serialFormatted {
+                        HStack {
+                            Text(sn)
+                                .font(.system(size: 9.5, weight: .medium, design: .monospaced))
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.6)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 1.5)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                                        .fill(Color.primary.opacity(0.04))
+                                )
+                                .foregroundStyle(.tertiary)
+                            Spacer()
+                        }
+                    }
+                }
+            }
+        }
+        .padding(9)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.primary.opacity(colorScheme == .dark ? 0.04 : 0.02))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(Color.primary.opacity(0.06), lineWidth: 0.5)
+        )
+    }
+
+    private func powerSupplyRow(_ device: USBDeviceItem) -> some View {
+        HStack(spacing: 8) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(Color.orange.opacity(0.14))
+                    .frame(width: 22, height: 22)
+
+                Image(systemName: "bolt.fill")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(Color.orange)
+            }
+
+            Text(device.name)
+                .font(.system(size: 12, weight: .bold))
+                .foregroundStyle(.primary)
+
+            if let tag = device.vendor, !tag.isEmpty {
+                Text(tag)
+                    .font(.system(size: 9.5, weight: .bold))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule()
+                            .fill(Color.orange.opacity(0.12))
+                    )
+                    .foregroundStyle(Color.orange)
+            }
+
+            Spacer()
+
+            Text(device.speedLabel)
+                .font(.system(size: 12, weight: .bold, design: .rounded))
+                .foregroundStyle(.primary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.primary.opacity(colorScheme == .dark ? 0.04 : 0.02))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(Color.primary.opacity(0.06), lineWidth: 0.5)
+        )
+    }
+
+    @ViewBuilder
+    private func renderUSBDevicesList(_ devices: [USBDeviceItem]) -> some View {
+        let allHubs = devices.filter { $0.isHub }
+        let nonHubs = devices.filter { !$0.isHub }
+
+        if !allHubs.isEmpty {
+            let hubIDs = Set(allHubs.map { $0.id })
+            let masterHub = allHubs.max(by: { ($0.speedMbps ?? 0) < ($1.speedMbps ?? 0) }) ?? allHubs[0]
+
+            // Devices physically connected under hub chips
+            let hubChildren = nonHubs.filter { dev in
+                guard let pId = dev.parentId else { return false }
+                return hubIDs.contains(pId)
+            }
+
+            // Standalone devices connected directly to Mac ports (e.g. SL300 SSD, TP-Link LAN)
+            let standaloneDevices = nonHubs.filter { dev in
+                guard let pId = dev.parentId else { return true }
+                return !hubIDs.contains(pId)
+            }
+
+            VStack(spacing: 8) {
+                if !hubChildren.isEmpty || !allHubs.isEmpty {
+                    masterHubContainer(hub: masterHub, childDevices: hubChildren)
+                }
+
+                ForEach(standaloneDevices) { device in
+                    usbDeviceRow(device)
+                }
+            }
+        } else {
+            VStack(spacing: 6) {
+                ForEach(nonHubs) { device in
+                    usbDeviceRow(device)
+                }
+            }
+        }
+    }
+
+    private func masterHubContainer(hub: USBDeviceItem, childDevices: [USBDeviceItem]) -> some View {
+        let hubTitle = (hub.vendor != nil && !hub.vendor!.isEmpty && hub.vendor != hub.name) ? "\(hub.name) (\(hub.vendor!))" : hub.name
+
+        return VStack(alignment: .leading, spacing: 6) {
+            // Master Hub Header
+            HStack(spacing: 8) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color.blue.opacity(0.16))
+                        .frame(width: 24, height: 24)
+
+                    Image(systemName: "rectangle.grid.2x2.fill")
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundStyle(Color.blue)
+                }
+
+                Text(hubTitle)
+                    .font(.system(size: 12.5, weight: .bold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+
+                Spacer(minLength: 4)
+
+                Text(hub.speedLabel)
+                    .font(.system(size: 10, weight: .semibold))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule()
+                            .fill(Color.blue.opacity(0.12))
+                    )
+                    .foregroundStyle(Color.blue)
+            }
+
+            // Indented Children Sub-Devices
+            if !childDevices.isEmpty {
+                VStack(alignment: .leading, spacing: 5) {
+                    ForEach(childDevices) { child in
+                        HStack(spacing: 6) {
+                            Rectangle()
+                                .fill(Color.blue.opacity(0.35))
+                                .frame(width: 2)
+                                .padding(.vertical, 2)
+
+                            usbDeviceRow(child)
+                        }
+                    }
+                }
+                .padding(.leading, 6)
+            }
+        }
+        .padding(9)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.primary.opacity(colorScheme == .dark ? 0.05 : 0.025))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(Color.blue.opacity(0.18), lineWidth: 0.8)
+        )
+    }
+
+    private func deviceColor(for device: USBDeviceItem) -> Color {
+        if device.category == .charger { return .orange }
+        if device.category == .ethernet { return .green }
+        let combined = "\(device.name) \(device.vendor ?? "")".lowercased()
+        if combined.contains("ax88") || combined.contains("rtl81") || combined.contains("ethernet") || combined.contains("lan adapter") || combined.contains("asix") {
+            return .green
+        }
+        if combined.contains("wlan") || combined.contains("wifi") || combined.contains("802.11") || combined.contains("wireless") {
+            return .cyan
+        }
+        if combined.contains("display") || combined.contains("monitor") || combined.contains("hdmi") || combined.contains("billboard") || combined.contains("displaylink") {
+            return .indigo
+        }
+        guard let mbps = device.speedMbps else { return .secondary }
+        if mbps >= 40000 { return .purple } // USB4 / Thunderbolt 3/4/5
+        if mbps >= 5000 { return .blue }    // USB 3.0 / 3.1 / 3.2 SuperSpeed
+        return .secondary                   // USB 1.1 / 2.0 High Speed
+    }
+}

--- a/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
@@ -754,6 +754,7 @@ extension AppFeature {
         case .monitorMemory: return s.monitorShowMemory
         case .monitorNetwork: return s.monitorShowNetwork
         case .monitorDisk: return s.diskSection
+        case .monitorUSB: return s.usbSection
         case .monitorPower: return s.powerSection
         case .fanControl: return FeatureStrings.fanControl(L10n.shared.language).title
         }
@@ -824,6 +825,7 @@ extension AppFeature {
         case .monitorMemory: return hub.descMonitorMemory
         case .monitorNetwork: return hub.descMonitorNetwork
         case .monitorDisk: return hub.descMonitorDisk
+        case .monitorUSB: return "List and manage connected USB devices, speeds, and versions."
         case .monitorPower: return hub.descMonitorPower
         case .fanControl: return FeatureStrings.fanControl(L10n.shared.language).hubDescription
         }

--- a/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
@@ -245,7 +245,7 @@ extension AppFeature {
         case .screenRecorder:
             return FeatureSettingsDestination(.screenshot, sectionAnchor: .screenRecorder)
 
-        case .monitorCPU, .monitorGPU, .monitorMemory, .monitorNetwork, .monitorDisk, .monitorPower:
+        case .monitorCPU, .monitorGPU, .monitorMemory, .monitorNetwork, .monitorDisk, .monitorUSB, .monitorPower:
             return FeatureSettingsDestination(.monitor)
         case .fanControl:
             return FeatureSettingsDestination(.monitor, sectionAnchor: .fanControl)
@@ -257,7 +257,7 @@ extension AppFeature {
 /// features only disappears when ALL of them are switched off in the hub.
 enum FeatureVisibilitySupport {
     static let monitorFeatures: [AppFeature] = [
-        .monitorCPU, .monitorGPU, .monitorMemory, .monitorNetwork, .monitorDisk, .monitorPower,
+        .monitorCPU, .monitorGPU, .monitorMemory, .monitorNetwork, .monitorDisk, .monitorUSB, .monitorPower,
         .fanControl,
     ]
 

--- a/Sources/Vorssaint/UI/Settings/MonitorPanelConfig.swift
+++ b/Sources/Vorssaint/UI/Settings/MonitorPanelConfig.swift
@@ -14,6 +14,8 @@ struct MonitorPanelConfig: View {
 
     @AppStorage(DefaultsKey.monitorShowSystem) private var showSystem = true
     @AppStorage(DefaultsKey.monitorSysTemps) private var sysTemps = true
+    @AppStorage(DefaultsKey.monitorSysDetailedTemps) private var sysDetailedTemps = false
+    @AppStorage(DefaultsKey.monitorSysFanSpeeds) private var sysFanSpeeds = true
     @AppStorage(DefaultsKey.monitorSysCPU) private var sysCPU = true
     @AppStorage(DefaultsKey.monitorSysGPU) private var sysGPU = true
     @AppStorage(DefaultsKey.monitorPwrTemperature) private var pwrTemperature = true
@@ -28,6 +30,10 @@ struct MonitorPanelConfig: View {
     @AppStorage(DefaultsKey.monitorNetTest) private var netTest = true
 
     @AppStorage(DefaultsKey.monitorShowDisk) private var showDisk = true
+    @AppStorage(DefaultsKey.monitorShowUSB) private var showUSB = true
+    @AppStorage(DefaultsKey.usbShowTechnicalDetails) private var usbTechDetails = false
+    @AppStorage(DefaultsKey.usbShowEthernet) private var usbShowEthernet = false
+    @AppStorage(DefaultsKey.usbShowPowerCable) private var usbShowPower = false
     @AppStorage(DefaultsKey.monitorDiskUsage) private var diskUsage = true
     @AppStorage(DefaultsKey.monitorDiskActivity) private var diskActivity = true
     @AppStorage(DefaultsKey.monitorDiskSMART) private var diskSMART = true
@@ -48,6 +54,9 @@ struct MonitorPanelConfig: View {
             block(.system, title: l10n.s.systemSection, master: $showSystem) {
                 if AppFeature.monitorCPU.isAvailable || AppFeature.monitorGPU.isAvailable {
                     Toggle(l10n.s.temperatures, isOn: $sysTemps)
+                    Toggle(l10n.s.monitorSysDetailedTemps, isOn: $sysDetailedTemps)
+                        .disabled(!sysTemps)
+                    Toggle(l10n.s.monitorSysFanSpeeds, isOn: $sysFanSpeeds)
                 }
                 if AppFeature.monitorCPU.isAvailable {
                     Toggle(l10n.s.cpuLabel, isOn: $sysCPU)
@@ -76,6 +85,13 @@ struct MonitorPanelConfig: View {
                 Toggle(l10n.s.monitorItemDiskSMART, isOn: $diskSMART)
                 Toggle(l10n.s.monitorItemDiskProtection, isOn: $diskProtection)
                 Toggle(l10n.s.monitorItemDiskTools, isOn: $diskTools)
+            }
+        }
+        if AppFeature.monitorUSB.isAvailable {
+            block(.usb, title: l10n.s.usbSection, master: $showUSB) {
+                Toggle(l10n.s.usbShowTechDetails, isOn: $usbTechDetails)
+                Toggle(l10n.s.usbShowEthernet, isOn: $usbShowEthernet)
+                Toggle(l10n.s.usbShowPowerCable, isOn: $usbShowPower)
             }
         }
         if AppFeature.monitorPower.isAvailable {
@@ -136,5 +152,5 @@ struct MonitorPanelConfig: View {
 }
 
 private enum PanelConfigBlock: Hashable {
-    case system, network, disk, power
+    case system, network, disk, usb, power
 }

--- a/Sources/Vorssaint/UI/Settings/MonitorSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/MonitorSettings.swift
@@ -306,6 +306,10 @@ private struct MenuBarMetricOrderEditor: View {
                         NetworkMenuBarOrderOption()
                     }
 
+                    if metric == .connectedDevices {
+                        ConnectedDevicesMenuBarOrderOptions()
+                    }
+
                     if metric != visibleOrder.last {
                         Divider()
                     }
@@ -392,6 +396,26 @@ private struct NetworkMenuBarOrderOption: View {
     var body: some View {
         if menuBarNetwork {
             MetricRowOptionToggle(label: l10n.s.monitorNetworkUploadFirst, isOn: $uploadFirst)
+        }
+    }
+}
+
+private struct ConnectedDevicesMenuBarOrderOptions: View {
+    @ObservedObject private var l10n = L10n.shared
+    @AppStorage(DefaultsKey.menuBarConnectedDevices) private var menuBarConnectedDevices = false
+    @AppStorage(DefaultsKey.usbExcludeChargersFromCount) private var excludeChargers = false
+    @AppStorage(DefaultsKey.usbExcludeHubsFromCount) private var excludeHubs = false
+    @AppStorage(DefaultsKey.usbExcludeEthernetFromCount) private var excludeEthernet = false
+    @AppStorage(DefaultsKey.usbExcludeStorageFromCount) private var excludeStorage = false
+
+    var body: some View {
+        if menuBarConnectedDevices {
+            VStack(spacing: 2) {
+                MetricRowOptionToggle(label: l10n.s.usbExcludeChargers, isOn: $excludeChargers)
+                MetricRowOptionToggle(label: l10n.s.usbExcludeHubs, isOn: $excludeHubs)
+                MetricRowOptionToggle(label: l10n.s.usbExcludeEthernet, isOn: $excludeEthernet)
+                MetricRowOptionToggle(label: l10n.s.usbExcludeStorage, isOn: $excludeStorage)
+            }
         }
     }
 }

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -4429,7 +4429,7 @@ struct MetricsTests {
         expect(registeredDefaults[DefaultsKey.menuBarFanSpeed] as? Bool == false,
                "menu bar fan speed is opt-in")
         expect(registeredDefaults[DefaultsKey.menuBarMetricOrder] as? String
-               == "cpu,cpuTemperature,gpu,gpuTemperature,memory,battery,batteryTime,batteryTemperature,peripheralBattery,network,diskUsage,diskActivity,power,fanSpeed",
+               == "cpu,cpuTemperature,gpu,gpuTemperature,memory,battery,batteryTime,batteryTemperature,peripheralBattery,network,diskUsage,diskActivity,diskCount,connectedDevices,power,fanSpeed",
                "menu bar metric order keeps temperature sensors next to their components and disk near live I/O")
         expect(registeredDefaults[DefaultsKey.menuBarCombineTemperatures] as? Bool == true,
                "menu bar combines usage and temperature by default")
@@ -5726,11 +5726,11 @@ struct MetricsTests {
         expect(Defaults.sanitizedMenuBarMemoryStyle("bad") == "percent", "invalid memory style falls back to percent")
         expect(Defaults.sanitizedMenuBarMetricOrder("cpu,gpu,memory,network,battery,power")
                == ["cpu", "gpu", "memory", "network", "battery", "power",
-                   "cpuTemperature", "gpuTemperature", "batteryTime", "batteryTemperature", "peripheralBattery", "diskUsage", "diskActivity", "fanSpeed"],
+                   "cpuTemperature", "gpuTemperature", "batteryTime", "batteryTemperature", "peripheralBattery", "diskUsage", "diskActivity", "diskCount", "connectedDevices", "fanSpeed"],
                "menu bar metric order appends temperature sensors without rewriting existing saved order")
         expect(Defaults.sanitizedMenuBarMetricOrder("temperature,cpu,cpu,bad")
                == ["cpuTemperature", "gpuTemperature", "batteryTemperature",
-                   "cpu", "gpu", "memory", "battery", "batteryTime", "peripheralBattery", "network", "diskUsage", "diskActivity", "power", "fanSpeed"],
+                   "cpu", "gpu", "memory", "battery", "batteryTime", "peripheralBattery", "network", "diskUsage", "diskActivity", "diskCount", "connectedDevices", "power", "fanSpeed"],
                "menu bar metric order migrates the old generic temperature value")
         expect(Defaults.sanitizedBundleIdentifierList([" com.example.One ", "", "com.example.One", "com.example.Two"])
                == ["com.example.One", "com.example.Two"],
@@ -14822,7 +14822,7 @@ struct MetricsTests {
 
         // MARK: Features hub catalog
 
-        expect(AppFeature.allCases.count == 57, "feature catalog has 57 features")
+        expect(AppFeature.allCases.count == 58, "feature catalog has 58 features")
         expect(Set(AppFeature.allCases.map(\.rawValue)).count == AppFeature.allCases.count,
                "feature ids are unique")
         expect(AppFeature.allCases.map(\.rawValue) == [
@@ -14836,7 +14836,7 @@ struct MetricsTests {
             "quickLauncher", "quickToggles", "colorPicker", "screenOCR", "cleaningMode", "mediaTools",
             "cleaner", "uninstaller", "homebrew", "appUpdates", "screenshot", "cameraPreview",
             "radialMenu", "scratchpad", "commandBar", "screenRecorder", "killProcess",
-            "monitorCPU", "monitorGPU", "monitorMemory", "monitorNetwork", "monitorDisk", "monitorPower",
+            "monitorCPU", "monitorGPU", "monitorMemory", "monitorNetwork", "monitorDisk", "monitorUSB", "monitorPower",
             "fanControl",
         ], "feature ids are stable (they persist inside availability keys)")
         expect(MouseAccelerationSupport.validatedRegistryID(nil) == nil


### PR DESCRIPTION
This PR adds the ability to track the number of connected USB/Thunderbolt devices and external disks directly in the menu bar with category exclusions.

### Features
- **Connected Devices Metric:** Displays the count of connected USB/Thunderbolt devices in the menu bar.
- **External Disks Count Metric:** Displays the count of connected disks.
- **Category Exclusions:** Users can choose to exclude specific device categories from the count:
  - Exclude Power Supplies / Chargers
  - Exclude USB Hubs & Docks
  - Exclude Network & Ethernet Adapters
  - Exclude External Storage
- **Accurate Storage Deduplication:** Recursively matches IOKit USB devices to mounted partition volumes via BSD identifier, ensuring connected drives are counted once rather than duplicated.
- **Live Updates:** Counts update live in the menu bar using `NSWorkspace` and `IOKit` notifications.
- **Metric Detail Popover:** Provides detailed overview of connected devices, speeds, and volumes.

### Screenshots

#### Menu Bar Metric
![Connected Devices in Menu Bar](https://raw.githubusercontent.com/kirolos-esmat/vorssaint-utils/screenshots/connected-devices-menubar.png)

#### Settings & Category Exclusions
![Connected Devices Settings](https://raw.githubusercontent.com/kirolos-esmat/vorssaint-utils/screenshots/connected-devices-settings.png)