### PR TITLE
feat(menu-panel): show the current track with transport controls

### DIFF
--- a/Sources/Vorssaint/Core/Defaults.swift
+++ b/Sources/Vorssaint/Core/Defaults.swift
@@ -287,6 +287,7 @@ enum DefaultsKey {
     static let panelShowUtilities = "panelShowUtilities"
     static let panelShowControls = "panelShowControls"
     static let panelShowToggles = "panelShowToggles"
+    static let panelShowNowPlaying = "panelShowNowPlaying"
     // Quick toggles tab: per-action visibility (the order lives in panelToggleOrder).
     static let panelToggleDarkMode = "panelToggleDarkMode"
     static let panelToggleKeyboardLight = "panelToggleKeyboardLight"
@@ -1105,6 +1106,7 @@ enum Defaults {
         DefaultsKey.panelShowUtilities: true,
         DefaultsKey.panelShowControls: true,
         DefaultsKey.panelShowToggles: true,
+        DefaultsKey.panelShowNowPlaying: true,
         DefaultsKey.panelToggleDarkMode: true,
         DefaultsKey.panelToggleKeyboardLight: true,
         DefaultsKey.panelToggleMicMute: true,
@@ -1829,6 +1831,39 @@ enum Defaults {
             let lower = item.lowercased()
             guard !item.isEmpty, seen.insert(lower).inserted else { continue }
             result.append(item)
+        }
+        return result
+    }
+
+    /// Panel sections added after orders started being saved, and the section
+    /// each one belongs after. Keys are `PanelSectionID` raw values, which are
+    /// the identifiers already persisted in the saved order.
+    static let panelSectionPredecessors: [String: String] = [
+        "disk": "network",
+        "controls": "utilities",
+        "brightness": "keepAwake",
+        "nowPlaying": "mixer",
+    ]
+
+    /// Merges a saved section order with the canonical one. A section that
+    /// saved order predates lands next to the section it belongs after rather
+    /// than at the end, where a user who has reordered their panel once would
+    /// never find it. `after` carries that rule for every section added since
+    /// orders started being saved; four copies of this arithmetic used to sit
+    /// in `PanelLayout.order`, one per section.
+    static func sanitizedSectionOrder(_ raw: String,
+                                      canonical: [String],
+                                      after: [String: String]) -> [String] {
+        let saved = raw.split(separator: ",").map(String.init).filter(canonical.contains)
+        var seen = Set<String>()
+        var result: [String] = []
+        for id in saved where seen.insert(id).inserted { result.append(id) }
+        for id in canonical where seen.insert(id).inserted {
+            if let predecessor = after[id], let index = result.firstIndex(of: predecessor) {
+                result.insert(id, at: index + 1)
+            } else {
+                result.append(id)
+            }
         }
         return result
     }

--- a/Sources/Vorssaint/Core/FeatureCatalog.swift
+++ b/Sources/Vorssaint/Core/FeatureCatalog.swift
@@ -22,7 +22,7 @@ enum AppFeature: String, CaseIterable {
     case clipboardHistory, pastePlain, finderCutPaste, finderRename, shelf, urlCleaner,
          diskImageInstaller
     // Sound
-    case mixer, soundOutputSwitcher, micMute, musicBlock
+    case mixer, soundOutputSwitcher, micMute, musicBlock, nowPlaying
     // Energy and display
     case keepAwake, brightness, extraBrightness, bluetoothSleep
     // Tools
@@ -103,7 +103,7 @@ extension AppFeature {
         case .clipboardHistory, .pastePlain, .finderCutPaste, .finderRename, .shelf, .urlCleaner,
              .diskImageInstaller:
             return .clipboardFiles
-        case .mixer, .soundOutputSwitcher, .micMute, .musicBlock:
+        case .mixer, .soundOutputSwitcher, .micMute, .musicBlock, .nowPlaying:
             return .sound
         case .keepAwake, .brightness, .extraBrightness, .bluetoothSleep:
             return .energyDisplay
@@ -151,6 +151,7 @@ extension AppFeature {
         case .soundOutputSwitcher: return "hifispeaker"
         case .micMute: return "mic.slash"
         case .musicBlock: return "music.note"
+        case .nowPlaying: return "play.circle"
         case .keepAwake: return "moon.zzz.fill"
         case .brightness: return "display.2"
         case .extraBrightness: return "sun.max.fill"
@@ -233,7 +234,7 @@ extension AppFeature {
         case .brightness: return [DefaultsKey.brightnessControlEnabled]
         case .extraBrightness: return [DefaultsKey.extraBrightnessEnabled]
         case .bluetoothSleep: return [DefaultsKey.bluetoothSleepEnabled]
-        case .windowLayout, .diskImageInstaller, .mixer, .micMute, .keepAwake,
+        case .windowLayout, .diskImageInstaller, .mixer, .micMute, .keepAwake, .nowPlaying,
              .quickLauncher, .quickToggles, .colorPicker, .screenOCR, .cleaningMode, .mediaTools,
              .cleaner, .uninstaller, .homebrew, .appUpdates, .screenshot, .cameraPreview, .scratchpad,
              .commandBar, .screenRecorder, .killProcess,
@@ -283,7 +284,7 @@ extension AppFeature {
         case .mixer: return [.audioCapture, .accessibility]
         case .monitorCPU, .monitorMemory, .monitorDisk, .monitorPower: return [.notifications]
         case .clipboardHistory, .shelf, .urlCleaner,
-             .soundOutputSwitcher, .musicBlock,
+             .soundOutputSwitcher, .musicBlock, .nowPlaying,
              .extraBrightness, .bluetoothSleep, .quickLauncher, .colorPicker, .micMute, .mediaTools,
              .scratchpad, .monitorGPU, .monitorNetwork, .fanControl, .killProcess:
             return []
@@ -314,7 +315,7 @@ extension AppFeature {
         Dictionary(uniqueKeysWithValues: allCases.map {
             ($0.availabilityKey,
              $0 != .focusFollowsMouse && $0 != .fanControl && $0 != .diskImageInstaller
-                && $0 != .killProcess)
+                && $0 != .killProcess && $0 != .nowPlaying)
         })
     }
 

--- a/Sources/Vorssaint/Core/FeatureCatalog.swift
+++ b/Sources/Vorssaint/Core/FeatureCatalog.swift
@@ -256,6 +256,10 @@ extension AppFeature {
              .keyboardDebounce, .textSnippets, .superKey, .mouseClickDebounce,
              .dockClick, .windowMaximizer, .windowLayout,
              .autoQuit, .quitWindowProtection, .cleaningMode, .pastePlain, .radialMenu,
+             // Pressing a media key is posting a synthetic event, the same as
+             // the radial menu's media slices: without Accessibility the post
+             // is dropped and the transport silently does nothing.
+             .nowPlaying,
              // The bar reads other apps' menus and windows and types at the
              // caret, all of it through Accessibility.
              .commandBar:
@@ -284,7 +288,7 @@ extension AppFeature {
         case .mixer: return [.audioCapture, .accessibility]
         case .monitorCPU, .monitorMemory, .monitorDisk, .monitorPower: return [.notifications]
         case .clipboardHistory, .shelf, .urlCleaner,
-             .soundOutputSwitcher, .musicBlock, .nowPlaying,
+             .soundOutputSwitcher, .musicBlock,
              .extraBrightness, .bluetoothSleep, .quickLauncher, .colorPicker, .micMute, .mediaTools,
              .scratchpad, .monitorGPU, .monitorNetwork, .fanControl, .killProcess:
             return []
@@ -298,7 +302,7 @@ extension AppFeature {
         switch self {
         case .keepAwake, .brightness, .radialMenu, .quickToggles, .cleaner,
              .uninstaller, .homebrew, .appUpdates, .mixer, .cameraPreview,
-             .micMute:
+             .micMute, .nowPlaying:
             return []
         default:
             return permissions.filter { $0 == .accessibility || $0 == .screenRecording }

--- a/Sources/Vorssaint/Core/FeaturePresets.swift
+++ b/Sources/Vorssaint/Core/FeaturePresets.swift
@@ -123,7 +123,7 @@ extension AppFeature {
              .musicBlock, .bluetoothSleep, .keepAwake, .brightness, .quickLauncher, .quickToggles, .colorPicker,
              .screenOCR, .cleaningMode, .mediaTools, .cleaner, .uninstaller, .homebrew, .screenshot,
              .cameraPreview, .scratchpad, .commandBar, .screenRecorder, .fanControl,
-             .diskImageInstaller, .killProcess:
+             .diskImageInstaller, .killProcess, .nowPlaying:
             return .idle
         case .appUpdates:
             // The list is on demand; only a background schedule keeps a timer.

--- a/Sources/Vorssaint/Core/NowPlayingStrings.swift
+++ b/Sources/Vorssaint/Core/NowPlayingStrings.swift
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Foundation
+
+/// Localized strings for the panel's Now Playing section. The section title is
+/// not here: `RadialMenuFeatureStrings.mediaNowPlaying` already carries "Now
+/// Playing" in every language, and a second copy would need a test to keep the
+/// two in agreement.
+struct NowPlayingFeatureStrings {
+    let hubDescription: String
+    let nothingPlaying: String
+}
+
+extension FeatureStrings {
+    static func nowPlaying(_ language: AppLanguage) -> NowPlayingFeatureStrings {
+        switch language {
+        case .enUS: return .enUS
+        case .ptBR: return .ptBR
+        case .tr: return .tr
+        case .ru: return .ru
+        case .es: return .es
+        case .de: return .de
+        case .fr: return .fr
+        case .it: return .it
+        case .ja: return .ja
+        case .ko: return .ko
+        case .zhHans: return .zhHans
+        case .zhTW: return .zhTW
+        case .zhHK: return .zhHK
+        }
+    }
+}
+
+extension NowPlayingFeatureStrings {
+    static let enUS = NowPlayingFeatureStrings(
+        hubDescription: "Shows what is playing in the panel, with playback controls",
+        nothingPlaying: "Nothing playing"
+    )
+    static let ptBR = NowPlayingFeatureStrings(
+        hubDescription: "Mostra o que está tocando no painel, com controles de reprodução",
+        nothingPlaying: "Nada sendo reproduzido"
+    )
+    static let tr = NowPlayingFeatureStrings(
+        hubDescription: "Panelde ne çaldığını oynatma denetimleriyle gösterir",
+        nothingPlaying: "Çalan bir şey yok"
+    )
+    static let ru = NowPlayingFeatureStrings(
+        hubDescription: "Показывает, что воспроизводится, и добавляет кнопки управления в панель",
+        nothingPlaying: "Ничего не воспроизводится"
+    )
+    static let es = NowPlayingFeatureStrings(
+        hubDescription: "Muestra lo que se está reproduciendo en el panel, con controles de reproducción",
+        nothingPlaying: "No se está reproduciendo nada"
+    )
+    static let de = NowPlayingFeatureStrings(
+        hubDescription: "Zeigt die aktuelle Wiedergabe im Panel, mit Steuerung",
+        nothingPlaying: "Keine Wiedergabe"
+    )
+    static let fr = NowPlayingFeatureStrings(
+        hubDescription: "Affiche la lecture en cours dans le panneau, avec les commandes",
+        nothingPlaying: "Aucune lecture en cours"
+    )
+    static let it = NowPlayingFeatureStrings(
+        hubDescription: "Mostra cosa è in riproduzione nel pannello, con i controlli",
+        nothingPlaying: "Nessuna riproduzione"
+    )
+    static let ja = NowPlayingFeatureStrings(
+        hubDescription: "パネルに再生中の項目と再生コントロールを表示します",
+        nothingPlaying: "再生中の項目はありません"
+    )
+    static let ko = NowPlayingFeatureStrings(
+        hubDescription: "패널에 재생 중인 항목과 재생 컨트롤을 표시합니다",
+        nothingPlaying: "재생 중인 항목 없음"
+    )
+    static let zhHans = NowPlayingFeatureStrings(
+        hubDescription: "在面板中显示正在播放的内容和播放控件",
+        nothingPlaying: "没有正在播放的内容"
+    )
+    static let zhTW = NowPlayingFeatureStrings(
+        hubDescription: "在面板中顯示正在播放的項目與播放控制項",
+        nothingPlaying: "沒有正在播放的項目"
+    )
+    static let zhHK = NowPlayingFeatureStrings(
+        hubDescription: "在面板中顯示正在播放的項目與播放控制項",
+        nothingPlaying: "沒有正在播放的項目"
+    )
+}

--- a/Sources/Vorssaint/Services/Media/MediaKeyInput.swift
+++ b/Sources/Vorssaint/Services/Media/MediaKeyInput.swift
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import AppKit
+import Foundation
+
+/// Presses a media key on the user's behalf, so whatever player owns the
+/// physical keys reacts exactly as if F7/F8/F9 was pressed. Reading Now
+/// Playing needs a platform binary (`Sources/NowPlayingAdapter`), but
+/// *controlling* it does not: the aux-button pair reaches the owning player
+/// through the same path the hardware uses, with no private framework and no
+/// per-application integration.
+///
+/// One poster for the whole app. The radial menu's media slices and the
+/// panel's Now Playing section press the same keys, and #937 is the record of
+/// what happens when each caller grows its own copy of a synthetic-event
+/// construction.
+enum MediaKeyInput {
+    /// `RadialMenuMediaKey.auxKeyType` owns the code numbers; this owns the
+    /// event. A key with no aux code (Now Playing) is not a press.
+    static func post(auxKeyType: Int32) {
+        postAuxKey(auxKeyType, down: true)
+        postAuxKey(auxKeyType, down: false)
+    }
+
+    private static func postAuxKey(_ type: Int32, down: Bool) {
+        let stateFlags: NSEvent.ModifierFlags = down
+            ? NSEvent.ModifierFlags(rawValue: 0xA00)
+            : NSEvent.ModifierFlags(rawValue: 0xB00)
+        let data1 = (Int(type) << 16) | ((down ? 0xA : 0xB) << 8)
+        guard let event = NSEvent.otherEvent(with: .systemDefined,
+                                             location: .zero,
+                                             modifierFlags: stateFlags,
+                                             timestamp: ProcessInfo.processInfo.systemUptime,
+                                             windowNumber: 0,
+                                             context: nil,
+                                             subtype: 8,
+                                             data1: data1,
+                                             data2: -1)
+        else { return }
+        event.cgEvent?.post(tap: .cghidEventTap)
+    }
+}

--- a/Sources/Vorssaint/Services/Media/NowPlayingPanelService.swift
+++ b/Sources/Vorssaint/Services/Media/NowPlayingPanelService.swift
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import Combine
+import Foundation
+
+/// Backs the panel's Now Playing section. The read is the same out-of-process
+/// one the radial menu's card uses (`MediaRemoteNowPlayingBridge`); only the
+/// paused-session question is answered differently, and the state lives here
+/// rather than on `RadialNowPlayingService` so opening the panel never
+/// disturbs the card the wheel is holding.
+///
+/// Nothing polls. The panel is a popover, so a read happens when the section
+/// appears and after a transport press, and never while the panel is shut.
+final class NowPlayingPanelService: ObservableObject {
+    static let shared = NowPlayingPanelService()
+
+    @Published private(set) var state = RadialNowPlayingState.nothingPlaying
+
+    private let bridge = MediaRemoteNowPlayingBridge()
+    private var generation = 0
+
+    private init() {}
+
+    func refresh() {
+        generation += 1
+        let requested = generation
+        if case .playing = state {} else { state = .loading }
+        bridge.fetch(includesPaused: true) { [weak self] snapshot in
+            DispatchQueue.main.async {
+                guard let self, self.generation == requested else { return }
+                self.state = snapshot.map(RadialNowPlayingState.playing) ?? .nothingPlaying
+            }
+        }
+    }
+
+    /// The glyph flips before the player answers, because the read costs a
+    /// process launch and a media key that looked like it did nothing is worse
+    /// than one that corrects itself. The confirming read follows, and a
+    /// stale reply loses to `generation`.
+    func press(_ key: RadialMenuMediaKey) {
+        guard let auxKeyType = key.auxKeyType else { return }
+        MediaKeyInput.post(auxKeyType: auxKeyType)
+        if key == .playPause, case let .playing(snapshot) = state {
+            state = .playing(snapshot.togglingPlayback)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { [weak self] in
+            self?.refresh()
+        }
+    }
+}

--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift
@@ -844,30 +844,9 @@ final class RadialMenuService: ObservableObject {
         }
     }
 
-    /// Posts the aux-button pair the physical media keys produce, so whatever
-    /// player owns the media keys reacts exactly as if F8 was pressed.
     private static func postMediaKey(_ key: RadialMenuMediaKey) {
         guard let auxKeyType = key.auxKeyType else { return }
-        postAuxKey(auxKeyType, down: true)
-        postAuxKey(auxKeyType, down: false)
-    }
-
-    private static func postAuxKey(_ type: Int32, down: Bool) {
-        let stateFlags: NSEvent.ModifierFlags = down
-            ? NSEvent.ModifierFlags(rawValue: 0xA00)
-            : NSEvent.ModifierFlags(rawValue: 0xB00)
-        let data1 = (Int(type) << 16) | ((down ? 0xA : 0xB) << 8)
-        guard let event = NSEvent.otherEvent(with: .systemDefined,
-                                             location: .zero,
-                                             modifierFlags: stateFlags,
-                                             timestamp: ProcessInfo.processInfo.systemUptime,
-                                             windowNumber: 0,
-                                             context: nil,
-                                             subtype: 8,
-                                             data1: data1,
-                                             data2: -1)
-        else { return }
-        event.cgEvent?.post(tap: .cghidEventTap)
+        MediaKeyInput.post(auxKeyType: auxKeyType)
     }
 
     // MARK: - Panel

--- a/Sources/Vorssaint/Services/RadialMenu/RadialMenuSupport.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialMenuSupport.swift
@@ -483,10 +483,27 @@ struct RadialNowPlayingSnapshot: Equatable {
     let artworkData: Data?
     let appBundleIdentifier: String?
     let appPID: Int32?
+    /// Whether the session is playing right now. The radial menu never sees a
+    /// paused one, so this is always true there; the panel asks for paused
+    /// sessions too and draws play or pause from it.
+    let isPlaying: Bool
 
     var radialLabel: String? {
         let parts = [title, artist].compactMap { $0 }
         return parts.isEmpty ? nil : parts.joined(separator: "\n")
+    }
+
+    /// The same session with playback inverted. A transport press flips the
+    /// glyph before the player has answered, because the confirming read costs
+    /// a process launch.
+    var togglingPlayback: RadialNowPlayingSnapshot {
+        RadialNowPlayingSnapshot(title: title,
+                                 artist: artist,
+                                 album: album,
+                                 artworkData: artworkData,
+                                 appBundleIdentifier: appBundleIdentifier,
+                                 appPID: appPID,
+                                 isPlaying: !isPlaying)
     }
 }
 
@@ -552,11 +569,18 @@ enum RadialNowPlayingSupport {
                             isPlaying: fields["isPlaying"] as? Bool)
     }
 
+    /// `includesPaused` is the whole difference between the two callers. The
+    /// radial menu shows a slice only while something plays, so a paused
+    /// session has to read as nothing playing there. A mini player that went
+    /// blank the moment you hit pause would be telling the user the wrong
+    /// thing, so the panel asks for the paused session and draws a play
+    /// button on it.
     static func snapshot(info: [String: Any],
                          isPlaying: Bool,
                          appBundleIdentifier: String?,
-                         appPID: Int32) -> RadialNowPlayingSnapshot? {
-        guard isPlaying else { return nil }
+                         appPID: Int32,
+                         includesPaused: Bool = false) -> RadialNowPlayingSnapshot? {
+        guard isPlaying || includesPaused else { return nil }
         let title = sanitizedText(info[titleKey])
         let artist = sanitizedText(info[artistKey])
         let album = sanitizedText(info[albumKey])
@@ -569,7 +593,8 @@ enum RadialNowPlayingSupport {
                                         album: album,
                                         artworkData: artworkData,
                                         appBundleIdentifier: bundleIdentifier,
-                                        appPID: pid)
+                                        appPID: pid,
+                                        isPlaying: isPlaying)
     }
 
     private static func sanitizedText(_ value: Any?) -> String? {

--- a/Sources/Vorssaint/Services/RadialMenu/RadialNowPlayingService.swift
+++ b/Sources/Vorssaint/Services/RadialMenu/RadialNowPlayingService.swift
@@ -292,7 +292,7 @@ enum RadialNowPlayingApplication {
 /// processes carrying Apple's signature; perl is one, the app is not. A
 /// missing script or library, a failed run, a timeout and malformed output
 /// all read as an empty playback session.
-private final class MediaRemoteNowPlayingBridge {
+final class MediaRemoteNowPlayingBridge {
     private let queue = DispatchQueue(label: "com.vorssaint.radial-now-playing", qos: .userInitiated)
     /// 2 s: a cold perl load measured 500 ms with no session playing, and a
     /// real reply adds the MediaRemote round trip plus up to 16 MB of base64
@@ -302,7 +302,8 @@ private final class MediaRemoteNowPlayingBridge {
     /// second costs nothing on screen.
     private static let replyTimeout: TimeInterval = 2.0
 
-    func fetch(completion: @escaping (RadialNowPlayingSnapshot?) -> Void) {
+    func fetch(includesPaused: Bool = false,
+               completion: @escaping (RadialNowPlayingSnapshot?) -> Void) {
         guard let script = Bundle.main.url(forResource: "now-playing", withExtension: "pl"),
               let library = Bundle.main.privateFrameworksURL?
                 .appendingPathComponent("libVorssaintNowPlaying.dylib"),
@@ -324,7 +325,8 @@ private final class MediaRemoteNowPlayingBridge {
             completion(RadialNowPlayingSupport.snapshot(info: reply.info,
                                                         isPlaying: isPlaying,
                                                         appBundleIdentifier: reply.displayID,
-                                                        appPID: reply.pid))
+                                                        appPID: reply.pid,
+                                                        includesPaused: includesPaused))
         }
     }
 }

--- a/Sources/Vorssaint/UI/MenuPanel/MenuPanelView.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/MenuPanelView.swift
@@ -77,6 +77,7 @@ struct MenuPanelView: View {
     @AppStorage(DefaultsKey.panelShowUtilities) private var showUtilities = true
     @AppStorage(DefaultsKey.panelShowControls) private var showControls = true
     @AppStorage(DefaultsKey.panelShowToggles) private var showToggles = true
+    @AppStorage(DefaultsKey.panelShowNowPlaying) private var showNowPlaying = true
     @AppStorage(DefaultsKey.panelSectionOrder) private var sectionOrderRaw = ""
     @State private var navigableContentHeight: CGFloat = 0
     @State private var metricContentHeight: CGFloat = 0
@@ -256,6 +257,7 @@ struct MenuPanelView: View {
         case .keepAwake: return 250
         case .brightness: return 140
         case .mixer: return 250
+        case .nowPlaying: return 170
         case .system: return 460
         case .network: return 190
         case .disk: return 360
@@ -287,6 +289,7 @@ struct MenuPanelView: View {
         case .keepAwake: KeepAwakeCard(collapsible: collapsible)
         case .brightness: if showBrightness { BrightnessSection(collapsible: collapsible) }
         case .mixer: if showMixer { MixerSection(collapsible: collapsible) }
+        case .nowPlaying: if showNowPlaying { NowPlayingSection(collapsible: collapsible) }
         case .system: if showSystem { SystemSection(collapsible: collapsible) }
         case .network: if showNetwork { NetworkSection(collapsible: collapsible) }
         case .disk: if showDisk { DiskSection(collapsible: collapsible) }
@@ -306,6 +309,7 @@ struct MenuPanelView: View {
         // it is switched on in Settings, not from an empty panel screen.
         case .brightness: return showBrightness && brightnessEnabled
         case .mixer: return showMixer
+        case .nowPlaying: return showNowPlaying
         case .system: return showSystem
         case .network: return showNetwork
         case .disk: return showDisk

--- a/Sources/Vorssaint/UI/MenuPanel/NowPlayingSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/NowPlayingSection.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct NowPlayingSection: View {
     @ObservedObject private var l10n = L10n.shared
     @ObservedObject private var service = NowPlayingPanelService.shared
+    @ObservedObject private var permissions = Permissions.shared
     var collapsible = true
 
     private var media: RadialMenuFeatureStrings { FeatureStrings.radialMenu(l10n.language) }
@@ -58,6 +59,14 @@ struct NowPlayingSection: View {
                 Spacer(minLength: 0)
             }
             transport
+            if !permissions.accessibility {
+                // A press without the grant is dropped by the window server,
+                // so the row says so rather than looking broken.
+                Text("\(l10n.s.permissionRequired): \(l10n.s.permissionAccessibility)")
+                    .font(.system(size: 9.5))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity)
+            }
         }
     }
 
@@ -107,6 +116,12 @@ struct NowPlayingSection: View {
 
     private func button(_ key: RadialMenuMediaKey, symbol: String, label: String) -> some View {
         Button {
+            // Posting a media key needs Accessibility. Ask for it at the
+            // moment the control is used, rather than at first run.
+            guard permissions.accessibility else {
+                permissions.requestAccessibility()
+                return
+            }
             service.press(key)
         } label: {
             Image(systemName: symbol)

--- a/Sources/Vorssaint/UI/MenuPanel/NowPlayingSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/NowPlayingSection.swift
@@ -27,6 +27,9 @@ struct NowPlayingSection: View {
                 }
             }
             .onAppear { service.refresh() }
+            .onReceive(NotificationCenter.default.publisher(for: .menuPanelWillShow)) { _ in
+                service.refresh()
+            }
         }
     }
 
@@ -94,6 +97,7 @@ struct NowPlayingSection: View {
                    label: media.mediaPlayPause)
             button(.nextTrack, symbol: "forward.fill", label: media.mediaNext)
         }
+        .frame(maxWidth: .infinity)
     }
 
     private var isPlaying: Bool {

--- a/Sources/Vorssaint/UI/MenuPanel/NowPlayingSection.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/NowPlayingSection.swift
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Vorssaint
+
+import SwiftUI
+
+/// Panel section showing the system's Now Playing session with transport
+/// controls. The read arrives from `NowPlayingPanelService` and happens when
+/// the section appears, so a panel that is shut costs nothing.
+struct NowPlayingSection: View {
+    @ObservedObject private var l10n = L10n.shared
+    @ObservedObject private var service = NowPlayingPanelService.shared
+    var collapsible = true
+
+    private var media: RadialMenuFeatureStrings { FeatureStrings.radialMenu(l10n.language) }
+    private var strings: NowPlayingFeatureStrings { FeatureStrings.nowPlaying(l10n.language) }
+
+    var body: some View {
+        PanelSection(.nowPlaying, title: media.mediaNowPlaying, collapsible: collapsible) {
+            VStack(alignment: .leading, spacing: 10) {
+                switch service.state {
+                case let .playing(snapshot):
+                    session(snapshot)
+                case .loading, .nothingPlaying:
+                    Text(strings.nothingPlaying)
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .onAppear { service.refresh() }
+        }
+    }
+
+    private func session(_ snapshot: RadialNowPlayingSnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 10) {
+                artwork(snapshot)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(snapshot.title ?? RadialNowPlayingApplication.name(for: snapshot)
+                            ?? media.mediaNowPlaying)
+                        .font(.system(size: 12, weight: .semibold))
+                        .lineLimit(2)
+                    if let artist = snapshot.artist {
+                        Text(artist)
+                            .font(.system(size: 10.5))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    if let album = snapshot.album {
+                        Text(album)
+                            .font(.system(size: 10))
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            transport
+        }
+    }
+
+    @ViewBuilder
+    private func artwork(_ snapshot: RadialNowPlayingSnapshot) -> some View {
+        let shape = RoundedRectangle(cornerRadius: 8, style: .continuous)
+        if let data = snapshot.artworkData, let image = NSImage(data: data) {
+            Image(nsImage: image)
+                .resizable()
+                .interpolation(.high)
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 54, height: 54)
+                .clipShape(shape)
+        } else {
+            shape
+                .fill(Color.primary.opacity(0.08))
+                .frame(width: 54, height: 54)
+                .overlay {
+                    if let icon = RadialNowPlayingApplication.icon(for: snapshot) {
+                        Image(nsImage: icon)
+                            .resizable()
+                            .interpolation(.high)
+                            .frame(width: 30, height: 30)
+                    } else {
+                        Image(systemName: "music.note")
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+        }
+    }
+
+    private var transport: some View {
+        HStack(spacing: 6) {
+            button(.previousTrack, symbol: "backward.fill", label: media.mediaPrevious)
+            button(.playPause, symbol: isPlaying ? "pause.fill" : "play.fill",
+                   label: media.mediaPlayPause)
+            button(.nextTrack, symbol: "forward.fill", label: media.mediaNext)
+        }
+    }
+
+    private var isPlaying: Bool {
+        if case let .playing(snapshot) = service.state { return snapshot.isPlaying }
+        return false
+    }
+
+    private func button(_ key: RadialMenuMediaKey, symbol: String, label: String) -> some View {
+        Button {
+            service.press(key)
+        } label: {
+            Image(systemName: symbol)
+                .font(.system(size: 11, weight: .semibold))
+                .frame(width: 30, height: 22)
+                .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .background(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(Color.primary.opacity(0.07))
+        )
+        .help(label)
+        .accessibilityLabel(label)
+    }
+}

--- a/Sources/Vorssaint/UI/MenuPanel/PanelLayout.swift
+++ b/Sources/Vorssaint/UI/MenuPanel/PanelLayout.swift
@@ -10,8 +10,8 @@ protocol PanelOrderItem: RawRepresentable, CaseIterable, Hashable where RawValue
 /// stable identifiers persisted in the saved order and the collapsed set, so
 /// renaming a case would orphan a user's stored layout — keep them stable.
 enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
-    case keepAwake, brightness, mixer, system, network, disk, power, fanControl, utilities, controls,
-         toggles
+    case keepAwake, brightness, mixer, nowPlaying, system, network, disk, power, fanControl,
+         utilities, controls, toggles
 
     var id: String { rawValue }
 
@@ -21,6 +21,7 @@ enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
         case .keepAwake: return s.keepAwakeTitle
         case .brightness: return FeatureStrings.brightness(L10n.shared.language).pageTitle
         case .mixer: return s.mixerSection
+        case .nowPlaying: return FeatureStrings.radialMenu(L10n.shared.language).mediaNowPlaying
         case .system: return s.systemSection
         case .network: return s.networkSection
         case .disk: return s.diskSection
@@ -37,6 +38,7 @@ enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
         case .keepAwake: return "moon.zzz.fill"
         case .brightness: return "display.2"
         case .mixer: return "slider.horizontal.3"
+        case .nowPlaying: return "play.circle"
         case .system: return "cpu"
         case .network: return "network"
         case .disk: return "internaldrive"
@@ -56,6 +58,7 @@ enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
         case .keepAwake: return DefaultsKey.panelShowKeepAwake
         case .brightness: return DefaultsKey.panelShowBrightness
         case .mixer: return DefaultsKey.monitorShowMixer
+        case .nowPlaying: return DefaultsKey.panelShowNowPlaying
         case .system: return DefaultsKey.monitorShowSystem
         case .network: return DefaultsKey.monitorShowNetwork
         case .disk: return DefaultsKey.monitorShowDisk
@@ -79,6 +82,7 @@ enum PanelSectionID: String, CaseIterable, Identifiable, Hashable {
         case .keepAwake: return [.keepAwake]
         case .brightness: return [.brightness]
         case .mixer: return [.mixer]
+        case .nowPlaying: return [.nowPlaying]
         case .system: return [.monitorCPU, .monitorGPU, .monitorMemory]
         case .network: return [.monitorNetwork]
         case .disk: return [.monitorDisk]
@@ -111,26 +115,14 @@ enum PanelLayout {
     /// The sections in display order: the user's saved order first, then any not
     /// yet listed, in their canonical order.
     static var order: [PanelSectionID] {
-        let saved = (defaults.string(forKey: DefaultsKey.panelSectionOrder) ?? "")
-            .split(separator: ",")
-            .compactMap { PanelSectionID(rawValue: String($0)) }
-        var seen = Set<PanelSectionID>()
-        var result: [PanelSectionID] = []
-        for id in saved where seen.insert(id).inserted { result.append(id) }
-        for id in PanelSectionID.allCases where seen.insert(id).inserted {
-            if id == .disk, let networkIndex = result.firstIndex(of: .network) {
-                result.insert(id, at: networkIndex + 1)
-            } else if id == .controls, let utilitiesIndex = result.firstIndex(of: .utilities) {
-                result.insert(id, at: utilitiesIndex + 1)
-            } else if id == .brightness, let keepAwakeIndex = result.firstIndex(of: .keepAwake) {
-                // New in 3.1.13: saved orders predate it, so it slots in at
-                // its canonical place instead of the end.
-                result.insert(id, at: keepAwakeIndex + 1)
-            } else {
-                result.append(id)
-            }
-        }
-        return result
+        sanitizedOrder(defaults.string(forKey: DefaultsKey.panelSectionOrder) ?? "")
+    }
+
+    static func sanitizedOrder(_ raw: String) -> [PanelSectionID] {
+        Defaults.sanitizedSectionOrder(raw,
+                                       canonical: PanelSectionID.allCases.map(\.rawValue),
+                                       after: Defaults.panelSectionPredecessors)
+            .compactMap(PanelSectionID.init(rawValue:))
     }
 
     static func setOrder(_ ids: [PanelSectionID]) {

--- a/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureHubSettings.swift
@@ -728,6 +728,7 @@ extension AppFeature {
         case .soundOutputSwitcher: return s.soundOutputSwitcherTitle
         case .micMute: return s.micMuteName
         case .musicBlock: return hub.titleMusicBlock
+        case .nowPlaying: return FeatureStrings.radialMenu(L10n.shared.language).mediaNowPlaying
         case .keepAwake: return s.keepAwakeTitle
         case .brightness: return FeatureStrings.brightness(L10n.shared.language).pageTitle
         case .extraBrightness: return s.extraBrightnessName
@@ -792,6 +793,7 @@ extension AppFeature {
         case .soundOutputSwitcher: return hub.descSoundOutputSwitcher
         case .micMute: return hub.descMicMute
         case .musicBlock: return hub.descMusicBlock
+        case .nowPlaying: return FeatureStrings.nowPlaying(L10n.shared.language).hubDescription
         case .keepAwake: return hub.descKeepAwake
         case .brightness: return FeatureStrings.brightness(L10n.shared.language).hubDescription
         case .extraBrightness: return hub.descExtraBrightness

--- a/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
+++ b/Sources/Vorssaint/UI/Settings/FeatureVisibilitySupport.swift
@@ -208,6 +208,8 @@ extension AppFeature {
             return FeatureSettingsDestination(.quickTools, sectionAnchor: .micMute)
         case .musicBlock:
             return FeatureSettingsDestination(.general, sectionAnchor: .musicBlocking)
+        case .nowPlaying:
+            return FeatureSettingsDestination(.general, sectionAnchor: .panelConfiguration)
 
         case .keepAwake:
             return FeatureSettingsDestination(.energy, sectionAnchor: .keepAwake)

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -15502,7 +15502,7 @@ struct MetricsTests {
                "Window Layout does not poll permissions when every snap zone is off")
 
         expect(activeSet(.accessibility)
-                == [.windowLayout, .cleaningMode, .commandBar, .screenRecorder],
+                == [.windowLayout, .nowPlaying, .cleaningMode, .commandBar, .screenRecorder],
                "with nothing enabled only on-demand features use accessibility")
         expect(activeSet(.accessibility, on: [DefaultsKey.scrollInverterEnabled]).contains(.scrollInverter),
                "an enabled feature counts as using its permission")

--- a/Tests/MetricsTests.swift
+++ b/Tests/MetricsTests.swift
@@ -14824,7 +14824,7 @@ struct MetricsTests {
 
         // MARK: Features hub catalog
 
-        expect(AppFeature.allCases.count == 57, "feature catalog has 57 features")
+        expect(AppFeature.allCases.count == 58, "feature catalog has 58 features")
         expect(Set(AppFeature.allCases.map(\.rawValue)).count == AppFeature.allCases.count,
                "feature ids are unique")
         expect(AppFeature.allCases.map(\.rawValue) == [
@@ -14833,7 +14833,7 @@ struct MetricsTests {
             "mouseClickDebounce", "keyboardDebounce", "textSnippets", "superKey", "quitWindowProtection",
             "clipboardHistory", "pastePlain", "finderCutPaste", "finderRename", "shelf", "urlCleaner",
             "diskImageInstaller",
-            "mixer", "soundOutputSwitcher", "micMute", "musicBlock",
+            "mixer", "soundOutputSwitcher", "micMute", "musicBlock", "nowPlaying",
             "keepAwake", "brightness", "extraBrightness", "bluetoothSleep",
             "quickLauncher", "quickToggles", "colorPicker", "screenOCR", "cleaningMode", "mediaTools",
             "cleaner", "uninstaller", "homebrew", "appUpdates", "screenshot", "cameraPreview",
@@ -14962,9 +14962,10 @@ struct MetricsTests {
                 && (AppFeature.availabilityDefaults[AppFeature.diskImageInstaller.availabilityKey] as? Bool) == false
                 && (AppFeature.availabilityDefaults[AppFeature.focusFollowsMouse.availabilityKey] as? Bool) == false
                 && (AppFeature.availabilityDefaults[AppFeature.killProcess.availabilityKey] as? Bool) == false
+                && (AppFeature.availabilityDefaults[AppFeature.nowPlaying.availabilityKey] as? Bool) == false
                 && AppFeature.allCases.filter {
                     $0 != .focusFollowsMouse && $0 != .fanControl && $0 != .diskImageInstaller
-                        && $0 != .killProcess
+                        && $0 != .killProcess && $0 != .nowPlaying
                 }.allSatisfy {
                     (AppFeature.availabilityDefaults[$0.availabilityKey] as? Bool) == true
                 },
@@ -17145,6 +17146,90 @@ struct MetricsTests {
                     appBundleIdentifier: adapterPaused?.displayID,
                     appPID: adapterPaused?.pid ?? 0) == nil,
                "a paused adapter reply degrades to Nothing Playing through the same path as before")
+        // The panel's Now Playing section asks the same reader a different
+        // question: it keeps a paused session so a mini player does not go
+        // blank the moment playback stops.
+        let pausedPanelInfo: [String: Any] = [
+            RadialNowPlayingSupport.titleKey: "Midnight City",
+            RadialNowPlayingSupport.playbackRateKey: 0.0,
+        ]
+        expect(RadialNowPlayingSupport.snapshot(info: pausedPanelInfo,
+                                                isPlaying: false,
+                                                appBundleIdentifier: "com.apple.Music",
+                                                appPID: 42) == nil,
+               "the default stays what the radial menu needs: paused reads as nothing playing")
+        let pausedPanelSnapshot = RadialNowPlayingSupport.snapshot(info: pausedPanelInfo,
+                                                                  isPlaying: false,
+                                                                  appBundleIdentifier: "com.apple.Music",
+                                                                  appPID: 42,
+                                                                  includesPaused: true)
+        expect(pausedPanelSnapshot?.title == "Midnight City" && pausedPanelSnapshot?.isPlaying == false,
+               "the panel keeps a paused session and records that it is paused")
+        expect(RadialNowPlayingSupport.snapshot(info: pausedPanelInfo,
+                                                isPlaying: true,
+                                                appBundleIdentifier: "com.apple.Music",
+                                                appPID: 42,
+                                                includesPaused: true)?.isPlaying == true,
+               "a playing session still reads as playing when paused sessions are allowed")
+        expect(RadialNowPlayingSupport.snapshot(info: [:],
+                                                isPlaying: false,
+                                                appBundleIdentifier: nil,
+                                                appPID: 0,
+                                                includesPaused: true) == nil,
+               "ownerless metadata is nothing playing whether or not paused sessions are allowed")
+        expect(pausedPanelSnapshot?.togglingPlayback.isPlaying == true
+                && pausedPanelSnapshot?.togglingPlayback.title == pausedPanelSnapshot?.title
+                && pausedPanelSnapshot?.togglingPlayback.artworkData == pausedPanelSnapshot?.artworkData,
+               "the optimistic transport flip changes the playback state and nothing else")
+
+        // One poster for the aux-button pair. A second copy of the event
+        // construction is what #937 is about, so the radial menu has to reach
+        // it through the shared one rather than build its own.
+        let mediaKeyInputSource = (try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/Media/MediaKeyInput.swift",
+            encoding: .utf8)) ?? ""
+        let mediaKeyRadialCode = ((try? String(
+            contentsOfFile: "Sources/Vorssaint/Services/RadialMenu/RadialMenuService.swift",
+            encoding: .utf8)) ?? "")
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
+        expect(mediaKeyInputSource.contains("NSEvent.otherEvent(with: .systemDefined")
+                && !mediaKeyRadialCode.contains("NSEvent.otherEvent(with: .systemDefined")
+                && mediaKeyRadialCode.contains("MediaKeyInput.post(auxKeyType:"),
+               "the media-key event is built in one place and the radial menu presses it through that")
+
+        // A saved panel order predates the section, so it has to slot in
+        // beside the mixer rather than land after Quick toggles.
+        let panelSections = ["keepAwake", "brightness", "mixer", "nowPlaying", "system", "network",
+                             "disk", "power", "fanControl", "utilities", "controls", "toggles"]
+        // Read from the table the app uses, so dropping the rule goes red here.
+        let panelPredecessors = Defaults.panelSectionPredecessors
+        expect(panelPredecessors["nowPlaying"] == "mixer",
+               "Now Playing is registered as belonging after the mixer")
+        let legacyPanelOrder = panelSections.filter { $0 != "nowPlaying" }.joined(separator: ",")
+        let upgradedPanelOrder = Defaults.sanitizedSectionOrder(legacyPanelOrder,
+                                                               canonical: panelSections,
+                                                               after: panelPredecessors)
+        expect(upgradedPanelOrder.count == panelSections.count
+                && Set(upgradedPanelOrder) == Set(panelSections),
+               "upgrading a saved panel order loses and duplicates nothing")
+        expect(upgradedPanelOrder.firstIndex(of: "nowPlaying")
+                == upgradedPanelOrder.firstIndex(of: "mixer").map { $0 + 1 },
+               "a section a saved order predates joins it after the section it belongs to")
+        // A reordered panel still gets it beside the mixer, wherever that moved to.
+        let reorderedPanel = Defaults.sanitizedSectionOrder("toggles,mixer,keepAwake",
+                                                           canonical: panelSections,
+                                                           after: panelPredecessors)
+        expect(reorderedPanel.firstIndex(of: "nowPlaying")
+                == reorderedPanel.firstIndex(of: "mixer").map { $0 + 1 }
+                && reorderedPanel.prefix(2) == ["toggles", "mixer"],
+               "the rule follows the user's own order rather than the canonical one")
+        expect(Defaults.sanitizedSectionOrder("mixer,bogus,mixer",
+                                              canonical: panelSections,
+                                              after: panelPredecessors).count == panelSections.count,
+               "an unknown or repeated saved id never shrinks or grows the panel")
+
         expect(RadialNowPlayingSupport.adapterReply(from: Data(#"{"error":"MRMediaRemoteGetNowPlayingInfo unavailable"}"#.utf8)) == nil
                 && RadialNowPlayingSupport.adapterReply(from: Data("[1,2]".utf8)) == nil
                 && RadialNowPlayingSupport.adapterReply(from: Data("perl: cannot load".utf8)) == nil

--- a/build.sh
+++ b/build.sh
@@ -314,6 +314,7 @@ if (( TEST )); then
         Sources/Vorssaint/Core/Localizations/Strings+*.swift
         Sources/Vorssaint/Core/FeatureStrings.swift
         Sources/Vorssaint/Core/KillProcessStrings.swift
+        Sources/Vorssaint/Core/NowPlayingStrings.swift
         Sources/Vorssaint/Core/WhatsAppDownloadStrings.swift
         Sources/Vorssaint/Core/WhatsAppOrganizerStrings.swift
         Sources/Vorssaint/Core/ReleaseNotes.swift


### PR DESCRIPTION
Picks up #303. The blocker named on it is gone — per the note in #838, this builds on the Now Playing bridge that is in `main` and driving the radial menu's card, rather than rebasing the branch that died with the old one.

Two things up front. It has **not** yet had the few days of living-with that a feature here is supposed to get, and the exact gaps are listed under *Verified where* rather than left implied. And there are two direction questions at the bottom — the first one changes the size of this diff substantially, so it is worth answering before anyone reads the code closely.

Refs #303

## Before / after

Before, the current track was visible inside Vorssaint only as the radial menu's card — unreachable if you do not use the wheel, which is what the reporter said in #303 — and that card has no playback controls. After, the menu bar panel has a Now Playing section: artwork, title, artist, album, and previous / play-pause / next for whatever owns the system Now Playing session.

Ships uninstalled, as a hub feature under Sound, hideable from the panel like every other section.

## Built on what is already in main

Per the note in #838 ("whoever picks #303 up again should build on that, not rebase the old branch"):

- **The read** is the same out-of-process one the radial card uses — `Sources/NowPlayingAdapter` through `BoundedProcessRunner`. The bridge grew one parameter and a second caller. Nothing new reads MediaRemote, and no new private framework is taken.
- **The transport** posts the aux-button pair the physical media keys post, so it reaches whatever owns the session with no per-application integration. It does need **Accessibility**, since that is a synthetic event — the same grant the radial menu's media slices already declare. (I had this wrong in the first push of this branch and the buttons silently did nothing; the second commit fixes the declaration.)
- **Nothing polls.** The panel is a popover, so a read happens when the section appears and once after a transport press, never while the panel is shut.

## Three shared things I changed rather than copied

1. `postAuxKey` was private to `RadialMenuService`. It is now `MediaKeyInput`, pressed by both callers, so the media-key path did not become another private copy of a synthetic-event builder — #937 is the record of what that costs.
2. `RadialNowPlayingSupport.snapshot` gained `includesPaused`, defaulting to the radial menu's existing behaviour. A paused session must read as nothing playing on the wheel, but a mini player that went blank the moment you hit pause tells the user something false, so the panel asks for it and draws a play button. The snapshot now carries `isPlaying`.
3. The four rules in `PanelLayout.order` that place a section an existing saved order predates were one expression copied per section, and none of it was reachable from the test list. Now one table and one function in `Defaults`, so the new section landing next to the mixer instead of after Quick toggles is covered by a test rather than by inspection. Callers checked: `PanelLayout.order` is the only reader, via `MenuPanelView` and the layout editors.

## Tests

Added to the existing Now Playing block: the `includesPaused` contract in both directions, that ownerless metadata is still nothing playing either way, the optimistic flip changing only playback state, a source-shape assertion that the aux event is built in one place and the radial menu presses it through that (comments stripped first), and the saved-order upgrade path including a reordered panel. Verified red with each of the three pieces of logic reverted — six assertions fail, then green again.

`AppFeature.allCases.count` 57 → 58 and the ordered raw-value list updated.

## Verified where

MacBook Pro (Mac16,8), M4 Pro, macOS 26.6.1 (25G76), single built-in display, one Space, English, a `--dev` build installed beside the released 3.3.5.

- `./build.sh` finishes clean with no warnings, `--selftest` OK, `./build.sh --test` OK (32383 checks). The full `./build.sh` was run as well as `--test`, since this touches `UI/`.
- The new assertions were checked in both directions: reverting each of the three pieces of logic turns six of them red, and they go green again with the logic in place.
- **The read path was exercised against the installed bundle on this machine** and came back with a real session, artwork included. Worth stating explicitly because this is the path that returns nothing to an unsigned process on 15.4+, and it is what the earlier #303 branch died on.
- That session was **paused**, which is exactly the case this branch is about: the existing builder discards a paused session, so without `includesPaused` the panel would have reported nothing playing while a track was plainly loaded.
- The app launches with the feature installed and stays up, and **the section renders** — artwork, title, the second metadata line and the transport, with the section's tab in the panel's navigation strip.
- Two defects came out of actually using it, both fixed in the second commit: the transport declared no permissions (so it did nothing at all until Accessibility was granted), and the section only read on `onAppear`, so a session that changed while the popover was shut stayed stale on screen until a button was pressed. Neither was visible from the code or the tests; both took opening the panel.

**Not verified, and I would rather say so than imply otherwise:**

- It has not had the few days of use a feature here is supposed to get. That is why this is a draft.
- Any language other than English. The two new strings are machine-assisted and want a native reader; the section title reuses the already-translated `mediaNowPlaying`.
- Multiple displays, multiple Spaces, a release build, and VoiceOver on the transport buttons.
- **The transport actually changing playback.** The permission declaration is fixed and correct by inspection against the radial menu's, but I have not yet watched a press move a player with the grant in place.
- Covered since: a browser tab (WebKit) as the session owner renders correctly, title and artwork included. Still untested is anything that reports no title at all, where the section falls back to the owning app's name.

## Two questions

1. **Own feature, or fold into the Sound section?** As written this is a new hub feature and a new panel section, which is most of the diff. Folding it into the existing mixer/Sound section would cut roughly 140 lines and ten touched files, at the cost of needing the Mixer installed to see your current track. I picked the standalone shape because #303 asks for a player and the reporter does not use the radial menu, but the smaller one is a one-commit change if you prefer it.
2. **Should the radial card show paused sessions too?** `includesPaused` defaults to off purely to leave the wheel's behaviour untouched. If a paused track should appear there as well, the parameter disappears and the decision moves to the two callers, which is tidier.

Not in scope, and worth saying so: **there is no progress bar or scrubbing.** The adapter forwards no elapsed time or duration, so that needs the bridge to grow, which is a bigger argument than this branch.
